### PR TITLE
fix: tekton artifact list

### DIFF
--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -460,5 +460,5 @@ var hotfixVersionValidator *regexp.Regexp = regexp.MustCompile(`^v(\d+\.\d+)\.\d
 var gitRefValidator *regexp.Regexp = regexp.MustCompile(`^((v\d.*)|(pull/\d+)|([0-9a-fA-F]{40})|(release-.*)|master|main|(tag/.+)|(branch/.+))$`)
 var githubRepoValidator *regexp.Regexp = regexp.MustCompile(`^([\w_-]+/[\w_-]+)$`)
 
-const tektonURL = "https://do.pingcap.net/tekton/#/namespaces/ee-cd/pipelineruns/"
+const tektonURL = "https://do.pingcap.net/tekton/#/namespaces/ee-cd/pipelineruns"
 const oras_fileserver_url = "https://internal.do.pingcap.net:30443/dl"

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -384,6 +384,12 @@ func compute_tekton_status(status *TektonStatus) {
 	var failure_platforms = map[Platform]struct{}{}
 	var triggered_platforms = map[Platform]struct{}{}
 	var latest_endat *time.Time
+	if status.BuildReport == nil {
+		status.BuildReport = &BuildReport{}
+	} else {
+		status.BuildReport.Images = nil
+		status.BuildReport.Binaries = nil
+	}
 	for _, pipeline := range status.Pipelines {
 		switch pipeline.Status {
 		case BuildStatusSuccess:
@@ -392,12 +398,6 @@ func compute_tekton_status(status *TektonStatus) {
 			failure_platforms[pipeline.Platform] = struct{}{}
 		}
 		triggered_platforms[pipeline.Platform] = struct{}{}
-		if status.BuildReport == nil {
-			status.BuildReport = &BuildReport{}
-		} else {
-			status.BuildReport.Images = nil
-			status.BuildReport.Binaries = nil
-		}
 		status.BuildReport.GitHash = pipeline.GitHash
 		for _, files := range pipeline.OrasArtifacts {
 			status.BuildReport.Binaries = append(status.BuildReport.Binaries, oras_to_files(pipeline.Platform, files)...)

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -365,17 +365,20 @@ func TestTektonStatusMerge(t *testing.T) {
 			Pipelines: []TektonPipeline{
 				{Name: "pipelinerun1", Status: BuildStatusSuccess, Platform: LinuxAmd64,
 					PipelineStartAt: &starttime,
-					OrasArtifacts:   []OrasArtifact{{Repo: "harbor.net/org/repo", Files: []string{"a.tar.gz", "b.tar.gz"}}},
+					OrasArtifacts:   []OrasArtifact{{Repo: "harbor.net/org/repo", Tag: "master", Files: []string{"a.tar.gz", "b.tar.gz"}}},
 					Images:          []ImageArtifact{{URL: "harbor.net/org/image:tag1"}}},
 				{Name: "pipelinerun2", Status: BuildStatusSuccess, Platform: LinuxArm64,
 					PipelineStartAt: &starttime,
 					PipelineEndAt:   &endtime,
-					OrasArtifacts:   []OrasArtifact{{Repo: "harbor.net/org/repo", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
+					Images:          []ImageArtifact{{URL: "harbor.net/org/image:tag2"}},
+					OrasArtifacts:   []OrasArtifact{{Repo: "harbor.net/org/repo", Tag: "master", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
 			},
 		}
 		compute_tekton_status(status)
 		require.Equal(t, BuildStatusSuccess, status.Status)
 		require.Equal(t, endtime.Sub(starttime), status.PipelineEndAt.Sub(*status.PipelineStartAt))
+		require.Equal(t, 2, len(status.BuildReport.Images))
+		require.Equal(t, 4, len(status.BuildReport.Binaries))
 	})
 
 	t.Run("processing", func(t *testing.T) {


### PR DESCRIPTION
# Why:
- pipeline url typo (we can make it configurable later)
- fix build report flash old artifacts while processing new event

# How:
- fix typo
- avoid flash BuildReport.Images every time while processing each pipeline event