### PR TITLE
feat(chatops-lark): lark bot reply enhance

### DIFF
--- a/chatops-lark/pkg/botinfo/client.go
+++ b/chatops-lark/pkg/botinfo/client.go
@@ -69,7 +69,7 @@ func GetBotOpenID(ctx context.Context, appID, appSecret string) (string, error) 
 		}
 
 		if botResp.Bot.OpenID == "" {
-			return "", fmt.Errorf("bot openID is empty in API response")
+			return "", fmt.Errorf("bot openID is empty in API response from %s", botInfoPathURL)
 		}
 	}
 

--- a/chatops-lark/pkg/botinfo/client.go
+++ b/chatops-lark/pkg/botinfo/client.go
@@ -68,14 +68,10 @@ func GetBotOpenID(ctx context.Context, appID, appSecret string) (string, error) 
 			return "", fmt.Errorf("API error: %s (code: %d)", botResp.Msg, botResp.Code)
 		}
 
-		// Remove AppName check
-		// if botResp.Bot.AppName == "" {
-		// 	return "", "", fmt.Errorf("bot name is empty in API response")
-		// }
 		if botResp.Bot.OpenID == "" {
 			return "", fmt.Errorf("bot openID is empty in API response")
 		}
 	}
-	// Return only OpenID
+
 	return botResp.Bot.OpenID, nil
 }

--- a/chatops-lark/pkg/botinfo/client_test.go
+++ b/chatops-lark/pkg/botinfo/client_test.go
@@ -21,8 +21,8 @@ var (
 // 	os.Exit(m.Run())
 // }
 
-func TestGetBotName(t *testing.T) {
-	// You should run it with: go test -run=TestGetBotName/real_test ./pkg/botinfo -app-id <app-id> -app-secret <app-secret>
+func TestGetBotInfo(t *testing.T) {
+	// You should run it with: go test -run=TestGetBotInfo/real_test ./pkg/botinfo -app-id <app-id> -app-secret <app-secret>
 	t.Run("real test", func(tt *testing.T) {
 		flag.Parse()
 
@@ -34,14 +34,17 @@ func TestGetBotName(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		name, err := GetBotName(ctx, *testAppID, *testAppSecret)
+		name, openID, err := GetBotInfo(ctx, *testAppID, *testAppSecret)
 		if err != nil {
 			tt.Fatal(err)
 		}
 
-		tt.Log(name)
+		tt.Logf("Name: %s, OpenID: %s", name, openID)
 		if name == "" {
 			tt.Fatal("Expected non-empty bot name")
+		}
+		if openID == "" {
+			tt.Fatal("Expected non-empty bot openID")
 		}
 	})
 }

--- a/chatops-lark/pkg/botinfo/client_test.go
+++ b/chatops-lark/pkg/botinfo/client_test.go
@@ -21,8 +21,8 @@ var (
 // 	os.Exit(m.Run())
 // }
 
-func TestGetBotInfo(t *testing.T) {
-	// You should run it with: go test -run=TestGetBotInfo/real_test ./pkg/botinfo -app-id <app-id> -app-secret <app-secret>
+func TestGetBotOpenID(t *testing.T) {
+	// You should run it with: go test -run=TestGetBotOpenID/real_test ./pkg/botinfo -app-id <app-id> -app-secret <app-secret>
 	t.Run("real test", func(tt *testing.T) {
 		flag.Parse()
 
@@ -34,15 +34,17 @@ func TestGetBotInfo(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		name, openID, err := GetBotInfo(ctx, *testAppID, *testAppSecret)
+		// Call the new function and handle only openID return value
+		openID, err := GetBotOpenID(ctx, *testAppID, *testAppSecret)
 		if err != nil {
 			tt.Fatal(err)
 		}
 
-		tt.Logf("Name: %s, OpenID: %s", name, openID)
-		if name == "" {
-			tt.Fatal("Expected non-empty bot name")
-		}
+		tt.Logf("OpenID: %s", openID) // Log only openID
+		// Remove name check
+		// if name == "" {
+		// 	tt.Fatal("Expected non-empty bot name")
+		// }
 		if openID == "" {
 			tt.Fatal("Expected non-empty bot openID")
 		}

--- a/chatops-lark/pkg/botinfo/client_test.go
+++ b/chatops-lark/pkg/botinfo/client_test.go
@@ -12,14 +12,6 @@ var (
 	testAppSecret = flag.String("app-secret", "", "app secret")
 )
 
-// // TestMain handles setup for all tests in the package
-// func TestMain(m *testing.M) {
-// 	// Parse the flags
-// 	flag.Parse()
-
-// 	// Run the tests
-// 	os.Exit(m.Run())
-// }
 
 func TestGetBotOpenID(t *testing.T) {
 	// You should run it with: go test -run=TestGetBotOpenID/real_test ./pkg/botinfo -app-id <app-id> -app-secret <app-secret>
@@ -41,10 +33,7 @@ func TestGetBotOpenID(t *testing.T) {
 		}
 
 		tt.Logf("OpenID: %s", openID) // Log only openID
-		// Remove name check
-		// if name == "" {
-		// 	tt.Fatal("Expected non-empty bot name")
-		// }
+
 		if openID == "" {
 			tt.Fatal("Expected non-empty bot openID")
 		}

--- a/chatops-lark/pkg/response/reply.go
+++ b/chatops-lark/pkg/response/reply.go
@@ -20,7 +20,7 @@ type info struct {
 	Message string
 }
 
-func NewReplyMessageReq(msgID string, status, msg string) (*larkim.ReplyMessageReq, error) {
+func NewReplyMessageReq(msgID string, replyInThread bool, status, msg string) (*larkim.ReplyMessageReq, error) {
 	rawContent, err := newLarkCardWithGoTemplate(&info{Status: status, Message: msg})
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func NewReplyMessageReq(msgID string, status, msg string) (*larkim.ReplyMessageR
 		MessageId(msgID).
 		Body(larkim.NewReplyMessageReqBodyBuilder().
 			MsgType(larkim.MsgTypeInteractive).
-			ReplyInThread(true).
+			ReplyInThread(replyInThread).
 			Content(rawContent).
 			Build()).
 		Build(), nil


### PR DESCRIPTION
* Only reply in group chat conversations by creating a topic, and reply directly in one-on-one chats.
* In a private one-on-one chat, remind the user that they do not need to @ bot.