### PR TITLE
fix(chatops-lark): update credential configuration and command registry

### DIFF
--- a/chatops-lark/README.md
+++ b/chatops-lark/README.md
@@ -7,7 +7,8 @@ You can run it by following steps:
 1. Prepare the configuration file `config.yaml`. An example configuration file is provided at `config.yaml.example`:
   ```yaml
   # Bot configuration
-  bot_name: "ChatOps Bot"  # Optional: will be automatically fetched from API if not provided
+  app_id: <app_id> # or set it from cli options `--app-id`
+  app_secret: <app_secret> # or set it from cli options `--app-secret`
 
   # Cherry pick configuration
   cherry_pick_invite:
@@ -34,7 +35,7 @@ You can run it by following steps:
 
 2. Run the lark bot app:
   ```bash
-  go run ./cmd/server -app-id=<your_app_id> -app-secret=<your_app_secret>
+  go run ./cmd/server [-app-id=<your_app_id>] [-app-secret=<your_app_secret>]
   ```
 
 ## Deployment

--- a/chatops-lark/config.yaml.example
+++ b/chatops-lark/config.yaml.example
@@ -1,7 +1,8 @@
 # Example configuration file for chatops-lark
 
 # Bot configuration
-bot_name: "ChatOps Bot" # Optional: will be automatically fetched from API if not provided
+app_id: <app_id> # or set it from cli options `--app-id`
+app_secret: <app_secret> # or set it from cli options `--app-secret`
 
 # Cherry pick configuration
 cherry_pick_invite:

--- a/chatops-lark/pkg/events/handler/root.go
+++ b/chatops-lark/pkg/events/handler/root.go
@@ -22,9 +22,6 @@ import (
 	"github.com/PingCAP-QE/ee-apps/chatops-lark/pkg/response"
 )
 
-// TODO: support command /sync_docker_image
-var commandConfigs = map[string]CommandConfig{}
-
 func NewRootForMessage(cfg *config.Config, clientOpts ...lark.ClientOptionFunc) func(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
 	h := &rootHandler{Config: *cfg}
 	return h.Handle
@@ -226,7 +223,7 @@ func (r *rootHandler) handleCommand(ctx context.Context, command *Command) (stri
 }
 
 func (r *rootHandler) getCommandConfig(command *Command, cmdLogger zerolog.Logger) (*CommandConfig, error) {
-	cmdConfig, ok := commandConfigs[command.Name]
+	cmdConfig, ok := r.commandRegistry[command.Name]
 	if !ok {
 		cmdLogger.Warn().Msg("Unsupported command")
 


### PR DESCRIPTION
- Move app credentials to config file and make CLI options optional.
- Replace global commandConfigs variable with rootHandler.commandRegistry field.