### PR TITLE
fix: add `startAt` and `endAt` for Tekton runs

### DIFF
--- a/tibuild/docs/docs.go
+++ b/tibuild/docs/docs.go
@@ -343,6 +343,9 @@ const docTemplate = `{
                 "platform": {
                     "type": "string"
                 },
+                "sha256OciFile": {
+                    "$ref": "#/definitions/service.OciFile"
+                },
                 "sha256URL": {
                     "type": "string"
                 },
@@ -672,6 +675,9 @@ const docTemplate = `{
         "service.TektonPipeline": {
             "type": "object",
             "properties": {
+                "endAt": {
+                    "type": "string"
+                },
                 "gitHash": {
                     "type": "string"
                 },
@@ -684,19 +690,16 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
-                "ociArtifacts": {
+                "orasArtifacts": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/service.OciArtifact"
                     }
                 },
-                "pipelineEndAt": {
-                    "type": "string"
-                },
-                "pipelineStartAt": {
-                    "type": "string"
-                },
                 "platform": {
+                    "type": "string"
+                },
+                "startAt": {
                     "type": "string"
                 },
                 "status": {

--- a/tibuild/docs/docs.go
+++ b/tibuild/docs/docs.go
@@ -690,7 +690,7 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
-                "orasArtifacts": {
+                "ociArtifacts": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/service.OciArtifact"

--- a/tibuild/docs/swagger.json
+++ b/tibuild/docs/swagger.json
@@ -331,6 +331,9 @@
                 "platform": {
                     "type": "string"
                 },
+                "sha256OciFile": {
+                    "$ref": "#/definitions/service.OciFile"
+                },
                 "sha256URL": {
                     "type": "string"
                 },
@@ -660,6 +663,9 @@
         "service.TektonPipeline": {
             "type": "object",
             "properties": {
+                "endAt": {
+                    "type": "string"
+                },
                 "gitHash": {
                     "type": "string"
                 },
@@ -672,19 +678,16 @@
                 "name": {
                     "type": "string"
                 },
-                "ociArtifacts": {
+                "orasArtifacts": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/service.OciArtifact"
                     }
                 },
-                "pipelineEndAt": {
-                    "type": "string"
-                },
-                "pipelineStartAt": {
-                    "type": "string"
-                },
                 "platform": {
+                    "type": "string"
+                },
+                "startAt": {
                     "type": "string"
                 },
                 "status": {

--- a/tibuild/docs/swagger.json
+++ b/tibuild/docs/swagger.json
@@ -678,7 +678,7 @@
                 "name": {
                     "type": "string"
                 },
-                "orasArtifacts": {
+                "ociArtifacts": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/service.OciArtifact"

--- a/tibuild/docs/swagger.yaml
+++ b/tibuild/docs/swagger.yaml
@@ -14,6 +14,8 @@ definitions:
         $ref: '#/definitions/service.OciFile'
       platform:
         type: string
+      sha256OciFile:
+        $ref: '#/definitions/service.OciFile'
       sha256URL:
         type: string
       url:
@@ -244,6 +246,8 @@ definitions:
     type: object
   service.TektonPipeline:
     properties:
+      endAt:
+        type: string
       gitHash:
         type: string
       images:
@@ -252,15 +256,13 @@ definitions:
         type: array
       name:
         type: string
-      ociArtifacts:
+      orasArtifacts:
         items:
           $ref: '#/definitions/service.OciArtifact'
         type: array
-      pipelineEndAt:
-        type: string
-      pipelineStartAt:
-        type: string
       platform:
+        type: string
+      startAt:
         type: string
       status:
         $ref: '#/definitions/service.BuildStatus'

--- a/tibuild/docs/swagger.yaml
+++ b/tibuild/docs/swagger.yaml
@@ -256,7 +256,7 @@ definitions:
         type: array
       name:
         type: string
-      orasArtifacts:
+      ociArtifacts:
         items:
           $ref: '#/definitions/service.OciArtifact'
         type: array

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -406,11 +406,11 @@ func collectTektonArtifacts(pipelines []TektonPipeline, report *BuildReport) {
 func getTektonStartAt(pipelines []TektonPipeline) *time.Time {
 	var startAt *time.Time = nil
 	for _, pipeline := range pipelines {
-		if pipeline.PipelineStartAt != nil {
+		if pipeline.StartAt != nil {
 			if startAt == nil {
-				startAt = pipeline.PipelineStartAt
-			} else if pipeline.PipelineStartAt.Before(*startAt) {
-				startAt = pipeline.PipelineStartAt
+				startAt = pipeline.StartAt
+			} else if pipeline.StartAt.Before(*startAt) {
+				startAt = pipeline.StartAt
 			}
 		}
 	}
@@ -444,11 +444,11 @@ func computeTektonPhase(pipelines []TektonPipeline) BuildStatus {
 func getLatestEndAt(pipelines []TektonPipeline) *time.Time {
 	var latest_endat *time.Time
 	for _, pipeline := range pipelines {
-		if pipeline.PipelineEndAt != nil {
+		if pipeline.EndAt != nil {
 			if latest_endat == nil {
-				latest_endat = pipeline.PipelineEndAt
-			} else if latest_endat.Before(*pipeline.PipelineEndAt) {
-				latest_endat = pipeline.PipelineEndAt
+				latest_endat = pipeline.EndAt
+			} else if latest_endat.Before(*pipeline.EndAt) {
+				latest_endat = pipeline.EndAt
 			}
 		}
 	}

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -366,14 +366,14 @@ func TestTektonStatusMerge(t *testing.T) {
 		status := &TektonStatus{
 			Pipelines: []TektonPipeline{
 				{Name: "pipelinerun1", Status: BuildStatusSuccess, Platform: LinuxAmd64,
-					PipelineStartAt: &starttime,
-					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Tag: "master", Files: []string{"a.tar.gz", "b.tar.gz"}}},
-					Images:          []ImageArtifact{{URL: "harbor.net/org/image:tag1"}}},
+					StartAt:      &starttime,
+					OciArtifacts: []OciArtifact{{Repo: "harbor.net/org/repo", Tag: "master", Files: []string{"a.tar.gz", "b.tar.gz"}}},
+					Images:       []ImageArtifact{{URL: "harbor.net/org/image:tag1"}}},
 				{Name: "pipelinerun2", Status: BuildStatusSuccess, Platform: LinuxArm64,
-					PipelineStartAt: &starttime,
-					PipelineEndAt:   &endtime,
-					Images:          []ImageArtifact{{URL: "harbor.net/org/image:tag2"}},
-					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Tag: "master", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
+					StartAt:      &starttime,
+					EndAt:        &endtime,
+					Images:       []ImageArtifact{{URL: "harbor.net/org/image:tag2"}},
+					OciArtifacts: []OciArtifact{{Repo: "harbor.net/org/repo", Tag: "master", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
 			},
 		}
 		computeTektonStatus(status)
@@ -387,13 +387,13 @@ func TestTektonStatusMerge(t *testing.T) {
 		status := &TektonStatus{
 			Pipelines: []TektonPipeline{
 				{Name: "pipelinerun1", Status: BuildStatusSuccess, Platform: LinuxAmd64,
-					PipelineStartAt: &starttime,
-					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Files: []string{"a.tar.gz", "b.tar.gz"}}},
-					Images:          []ImageArtifact{{URL: "harbor.net/org/image:tag1"}}},
+					StartAt:      &starttime,
+					OciArtifacts: []OciArtifact{{Repo: "harbor.net/org/repo", Files: []string{"a.tar.gz", "b.tar.gz"}}},
+					Images:       []ImageArtifact{{URL: "harbor.net/org/image:tag1"}}},
 				{Name: "pipelinerun2", Status: BuildStatusProcessing, Platform: LinuxArm64,
-					PipelineStartAt: &starttime,
-					PipelineEndAt:   &endtime,
-					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
+					StartAt:      &starttime,
+					EndAt:        &endtime,
+					OciArtifacts: []OciArtifact{{Repo: "harbor.net/org/repo", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
 			},
 		}
 		computeTektonStatus(status)
@@ -403,13 +403,13 @@ func TestTektonStatusMerge(t *testing.T) {
 		status := &TektonStatus{
 			Pipelines: []TektonPipeline{
 				{Name: "pipelinerun1", Status: BuildStatusSuccess, Platform: LinuxAmd64,
-					PipelineStartAt: &starttime,
-					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Tag: "latest", Files: []string{"a.tar.gz", "b.tar.gz"}}},
-					Images:          []ImageArtifact{{URL: "harbor.net/org/image:tag1"}}},
+					StartAt:      &starttime,
+					OciArtifacts: []OciArtifact{{Repo: "harbor.net/org/repo", Tag: "latest", Files: []string{"a.tar.gz", "b.tar.gz"}}},
+					Images:       []ImageArtifact{{URL: "harbor.net/org/image:tag1"}}},
 				{Name: "pipelinerun2", Status: BuildStatusFailure, Platform: LinuxArm64,
-					PipelineStartAt: &starttime,
-					PipelineEndAt:   &endtime,
-					OciArtifacts:    []OciArtifact{{Repo: "harbor.net/org/repo", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
+					StartAt:      &starttime,
+					EndAt:        &endtime,
+					OciArtifacts: []OciArtifact{{Repo: "harbor.net/org/repo", Files: []string{"c.tar.gz", "d.tar.gz"}}}},
 			},
 		}
 		computeTektonStatus(status)

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -262,7 +262,7 @@ type TektonPipeline struct {
 	Platform     Platform        `json:"platform,omitempty"`
 	StartAt      *time.Time      `json:"startAt,omitempty"`
 	EndAt        *time.Time      `json:"endAt,omitempty"`
-	OciArtifacts []OciArtifact   `json:"orasArtifacts,omitempty"`
+	OciArtifacts []OciArtifact   `json:"ociArtifacts,omitempty"`
 	Images       []ImageArtifact `json:"images,omitempty"`
 }
 

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -259,15 +259,15 @@ type TektonStatus struct {
 }
 
 type TektonPipeline struct {
-	Name            string          `json:"name"`
-	URL             string          `json:"url,omitempty"`
-	GitHash         string          `json:"gitHash,omitempty"`
-	Status          BuildStatus     `json:"status"`
-	Platform        Platform        `json:"platform,omitempty"`
-	PipelineStartAt *time.Time      `json:"pipelineStartAt,omitempty"`
-	PipelineEndAt   *time.Time      `json:"pipelineEndAt,omitempty"`
-	OciArtifacts    []OciArtifact   `json:"orasArtifacts,omitempty"`
-	Images          []ImageArtifact `json:"images,omitempty"`
+	Name         string          `json:"name"`
+	URL          string          `json:"url,omitempty"`
+	GitHash      string          `json:"gitHash,omitempty"`
+	Status       BuildStatus     `json:"status"`
+	Platform     Platform        `json:"platform,omitempty"`
+	StartAt      *time.Time      `json:"startAt,omitempty"`
+	EndAt        *time.Time      `json:"endAt,omitempty"`
+	OciArtifacts []OciArtifact   `json:"orasArtifacts,omitempty"`
+	Images       []ImageArtifact `json:"images,omitempty"`
 }
 
 type OciArtifact struct {

--- a/tibuild/pkg/webhook/service/cloudevent.go
+++ b/tibuild/pkg/webhook/service/cloudevent.go
@@ -94,13 +94,13 @@ func toDevbuildPipeline(pipeline tekton.PipelineRun) (*rest.TektonPipeline, erro
 		return nil, fmt.Errorf("parse image failed:%w", err)
 	}
 	return &rest.TektonPipeline{
-		Name:            pipeline.Name,
-		Platform:        parsePlatform(pipeline),
-		GitHash:         parseGitHash(pipeline),
-		OciArtifacts:    convertOciArtifacts(pipeline),
-		Images:          images,
-		PipelineStartAt: &pipeline.Status.StartTime.Time,
-		PipelineEndAt:   &pipeline.Status.CompletionTime.Time,
+		Name:         pipeline.Name,
+		Platform:     parsePlatform(pipeline),
+		GitHash:      parseGitHash(pipeline),
+		OciArtifacts: convertOciArtifacts(pipeline),
+		Images:       images,
+		StartAt:      &pipeline.Status.StartTime.Time,
+		EndAt:        &pipeline.Status.CompletionTime.Time,
 	}, nil
 }
 

--- a/tibuild/pkg/webhook/service/cloudevent.go
+++ b/tibuild/pkg/webhook/service/cloudevent.go
@@ -94,11 +94,13 @@ func toDevbuildPipeline(pipeline tekton.PipelineRun) (*rest.TektonPipeline, erro
 		return nil, fmt.Errorf("parse image failed:%w", err)
 	}
 	return &rest.TektonPipeline{
-		Name:         pipeline.Name,
-		Platform:     parsePlatform(pipeline),
-		GitHash:      parseGitHash(pipeline),
-		OciArtifacts: convertOciArtifacts(pipeline),
-		Images:       images,
+		Name:            pipeline.Name,
+		Platform:        parsePlatform(pipeline),
+		GitHash:         parseGitHash(pipeline),
+		OciArtifacts:    convertOciArtifacts(pipeline),
+		Images:          images,
+		PipelineStartAt: &pipeline.Status.StartTime.Time,
+		PipelineEndAt:   &pipeline.Status.CompletionTime.Time,
 	}, nil
 }
 


### PR DESCRIPTION
Why:
- currently the pipeline start at and end at are not properly set