### PR TITLE
feat(chatops-lark): support reply to group mention bot message

### DIFF
--- a/chatops-lark/.gitignore
+++ b/chatops-lark/.gitignore
@@ -1,0 +1,1 @@
+config.yaml

--- a/chatops-lark/README.md
+++ b/chatops-lark/README.md
@@ -8,6 +8,7 @@ You can run it by following steps:
   ```yaml
   cherry-pick-invite.audit_webhook: <your_audit_lark_webhook>
   cherry-pick-invite.github_token: <your_github_token>
+  bot_name: <your_bot_name> # for @bot mention in group chat
   ```
 2. Run the lark bot app:
   ```bash

--- a/chatops-lark/pkg/events/handler/root.go
+++ b/chatops-lark/pkg/events/handler/root.go
@@ -64,11 +64,9 @@ var (
 )
 
 type Command struct {
-	Name    string
-	Args    []string
-	Sender  *CommandSender
-	MsgType string // Message type: private or group
-	ChatID  string // Group ID, only valid when MsgType is group
+	Name   string
+	Args   []string
+	Sender *CommandSender
 }
 
 type CommandSender struct {
@@ -288,9 +286,11 @@ func (r *rootHandler) deleteReaction(reqMsgID, reactionID string) error {
 // determineMessageType determines the message type and checks if the bot was mentioned
 func determineMessageType(event *larkim.P2MessageReceiveV1, botName string) (msgType string, chatID string, isMentionBot bool) {
 	// Check if the message is from a group chat
-	if event.Event.Message.ChatId != nil && event.Event.Message.ChatType != nil && *event.Event.Message.ChatType == "group" {
+	if event.Event.Message.ChatType != nil && *event.Event.Message.ChatType == "group" {
 		msgType = msgTypeGroup
-		chatID = *event.Event.Message.ChatId
+		if event.Event.Message.ChatId != nil {
+			chatID = *event.Event.Message.ChatId
+		}
 		isMentionBot = checkIfBotMentioned(event, botName)
 	} else {
 		msgType = msgTypePrivate


### PR DESCRIPTION
The current bot will listen to and reply to all group messages. To avoid disrupting other conversations in the group, it needs to only respond to messages that mention @bot.