### PR TITLE
feat(chatops-lark): avoid handling for dup events

### DIFF
--- a/chatops-lark/go.mod
+++ b/chatops-lark/go.mod
@@ -5,6 +5,7 @@ go 1.23.4
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/PingCAP-QE/ee-apps/tibuild v0.0.0-20250124071050-8a17a7b19353
+	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/google/go-github/v68 v68.0.0
 	github.com/larksuite/oapi-sdk-go/v3 v3.4.7

--- a/chatops-lark/go.sum
+++ b/chatops-lark/go.sum
@@ -8,6 +8,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/PingCAP-QE/ee-apps/tibuild v0.0.0-20250124071050-8a17a7b19353 h1:g9a3BYfZoveY7ZLIggj+3Hbf2gqS7ydq7s2a3gT6I4M=
 github.com/PingCAP-QE/ee-apps/tibuild v0.0.0-20250124071050-8a17a7b19353/go.mod h1:hByrZUdMe1lJVhyk29FYNCM2tT4lo4O/z0HCS6+2J6g=
+github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=
+github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/bndr/gojenkins v1.1.0 h1:TWyJI6ST1qDAfH33DQb3G4mD8KkrBfyfSUoZBHQAvPI=
 github.com/bndr/gojenkins v1.1.0/go.mod h1:QeskxN9F/Csz0XV/01IC8y37CapKKWvOHa0UHLLX1fM=
 github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=

--- a/chatops-lark/pkg/events/handler/cherrypick.go
+++ b/chatops-lark/pkg/events/handler/cherrypick.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v68/github"
+	"github.com/rs/zerolog/log"
 )
 
 func runCommandCherryPickInvite(ctx context.Context, args []string) (string, error) {
@@ -56,12 +57,13 @@ func cherryPickInvite(prUrl string, collaboratorUsername string, gc *github.Clie
 		return "", fmt.Errorf("Failed to invite collaborator: %v", err)
 	}
 	switch res.StatusCode {
-	case http.StatusOK:
+	case http.StatusOK, http.StatusCreated:
 		return fmt.Sprintf("Successfully invited collaborator %s into repo %s. Please click https://github.com/%s/invitations to accept the invitation.(Invitations expire after 7 days)",
 			collaboratorUsername, botForkRepoFullName, botForkRepoFullName), nil
 	case http.StatusNoContent:
 		return "", fmt.Errorf("User %s is already a collaborator of repo %s", collaboratorUsername, botForkRepoFullName)
 	default:
+		log.Error().Msgf("Failed to invite collaborator, status code: %d", res.StatusCode)
 		return "", fmt.Errorf("Fail to invite collaborator, Please contact the EE team members for feedback.")
 	}
 }


### PR DESCRIPTION
This pull request includes several changes to enhance the `chatops-lark` package, focusing on improving error handling, adding caching, and extending functionality. The most important changes include adding a new dependency, enhancing the `rootHandler` struct, and improving the `cherryPickInvite` function.

### Dependency Management:
* Added `github.com/allegro/bigcache/v3 v3.1.0` to the `go.mod` file.

### Error Handling and Logging:
* Added `github.com/rs/zerolog/log` for logging in `cherrypick.go` and `root.go`. [[1]](diffhunk://#diff-f58f7cb1bbf4c74d32dee9cd3f59873035c52a0fd3c0ed8e23325eba6d4561b0R13) [[2]](diffhunk://#diff-0a367f483d9dcab41f47dd231972be9d8e05084330e66c00b27a7bbee7fd196aR9-R13)
* Enhanced error logging in the `cherryPickInvite` function to include the status code when an invitation fails.

### Caching:
* Introduced `bigcache` to cache event handling in `root.go`. This prevents reprocessing of already handled events by adding an `eventCache` to the `rootHandler` struct and checking the cache before processing.

### Functionality Enhancements:
* Added `addReaction` and `deleteReaction` methods to handle message reactions, and updated the `Handle` method to use these for sending and deleting reactions asynchronously.

These changes collectively improve the efficiency and reliability of the `chatops-lark` package by reducing redundant processing and enhancing error visibility.