### PR TITLE
fix(chatops-lark): remove the dup response

### DIFF
--- a/chatops-lark/pkg/response/command-response.yaml.tmpl
+++ b/chatops-lark/pkg/response/command-response.yaml.tmpl
@@ -10,7 +10,7 @@ elements:
       - tag: plain_text
         content: "EE ChatOps Bot developed by EE team"
 header:
-  template: '{{ if eq .Status "success" }}green{{ else }}red{{ end }}'
+  template: '{{ if eq .Status "success" }}green{{ else if eq .Status "skip" }}grey{{ else if eq .Status "info" }}blue{{ else }}red{{ end }}'
   title:
     content: "{{ .Status }}"
     tag: plain_text


### PR DESCRIPTION
Also add more level for responses:
- skip: color gray.
- info: color blue.

Added two type error types. Here's how you can use these error types in the context of the provided code:

1. **Define Errors**: You can define errors as `InformationError` or `SkipError` to represent different levels of errors.
    ```go
    var infoErr InformationError = errors.New("this is an informational message")
    var skipErr SkipError = errors.New("this operation was skipped")
    ```

2. **Handle Errors**: When handling commands, you can return these errors to indicate specific conditions.
    ```go
    func handleCommand(ctx context.Context, command string) (string, error) {
        // Your command handling logic

        // Return an informational error
        if someCondition {
            return "Some message", infoErr
        }

        // Return a skip error
        if someOtherCondition {
            return "Some message", skipErr
        }

        // Return a regular error
        return "", errors.New("an error occurred")
    }
    ```

3. **Respond to Errors**: When the command execution completes, the code will check the type of error and send an appropriate response.
    ```go
    message, err := r.handleCommand(ctx, command)
    if err == nil {
        r.sendResponse(*event.Event.Message.MessageId, StatusSuccess, message)
        return
    }

    switch e := err.(type) {
    case SkipError:
        message = fmt.Sprintf("%s\n---\n**skip:**\n%v", message, e)
        r.sendResponse(*event.Event.Message.MessageId, StatusSkip, message)
    case InformationError:
        message = fmt.Sprintf("%s\n---\n**information:**\n%v", message, e)
        r.sendResponse(*event.Event.Message.MessageId, StatusInfo, message)
    default:
        message = fmt.Sprintf("%s\n---\n**error:**\n%v", message, err)
        r.sendResponse(*event.Event.Message.MessageId, StatusFailure, message)
    }
    ```

In summary, `InformationError` and `SkipError` are custom error types that help categorize the errors and send different responses based on the error type. This makes error handling and response more structured and informative.