### PR TITLE
refactor(publisher): update the target bucket key for publishing to fileserver

### DIFF
--- a/publisher/pkg/impl/funcs_fs_test.go
+++ b/publisher/pkg/impl/funcs_fs_test.go
@@ -31,7 +31,7 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 			name: "Valid fs config - tidb",
 			args: args{
 				repo: "hub.pingcap.net/pingcap/tidb/package",
-				tag:  "master_linux_amd64",
+				tag:  "v8.1.1_linux_amd64",
 			},
 			want: []PublishRequest{
 				{
@@ -39,14 +39,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tidb/package",
-							Tag:  "sha256:1b146aa1b65e0a4fb2044f464a7fbceb025fcd6a2ddf0c28ab53f671503eea9d",
-							File: "tidb-v8.5.0-alpha-22-ga22fc590cc-linux-amd64.tar.gz",
+							Tag:  "sha256:b99b4e4f301bae87fa30fa58319da55bb6bdec94cbb29dccc35cf296815c3276",
+							File: "tidb-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "tidb",
-						Version:    "master#a22fc590cc9efb13c025386712f39338c9821187",
-						EntryPoint: "centos7/tidb-server.tar.gz",
+						Version:    "v8.1.1#a7df4f9845d5d6a590c5d45dad0dcc9f21aa8765",
+						EntryPoint: "linux_amd64/tidb-server.tar.gz",
 					},
 				},
 				{
@@ -54,14 +54,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tidb/package",
-							Tag:  "sha256:1b146aa1b65e0a4fb2044f464a7fbceb025fcd6a2ddf0c28ab53f671503eea9d",
-							File: "br-v8.5.0-alpha-22-ga22fc590cc-linux-amd64.tar.gz",
+							Tag:  "sha256:b99b4e4f301bae87fa30fa58319da55bb6bdec94cbb29dccc35cf296815c3276",
+							File: "br-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "br",
-						Version:    "master#a22fc590cc9efb13c025386712f39338c9821187",
-						EntryPoint: "centos7/br.tar.gz",
+						Version:    "v8.1.1#a7df4f9845d5d6a590c5d45dad0dcc9f21aa8765",
+						EntryPoint: "linux_amd64/br.tar.gz",
 					},
 				},
 				{
@@ -69,14 +69,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tidb/package",
-							Tag:  "sha256:1b146aa1b65e0a4fb2044f464a7fbceb025fcd6a2ddf0c28ab53f671503eea9d",
-							File: "dumpling-v8.5.0-alpha-22-ga22fc590cc-linux-amd64.tar.gz",
+							Tag:  "sha256:b99b4e4f301bae87fa30fa58319da55bb6bdec94cbb29dccc35cf296815c3276",
+							File: "dumpling-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "dumpling",
-						Version:    "master#a22fc590cc9efb13c025386712f39338c9821187",
-						EntryPoint: "centos7/dumpling.tar.gz",
+						Version:    "v8.1.1#a7df4f9845d5d6a590c5d45dad0dcc9f21aa8765",
+						EntryPoint: "linux_amd64/dumpling.tar.gz",
 					},
 				},
 				{
@@ -84,14 +84,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tidb/package",
-							Tag:  "sha256:1b146aa1b65e0a4fb2044f464a7fbceb025fcd6a2ddf0c28ab53f671503eea9d",
-							File: "tidb-lightning-v8.5.0-alpha-22-ga22fc590cc-linux-amd64.tar.gz",
+							Tag:  "sha256:b99b4e4f301bae87fa30fa58319da55bb6bdec94cbb29dccc35cf296815c3276",
+							File: "tidb-lightning-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "tidb-lightning",
-						Version:    "master#a22fc590cc9efb13c025386712f39338c9821187",
-						EntryPoint: "centos7/tidb-lightning.tar.gz",
+						Version:    "v8.1.1#a7df4f9845d5d6a590c5d45dad0dcc9f21aa8765",
+						EntryPoint: "linux_amd64/tidb-lightning.tar.gz",
 					},
 				},
 			},
@@ -101,7 +101,7 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 			name: "Valid fs config - tiflow",
 			args: args{
 				repo: "hub.pingcap.net/pingcap/tiflow/package",
-				tag:  "master_linux_amd64",
+				tag:  "v8.1.1_linux_amd64",
 			},
 			want: []PublishRequest{
 				{
@@ -109,14 +109,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: "oci",
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tiflow/package",
-							Tag:  "sha256:3bd51f5057646e3d7894573d07af1af63d94336f9323c67106caf265c191054f",
-							File: "cdc-v8.5.0-alpha-3-g0510cf054-linux-amd64.tar.gz",
+							Tag:  "sha256:14e97372e2884406dc1b8c8a9390a1fbdd57d91eee67ba340032622409e5c288",
+							File: "cdc-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "cdc",
-						Version:    "master#0510cf05400ec2302052a517d281bf3aff7cfc04",
-						EntryPoint: "centos7/cdc.tar.gz",
+						Version:    "v8.1.1#8ee0f3783a277161397d38bc62c48823de486b0d",
+						EntryPoint: "linux_amd64/cdc.tar.gz",
 					},
 				},
 				{
@@ -124,14 +124,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: "oci",
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tiflow/package",
-							Tag:  "sha256:3bd51f5057646e3d7894573d07af1af63d94336f9323c67106caf265c191054f",
-							File: "dm-master-v8.5.0-alpha-3-g0510cf054-linux-amd64.tar.gz",
+							Tag:  "sha256:14e97372e2884406dc1b8c8a9390a1fbdd57d91eee67ba340032622409e5c288",
+							File: "dm-master-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "dm-master",
-						Version:    "master#0510cf05400ec2302052a517d281bf3aff7cfc04",
-						EntryPoint: "centos7/dm-master.tar.gz",
+						Version:    "v8.1.1#8ee0f3783a277161397d38bc62c48823de486b0d",
+						EntryPoint: "linux_amd64/dm-master.tar.gz",
 					},
 				},
 				{
@@ -139,14 +139,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: "oci",
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tiflow/package",
-							Tag:  "sha256:3bd51f5057646e3d7894573d07af1af63d94336f9323c67106caf265c191054f",
-							File: "dm-worker-v8.5.0-alpha-3-g0510cf054-linux-amd64.tar.gz",
+							Tag:  "sha256:14e97372e2884406dc1b8c8a9390a1fbdd57d91eee67ba340032622409e5c288",
+							File: "dm-worker-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "dm-worker",
-						Version:    "master#0510cf05400ec2302052a517d281bf3aff7cfc04",
-						EntryPoint: "centos7/dm-worker.tar.gz",
+						Version:    "v8.1.1#8ee0f3783a277161397d38bc62c48823de486b0d",
+						EntryPoint: "linux_amd64/dm-worker.tar.gz",
 					},
 				},
 				{
@@ -154,14 +154,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: "oci",
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tiflow/package",
-							Tag:  "sha256:3bd51f5057646e3d7894573d07af1af63d94336f9323c67106caf265c191054f",
-							File: "dmctl-v8.5.0-alpha-3-g0510cf054-linux-amd64.tar.gz",
+							Tag:  "sha256:14e97372e2884406dc1b8c8a9390a1fbdd57d91eee67ba340032622409e5c288",
+							File: "dmctl-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "dmctl",
-						Version:    "master#0510cf05400ec2302052a517d281bf3aff7cfc04",
-						EntryPoint: "centos7/dmctl.tar.gz",
+						Version:    "v8.1.1#8ee0f3783a277161397d38bc62c48823de486b0d",
+						EntryPoint: "linux_amd64/dmctl.tar.gz",
 					},
 				},
 			},
@@ -171,7 +171,7 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 			name: "Valid fs config - tiflash",
 			args: args{
 				repo: "hub.pingcap.net/pingcap/tiflash/package",
-				tag:  "master_linux_amd64",
+				tag:  "v8.1.1_linux_amd64",
 			},
 			want: []PublishRequest{
 				{
@@ -179,14 +179,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tiflash/package",
-							Tag:  "sha256:0903955bbcf4ce8306af7f3138863ed899c5000112cd64d04ce07bb7dd9a816a",
-							File: "tiflash-v8.5.0-alpha-7-g5dd3a733a-linux-amd64.tar.gz",
+							Tag:  "sha256:4ba33a9106feb2189a5b1726155b6e1c15b102b8094956ece069afc01d9bb4a2",
+							File: "tiflash-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "tiflash",
-						Version:    "master#5dd3a733a2dec9ee3548353356583b21cd03d54d",
-						EntryPoint: "centos7/tiflash.tar.gz",
+						Version:    "v8.1.1#eb585f7d95d588bf8450c3cec02c36bb42c5e429",
+						EntryPoint: "linux_amd64/tiflash.tar.gz",
 					},
 				},
 			},
@@ -196,7 +196,7 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 			name: "Valid fs config - pd",
 			args: args{
 				repo: "hub.pingcap.net/tikv/pd/package",
-				tag:  "master_linux_amd64",
+				tag:  "v8.1.1_linux_amd64",
 			},
 			want: []PublishRequest{
 				{
@@ -204,14 +204,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/tikv/pd/package",
-							Tag:  "sha256:eac8e279cd5acb2fa900640175418837c3f8517299d76a7509afd5ab9c6f939d",
-							File: "pd-v8.5.0-alpha-2-g649393a4-linux-amd64.tar.gz",
+							Tag:  "sha256:4d1222a01dd594176ec7f2dcf0b8e8cdaa2f838621d7738b56cdb39c9847f0a7",
+							File: "pd-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "pd",
-						Version:    "master#649393a40725e9c91397790ede93dd3a0b7f08ef",
-						EntryPoint: "centos7/pd.tar.gz",
+						Version:    "v8.1.1#f3dd0b62857ba0da97842349808aa4d4d4eefb34",
+						EntryPoint: "linux_amd64/pd-server.tar.gz",
 					},
 				},
 				{
@@ -219,14 +219,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/tikv/pd/package",
-							Tag:  "sha256:eac8e279cd5acb2fa900640175418837c3f8517299d76a7509afd5ab9c6f939d",
-							File: "pd-recover-v8.5.0-alpha-2-g649393a4-linux-amd64.tar.gz",
+							Tag:  "sha256:4d1222a01dd594176ec7f2dcf0b8e8cdaa2f838621d7738b56cdb39c9847f0a7",
+							File: "pd-recover-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "pd-recover",
-						Version:    "master#649393a40725e9c91397790ede93dd3a0b7f08ef",
-						EntryPoint: "centos7/pd-recover.tar.gz",
+						Version:    "v8.1.1#f3dd0b62857ba0da97842349808aa4d4d4eefb34",
+						EntryPoint: "linux_amd64/pd-recover.tar.gz",
 					},
 				},
 			},
@@ -236,7 +236,7 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 			name: "Valid fs config - tikv",
 			args: args{
 				repo: "hub.pingcap.net/tikv/tikv/package",
-				tag:  "master_linux_amd64",
+				tag:  "v8.1.1_linux_amd64",
 			},
 			want: []PublishRequest{
 				{
@@ -244,14 +244,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/tikv/tikv/package",
-							Tag:  "sha256:c7a9b221bed19c885bf8a1bc00af1fb35cc5d789337c842508682eea4064f2fa",
-							File: "tikv-v8.5.0-alpha-2-gdc9cd3dbd-linux-amd64.tar.gz",
+							Tag:  "sha256:b526c02e883d54f97162c445294e9aa805620d5af9979b24667958aff870be06",
+							File: "tikv-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "tikv",
-						Version:    "master#dc9cd3dbdace23ac1f590aaee7966705a7e12825",
-						EntryPoint: "centos7/tikv.tar.gz",
+						Version:    "v8.1.1#7793f1d5dc40206fe406ca001be1e0d7f1b83a8f",
+						EntryPoint: "linux_amd64/tikv-server.tar.gz",
 					},
 				},
 			},
@@ -261,7 +261,7 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 			name: "Valid fs config - tidb-tools",
 			args: args{
 				repo: "hub.pingcap.net/pingcap/tidb-tools/package",
-				tag:  "master_linux_amd64",
+				tag:  "v8.1.1_linux_amd64",
 			},
 			want: []PublishRequest{
 				{
@@ -269,14 +269,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tidb-tools/package",
-							Tag:  "sha256:315dbe7cc91fb998f9b2f3cd256f11d236cf235537a0b8f27457381c6cd30b19",
-							File: "tidb-tools-v7.5.3-2-gd226440-linux-amd64.tar.gz",
+							Tag:  "sha256:b50b45ffb0f53e3bf7c6140aa57fb768c4f2a9f6471e2987c423c0da217338b6",
+							File: "tidb-tools-v8.1.1-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "tidb-tools",
-						Version:    "master#d226440121147098eb5eb99cbc1efb94092ec68e",
-						EntryPoint: "centos7/tidb-tools.tar.gz",
+						Version:    "v8.1.1#d226440121147098eb5eb99cbc1efb94092ec68e",
+						EntryPoint: "linux_amd64/tidb-tools.tar.gz",
 					},
 				},
 			},
@@ -286,7 +286,7 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 			name: "Valid fs config - tidb-binlog",
 			args: args{
 				repo: "hub.pingcap.net/pingcap/tidb-binlog/package",
-				tag:  "master_linux_amd64",
+				tag:  "v8.1.1_linux_amd64",
 			},
 			want: []PublishRequest{
 				{
@@ -294,14 +294,14 @@ func Test_analyzeFsFromOciArtifact(t *testing.T) {
 						Type: FromTypeOci,
 						Oci: &FromOci{
 							Repo: "hub.pingcap.net/pingcap/tidb-binlog/package",
-							Tag:  "sha256:437cf5943318cebae48adc6698380537a2c5173422ba7048196124c198aaa1b8",
-							File: "binaries-v8.3.0-alpha-1-g6905951-linux-amd64.tar.gz",
+							Tag:  "sha256:2c4704588ef754eaaed5d0034f44c6077257cebd382b90b2241b5e0ff4be640c",
+							File: "binaries-v8.1.1-pre-linux-amd64.tar.gz",
 						},
 					},
 					Publish: PublishInfo{
 						Name:       "tidb-binlog",
-						Version:    "master#6905951ca9460e2d4e5a82273e01f6a36b4d1ef3",
-						EntryPoint: "centos7/tidb-binlog.tar.gz",
+						Version:    "v8.1.1#79416e288d69bb530247546a846e7a89a8ef6d2f",
+						EntryPoint: "linux_amd64/tidb-binlog.tar.gz",
 					},
 				},
 			},


### PR DESCRIPTION
- from `centos7/*.tar.gz` to `<os>_<arch>/*.tar.gz`

Signed-off-by: wuhuizuo <wuhuizuo@126.com>