### PR TITLE
feat(chatops-lark): add health checking

### DIFF
--- a/chatops-lark/README.md
+++ b/chatops-lark/README.md
@@ -1,0 +1,20 @@
+# ChatOps Lark Bot
+
+## Debug or Run locally
+
+You can run it by following steps:
+
+1. Prepare the configuration file `config.yaml`, example:
+  ```yaml
+  cherry-pick-invite.audit_webhook: <your_audit_lark_webhook>
+  cherry-pick-invite.github_token: <your_github_token>
+  ```
+2. Run the lark bot app:
+  ```bash
+  go run ./cmd/server -app-id=<your_app_id> -app-secret=<your_app_secret>
+  ```
+
+## Deployment
+
+We are deploying the bot with GitOps using FluxCD, the manifest is in the [`chatops-lark` directory in `ee-ops`](https://github.com/PingCAP-QE/ee-ops/tree/main/apps/prod/chatops-lark).
+So if you want to bump the image or update the configuration, you contribute a PR to the repository.


### PR DESCRIPTION
This pull request introduces significant updates to the `chatops-lark` bot, including new documentation, the addition of a health check server, and improvements to the main server functionality. The most important changes are summarized below:

### Documentation Updates:

* [`chatops-lark/README.md`](diffhunk://#diff-d7ff5847475dddd947f9882814d5016b004e1281ddeb633fc70c37217d5a5d88R1-R20): Added a new section detailing how to debug, run locally, and deploy the `chatops-lark` bot. This includes configuration examples and deployment instructions using FluxCD.

### Server Enhancements:

* [`chatops-lark/cmd/server/main.go`](diffhunk://#diff-59a24a1fb5af6bcb691d8411a211b0df320f16edceee725cc1076db374c51a0aR25-R47): Introduced a health check HTTP server that listens on a configurable address (`http-addr`) and responds with "OK" on the `/healthz` endpoint. This server runs in a separate goroutine. [[1]](diffhunk://#diff-59a24a1fb5af6bcb691d8411a211b0df320f16edceee725cc1076db374c51a0aR25-R47) [[2]](diffhunk://#diff-59a24a1fb5af6bcb691d8411a211b0df320f16edceee725cc1076db374c51a0aR61-R68)
* [`chatops-lark/cmd/server/main.go`](diffhunk://#diff-59a24a1fb5af6bcb691d8411a211b0df320f16edceee725cc1076db374c51a0aR61-R68): Improved logging for the WebSocket client by specifying the log message when the client fails to start.

### Codebase Improvements:

* [`chatops-lark/cmd/server/main.go`](diffhunk://#diff-59a24a1fb5af6bcb691d8411a211b0df320f16edceee725cc1076db374c51a0aR6): Added the `net/http` package import to support the new health check server functionality.