### PR TITLE
feat(chatops-lark): add support for GitHub ID custom user attribute

### DIFF
--- a/chatops-lark/pkg/config/config.go
+++ b/chatops-lark/pkg/config/config.go
@@ -11,8 +11,11 @@ import (
 // Config represents the overall application configuration, including all subcommands.
 type Config struct {
 	// Bot configuration
-	AppID     string `yaml:"app_id" json:"app_id"`
-	AppSecret string `yaml:"app_secret" json:"app_secret"`
+	AppID             string `yaml:"app_id" json:"app_id"`
+	AppSecret         string `yaml:"app_secret" json:"app_secret"`
+	UserCustomAttrIDs *struct {
+		GitHubID string `yaml:"github_id" json:"github_id"`
+	} `yaml:"user_custom_attr_ids,omitempty" json:"user_custom_attr_ids,omitempty"`
 
 	// Cherry pick configuration
 	CherryPickInvite struct {

--- a/chatops-lark/pkg/events/handler/func_lark.go
+++ b/chatops-lark/pkg/events/handler/func_lark.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"regexp"
+	"slices"
 	"strings"
 
 	larkcontact "github.com/larksuite/oapi-sdk-go/v3/service/contact/v3"
@@ -104,8 +105,13 @@ func shouldHandle(event *larkim.P2MessageReceiveV1, botOpenID string) *Command {
 }
 
 func parseUserCustomAttr(attrID string, info *larkcontact.User) *string {
+	emptyValues := []string{"无", "NaN", "N/A", "NA", ""}
+
 	for _, attr := range info.CustomAttrs {
 		if attr.Id != nil && *attr.Id == attrID && attr.Value != nil && attr.Value.Text != nil {
+			if slices.Contains(emptyValues, *attr.Value.Text) {
+				return nil
+			}
 			return attr.Value.Text
 		}
 	}

--- a/chatops-lark/pkg/events/handler/types.go
+++ b/chatops-lark/pkg/events/handler/types.go
@@ -37,8 +37,9 @@ type Command struct {
 }
 
 type CommandActor struct {
-	OpenID string
-	Email  string
+	OpenID   string
+	Email    string
+	GitHubID *string
 }
 
 type CommandResponse struct {


### PR DESCRIPTION
Parse and attach GitHub ID from Lark user custom attributes if configured.