### PR TITLE
fix(charts/publisher,charts/publisher-worker): use new image and update the templates

### DIFF
--- a/charts/publisher-worker/Chart.yaml
+++ b/charts/publisher-worker/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v2025.11.30-14-g5469f73
+appVersion: v2025.11.30-17-gbeadfd1

--- a/charts/publisher-worker/templates/deployment.yaml
+++ b/charts/publisher-worker/templates/deployment.yaml
@@ -40,7 +40,6 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [{{ .Values.command }}]
           args:
             {{- with .Values.worker.config.secretKey }}
             - -config=/etc/config/{{ . }}

--- a/charts/publisher-worker/values.yaml
+++ b/charts/publisher-worker/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: ghcr.io/pingcap-qe/ee-apps/publisher
+  repository: ghcr.io/pingcap-qe/ee-apps/publisher-worker
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
@@ -98,7 +98,6 @@ tolerations: []
 
 affinity: {}
 
-command: /app/worker # the entrypoint executor in the image.
 worker:
   debug: false
   config:

--- a/charts/publisher/Chart.yaml
+++ b/charts/publisher/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v2025.11.30-14-g5469f73
+appVersion: v2025.11.30-17-gbeadfd1

--- a/charts/publisher/templates/deployment.yaml
+++ b/charts/publisher/templates/deployment.yaml
@@ -40,7 +40,6 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [{{ .Values.command }}]
           args:
             - "-domain=:{{ .Values.service.port }}"
             {{- with .Values.server.config.secretKey }}

--- a/charts/publisher/values.yaml
+++ b/charts/publisher/values.yaml
@@ -160,7 +160,6 @@ tolerations: []
 
 affinity: {}
 
-command: /app/publisher # the entrypoint executor in the image.
 server:
   debug: false
   config:


### PR DESCRIPTION

- Update appVersion for publisher and publisher-worker, the new version images were built with `ko` tool.
- Remove explicit command entries from deployments and values so containers use the image `ENTRYPOINT`.
- Change publisher-worker image repository to `ghcr.io/pingcap-qe/ee-apps/publisher-worker`