### PR TITLE
build(publisher): split publisher images and add CLI Dockerfile

### DIFF
--- a/publisher/cli.Dockerfile
+++ b/publisher/cli.Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.25.5-alpine AS builder
+
+COPY . /ws
+WORKDIR /ws
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o bin/publisher-cli ./cmd/publisher-cli
+
+# final image
+# there tiup tools in the image, we need to call it in worker.
+FROM ghcr.io/pingcap-qe/cd/utils/release:v2025.10.26-7-geb77a69
+LABEL org.opencontainers.image.title="PingCAP Publisher CLI tool"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.source="https://github.com/PingCAP-QE/ee-apps"
+LABEL org.opencontainers.image.url="https://github.com/PingCAP-QE/ee-apps/tree/main/publisher"
+
+
+COPY --from=builder --chown=root:root /ws/bin/publisher-cli /app/publisher-cli
+ENTRYPOINT ["/app/worker"]

--- a/publisher/skaffold.yaml
+++ b/publisher/skaffold.yaml
@@ -6,8 +6,29 @@ build:
   platforms: ["linux/amd64", "linux/arm64"]
   artifacts:
     - image: publisher
+      ko:
+        fromImage: gcr.io/distroless/static
+        main: ./cmd/publisher
+        dependencies:
+          paths:
+            - "**/*.go"
+            - "go.mod"
+            - "go.sum"
+        flags:
+          - -trimpath # Ko build flags (optional)
+          - -v
+        labels:
+          org.opencontainers.image.title: PingCAP Publisher Server
+          org.opencontainers.image.licenses: MIT License
+          org.opencontainers.image.source: https://github.com/PingCAP-QE/ee-apps
+          org.opencontainers.image.url: https://github.com/PingCAP-QE/ee-apps/tree/main/publisher
+
+    - image: publisher-worker
       docker:
-        dockerfile: Dockerfile
+        dockerfile: worker.Dockerfile
+    - image: publisher-cli
+      docker:
+        dockerfile: cli.Dockerfile
   local:
     useDockerCLI: true
     useBuildkit: true

--- a/publisher/worker.Dockerfile
+++ b/publisher/worker.Dockerfile
@@ -1,18 +1,18 @@
-FROM golang:1.25.4-alpine AS builder
+FROM golang:1.25.5-alpine AS builder
 
 COPY . /ws
 WORKDIR /ws
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o bin/publisher ./cmd/publisher && \
-    go build -o bin/publisher-cli ./cmd/publisher-cli && \
     go build -o bin/worker ./cmd/worker
 
 # final image
 # there tiup tools in the image, we need to call it in worker.
-FROM ghcr.io/pingcap-qe/cd/utils/release:v20240901-17-g6749b2e
+FROM ghcr.io/pingcap-qe/cd/utils/release:v2025.10.26-7-geb77a69
+LABEL org.opencontainers.image.title="PingCAP Publisher Worker"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/PingCAP-QE/ee-apps"
+LABEL org.opencontainers.image.url="https://github.com/PingCAP-QE/ee-apps/tree/main/publisher"
 
-COPY --from=builder --chown=root:root /ws/bin /app
+COPY --from=builder --chown=root:root /ws/bin/worker /app/worker
 ENTRYPOINT ["/app/worker"]


### PR DESCRIPTION
Add ko build config for publisher and a publisher-cli artifact in skaffold. Rename Dockerfile to worker.Dockerfile and adjust the builder to only build the worker binary. Bump Go base to 1.25.5, update the release image tag, and add OCI labels for worker and CLI images.