### PR TITLE
feat(tibuild): support profile for tekton engine

### DIFF
--- a/tibuild/pkg/rest/service/cloud_event_client.go
+++ b/tibuild/pkg/rest/service/cloud_event_client.go
@@ -78,6 +78,7 @@ func newDevBuildCloudEvent(dev DevBuild) (*cloudevents.Event, error) {
 	event.SetSubject(fmt.Sprint(dev.ID))
 	event.SetSource("tibuild.pingcap.net/api/devbuilds/" + fmt.Sprint(dev.ID))
 	event.SetExtension("user", dev.Meta.CreatedBy)
+	event.SetExtension("paramProfile", dev.Spec.Edition)
 	if dev.Spec.BuilderImg != "" {
 		event.SetExtension("paramBuilderImage", dev.Spec.BuilderImg)
 	}


### PR DESCRIPTION
This pull request includes a small change to the `tibuild/pkg/rest/service/cloud_event_client.go` file. The change adds a new extension parameter to the cloud event for the `paramProfile` field.

* [`tibuild/pkg/rest/service/cloud_event_client.go`](diffhunk://#diff-12f7cc6dce0ce0b270c4b652690b1d70621d252829df2db7ec36fa48691714b6R81): Added `paramProfile` extension to the cloud event in the `newDevBuildCloudEvent` function.