### PR TITLE
feat: add basic auth to allow target

### DIFF
--- a/tibuild/api/api.go
+++ b/tibuild/api/api.go
@@ -102,7 +102,7 @@ func routeRestAPI(router *gin.Engine, cfg *configs.ConfigYaml) {
 		panic(err)
 	}
 	devBuildGroup := apiGroup.Group("/devbuilds")
-	devBuildHandler := controllers.NewDevBuildHandler(context.Background(), jenkins, database.DBConn.DB)
+	devBuildHandler := controllers.NewDevBuildHandler(context.Background(), jenkins, database.DBConn.DB, cfg.TiBuild.AdminPasswd)
 	{
 		devBuildGroup.POST("", devBuildHandler.Create)
 		devBuildGroup.GET("", devBuildHandler.List)

--- a/tibuild/api/api.go
+++ b/tibuild/api/api.go
@@ -102,7 +102,7 @@ func routeRestAPI(router *gin.Engine, cfg *configs.ConfigYaml) {
 		panic(err)
 	}
 	devBuildGroup := apiGroup.Group("/devbuilds")
-	devBuildHandler := controllers.NewDevBuildHandler(context.Background(), jenkins, database.DBConn.DB, cfg.TiBuild.AdminPasswd)
+	devBuildHandler := controllers.NewDevBuildHandler(context.Background(), jenkins, database.DBConn.DB, cfg.AuthConfig)
 	{
 		devBuildGroup.POST("", devBuildHandler.Create)
 		devBuildGroup.GET("", devBuildHandler.List)

--- a/tibuild/api/api.go
+++ b/tibuild/api/api.go
@@ -102,7 +102,7 @@ func routeRestAPI(router *gin.Engine, cfg *configs.ConfigYaml) {
 		panic(err)
 	}
 	devBuildGroup := apiGroup.Group("/devbuilds")
-	devBuildHandler := controllers.NewDevBuildHandler(context.Background(), jenkins, database.DBConn.DB, cfg.AuthConfig)
+	devBuildHandler := controllers.NewDevBuildHandler(context.Background(), jenkins, database.DBConn.DB, cfg.RestApiSecret)
 	{
 		devBuildGroup.POST("", devBuildHandler.Create)
 		devBuildGroup.GET("", devBuildHandler.List)

--- a/tibuild/commons/configs/config.go
+++ b/tibuild/commons/configs/config.go
@@ -4,6 +4,7 @@ package configs
 
 import (
 	"fmt"
+
 	"github.com/jinzhu/configor"
 )
 
@@ -28,6 +29,10 @@ type ConfigYaml struct {
 
 	Github struct {
 		Token string
+	}
+
+	TiBuild struct {
+		AdminPasswd string
 	}
 }
 

--- a/tibuild/commons/configs/config.go
+++ b/tibuild/commons/configs/config.go
@@ -31,12 +31,12 @@ type ConfigYaml struct {
 		Token string
 	}
 
-	AuthConfig TiBuildAuthCfg
+	RestApiSecret RestApiSecret
 }
 
-type TiBuildAuthCfg struct {
-	AdminPasswd   string
-	TiBuildPasswd string
+type RestApiSecret struct {
+	AdminToken   string
+	TiBuildToken string
 }
 
 var Config = &ConfigYaml{}

--- a/tibuild/commons/configs/config.go
+++ b/tibuild/commons/configs/config.go
@@ -31,9 +31,12 @@ type ConfigYaml struct {
 		Token string
 	}
 
-	TiBuild struct {
-		AdminPasswd string
-	}
+	AuthConfig TiBuildAuthCfg
+}
+
+type TiBuildAuthCfg struct {
+	AdminPasswd   string
+	TiBuildPasswd string
 }
 
 var Config = &ConfigYaml{}
@@ -41,5 +44,8 @@ var Config = &ConfigYaml{}
 // Load config from file into 'Config' variable
 func LoadConfig(file string) {
 	fmt.Printf("file:%s\n", file)
-	configor.Load(Config, file)
+	err := configor.Load(Config, file)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/tibuild/commons/configs/config_test.go
+++ b/tibuild/commons/configs/config_test.go
@@ -2,9 +2,12 @@ package configs
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadConfig(t *testing.T) {
-	t.Skip()
-	LoadConfig("../../config.yaml")
+	LoadConfig("../../configs/config.yaml")
+	cfg := Config.AuthConfig
+	assert.NotEmpty(t, cfg.TiBuildPasswd)
 }

--- a/tibuild/commons/configs/config_test.go
+++ b/tibuild/commons/configs/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	LoadConfig("../../configs/config.yaml")
+	LoadConfig("../../configs/config_example.yaml")
 	cfg := Config.AuthConfig
 	assert.NotEmpty(t, cfg.TiBuildPasswd)
 }

--- a/tibuild/commons/configs/config_test.go
+++ b/tibuild/commons/configs/config_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	LoadConfig("../../configs/config_example.yaml")
-	cfg := Config.AuthConfig
-	assert.NotEmpty(t, cfg.TiBuildPasswd)
+	cfg := Config.RestApiSecret
+	assert.NotEmpty(t, cfg.TiBuildToken)
 }

--- a/tibuild/configs/config_example.yaml
+++ b/tibuild/configs/config_example.yaml
@@ -17,6 +17,6 @@ jenkins:
 github:
   token: ""
 
-authconfig:
-  adminpasswd: "1"
-  tibuildpasswd: "2"
+restapisecret:
+  admintoken: "1"
+  tibuildtoken: "2"

--- a/tibuild/configs/config_example.yaml
+++ b/tibuild/configs/config_example.yaml
@@ -3,16 +3,20 @@
 # All configuration information keys is in /tirelease/commons/configs/config.go in struct of ConfigYaml
 # Config like this:
 mysql:
-  username: ""
-  password: ""
-  host: ""
-  port: ""
-  database: ""
+  username: "your user name"
+  password: "your password"
+  host: "127.0.0.1"
+  port: "127.0.0.1"
+  database: "you_db_name"
   charset: ""
   timezone: ""
 
 jenkins:
-  username: ""
-  password: ""
+  username: "your jenkins account"
+  password: "your password"
 github:
   token: ""
+
+authconfig:
+  adminpasswd: "1"
+  tibuildpasswd: "2"

--- a/tibuild/docs/docs.go
+++ b/tibuild/docs/docs.go
@@ -485,7 +485,7 @@ const docTemplate = `{
                 "productDockerfile": {
                     "type": "string"
                 },
-                "targetImage": {
+                "targetImg": {
                     "type": "string"
                 },
                 "version": {

--- a/tibuild/docs/docs.go
+++ b/tibuild/docs/docs.go
@@ -485,6 +485,9 @@ const docTemplate = `{
                 "productDockerfile": {
                     "type": "string"
                 },
+                "targetImage": {
+                    "type": "string"
+                },
                 "version": {
                     "type": "string"
                 }

--- a/tibuild/docs/swagger.json
+++ b/tibuild/docs/swagger.json
@@ -473,6 +473,9 @@
                 "productDockerfile": {
                     "type": "string"
                 },
+                "targetImage": {
+                    "type": "string"
+                },
                 "version": {
                     "type": "string"
                 }

--- a/tibuild/docs/swagger.json
+++ b/tibuild/docs/swagger.json
@@ -473,7 +473,7 @@
                 "productDockerfile": {
                     "type": "string"
                 },
-                "targetImage": {
+                "targetImg": {
                     "type": "string"
                 },
                 "version": {

--- a/tibuild/docs/swagger.yaml
+++ b/tibuild/docs/swagger.yaml
@@ -110,6 +110,8 @@ definitions:
         type: string
       productDockerfile:
         type: string
+      targetImage:
+        type: string
       version:
         type: string
     type: object

--- a/tibuild/docs/swagger.yaml
+++ b/tibuild/docs/swagger.yaml
@@ -110,7 +110,7 @@ definitions:
         type: string
       productDockerfile:
         type: string
-      targetImage:
+      targetImg:
         type: string
       version:
         type: string

--- a/tibuild/pkg/rest/controller/common.go
+++ b/tibuild/pkg/rest/controller/common.go
@@ -33,6 +33,8 @@ func errorToCode(err error) int {
 		return 400
 	} else if errors.Is(err, service.ErrServerRefuse) {
 		return 422
+	} else if errors.Is(err, service.ErrAuth) {
+		return 401
 	} else {
 		return 500
 	}

--- a/tibuild/pkg/rest/controller/dev_build_handler.go
+++ b/tibuild/pkg/rest/controller/dev_build_handler.go
@@ -17,10 +17,10 @@ import (
 
 type DevBuildHandler struct {
 	svc  service.DevBuildService
-	auth configs.TiBuildAuthCfg
+	auth configs.RestApiSecret
 }
 
-func NewDevBuildHandler(ctx context.Context, jenkins service.Jenkins, db *gorm.DB, auth configs.TiBuildAuthCfg) *DevBuildHandler {
+func NewDevBuildHandler(ctx context.Context, jenkins service.Jenkins, db *gorm.DB, auth configs.RestApiSecret) *DevBuildHandler {
 	db.AutoMigrate(&service.DevBuild{})
 	return &DevBuildHandler{svc: service.DevbuildServer{
 		Repo:    repo.DevBuildRepo{Db: db},
@@ -35,17 +35,17 @@ func (h DevBuildHandler) authenticate(c *gin.Context) (context.Context, error) {
 	if !ok {
 		return c.Request.Context(), nil
 	}
-	if user == service.AdminUserName {
-		if passwd == h.auth.AdminPasswd {
-			ctx := context.WithValue(c.Request.Context(), service.KeyOfUserName, user)
+	if user == service.AdminApiAccount {
+		if passwd == h.auth.AdminToken {
+			ctx := context.WithValue(c.Request.Context(), service.KeyOfApiAccount, user)
 			return ctx, nil
 		} else {
 			return nil, fmt.Errorf("authenticate error%w", service.ErrAuth)
 		}
 	}
-	if user == service.TibuildUserName {
-		if passwd == h.auth.TiBuildPasswd {
-			ctx := context.WithValue(c.Request.Context(), service.KeyOfUserName, user)
+	if user == service.TibuildApiAccount {
+		if passwd == h.auth.TiBuildToken {
+			ctx := context.WithValue(c.Request.Context(), service.KeyOfApiAccount, user)
 			return ctx, nil
 		} else {
 			return nil, fmt.Errorf("authenticate error%w", service.ErrAuth)

--- a/tibuild/pkg/rest/repo/dev_build_repo_test.go
+++ b/tibuild/pkg/rest/repo/dev_build_repo_test.go
@@ -24,7 +24,7 @@ func TestDevBuildCreate(t *testing.T) {
 	mock.ExpectBegin()
 	now := time.Unix(1, 0)
 	mock.ExpectExec("INSERT INTO `dev_builds`").WithArgs(now, "", now, ProductBr, "", "v6.7.0", CommunityEdition, "",
-		"AA=BB", "https://raw.example.com/Dockerfile", "", "pingcap/builder", "", false, "", false, "PENDING", 0, "", nil, nil, json.RawMessage("null")).WillReturnResult(sqlmock.NewResult(1, 1))
+		"AA=BB", "https://raw.example.com/Dockerfile", "", "pingcap/builder", "", false, "", false, "", "PENDING", 0, "", nil, nil, json.RawMessage("null")).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 	entity, err := repo.Create(context.TODO(), DevBuild{
 		Meta: DevBuildMeta{CreatedAt: now, UpdatedAt: now},
@@ -61,7 +61,7 @@ func TestDevBuildUpdate(t *testing.T) {
 	report_text, err := json.Marshal(report)
 	require.NoError(t, err)
 	mock.ExpectBegin()
-	mock.ExpectExec("UPDATE `dev_builds` SET").WithArgs(now, "", sqlmock.AnyArg(), ProductBr, "", "", "", "", "", "", "", "", "", false, "", false, "SUCCESS", 0, "", nil, nil, report_text, 1).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE `dev_builds` SET").WithArgs(now, "", sqlmock.AnyArg(), ProductBr, "", "", "", "", "", "", "", "", "", false, "", false, "", "SUCCESS", 0, "", nil, nil, report_text, 1).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 	entity, err := repo.Update(context.TODO(),
 		1,

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -24,7 +24,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 	req.Meta.CreatedAt = s.Now()
 	req.Status.Status = BuildStatusPending
 
-	if err := validate_permission(ctx, req); err != nil {
+	if err := validatePermission(ctx, req); err != nil {
 		return nil, fmt.Errorf("%s%w", err.Error(), ErrAuth)
 	}
 
@@ -81,7 +81,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 	return &entity, nil
 }
 
-func validate_permission(ctx context.Context, req DevBuild) error {
+func validatePermission(ctx context.Context, req DevBuild) error {
 	if req.Spec.TargetImg != "" && ctx.Value(KeyOfUserName) != AdminUserName {
 		return fmt.Errorf("targetImage deny because of permission")
 	}

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -24,7 +24,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 	req.Meta.CreatedAt = s.Now()
 	req.Status.Status = BuildStatusPending
 
-	if err := validatePermission(ctx, req); err != nil {
+	if err := validatePermission(ctx, &req); err != nil {
 		return nil, fmt.Errorf("%s%w", err.Error(), ErrAuth)
 	}
 
@@ -81,7 +81,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 	return &entity, nil
 }
 
-func validatePermission(ctx context.Context, req DevBuild) error {
+func validatePermission(ctx context.Context, req *DevBuild) error {
 	if req.Spec.TargetImg != "" && ctx.Value(KeyOfUserName) != AdminUserName {
 		return fmt.Errorf("targetImage deny because of permission")
 	}

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -82,7 +82,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 }
 
 func validatePermission(ctx context.Context, req *DevBuild) error {
-	if req.Spec.TargetImg != "" && ctx.Value(KeyOfUserName) != AdminUserName {
+	if req.Spec.TargetImg != "" && ctx.Value(KeyOfApiAccount) != AdminApiAccount {
 		return fmt.Errorf("targetImage deny because of permission")
 	}
 	return nil

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -287,6 +287,6 @@ var githubRepoValidator *regexp.Regexp
 func init() {
 	versionValidator = regexp.MustCompile(`^v(\d+\.\d+)\.\d+.*$`)
 	hotfixVersionValidator = regexp.MustCompile(`^v(\d+\.\d+)\.\d+-\d{8,}.*$`)
-	gitRefValidator = regexp.MustCompile(`^((v\d.*)|(pull/\d+)|([0-9a-fA-F]{40})|(release-.*)|master|main|(tag/[\w-_]+)|(branch/[\w-_\.]+))$`)
+	gitRefValidator = regexp.MustCompile(`^((v\d.*)|(pull/\d+)|([0-9a-fA-F]{40})|(release-.*)|master|main|(tag/.+)|(branch/.+))$`)
 	githubRepoValidator = regexp.MustCompile(`^([\w_-]+/[\w_-]+)$`)
 }

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -57,6 +57,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 		"BuilderImg":        entity.Spec.BuilderImg,
 		"ProductDockerfile": entity.Spec.ProductDockerfile,
 		"ProductBaseImg":    entity.Spec.ProductBaseImg,
+		"TargetImg":         entity.Spec.TargetImg,
 	}
 	qid, err := s.Jenkins.BuildJob(ctx, jobname, params)
 	if err != nil {

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -295,14 +295,7 @@ type DevBuildRepository interface {
 
 var _ DevBuildService = DevbuildServer{}
 
-var versionValidator *regexp.Regexp
-var hotfixVersionValidator *regexp.Regexp
-var gitRefValidator *regexp.Regexp
-var githubRepoValidator *regexp.Regexp
-
-func init() {
-	versionValidator = regexp.MustCompile(`^v(\d+\.\d+)\.\d+.*$`)
-	hotfixVersionValidator = regexp.MustCompile(`^v(\d+\.\d+)\.\d+-\d{8,}.*$`)
-	gitRefValidator = regexp.MustCompile(`^((v\d.*)|(pull/\d+)|([0-9a-fA-F]{40})|(release-.*)|master|main|(tag/.+)|(branch/.+))$`)
-	githubRepoValidator = regexp.MustCompile(`^([\w_-]+/[\w_-]+)$`)
-}
+var versionValidator *regexp.Regexp = regexp.MustCompile(`^v(\d+\.\d+)\.\d+.*$`)
+var hotfixVersionValidator *regexp.Regexp = regexp.MustCompile(`^v(\d+\.\d+)\.\d+-\d{8,}.*$`)
+var gitRefValidator *regexp.Regexp = regexp.MustCompile(`^((v\d.*)|(pull/\d+)|([0-9a-fA-F]{40})|(release-.*)|master|main|(tag/.+)|(branch/.+))$`)
+var githubRepoValidator *regexp.Regexp = regexp.MustCompile(`^([\w_-]+/[\w_-]+)$`)

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -81,7 +81,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 }
 
 func validate_permission(ctx context.Context, req DevBuild) error {
-	if req.Spec.TargetImage != "" && ctx.Value(KeyOfUserName) != AdminUserName {
+	if req.Spec.TargetImg != "" && ctx.Value(KeyOfUserName) != AdminUserName {
 		return fmt.Errorf("targetImage deny because of permission")
 	}
 	return nil

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -186,6 +186,9 @@ func validateReq(req DevBuild) error {
 		if !hotfixVersionValidator.MatchString((spec.Version)) {
 			return fmt.Errorf("verion must be like v7.0.0-20230102... for hotfix")
 		}
+		if spec.TargetImg != "" {
+			return fmt.Errorf("target image shall be empty for hotfix")
+		}
 	}
 	return nil
 }

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -153,6 +153,9 @@ func TestDevBuildCreate(t *testing.T) {
 		_, err = server.Create(context.TODO(), obj, DevBuildSaveOption{})
 		require.ErrorIs(t, err, ErrAuth)
 
+		_, err = server.Create(context.WithValue(context.TODO(), KeyOfUserName, "admi"), obj, DevBuildSaveOption{})
+		require.ErrorIs(t, err, ErrAuth)
+
 		_, err = server.Create(context.WithValue(context.TODO(), KeyOfUserName, AdminUserName), obj, DevBuildSaveOption{})
 		require.NoError(t, err)
 

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -75,7 +75,8 @@ func TestDevBuildCreate(t *testing.T) {
 		require.Equal(t, int64(0), entity.Status.PipelineBuildID)
 		require.Equal(t, map[string]string{"Edition": "enterprise", "GitRef": "pull/23", "Product": "tidb",
 			"Version": "v6.1.2", "PluginGitRef": "master", "IsPushGCR": "false", "IsHotfix": "false", "Features": "",
-			"GithubRepo": "pingcap/tidb", "TiBuildID": "1", "BuildEnv": "", "ProductDockerfile": "", "BuilderImg": "", "ProductBaseImg": ""}, mockedJenkins.params)
+			"GithubRepo": "pingcap/tidb", "TiBuildID": "1", "BuildEnv": "", "ProductDockerfile": "", "BuilderImg": "",
+			"ProductBaseImg": "", "TargetImg": ""}, mockedJenkins.params)
 		mockedJenkins.resume <- struct{}{}
 		time.Sleep(time.Millisecond)
 		require.Equal(t, int64(2), mockedRepo.saved.Status.PipelineBuildID)

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -154,10 +154,10 @@ func TestDevBuildCreate(t *testing.T) {
 		_, err = server.Create(context.TODO(), obj, DevBuildSaveOption{})
 		require.ErrorIs(t, err, ErrAuth)
 
-		_, err = server.Create(context.WithValue(context.TODO(), KeyOfUserName, "admi"), obj, DevBuildSaveOption{})
+		_, err = server.Create(context.WithValue(context.TODO(), KeyOfApiAccount, "admi"), obj, DevBuildSaveOption{})
 		require.ErrorIs(t, err, ErrAuth)
 
-		_, err = server.Create(context.WithValue(context.TODO(), KeyOfUserName, AdminUserName), obj, DevBuildSaveOption{})
+		_, err = server.Create(context.WithValue(context.TODO(), KeyOfApiAccount, AdminApiAccount), obj, DevBuildSaveOption{})
 		require.NoError(t, err)
 
 	})

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -149,7 +149,7 @@ func TestDevBuildCreate(t *testing.T) {
 		_, err := server.Create(context.TODO(), obj, DevBuildSaveOption{})
 		require.NoError(t, err)
 
-		obj.Spec.TargetImage = "hub.pingcap.net/temp/tidb:somefeat"
+		obj.Spec.TargetImg = "hub.pingcap.net/temp/tidb:somefeat"
 		_, err = server.Create(context.TODO(), obj, DevBuildSaveOption{})
 		require.ErrorIs(t, err, ErrAuth)
 

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -144,6 +144,20 @@ func TestDevBuildCreate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("validate target image", func(t *testing.T) {
+		obj := DevBuild{Spec: DevBuildSpec{Product: ProductTidb, Version: "v6.1.2", Edition: CommunityEdition, GitRef: "branch/feature/somefeat"}}
+		_, err := server.Create(context.TODO(), obj, DevBuildSaveOption{})
+		require.NoError(t, err)
+
+		obj.Spec.TargetImage = "hub.pingcap.net/temp/tidb:somefeat"
+		_, err = server.Create(context.TODO(), obj, DevBuildSaveOption{})
+		require.ErrorIs(t, err, ErrAuth)
+
+		_, err = server.Create(context.WithValue(context.TODO(), KeyOfUserName, AdminUserName), obj, DevBuildSaveOption{})
+		require.NoError(t, err)
+
+	})
+
 	t.Run("bad githubRepo", func(t *testing.T) {
 		_, err := server.Create(context.TODO(), DevBuild{Spec: DevBuildSpec{Product: ProductTidb, GitRef: "pull/23",
 			Version: "v6.1.2", Edition: CommunityEdition, GithubRepo: "aa/bb/cc"}}, DevBuildSaveOption{})

--- a/tibuild/pkg/rest/service/error.go
+++ b/tibuild/pkg/rest/service/error.go
@@ -9,3 +9,4 @@ var ErrInternalError = errors.New("")
 var ErrServerRefuse = errors.New("")
 
 var ErrNotFound = errors.New("")
+var ErrAuth = errors.New("")

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -267,7 +267,7 @@ type ImageSyncRequest struct {
 
 type TibuildCtxKey string
 
-var KeyOfUserName TibuildCtxKey = "username"
+var KeyOfApiAccount TibuildCtxKey = "apiAccount"
 
-const AdminUserName = "admin"
-const TibuildUserName = "tibuild"
+const AdminApiAccount = "admin"
+const TibuildApiAccount = "tibuild"

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -169,7 +169,7 @@ type DevBuildSpec struct {
 	IsPushGCR         bool           `json:"isPushGCR,omitempty"`
 	Features          string         `json:"features,omitempty" gorm:"type:varchar(128)"`
 	IsHotfix          bool           `json:"isHotfix,omitempty"`
-	TargetImage       string         `json:"targetImage,omitempty" gorm:"type:varchar(128)"`
+	TargetImg         string         `json:"targetImg,omitempty" gorm:"type:varchar(128)"`
 }
 
 type GitRef string
@@ -270,3 +270,4 @@ type TibuildCtxKey string
 var KeyOfUserName TibuildCtxKey = "username"
 
 const AdminUserName = "admin"
+const TibuildUserName = "tibuild"

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -265,5 +265,8 @@ type ImageSyncRequest struct {
 	Target string `json:"target"`
 }
 
-const KeyOfUserName = "username"
+type TibuildCtxKey string
+
+var KeyOfUserName TibuildCtxKey = "username"
+
 const AdminUserName = "admin"

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -169,6 +169,7 @@ type DevBuildSpec struct {
 	IsPushGCR         bool           `json:"isPushGCR,omitempty"`
 	Features          string         `json:"features,omitempty" gorm:"type:varchar(128)"`
 	IsHotfix          bool           `json:"isHotfix,omitempty"`
+	TargetImage       string         `json:"targetImage,omitempty" gorm:"type:varchar(128)"`
 }
 
 type GitRef string
@@ -263,3 +264,6 @@ type ImageSyncRequest struct {
 	Source string `json:"source"`
 	Target string `json:"target"`
 }
+
+const KeyOfUserName = "username"
+const AdminUserName = "admin"

--- a/tibuild/tbctl/tbctl.py
+++ b/tibuild/tbctl/tbctl.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
     parser_trigger.add_argument('--productDockerfile', help='dockerfile url for product')
     parser_trigger.add_argument('--productBaseImg', help='product base image')
     parser_trigger.add_argument('--builderImg', help='specify docker image for builder')
-    parser_trigger.add_argument('--targetImage', help=argparse.SUPPRESS)
+    parser_trigger.add_argument('--targetImg', help=argparse.SUPPRESS)
     parser_trigger.set_defaults(handler=trigger)
     parser_poll = devbuild.add_parser('poll')
     parser_poll.add_argument('build_id', type=int, help="the triggered build id")

--- a/tibuild/tbctl/tbctl.py
+++ b/tibuild/tbctl/tbctl.py
@@ -12,6 +12,7 @@ devbuild_url = 'https://tibuild.pingcap.net/api/devbuilds'
 
 NOBLOCK = False
 BUILD_CREATED_BY = ''
+BASIC_AUTH_CREDENTIAL=''
 
 
 def dev_build_url(build_id: int):
@@ -35,11 +36,14 @@ def trigger(args):
                      "buildEnv": ' '.join(args.buildEnv) if args.buildEnv else '',
                      "productDockerfile": args.productDockerfile,
                      "productBaseImg": args.productBaseImg,
-                     "builderImg":args.builderImg}}
+                     "builderImg":args.builderImg,
+                     "targetImg": args.targetImg}}
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",
     }
+    if BASIC_AUTH_CREDENTIAL:
+        headers['Authorization']="BASIC " + BASIC_AUTH_CREDENTIAL
     body = json.dumps(data).encode()
     req = urllib.request.Request(f"{devbuild_url}?dryrun={args.dryrun}", body, headers, method="POST")
     build_id = 0
@@ -107,6 +111,7 @@ def get_artifact(build: dict) -> str:
 if __name__ == "__main__":
     NOBLOCK = bool(os.environ.get('NOBLOCK'))
     BUILD_CREATED_BY = os.environ.get('BUILD_CREATED_BY') or ''
+    BASIC_AUTH_CREDENTIAL = os.environ.get('BASIC_AUTH_CREDENTIAL') or ''
     top_parser = argparse.ArgumentParser(
         prog='tbctl',
         description='tibuild commandline client'
@@ -133,6 +138,7 @@ if __name__ == "__main__":
     parser_trigger.add_argument('--productDockerfile', help='dockerfile url for product')
     parser_trigger.add_argument('--productBaseImg', help='product base image')
     parser_trigger.add_argument('--builderImg', help='specify docker image for builder')
+    parser_trigger.add_argument('--targetImage', help=argparse.SUPPRESS)
     parser_trigger.set_defaults(handler=trigger)
     parser_poll = devbuild.add_parser('poll')
     parser_poll.add_argument('build_id', type=int, help="the triggered build id")


### PR DESCRIPTION
Why:
- some users want use devbuild for nighly, hoping to push to given target image address

How:
- add basic auth, with shared token
- allow given target image if he is admin
- add a big account for front end and chat-bot
- allow GitRef like: branch/feature/...