### PR TITLE
fix(publisher): add struct tags, artifact URL and logs for TiUP

### DIFF
--- a/publisher/internal/service/gen/tiup/service.go
+++ b/publisher/internal/service/gen/tiup/service.go
@@ -101,11 +101,11 @@ type QueryPublishingStatusPayload struct {
 type RequestToPublishPayload struct {
 	// The full url of the pushed OCI artifact, contain the tag part. It will parse
 	// the repo from it.
-	ArtifactURL string
+	ArtifactURL string `json:"artifact_url,omitempty"`
 	// `staging` is http://tiup.pingcap.net:8988, `prod` is
 	// http://tiup.pingcap.net:8987.
 	TiupMirror string `json:"tiup_mirror,omitempty"`
 	// Force set the version. Default is the artifact version read from
 	// `org.opencontainers.image.version` of the manifest config.
-	Version *string
+	Version *string `json:"version,omitempty"`
 }

--- a/publisher/internal/service/impl/tiup/funcs.go
+++ b/publisher/internal/service/impl/tiup/funcs.go
@@ -182,13 +182,13 @@ func analyzeTiupDeliveries(url string, rules map[string][]DeliveryRule) ([]genti
 	// compute the delivery instructions
 	var deliveryInstructions []gentiup.RequestToPublishPayload
 	for _, rule := range repoRules {
-		deliveryInstructions = append(deliveryInstructions, computeDeliveryInstructionsForRule(rule, tag)...)
+		deliveryInstructions = append(deliveryInstructions, computeDeliveryInstructionsForRule(rule, repo, tag)...)
 	}
 
 	return slices.Compact(deliveryInstructions), nil
 }
 
-func computeDeliveryInstructionsForRule(rule DeliveryRule, ociTag string) []gentiup.RequestToPublishPayload {
+func computeDeliveryInstructionsForRule(rule DeliveryRule, ociRepo, ociTag string) []gentiup.RequestToPublishPayload {
 	var ret []gentiup.RequestToPublishPayload
 	var replacedVersion string
 	if rule.TagRegexReplace != nil {
@@ -199,7 +199,7 @@ func computeDeliveryInstructionsForRule(rule DeliveryRule, ociTag string) []gent
 		}
 	}
 	for _, m := range rule.DestMirrors {
-		instruction := gentiup.RequestToPublishPayload{TiupMirror: m}
+		instruction := gentiup.RequestToPublishPayload{TiupMirror: m, ArtifactURL: fmt.Sprintf("%s:%s", ociRepo, ociTag)}
 		if replacedVersion != "" {
 			instruction.Version = &replacedVersion
 		}

--- a/publisher/internal/service/impl/tiup/service.go
+++ b/publisher/internal/service/impl/tiup/service.go
@@ -54,6 +54,7 @@ func (s *tiupsrvc) DeliveryByRules(ctx context.Context, p *gentiup.DeliveryByRul
 	// 1. match for the rules
 	RequestToPublishPayloads, err := analyzeTiupDeliveries(p.ArtifactURL, s.deliveryConfig.TiupPublishRules)
 	if err != nil {
+		s.Logger.Err(err).Str("artifact_url", p.ArtifactURL).Msg("failed to analyze tiup deliveries")
 		return nil, err
 	}
 
@@ -61,6 +62,7 @@ func (s *tiupsrvc) DeliveryByRules(ctx context.Context, p *gentiup.DeliveryByRul
 	for _, payload := range RequestToPublishPayloads {
 		ids, err := s.RequestToPublish(ctx, &payload)
 		if err != nil {
+			s.Logger.Err(err).Msg("failed to request to publish")
 			return nil, err
 		}
 

--- a/publisher/internal/service/impl/tiup/types.go
+++ b/publisher/internal/service/impl/tiup/types.go
@@ -22,13 +22,13 @@ type PublishInfoTiUP struct {
 }
 
 type DeliveryRule struct {
-	Description     string   `json:"description,omitempty"`
-	TagsRegex       []string `json:"tags_regex"`
-	DestMirrors     []string `json:"dest_mirrors"`
-	Nightly         bool     `json:"nightly,omitempty"`
-	TagRegexReplace *string  `json:"tag_regex_replace,omitempty"`
+	Description     string   `json:"description,omitempty" yaml:"description,omitempty"`
+	TagsRegex       []string `json:"tags_regex" yaml:"tags_regex"`
+	DestMirrors     []string `json:"dest_mirrors" yaml:"dest_mirrors"`
+	Nightly         bool     `json:"nightly,omitempty" yaml:"nightly,omitempty"`
+	TagRegexReplace *string  `json:"tag_regex_replace,omitempty" yaml:"tag_regex_replace,omitempty"`
 }
 
 type DeliveryConfig struct {
-	TiupPublishRules map[string][]DeliveryRule `json:"tiup_publish_rules,omitempty"`
+	TiupPublishRules map[string][]DeliveryRule `json:"tiup_publish_rules,omitempty" yaml:"tiup_publish_rules,omitempty"`
 }


### PR DESCRIPTION
Add JSON tags to RequestToPublishPayload and YAML tags to DeliveryRule and DeliveryConfig. Populate ArtifactURL when computing delivery instructions (computeDeliveryInstructionsForRule now takes repo). Add error logging in DeliveryByRules for analyze and request failures.