### PR TITLE
refract: simplify tekton status

### DIFF
--- a/tibuild/docs/docs.go
+++ b/tibuild/docs/docs.go
@@ -710,23 +710,11 @@ const docTemplate = `{
         "service.TektonStatus": {
             "type": "object",
             "properties": {
-                "buildReport": {
-                    "$ref": "#/definitions/service.BuildReport"
-                },
-                "pipelineEndAt": {
-                    "type": "string"
-                },
-                "pipelineStartAt": {
-                    "type": "string"
-                },
                 "pipelines": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/service.TektonPipeline"
                     }
-                },
-                "status": {
-                    "$ref": "#/definitions/service.BuildStatus"
                 }
             }
         }

--- a/tibuild/docs/swagger.json
+++ b/tibuild/docs/swagger.json
@@ -698,23 +698,11 @@
         "service.TektonStatus": {
             "type": "object",
             "properties": {
-                "buildReport": {
-                    "$ref": "#/definitions/service.BuildReport"
-                },
-                "pipelineEndAt": {
-                    "type": "string"
-                },
-                "pipelineStartAt": {
-                    "type": "string"
-                },
                 "pipelines": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/service.TektonPipeline"
                     }
-                },
-                "status": {
-                    "$ref": "#/definitions/service.BuildStatus"
                 }
             }
         }

--- a/tibuild/docs/swagger.yaml
+++ b/tibuild/docs/swagger.yaml
@@ -269,18 +269,10 @@ definitions:
     type: object
   service.TektonStatus:
     properties:
-      buildReport:
-        $ref: '#/definitions/service.BuildReport'
-      pipelineEndAt:
-        type: string
-      pipelineStartAt:
-        type: string
       pipelines:
         items:
           $ref: '#/definitions/service.TektonPipeline'
         type: array
-      status:
-        $ref: '#/definitions/service.BuildStatus'
     type: object
 info:
   contact: {}

--- a/tibuild/pkg/rest/repo/dev_build_repo_test.go
+++ b/tibuild/pkg/rest/repo/dev_build_repo_test.go
@@ -62,7 +62,7 @@ func TestDevBuildUpdate(t *testing.T) {
 	now := time.Unix(1, 0)
 	report := BuildReport{GitHash: "a1b2c3"}
 	report_text, err := json.Marshal(report)
-	tekton_status := TektonStatus{Status: BuildStatusProcessing}
+	tekton_status := TektonStatus{}
 	tekton_text, err := json.Marshal(tekton_status)
 	require.NoError(t, err)
 	mock.ExpectBegin()
@@ -106,7 +106,7 @@ func TestDevBuildGet(t *testing.T) {
 		require.Empty(t, entity.Status.BuildReportJson)
 	})
 	t.Run("tekton_status", func(t *testing.T) {
-		tekton := TektonStatus{Status: BuildStatusProcessing}
+		tekton := TektonStatus{}
 		tekton_text, err := json.Marshal(tekton)
 		require.NoError(t, err)
 		rows := sqlmock.NewRows([]string{"id", "status", "tekton_status"}).AddRow(1, BuildStatusSuccess, tekton_text)

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -44,7 +44,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 		if err != nil {
 			return nil, err
 		}
-		req.Status.TektonStatus = &TektonStatus{Status: BuildStatusPending}
+		req.Status.TektonStatus = &TektonStatus{}
 	}
 	if option.DryRun {
 		req.ID = 1
@@ -359,34 +359,32 @@ func (s DevbuildServer) MergeTektonStatus(ctx context.Context, id int, pipeline 
 	if obj.Status.TektonStatus == nil {
 		obj.Status.TektonStatus = &TektonStatus{}
 	}
-	status := obj.Status.TektonStatus
+	tekton := obj.Status.TektonStatus
 	name := pipeline.Name
 	index := -1
-	for i, p := range status.Pipelines {
+	for i, p := range tekton.Pipelines {
 		if p.Name == name {
 			index = i
 		}
 	}
 	if index >= 0 {
-		status.Pipelines[index] = pipeline
+		tekton.Pipelines[index] = pipeline
 	} else {
-		status.Pipelines = append(status.Pipelines, pipeline)
+		tekton.Pipelines = append(tekton.Pipelines, pipeline)
 	}
-	computeTektonStatus(status)
 	if obj.Spec.PipelineEngine == TektonEngine {
-		obj.Status.Status = obj.Status.TektonStatus.Status
-		obj.Status.BuildReport = obj.Status.TektonStatus.BuildReport
+		computeTektonStatus(tekton, &obj.Status)
 	}
 	return s.Update(ctx, id, *obj, options)
 }
 
-func computeTektonStatus(status *TektonStatus) {
+func computeTektonStatus(tekton *TektonStatus, status *DevBuildStatus) {
 	status.BuildReport = &BuildReport{}
-	collectTektonArtifacts(status.Pipelines, status.BuildReport)
-	status.PipelineStartAt = getTektonStartAt(status.Pipelines)
-	status.Status = computeTektonPhase(status.Pipelines)
+	collectTektonArtifacts(tekton.Pipelines, status.BuildReport)
+	status.PipelineStartAt = getTektonStartAt(tekton.Pipelines)
+	status.Status = computeTektonPhase(tekton.Pipelines)
 	if status.Status.IsCompleted() {
-		status.PipelineEndAt = getLatestEndAt(status.Pipelines)
+		status.PipelineEndAt = getLatestEndAt(tekton.Pipelines)
 	}
 }
 
@@ -458,6 +456,10 @@ func getLatestEndAt(pipelines []TektonPipeline) *time.Time {
 func oras_to_files(platform Platform, oras OciArtifact) []BinArtifact {
 	var rt []BinArtifact
 	for _, file := range oras.Files {
+		if strings.HasSuffix(file, ".sha256") {
+			// ignore sha256 file
+			continue
+		}
 		rt = append(rt, BinArtifact{Platform: platform, OrasFile: &OrasFile{Repo: oras.Repo, Tag: oras.Tag, File: file}})
 	}
 	return rt

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -456,10 +456,6 @@ func getLatestEndAt(pipelines []TektonPipeline) *time.Time {
 func oras_to_files(platform Platform, oras OciArtifact) []BinArtifact {
 	var rt []BinArtifact
 	for _, file := range oras.Files {
-		if strings.HasSuffix(file, ".sha256") {
-			// ignore sha256 file
-			continue
-		}
 		rt = append(rt, BinArtifact{Platform: platform, OrasFile: &OrasFile{Repo: oras.Repo, Tag: oras.Tag, File: file}})
 	}
 	return rt

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -363,7 +363,7 @@ func TestTektonStatusMerge(t *testing.T) {
 	endtime := time.Unix(20, 0)
 
 	t.Run("success", func(t *testing.T) {
-		status := &TektonStatus{
+		tekton := &TektonStatus{
 			Pipelines: []TektonPipeline{
 				{Name: "pipelinerun1", Status: BuildStatusSuccess, Platform: LinuxAmd64,
 					PipelineStartAt: &starttime,
@@ -376,7 +376,8 @@ func TestTektonStatusMerge(t *testing.T) {
 					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Tag: "master", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
 			},
 		}
-		computeTektonStatus(status)
+		status := &DevBuildStatus{TektonStatus: tekton}
+		computeTektonStatus(tekton, status)
 		require.Equal(t, BuildStatusSuccess, status.Status)
 		require.Equal(t, endtime.Sub(starttime), status.PipelineEndAt.Sub(*status.PipelineStartAt))
 		require.Equal(t, 2, len(status.BuildReport.Images))
@@ -384,7 +385,7 @@ func TestTektonStatusMerge(t *testing.T) {
 	})
 
 	t.Run("processing", func(t *testing.T) {
-		status := &TektonStatus{
+		tekton := &TektonStatus{
 			Pipelines: []TektonPipeline{
 				{Name: "pipelinerun1", Status: BuildStatusSuccess, Platform: LinuxAmd64,
 					PipelineStartAt: &starttime,
@@ -396,11 +397,12 @@ func TestTektonStatusMerge(t *testing.T) {
 					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
 			},
 		}
-		computeTektonStatus(status)
+		status := &DevBuildStatus{TektonStatus: tekton}
+		computeTektonStatus(tekton, status)
 		require.Equal(t, BuildStatusProcessing, status.Status)
 	})
 	t.Run("processing", func(t *testing.T) {
-		status := &TektonStatus{
+		tekton := &TektonStatus{
 			Pipelines: []TektonPipeline{
 				{Name: "pipelinerun1", Status: BuildStatusSuccess, Platform: LinuxAmd64,
 					PipelineStartAt: &starttime,
@@ -412,7 +414,8 @@ func TestTektonStatusMerge(t *testing.T) {
 					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
 			},
 		}
-		computeTektonStatus(status)
+		status := &DevBuildStatus{TektonStatus: tekton}
+		computeTektonStatus(tekton, status)
 		require.Equal(t, BuildStatusFailure, status.Status)
 	})
 

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -251,11 +251,7 @@ type DevBuildStatus struct {
 }
 
 type TektonStatus struct {
-	Status          BuildStatus      `json:"status"`
-	PipelineStartAt *time.Time       `json:"pipelineStartAt,omitempty"`
-	PipelineEndAt   *time.Time       `json:"pipelineEndAt,omitempty"`
-	BuildReport     *BuildReport     `json:"buildReport,omitempty"`
-	Pipelines       []TektonPipeline `json:"pipelines"`
+	Pipelines []TektonPipeline `json:"pipelines"`
 }
 
 type TektonPipeline struct {


### PR DESCRIPTION
# Why:
- no need to  use multiple status, because now we only use one pipeline engine