### PR TITLE
fix(tiup-publisher): update tiup-publisher chart

### DIFF
--- a/charts/tiup-publisher/Chart.yaml
+++ b/charts/tiup-publisher/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.0"
+appVersion: v20240228-83-g645b571

--- a/charts/tiup-publisher/templates/deployment.yaml
+++ b/charts/tiup-publisher/templates/deployment.yaml
@@ -40,14 +40,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}


### PR DESCRIPTION
This pull request includes updates to the `charts/tiup-publisher` to reflect new versions and simplify the deployment configuration. The most important changes include updating the chart and application versions, and removing unnecessary liveness and readiness probes.

Version updates:

* [`charts/tiup-publisher/Chart.yaml`](diffhunk://#diff-f43428ddb40c8df41fbc79c59e4539afcd52bbe410ff3c968d38619b7eca29f5L18-R24): Updated the chart version from `0.1.0` to `0.2.0` and the application version from `v0.1.0` to `v20240228-83-g645b571`.

Deployment configuration simplification:

* [`charts/tiup-publisher/templates/deployment.yaml`](diffhunk://#diff-362d766865ad9f0819673029b8220a55e60773e2ae38099a76680329927dd43dL43-L50): Removed the `livenessProbe` and `readinessProbe` configurations to simplify the deployment setup.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>