### PR TITLE
fix(cloudevents-server): fix the issue of the EventConsumer close calls

### DIFF
--- a/cloudevents-server/pkg/events/handler/kafka.go
+++ b/cloudevents-server/pkg/events/handler/kafka.go
@@ -131,7 +131,6 @@ type EventConsumer struct {
 // consumer workers
 func (ec *EventConsumer) Start(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
-	defer ec.Close()
 	go func() {
 		defer wg.Done()
 		defer ec.Close()
@@ -164,8 +163,6 @@ func (ec *EventConsumer) Start(ctx context.Context, wg *sync.WaitGroup) {
 			}
 		}
 	}()
-
-	log.Info().Msg("Kafka consumer started")
 }
 
 func (ec *EventConsumer) Close() {


### PR DESCRIPTION
wrong added the defer close call, it will caused the consumer reading failure.

I tested the change manually, it's passed.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>