### PR TITLE
fix(cloud events-server): support mysql secure connection

### DIFF
--- a/cloudevents-server/Dockerfile
+++ b/cloudevents-server/Dockerfile
@@ -6,6 +6,9 @@ FROM debian:12
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/PingCAP-QE/ee-apps"
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder --chown=root:root /app/server /app/server
 EXPOSE 8080
 ENTRYPOINT [ "/app/server" ]

--- a/cloudevents-server/go.mod
+++ b/cloudevents-server/go.mod
@@ -1,6 +1,8 @@
 module github.com/PingCAP-QE/ee-apps/cloudevents-server
 
-go 1.23.0
+go 1.25.0
+
+toolchain go1.25.1
 
 require (
 	entgo.io/ent v0.14.5


### PR DESCRIPTION
This pull request updates the base Docker image and Go toolchain version for the `cloudevents-server` service, improving both runtime security and compatibility with newer Go features.

**Environment updates:**

* Updated the base image in `cloudevents-server/Dockerfile` to install and configure `ca-certificates`, ensuring secure HTTPS connections and cleaning up package lists to reduce image size.

**Toolchain upgrades:**

* Upgraded the Go version in `cloudevents-server/go.mod` from 1.23.0 to 1.25.0 and specified the toolchain as `go1.25.1`, enabling access to the latest language features and improvements.