### PR TITLE
fix(publisher): fix `splitRepoAndTag` function

### DIFF
--- a/publisher/pkg/tiup/funcs.go
+++ b/publisher/pkg/tiup/funcs.go
@@ -238,7 +238,7 @@ func AnalyzeFromOciArtifactUrl(url string) ([]PublishRequest, error) {
 
 func splitRepoAndTag(url string) (string, string, error) {
 	splitor := ":"
-	if !strings.Contains(url, "@sha256:") {
+	if strings.Contains(url, "@sha256:") {
 		splitor = "@"
 	}
 	parts := strings.SplitN(url, splitor, 2)


### PR DESCRIPTION

This pull request includes a small but important change to the `splitRepoAndTag` function in the `publisher/pkg/tiup/funcs.go` file. The change corrects the logic for determining the delimiter used to split the repository and tag in a given URL.

* [`publisher/pkg/tiup/funcs.go`](diffhunk://#diff-1d210de00b8fd357f0aee036762196bb4595ea47ab660b1d332bb04baeeb5e97L241-R241): Modified the `splitRepoAndTag` function to correctly identify URLs containing `@sha256:` and use the appropriate delimiter for splitting.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>
