### PR TITLE
feat(charts): add helm chart for chatops-lark app

### DIFF
--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -38,10 +38,10 @@ jobs:
         run: |
           echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-          for chart in cloudevents-server dl publisher; do
+          for chart in cloudevents-server dl publisher chatops-lark; do
             CHART_VERSION=$(grep 'version:' $chart/Chart.yaml | tail -n1 | awk '{ print $2 }')
             if helm show values oci://ghcr.io/pingcap-qe/ee-apps/charts/$chart --version $CHART_VERSION > /dev/null; then
-              echo "chart '$chart' has no new version, skip publish." 
+              echo "chart '$chart' has no new version, skip publish."
             else
               helm package $chart
               helm push $chart-${CHART_VERSION}.tgz oci://ghcr.io/pingcap-qe/ee-apps/charts

--- a/charts/chatops-lark/.helmignore
+++ b/charts/chatops-lark/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/chatops-lark/Chart.yaml
+++ b/charts/chatops-lark/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: chatops-lark
+description: A Helm chart for PingCAP internal ChatOps bot application based on Lark.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v2025.1.30-7-gce0dddc"

--- a/charts/chatops-lark/templates/NOTES.txt
+++ b/charts/chatops-lark/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "chatops-lark.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "chatops-lark.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "chatops-lark.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "chatops-lark.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/chatops-lark/templates/_helpers.tpl
+++ b/charts/chatops-lark/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chatops-lark.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chatops-lark.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chatops-lark.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chatops-lark.labels" -}}
+helm.sh/chart: {{ include "chatops-lark.chart" . }}
+{{ include "chatops-lark.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chatops-lark.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chatops-lark.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chatops-lark.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chatops-lark.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/chatops-lark/templates/deployment.yaml
+++ b/charts/chatops-lark/templates/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chatops-lark.fullname" . }}
+  labels:
+    {{- include "chatops-lark.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "chatops-lark.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chatops-lark.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "chatops-lark.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.secretName }}
+                  key: {{ .Values.server.appIdSecretKey }}
+            - name: APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.secretName }}
+                  key: {{ .Values.server.appSecretSecretKey }}
+            - name: CONFIG_PATH
+              value: /etc/chatops-lark/config.yaml
+          args:
+            - -http-addr
+            - ":8080"
+            - -app-id
+            - $(APP_ID)
+            - -app-secret
+            - $(APP_SECRET)
+            - "--config"
+            - $(CONFIG_PATH)
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/chatops-lark/config.yaml
+              subPath: {{ .Values.server.configFileSecretKey }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        - name: config
+          secret:
+            name: {{ .Values.server.secretName }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/chatops-lark/templates/hpa.yaml
+++ b/charts/chatops-lark/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chatops-lark.fullname" . }}
+  labels:
+    {{- include "chatops-lark.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chatops-lark.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/chatops-lark/templates/service.yaml
+++ b/charts/chatops-lark/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chatops-lark.fullname" . }}
+  labels:
+    {{- include "chatops-lark.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "chatops-lark.selectorLabels" . | nindent 4 }}

--- a/charts/chatops-lark/templates/serviceaccount.yaml
+++ b/charts/chatops-lark/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chatops-lark.serviceAccountName" . }}
+  labels:
+    {{- include "chatops-lark.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/chatops-lark/templates/tests/test-connection.yaml
+++ b/charts/chatops-lark/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "chatops-lark.fullname" . }}-test-connection"
+  labels:
+    {{- include "chatops-lark.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "chatops-lark.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/chatops-lark/values.yaml
+++ b/charts/chatops-lark/values.yaml
@@ -1,0 +1,115 @@
+# Default values for chatops-lark.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: http
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+server:
+  secretName: ""
+  appIdSecretKey: app_id
+  appSecretSecretKey: app_secret
+  configFileSecretKey: config


### PR DESCRIPTION
This pull request introduces a new Helm chart for the `chatops-lark` application, along with necessary configurations and templates. The changes include the addition of new files and modifications to existing ones to support the deployment and management of the `chatops-lark` application using Helm.

### Key Changes:

#### New Helm Chart for `chatops-lark`:

* **Chart Configuration:**
  * [`charts/chatops-lark/Chart.yaml`](diffhunk://#diff-e6df411db3462581ecff43a0fa950e5dbbefb5d40548ccdca1b53db00dc415cbR1-R24): Defines the metadata for the `chatops-lark` Helm chart, including its version, description, and type.
  * [`charts/chatops-lark/values.yaml`](diffhunk://#diff-2de6c72e0ad7f9dba9f12d675140522cd65cda9ba22f75e2d62090a2cea95e95R1-R115): Provides default values for the `chatops-lark` chart, including image repository, service account settings, pod annotations, and resource configurations.

* **Templates:**
  * [`charts/chatops-lark/templates/deployment.yaml`](diffhunk://#diff-216f98d8d70595e33393cf796083bdd6891cd8b9f8ed053bf37cf60022551ddbR1-R106): Defines the Kubernetes deployment for `chatops-lark`, including container specifications, environment variables, and volume mounts.
  * [`charts/chatops-lark/templates/service.yaml`](diffhunk://#diff-de6f558d0c339b301ac478eaa2810933742c8e7b173a1f22f75d2d2ae0108856R1-R15): Defines the Kubernetes service for `chatops-lark`, specifying the service type and ports.
  * [`charts/chatops-lark/templates/hpa.yaml`](diffhunk://#diff-f128369b2c856294c10062a4253944e57dc3bf0beb9f8c059aa8921012187719R1-R32): Configures the Horizontal Pod Autoscaler (HPA) for `chatops-lark` to manage scaling based on CPU and memory utilization.
  * [`charts/chatops-lark/templates/serviceaccount.yaml`](diffhunk://#diff-8eaad62b441876938a856ea3d2fd1647eff90bad80820f65f9bde17a990fc23cR1-R13): Creates a service account for `chatops-lark` if specified in the values file.
  * [`charts/chatops-lark/templates/NOTES.txt`](diffhunk://#diff-c6cbde6d041d805f29e61d924013c3ebfd7ae81d7adf747b6760aab0bedf3b35R1-R22): Provides instructions for accessing the application after deployment.
  * [`charts/chatops-lark/templates/_helpers.tpl`](diffhunk://#diff-28a9489fd097c01290a9185f0976369b2cd18d12c37b0c6c9c37997e1506e93fR1-R62): Contains helper templates for generating names, labels, and other common configurations used in the chart.

#### Workflow Updates:

* **Workflow Modification:**
  * [`.github/workflows/charts-release.yaml`](diffhunk://#diff-fd3b4519c61bf0dbb07ada66eafede8e9af5ebbf7bfbe5558fbffdb3bc6dd08fL41-R41): Adds `chatops-lark` to the list of charts to be processed in the release workflow.

#### Additional Configurations:

* **Ignore Patterns:**
  * [`charts/chatops-lark/.helmignore`](diffhunk://#diff-3212d6b5e936a45c952643237a85f6f15e4554a7da5b7534f94e898c015f1489R1-R23): Specifies patterns for files and directories to be ignored when building Helm packages.

These changes collectively enable the deployment and management of the `chatops-lark` application using Helm, providing a structured and scalable approach to handle the application's lifecycle.