### PR TITLE
fix: sha256sum for oci artifact

### DIFF
--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -424,9 +424,13 @@ func TestTektonStatusMerge(t *testing.T) {
 func TestOciArtifactToFiles(t *testing.T) {
 	files := ociArtifactToFiles(LinuxAmd64,
 		OciArtifact{Repo: "repo", Tag: "tag",
-			Files: []string{"f1.tar.gz", "f1.tar.gz.sha256"},
+			Files: []string{
+				"f1.tar.gz",
+				"f1.tar.gz.sha256",
+				"f2.tar.gz.sha256",
+				"f2.tar.gz"},
 		},
 	)
-	require.Equal(t, 1, len(files))
+	require.Equal(t, 2, len(files))
 	require.NotNil(t, files[0].Sha256OciFile)
 }

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -433,4 +433,5 @@ func TestOciArtifactToFiles(t *testing.T) {
 	)
 	require.Equal(t, 2, len(files))
 	require.NotNil(t, files[0].Sha256OciFile)
+	require.NotNil(t, files[1].Sha256OciFile)
 }

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -420,3 +420,13 @@ func TestTektonStatusMerge(t *testing.T) {
 	})
 
 }
+
+func TestOciArtifactToFiles(t *testing.T) {
+	files := ociArtifactToFiles(LinuxAmd64,
+		OciArtifact{Repo: "repo", Tag: "tag",
+			Files: []string{"f1.tar.gz", "f1.tar.gz.sha256"},
+		},
+	)
+	require.Equal(t, 1, len(files))
+	require.NotNil(t, files[0].Sha256OciFile)
+}

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -296,11 +296,12 @@ var (
 )
 
 type BinArtifact struct {
-	Component string   `json:"component,omitempty"`
-	Platform  Platform `json:"platform"`
-	URL       string   `json:"url"`
-	Sha256URL string   `json:"sha256URL"`
-	OciFile   *OciFile `json:"ociFile,omitempty"`
+	Component     string   `json:"component,omitempty"`
+	Platform      Platform `json:"platform"`
+	URL           string   `json:"url"`
+	Sha256URL     string   `json:"sha256URL"`
+	OciFile       *OciFile `json:"ociFile,omitempty"`
+	Sha256OciFile *OciFile `json:"sha256OciFile,omitempty"`
 }
 
 type OciFile struct {


### PR DESCRIPTION
# Why:
- fix relation between sha256 and origin file

![image](https://github.com/PingCAP-QE/ee-apps/assets/10222426/091a82ed-5386-4c63-a011-f05abb22abd4)
