### PR TITLE
fix(tibuild): fix src image checking regexp

### DIFF
--- a/tibuild/Dockerfile
+++ b/tibuild/Dockerfile
@@ -1,4 +1,4 @@
-# Copy 'website/' contents(not entire folder) into .(/webapp/) and build React 
+# Copy 'website/' contents(not entire folder) into .(/webapp/) and build React
 FROM node:20.18.0 as webbuilder
 WORKDIR /webapp
 COPY website/ .
@@ -6,9 +6,7 @@ RUN --mount=type=cache,target=/webapp/node_modules npm install && yarn build
 
 # Copy whole project's contents(not entire folder) into .(/goapp/) and build Golang
 FROM golang:1.23.4 as serverbuilder
-ENV GO111MODULE=on \
-    CGO_ENABLED=0 \
-    GOPROXY=https://goproxy.cn,direct
+ENV CGO_ENABLED=0
 WORKDIR /goapp
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod go build -o ./bin/tibuild ./cmd/tibuild
@@ -23,4 +21,3 @@ COPY --from=webbuilder /webapp/build/ ./website/build/
 COPY --from=serverbuilder /goapp/bin/tibuild ./bin/tibuild
 
 CMD ["/app/bin/tibuild"]
-

--- a/tibuild/pkg/rest/service/artifact_helper.go
+++ b/tibuild/pkg/rest/service/artifact_helper.go
@@ -45,8 +45,8 @@ var source_image_reg *regexp.Regexp
 var target_image_reg *regexp.Regexp
 
 func init() {
-	source_image_reg = regexp.MustCompile(`^hub.pingcap.net/(qa|pingcap|tikv)/[\w-/]+:v\d+\.\d+\.\d+-\d{8,}.*$`)
-	target_image_reg = regexp.MustCompile(`^(docker.io/)?pingcap/[\w-]+:v\d+\.\d+\.\d+-\d{8,}.*$`)
+	source_image_reg = regexp.MustCompile(`^hub\.pingcap\.net/(qa|pingcap|tikv)/[\w-/]+:v\d+\.\d+\.\d+-\d{8,}.*$`)
+	target_image_reg = regexp.MustCompile(`^(docker\.io/)?pingcap/[\w-]+:v\d+\.\d+\.\d+-\d{8,}.*$`)
 }
 
 func NewArtifactHelper(jenkins Jenkins) *ArtifactHelper {

--- a/tibuild/pkg/rest/service/artifact_helper.go
+++ b/tibuild/pkg/rest/service/artifact_helper.go
@@ -45,7 +45,7 @@ var source_image_reg *regexp.Regexp
 var target_image_reg *regexp.Regexp
 
 func init() {
-	source_image_reg = regexp.MustCompile(`^hub.pingcap.net/qa/[\w-]+:v\d+\.\d+\.\d+-\d{8,}.*$`)
+	source_image_reg = regexp.MustCompile(`^hub.pingcap.net/(qa|pingcap|tikv)/[\w-/]+:v\d+\.\d+\.\d+-\d{8,}.*$`)
 	target_image_reg = regexp.MustCompile(`^(docker.io/)?pingcap/[\w-]+:v\d+\.\d+\.\d+-\d{8,}.*$`)
 }
 


### PR DESCRIPTION
This pull request includes a modification to the regular expression used to match source image URLs in the `artifact_helper.go` file. The change expands the scope of acceptable URLs to include additional domains.

Changes to regular expression:

* [`tibuild/pkg/rest/service/artifact_helper.go`](diffhunk://#diff-8952fb6234b7e7797b74c5ddf576757ece54b503266c7c71a80fb4b726431b24L48-R48): Updated the `source_image_reg` regular expression to match URLs from `qa`, `pingcap`, and `tikv` domains.