### PR TITLE
fix(charts): fix chatops-lark deployment manifest templates

### DIFF
--- a/charts/chatops-lark/Chart.yaml
+++ b/charts/chatops-lark/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/chatops-lark/templates/NOTES.txt
+++ b/charts/chatops-lark/templates/NOTES.txt
@@ -1,11 +1,6 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+
+{{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "chatops-lark.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT

--- a/charts/chatops-lark/templates/deployment.yaml
+++ b/charts/chatops-lark/templates/deployment.yaml
@@ -78,18 +78,18 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
             - name: config
               mountPath: /etc/chatops-lark/config.yaml
               subPath: {{ .Values.server.configFileSecretKey }}
+          {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.volumes }}
       volumes:
         - name: config
           secret:
-            name: {{ .Values.server.secretName }}
+            secretName: {{ .Values.server.secretName }}
+      {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
This pull request includes changes to the Helm chart for the `chatops-lark` application to update the version, simplify the NOTES.txt template, and fix the volume mounts and volumes configuration in the deployment template.

Version update:

* [`charts/chatops-lark/Chart.yaml`](diffhunk://#diff-e6df411db3462581ecff43a0fa950e5dbbefb5d40548ccdca1b53db00dc415cbL18-R18): Incremented the chart version from 0.1.0 to 0.1.1.

Template simplification:

* [`charts/chatops-lark/templates/NOTES.txt`](diffhunk://#diff-c6cbde6d041d805f29e61d924013c3ebfd7ae81d7adf747b6760aab0bedf3b35L2-R3): Removed the conditional block for ingress and simplified the command to get the application URL when service type is `NodePort`.

Configuration fixes:

* [`charts/chatops-lark/templates/deployment.yaml`](diffhunk://#diff-216f98d8d70595e33393cf796083bdd6891cd8b9f8ed053bf37cf60022551ddbL81-R92): Corrected the indentation and usage of `volumeMounts` and `volumes` blocks to ensure proper configuration of secrets and volumes.