### PR TITLE
fix(tibuild): deduplicate images in DevBuild update

### DIFF
--- a/tibuild/pkg/rest/repo/dev_build_repo.go
+++ b/tibuild/pkg/rest/repo/dev_build_repo.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"gorm.io/gorm"
 
 	. "github.com/PingCAP-QE/ee-apps/tibuild/pkg/rest/service"
@@ -76,6 +77,8 @@ func (m DevBuildRepo) List(ctx context.Context, option DevBuildListOption) ([]De
 }
 
 func intoDB(entity *DevBuild) (err error) {
+	deduplicateImagesInReport(entity)
+
 	js, err := json.Marshal(entity.Status.BuildReport)
 	if err != nil {
 		return err
@@ -103,7 +106,15 @@ func outofDB(entity *DevBuild) (err error) {
 	}
 	entity.Status.TektonStatus, _ = tekton.(*TektonStatus)
 	entity.Status.TektonStatusJson = nil
+
+	deduplicateImagesInReport(entity)
 	return
+}
+
+func deduplicateImagesInReport(req *DevBuild) {
+	if req.Status.BuildReport != nil && len(req.Status.BuildReport.Images) > 0 {
+		req.Status.BuildReport.Images = mapset.NewSet(req.Status.BuildReport.Images...).ToSlice()
+	}
 }
 
 func fromRawMessage(js json.RawMessage, target any) (any, error) {

--- a/tibuild/pkg/webhook/service/cloudevent.go
+++ b/tibuild/pkg/webhook/service/cloudevent.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	mapset "github.com/deckarep/golang-set/v2"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"gopkg.in/yaml.v3"
 
@@ -195,7 +194,7 @@ type TektonImageStruct struct {
 }
 
 func parseTektonImage(results []tekton.PipelineRunResult) ([]rest.ImageArtifact, error) {
-	imageSet := mapset.NewSet[rest.ImageArtifact]()
+	var rt []rest.ImageArtifact
 	for _, r := range results {
 		if r.Name == "pushed-images" {
 			images := TektonImageStruct{}
@@ -205,16 +204,15 @@ func parseTektonImage(results []tekton.PipelineRunResult) ([]rest.ImageArtifact,
 			}
 			for _, image := range images.Images {
 				imgURL := fmt.Sprintf("%s:%s", image.Repo, image.Tag)
-				imageSet.Add(rest.ImageArtifact{URL: imgURL, Platform: image.Platform})
+				rt = append(rt, rest.ImageArtifact{URL: imgURL, Platform: image.Platform})
 
 				// if it has multi arch tags, then we append the multi-arch image with the first tag.
 				if len(image.MultiArchTags) > 0 {
 					multiArchImgURL := fmt.Sprintf("%s:%s", image.Repo, image.MultiArchTags[0])
-					imageSet.Add(rest.ImageArtifact{URL: multiArchImgURL, Platform: rest.MultiArch})
+					rt = append(rt, rest.ImageArtifact{URL: multiArchImgURL, Platform: rest.MultiArch})
 				}
 			}
 		}
 	}
-
-	return imageSet.ToSlice(), nil
+	return rt, nil
 }


### PR DESCRIPTION
Remove mapset dependency from webhook service and simplify image parsing logic