### PR TITLE
feat(chatops-lark): Optimize GitHub API usage with permission filtering and exclude org owners from repo admins.

### DIFF
--- a/chatops-lark/pkg/events/handler/repo_admin.go
+++ b/chatops-lark/pkg/events/handler/repo_admin.go
@@ -145,7 +145,7 @@ func formatAdminsResponse(owner, repo string, admins []string) string {
 		}
 	}
 
-	result.WriteString("\n\n→ Contact any admin above for write access")
+	result.WriteString("\n\n→ Contact any contact whose GitHub ID is in the above list")
 	return result.String()
 }
 


### PR DESCRIPTION
1. Simplify code by removing unnecessary team admin queries
2. Use Permission parameter to filter admin users at API level
3. Exclude org owners to direct users to repo-specific admins
4. add unit tests ensure the correctness of code logic