### PR TITLE
fix: github token getter

### DIFF
--- a/change-insight/lib/github/common.go
+++ b/change-insight/lib/github/common.go
@@ -27,31 +27,20 @@ type labelInfo struct {
 	Description string `json:"description"`
 }
 
-type Config struct {
-	Token  string
-	ApiURL string
+func getGitHubToken() string
+	return os.Getenv("GITHUB_TOKEN")
 }
 
-func NewConfig() (*Config, error) {
-	token := os.Getenv("GITHUB_TOKEN")
-	if token == "" {
-		return nil, fmt.Errorf("GITHUB_TOKEN environment variable is not set")
-	}
-	return &Config{
-		Token:  token,
-		ApiURL: "https://api.github.com/repos/",
-	}, nil
-}
-
-func apiCall(config *Config, apiUrl string) (*http.Response, error) {
+func apiCall(apiUrl string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", apiUrl, nil)
 	if err != nil {
 		log.Printf("request init error: %s\n", err.Error())
 		return nil, err
 	}
+	
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Authorization", "token "+config.Token)
-
+	req.Header.Set("Authorization", "token " + getGitHubToken())
+	
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Printf("request error: %s\n", err.Error())

--- a/change-insight/lib/github/common.go
+++ b/change-insight/lib/github/common.go
@@ -29,7 +29,7 @@ type labelInfo struct {
 
 var apiURL string = "https://api.github.com/repos/"
 
-func getGitHubToken() string
+func getGitHubToken() string {
 	return os.Getenv("GITHUB_TOKEN")
 }
 

--- a/change-insight/lib/github/common.go
+++ b/change-insight/lib/github/common.go
@@ -3,12 +3,14 @@ package github
 import (
 	"log"
 	"net/http"
+	"os"
 )
 
 type Repo struct {
 	Org  string // eg: pingcap
 	Repo string // eg: tidb
 }
+
 type UserInfo struct {
 	Login     string `json:"login"`
 	Id        int    `json:"id"`
@@ -25,17 +27,41 @@ type labelInfo struct {
 	Description string `json:"description"`
 }
 
-var token string = "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"
-var apiURL string = "https://api.github.com/repos/"
+type Config struct {
+	Token  string
+	ApiURL string
+}
 
-func apiCall(apiUrl string) (*http.Response, error) {
+func NewConfig() (*Config, error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return nil, fmt.Errorf("GITHUB_TOKEN environment variable is not set")
+	}
+	return &Config{
+		Token:  token,
+		ApiURL: "https://api.github.com/repos/",
+	}, nil
+}
+
+func apiCall(config *Config, apiUrl string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", apiUrl, nil)
 	if err != nil {
-		log.Printf("request init error : %s \n", err.Error())
+		log.Printf("request init error: %s\n", err.Error())
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Authorization", "token "+token)
-	//log.Printf("req: %+v \n", req)
-	return http.DefaultClient.Do(req)
+	req.Header.Set("Authorization", "token "+config.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("request error: %s\n", err.Error())
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("unexpected status code: %d\n", resp.StatusCode)
+		return resp, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return resp, nil
 }

--- a/change-insight/lib/github/common.go
+++ b/change-insight/lib/github/common.go
@@ -27,6 +27,8 @@ type labelInfo struct {
 	Description string `json:"description"`
 }
 
+var apiURL string = "https://api.github.com/repos/"
+
 func getGitHubToken() string
 	return os.Getenv("GITHUB_TOKEN")
 }


### PR DESCRIPTION
This pull request includes several changes to the `change-insight/lib/github/common.go` file to enhance security and improve error handling. The most important changes include the addition of environment variable support for GitHub tokens and improved error handling for API calls.

Enhancements to security:

* [`change-insight/lib/github/common.go`](diffhunk://#diff-5251738818d44ec5f50892200dc833237918634443d53426422f57f0a4ea14a9L28-R57): Replaced the hardcoded GitHub token with a function that retrieves the token from the environment variable `GITHUB_TOKEN`.

Improvements to error handling:

* [`change-insight/lib/github/common.go`](diffhunk://#diff-5251738818d44ec5f50892200dc833237918634443d53426422f57f0a4ea14a9L28-R57): Added error handling for unexpected status codes in the `apiCall` function, logging the status code and returning an error if it is not `http.StatusOK`.

Currently, the sub app that changed in this PR is planed to be deprecated.