### PR TITLE
feat(charts/dl): add httproute support

### DIFF
--- a/charts/dl/Chart.yaml
+++ b/charts/dl/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dl/templates/httproute.yaml
+++ b/charts/dl/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "dl.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "dl.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/dl/values.yaml
+++ b/charts/dl/values.yaml
@@ -75,6 +75,29 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- Expose the service via gateway-api HTTPRoute.
+# Requires Gateway API resources and a suitable controller installed in the cluster.
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs:
+    - name: gateway
+      sectionName: http
+      # namespace: default
+  hostnames:
+    - chart-example.local
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+  #   filters:
+  #     - type: URLRewrite
+  #       urlRewrite:
+  #         path:
+  #           type: ReplacePrefixMatch
+  #           replacePrefixMatch: /
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Summary
- add provider-agnostic `httpRoute` values to the `dl` chart
- add a `templates/httproute.yaml` template that renders a standard Gateway API `HTTPRoute`
- bump the `dl` chart version to `0.2.1`

## Validation
- `python3` YAML parse for `charts/dl/Chart.yaml` and `charts/dl/values.yaml`
- `/tmp/helm-v3.17.3 lint charts/dl`
- `/tmp/helm-v3.17.3 template dl charts/dl -f <sample-values>`
  - verified `HTTPRoute` renders with `parentRefs`, `hostnames`, `matches`, `filters`, and backend refs as expected
