### PR TITLE
fix(tibuild): fix experimental edition name to experiment

### DIFF
--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -493,7 +493,7 @@ func TestValidateReq(t *testing.T) {
 					Product:        ProductTidb,
 					GitRef:         "branch/main",
 					Version:        "v6.5.0",
-					Edition:        EditionExperimental, // Not in InvalidEditionForJenkins
+					Edition:        EditionExperiment, // Not in InvalidEditionForJenkins
 					PipelineEngine: JenkinsEngine,
 					GithubRepo:     "pingcap/tidb",
 				},

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -200,16 +200,16 @@ type GitRef string
 
 // Edition constants define the valid values for DevBuildSpec.Edition
 const (
-	EditionEnterprise   = "enterprise"
-	EditionCommunity    = "community"
-	EditionFailPoint    = "failpoint"
-	EditionFips         = "fips"
-	EditionExperimental = "experimental"
+	EditionEnterprise = "enterprise"
+	EditionCommunity  = "community"
+	EditionFailPoint  = "failpoint"
+	EditionFips       = "fips"
+	EditionExperiment = "experiment"
 )
 
 var (
 	InvalidEditionForJenkins = []string{EditionEnterprise, EditionCommunity}
-	InvalidEditionForTekton  = []string{EditionEnterprise, EditionCommunity, EditionFailPoint, EditionFips, EditionExperimental}
+	InvalidEditionForTekton  = []string{EditionEnterprise, EditionCommunity, EditionFailPoint, EditionFips, EditionExperiment}
 )
 
 type BuildStatus string


### PR DESCRIPTION
This commit renames EditionExperimental const to EditionExperiment to match
expected build edition name "experiment" in all references.