### PR TITLE
feat(charts/cloudevents-server): add httproute support

### DIFF
--- a/charts/cloudevents-server/Chart.yaml
+++ b/charts/cloudevents-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudevents-server/templates/httproute.yaml
+++ b/charts/cloudevents-server/templates/httproute.yaml
@@ -35,25 +35,4 @@ spec:
           port: {{ $svcPort }}
           weight: 1
     {{- end }}
----
-{{- if .Values.httpRoute.securityPolicy.enabled }}
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: SecurityPolicy
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "cloudevents-server.labels" . | nindent 4 }}
-  {{- with .Values.httpRoute.securityPolicy.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: {{ $fullName }}
-  basicAuth:
-    users:
-      name: {{ required "httpRoute.securityPolicy.basicAuth.secretName is required when httpRoute.securityPolicy.enabled=true" .Values.httpRoute.securityPolicy.basicAuth.secretName | quote }}
-{{- end }}
 {{- end }}

--- a/charts/cloudevents-server/templates/httproute.yaml
+++ b/charts/cloudevents-server/templates/httproute.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "cloudevents-server.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "cloudevents-server.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+---
+{{- if .Values.httpRoute.securityPolicy.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "cloudevents-server.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.securityPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ $fullName }}
+  basicAuth:
+    users:
+      name: {{ required "httpRoute.securityPolicy.basicAuth.secretName is required when httpRoute.securityPolicy.enabled=true" .Values.httpRoute.securityPolicy.basicAuth.secretName | quote }}
+{{- end }}
+{{- end }}

--- a/charts/cloudevents-server/values.yaml
+++ b/charts/cloudevents-server/values.yaml
@@ -65,6 +65,34 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- Expose the service via gateway-api HTTPRoute.
+# Requires Gateway API resources and a suitable controller installed in the cluster.
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs:
+    - name: gateway
+      sectionName: http
+      # namespace: default
+  hostnames:
+    - chart-example.local
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+  #   filters:
+  #     - type: URLRewrite
+  #       urlRewrite:
+  #         path:
+  #           type: ReplacePrefixMatch
+  #           replacePrefixMatch: /
+  securityPolicy:
+    enabled: false
+    annotations: {}
+    basicAuth:
+      secretName: ""
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/cloudevents-server/values.yaml
+++ b/charts/cloudevents-server/values.yaml
@@ -87,11 +87,6 @@ httpRoute:
   #         path:
   #           type: ReplacePrefixMatch
   #           replacePrefixMatch: /
-  securityPolicy:
-    enabled: false
-    annotations: {}
-    basicAuth:
-      secretName: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Summary
- add `httpRoute` support to the `cloudevents-server` Helm chart
- add an optional Envoy Gateway `SecurityPolicy` for HTTP basic auth bound to the generated `HTTPRoute`
- bump the chart version from `0.1.0` to `0.1.1`

## Validation
- `helm lint charts/cloudevents-server`
- `helm template cloudevents-server charts/cloudevents-server -f /tmp/cloudevents-httproute-values.yaml`

## Notes
This is intended to unblock the `ee-ops` side from configuring `cloudevents-server` exposure via `HTTPRoute` instead of having to define route resources fully out-of-chart.
