### PR TITLE
fix(tibuild): fix internal image URL assignment in inflate method

### DIFF
--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -262,6 +262,7 @@ func (s DevbuildServer) inflate(entity *DevBuild) {
 		entity.Status.PipelineViewURL = s.Jenkins.BuildURL(devbuildJobname, entity.Status.PipelineBuildID)
 		entity.Status.PipelineViewURLs = append(entity.Status.PipelineViewURLs, entity.Status.PipelineViewURL)
 	}
+
 	if entity.Status.BuildReport != nil {
 		for i, bin := range entity.Status.BuildReport.Binaries {
 			if bin.URL == "" && bin.OciFile != nil {
@@ -271,17 +272,18 @@ func (s DevbuildServer) inflate(entity *DevBuild) {
 				entity.Status.BuildReport.Binaries[i].Sha256URL = s.ociFileToUrl(*bin.Sha256OciFile)
 			}
 		}
-	}
-	if tek := entity.Status.TektonStatus; tek != nil {
-		for _, p := range tek.Pipelines {
-			entity.Status.PipelineViewURLs = append(entity.Status.PipelineViewURLs, fmt.Sprintf("%s/%s", s.TektonViewURL, p.Name))
+
+		// Append the internal image URL to the image list
+		for i, img := range entity.Status.BuildReport.Images {
+			if img.InternalURL == "" {
+				entity.Status.BuildReport.Images[i].InternalURL = s.getInternalImageURL(img.URL)
+			}
 		}
 	}
 
-	// Append the internal image URL to the image list
-	for i, img := range entity.Status.BuildReport.Images {
-		if img.InternalURL == "" {
-			entity.Status.BuildReport.Images[i].InternalURL = s.getInternalImageURL(img.URL)
+	if tek := entity.Status.TektonStatus; tek != nil {
+		for _, p := range tek.Pipelines {
+			entity.Status.PipelineViewURLs = append(entity.Status.PipelineViewURLs, fmt.Sprintf("%s/%s", s.TektonViewURL, p.Name))
 		}
 	}
 }


### PR DESCRIPTION
fix the panic issue:

```
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:262 (0x47e8d8)
/usr/local/go/src/runtime/signal_unix.go:925 (0x47e8a8)
/goapp/pkg/rest/service/dev_build_service.go:282 (0xcfd76c)
/goapp/pkg/rest/service/dev_build_service.go:199 (0xcfcac4)
/goapp/pkg/rest/controller/dev_build_handler.go:161 (0xd08588)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185 (0x991aeb)
/go/pkg/mod/github.com/gin-contrib/requestid@v1.0.5/requestid.go:48 (0x991ad9)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185 (0x97892a)
/goapp/api/cors.go:23 (0x131d60f)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185 (0x97892a)
/goapp/api/api_error.go:27 (0x131b904)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185 (0x9866ee)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/recovery.go:102 (0x9866db)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185 (0x9857c4)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/logger.go:249 (0x9857ab)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185 (0x984c4a)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/gin.go:644 (0x984607)
/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/gin.go:600 (0x98412c)
/usr/local/go/src/net/http/server.go:3340 (0x725a4d)
/usr/local/go/src/net/http/server.go:2109 (0x704364)
/usr/local/go/src/runtime/asm_amd64.s:1693 (0x4841c0)
```