### PR TITLE
ci: add weekly automated GitHub release workflow

### DIFF
--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,8 +49,6 @@ jobs:
               echo "has_changes=false" >> $GITHUB_OUTPUT
             fi
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get current date
         if: steps.check-changes.outputs.has_changes == 'true'
@@ -78,5 +78,3 @@ jobs:
               --title "Weekly Release $TAG_NAME" \
               --notes "Weekly automatic release created on $(date +'%Y-%m-%d')"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -1,0 +1,75 @@
+name: Weekly GitHub Release
+
+on:
+  schedule:
+    # Run weekly on Sunday at 00:00 UTC
+    - cron: "0 0 * * 0"
+  # Allow manual trigger
+  workflow_dispatch:
+
+# Ensure only one instance of this workflow runs at a time
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history for proper comparison
+          fetch-depth: 0
+
+      - name: Check for changes since last release
+        id: check-changes
+        run: |
+          # Get the latest release tag
+          LATEST_RELEASE=$(gh release list --limit 1 --json tagName --jq .[].tagName)
+
+          if [ -z "$LATEST_RELEASE" ]; then
+            echo "No previous releases found. Creating initial release."
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "Latest release: $LATEST_RELEASE"
+
+            # Check if there are any changes since the latest release
+            CHANGES=$(git log $LATEST_RELEASE..HEAD --oneline)
+
+            if [ -n "$CHANGES" ]; then
+              echo "Changes detected since last release"
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+            else
+              echo "No changes since last release"
+              echo "has_changes=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get current date
+        if: steps.check-changes.outputs.has_changes == 'true'
+        id: date
+        run: echo "date=$(date +'%Y.%-m.%-d')" >> $GITHUB_OUTPUT
+
+      - name: Create new tag and release
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          # Create tag name with date
+          TAG_NAME="v${{ steps.date.outputs.date }}"
+
+          # Create a new tag
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a $TAG_NAME -m "Weekly release $TAG_NAME"
+
+          # Push the tag
+          git push origin $TAG_NAME
+
+          # Create GitHub release
+          gh release create $TAG_NAME \
+            --title "Weekly Release $TAG_NAME" \
+            --notes "Weekly automatic release created on $(date +'%Y-%m-%d')"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -64,12 +64,17 @@ jobs:
           git config --local user.name "GitHub Action"
           git tag -a $TAG_NAME -m "Weekly release $TAG_NAME"
 
-          # Push the tag
-          git push origin $TAG_NAME
+          # Check if the tag already exists
+          if git ls-remote --tags origin $TAG_NAME; then
+            echo "Tag $TAG_NAME already exists, only one release can be created in same date, if you want to create a new release, please delete the existing tag"
+          else
+            # Push the tag
+            git push origin $TAG_NAME
 
-          # Create GitHub release
-          gh release create $TAG_NAME \
-            --title "Weekly Release $TAG_NAME" \
-            --notes "Weekly automatic release created on $(date +'%Y-%m-%d')"
+            # Create GitHub release
+            gh release create $TAG_NAME \
+              --title "Weekly Release $TAG_NAME" \
+              --notes "Weekly automatic release created on $(date +'%Y-%m-%d')"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creates a workflow that runs every Sunday at 00:00 UTC to automatically create a new GitHub release when changes are detected since the previous release.
The workflow can also be triggered manually.