### PR TITLE
fix(publisher): use constant TiUP delivery key and fix YAML import

### DIFF
--- a/publisher/internal/service/impl/tiup/service.go
+++ b/publisher/internal/service/impl/tiup/service.go
@@ -27,7 +27,7 @@ func NewService(logger *zerolog.Logger, cfg config.Service) gentiup.Service {
 	tiupCfg := cfg.Services["tiup"]
 	switch v := tiupCfg.(type) {
 	case map[string]any:
-		deliveryConfigFile := v["deliveryConfigFile"]
+		deliveryConfigFile := v[tiupServiceDeliveryCfgKey]
 		switch file := deliveryConfigFile.(type) {
 		case string:
 			// load the yaml from the file

--- a/publisher/internal/service/impl/tiup/types.go
+++ b/publisher/internal/service/impl/tiup/types.go
@@ -3,6 +3,7 @@ package tiup
 import "github.com/PingCAP-QE/ee-apps/publisher/internal/service/impl/share"
 
 const redisKeyPrefixTiupRateLimit = "ratelimit:tiup"
+const tiupServiceDeliveryCfgKey = "delivery_config_file"
 
 type PublishRequestTiUP struct {
 	From       share.From      `json:"from,omitzero"`

--- a/publisher/pkg/config/load.go
+++ b/publisher/pkg/config/load.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/stretchr/testify/assert/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // Load and parse configuration


### PR DESCRIPTION
Introduce tiupServiceDeliveryCfgKey = "delivery_config_file" and use it to access the TiUP delivery config value. Replace incorrect yaml import from github.com/stretchr/testify/assert/yaml with gopkg.in/yaml.v3.