### PR TITLE
ci: remediate GitHub Actions zizmor findings

### DIFF
--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -21,21 +21,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
           sparse-checkout: |
             charts
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
         with:
           version: v3.18.3
 
       - name: Release charts
         working-directory: charts
+        env:
+          REGISTRY_USERNAME: ${{ github.actor }}
         run: |
-          echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ github.token }}" | docker login ghcr.io -u "${REGISTRY_USERNAME}" --password-stdin
 
           for chart in cloudevents-server dl publisher publisher-worker chatops-lark tibuild-v2; do
             CHART_VERSION=$(grep 'version:' $chart/Chart.yaml | tail -n1 | awk '{ print $2 }')

--- a/.github/workflows/ci-tibuild-v2.yaml
+++ b/.github/workflows/ci-tibuild-v2.yaml
@@ -23,18 +23,19 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: "0"
           fetch-tags: "true"
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: experiments/tibuild-v2/go.mod
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,12 +34,13 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with: # we need it for skaffold build
           fetch-depth: "0"
           fetch-tags: "true"
+          persist-credentials: false
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         id: changes
         with:
           filters: |
@@ -56,17 +57,17 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             image=moby/buildkit:v0.12.4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,12 +33,13 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with: # we need it for skaffold build
           fetch-depth: "0"
           fetch-tags: "true"
+          persist-credentials: false
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         id: changes
         with:
           filters: |
@@ -57,17 +58,17 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: |
             image=moby/buildkit:v0.12.4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -22,10 +22,11 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Fetch all history for proper comparison
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for changes since last release
         id: check-changes
@@ -58,9 +59,11 @@ jobs:
 
       - name: Create new tag and release
         if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          RELEASE_DATE: ${{ steps.date.outputs.date }}
         run: |
           # Create tag name with date
-          TAG_NAME="v${{ steps.date.outputs.date }}"
+          TAG_NAME="v${RELEASE_DATE}"
 
           # Check if the tag already exists
           if git ls-remote --tags origin | grep -q "refs/tags/$TAG_NAME$"; then
@@ -72,6 +75,7 @@ jobs:
             git tag -a $TAG_NAME -m "Weekly release $TAG_NAME"
 
             # Push the tag
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push origin $TAG_NAME
 
             # Create GitHub release


### PR DESCRIPTION
## Summary\n- pin all third-party GitHub Actions references to full commit SHAs\n- disable persisted checkout credentials where push auth is not needed\n- remove template-injection findings by moving interpolated values into env vars and using explicit token-based push for weekly release\n\n## Validation\n- git diff --check\n- python3 YAML parse for all .github/workflows/*.yaml\n- zizmor . --no-progress --format json --no-online-audits -q (exit code 0)\n\nCloses #408