### PR TITLE
feat(ci-dashboard): polish flaky and ci-status metrics and visuals

### DIFF
--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -8,7 +8,7 @@ on:
       - main
     paths:
       - ".github/workflows/charts-release.yaml"
-      - "charts/*/Chart.yaml"
+      - "charts/**"
 
 jobs:
   release:
@@ -42,7 +42,6 @@ jobs:
           set -euo pipefail
 
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-
           for chart in ci-dashboard cloudevents-server dl publisher publisher-worker chatops-lark tibuild-v2; do
             CHART_VERSION=$(grep 'version:' $chart/Chart.yaml | tail -n1 | awk '{ print $2 }')
             if helm show values oci://ghcr.io/pingcap-qe/ee-apps/charts/$chart --version $CHART_VERSION > /dev/null; then

--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -8,7 +8,7 @@ on:
       - main
     paths:
       - ".github/workflows/charts-release.yaml"
-      - "charts/**"
+      - "charts/*/Chart.yaml"
 
 jobs:
   release:

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - wuhuizuo
+  - dillon-zheng
 
 reviewers:
   - purelind

--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-dashboard"
-version = "0.1.0"
+version = "0.1.1"
 description = "CI dashboard jobs and API scaffold"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ci-dashboard/src/ci_dashboard/api/queries/base.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/base.py
@@ -149,6 +149,14 @@ def builds_table_expr(
     *,
     alias: str = "b",
 ) -> str:
+    """Build the ci_l1_builds table reference with the narrowest useful TiDB hint.
+
+    We intentionally keep FORCE INDEX here because several page-level time-range
+    aggregations regressed to table scans in TiDB without a strong hint. This
+    helper centralizes the tradeoff: use the repo+time index when the query can
+    narrow by repo, otherwise fall back to the generic time-range index. SQLite
+    keeps the plain table reference so local tests stay portable.
+    """
     table = f"ci_l1_builds {alias}"
     if connection.dialect.name == "sqlite":
         return table

--- a/ci-dashboard/src/ci_dashboard/api/queries/base.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/base.py
@@ -88,7 +88,7 @@ def build_common_where(
         params["repo"] = filters.repo
 
     if filters.branch:
-        conditions.append(f"{branch_expr(table_alias)} = :branch")
+        conditions.append(branch_match_expr(table_alias))
         params["branch"] = filters.branch
 
     if filters.job_name:
@@ -115,6 +115,17 @@ def branch_expr(table_alias: str = "") -> str:
     return f"COALESCE(NULLIF({prefix}target_branch, ''), {prefix}base_ref)"
 
 
+def branch_match_expr(table_alias: str = "", *, bind_name: str = "branch") -> str:
+    prefix = f"{table_alias}." if table_alias else ""
+    bind = f":{bind_name}"
+    # Keep branch filtering semantically equivalent to COALESCE(NULLIF(target_branch,''), base_ref) = :branch,
+    # while avoiding a function-wrapped column predicate that can disable index selection in TiDB.
+    return (
+        f"({prefix}target_branch = {bind} OR "
+        f"(({prefix}target_branch IS NULL OR {prefix}target_branch = '') AND {prefix}base_ref = {bind}))"
+    )
+
+
 def bucket_expr(connection: Connection, column_name: str, granularity: str) -> str:
     if granularity == "day":
         return f"DATE({column_name})"
@@ -130,6 +141,26 @@ def bucket_expr(connection: Connection, column_name: str, granularity: str) -> s
         )
 
     return f"DATE_SUB(DATE({column_name}), INTERVAL WEEKDAY({column_name}) DAY)"
+
+
+def builds_table_expr(
+    connection: Connection,
+    filters: CommonFilters,
+    *,
+    alias: str = "b",
+) -> str:
+    table = f"ci_l1_builds {alias}"
+    if connection.dialect.name == "sqlite":
+        return table
+
+    # TiDB may choose table full scan for time-range aggregations without a strong hint.
+    # Pick the narrowest existing index based on available filters.
+    has_time_window = filters.start_date is not None or filters.end_date is not None
+    if filters.repo and has_time_window:
+        return f"{table} FORCE INDEX(idx_ci_l1_builds_repo_time)"
+    if has_time_window:
+        return f"{table} FORCE INDEX(idx_ci_l1_builds_start_time_id)"
+    return table
 
 
 def filter_complete_week_rows(

--- a/ci-dashboard/src/ci_dashboard/api/queries/builds.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/builds.py
@@ -9,6 +9,7 @@ from sqlalchemy.engine import Engine
 from ci_dashboard.api.queries.base import (
     CommonFilters,
     branch_expr,
+    builds_table_expr,
     bucket_expr,
     build_common_where,
     filter_complete_week_rows,
@@ -29,6 +30,7 @@ BUILD_TREND_JOB_RANKING_LIMIT = 10
 def get_outcome_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         bucket = bucket_expr(connection, "b.start_time", filters.granularity)
         success_where = success_expr("b")
         failure_like_where = failure_like_expr("b")
@@ -40,7 +42,7 @@ def get_outcome_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
                   COUNT(*) AS total_count,
                   SUM(CASE WHEN {success_where} THEN 1 ELSE 0 END) AS success_count,
                   SUM(CASE WHEN {failure_like_where} THEN 1 ELSE 0 END) AS failure_count
-                FROM ci_l1_builds b
+                FROM {builds_table}
                 WHERE {where_clause}
                 GROUP BY bucket_start
                 ORDER BY bucket_start
@@ -84,6 +86,7 @@ def get_outcome_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
 def get_duration_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         bucket = bucket_expr(connection, "b.start_time", filters.granularity)
         success_where = success_expr("b")
         rows = connection.execute(
@@ -94,7 +97,7 @@ def get_duration_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]
                   AVG(CASE WHEN {success_where} THEN b.queue_wait_seconds END) AS queue_avg_s,
                   AVG(CASE WHEN {success_where} THEN b.run_seconds END) AS run_avg_s,
                   AVG(CASE WHEN {success_where} THEN b.total_seconds END) AS total_avg_s
-                FROM ci_l1_builds b
+                FROM {builds_table}
                 WHERE {where_clause}
                   AND b.total_seconds IS NOT NULL
                 GROUP BY bucket_start
@@ -127,7 +130,7 @@ def get_duration_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]
                   AVG(CASE WHEN {success_where} THEN b.queue_wait_seconds END) AS queue_avg_s,
                   AVG(CASE WHEN {success_where} THEN b.run_seconds END) AS run_avg_s,
                   AVG(CASE WHEN {success_where} THEN b.total_seconds END) AS total_avg_s
-                FROM ci_l1_builds b
+                FROM {builds_table}
                 WHERE {where_clause}
                   AND b.total_seconds IS NOT NULL
                 """
@@ -155,6 +158,7 @@ def get_duration_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]
 def get_cloud_comparison(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         success_where = success_expr("b")
         rows = connection.execute(
             text(
@@ -166,7 +170,7 @@ def get_cloud_comparison(engine: Engine, filters: CommonFilters) -> dict[str, An
                   AVG(CASE WHEN {success_where} THEN b.queue_wait_seconds END) AS queue_avg_s,
                   AVG(CASE WHEN {success_where} THEN b.run_seconds END) AS run_avg_s,
                   AVG(CASE WHEN {success_where} THEN b.total_seconds END) AS total_avg_s
-                FROM ci_l1_builds b
+                FROM {builds_table}
                 WHERE {where_clause}
                 GROUP BY b.cloud_phase
                 ORDER BY b.cloud_phase
@@ -201,6 +205,7 @@ def get_cloud_comparison(engine: Engine, filters: CommonFilters) -> dict[str, An
 def get_cloud_posture_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         bucket = bucket_expr(connection, "b.start_time", "week")
         rows = connection.execute(
             text(
@@ -209,7 +214,7 @@ def get_cloud_posture_trend(engine: Engine, filters: CommonFilters) -> dict[str,
                   {bucket} AS bucket_start,
                   UPPER(COALESCE(b.cloud_phase, '')) AS cloud_phase,
                   COUNT(*) AS build_count
-                FROM ci_l1_builds b
+                FROM {builds_table}
                 WHERE {where_clause}
                   AND UPPER(COALESCE(b.cloud_phase, '')) IN ('GCP', 'IDC')
                 GROUP BY bucket_start, UPPER(COALESCE(b.cloud_phase, ''))
@@ -274,6 +279,7 @@ def get_cloud_posture_trend(engine: Engine, filters: CommonFilters) -> dict[str,
 def get_longest_avg_success_jobs(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         success_where = success_expr("b")
         normalized_job_path = _normalized_job_path_expr(connection, "b")
         rows = connection.execute(
@@ -287,7 +293,7 @@ def get_longest_avg_success_jobs(engine: Engine, filters: CommonFilters) -> dict
                     {normalized_job_path} AS normalized_job_path,
                     CASE WHEN {success_where} THEN 1 ELSE 0 END AS success_flag,
                     b.run_seconds
-                  FROM ci_l1_builds b
+                  FROM {builds_table}
                   WHERE {where_clause}
                 ),
                 latest_job_links AS (
@@ -354,6 +360,7 @@ def get_longest_avg_success_jobs(engine: Engine, filters: CommonFilters) -> dict
 def get_lowest_success_rate_jobs(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         success_where = success_expr("b")
         normalized_job_path = _normalized_job_path_expr(connection, "b")
         rows = connection.execute(
@@ -367,7 +374,7 @@ def get_lowest_success_rate_jobs(engine: Engine, filters: CommonFilters) -> dict
                     {normalized_job_path} AS normalized_job_path,
                     CASE WHEN {success_where} THEN 1 ELSE 0 END AS success_flag,
                     b.run_seconds
-                  FROM ci_l1_builds b
+                  FROM {builds_table}
                   WHERE {where_clause}
                 ),
                 latest_job_links AS (
@@ -433,6 +440,7 @@ def get_lowest_success_rate_jobs(engine: Engine, filters: CommonFilters) -> dict
 def get_cloud_repo_share(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         branch_name = f"COALESCE(NULLIF({branch_expr('b')}, ''), '(unknown branch)')"
         rows = connection.execute(
             text(
@@ -442,7 +450,7 @@ def get_cloud_repo_share(engine: Engine, filters: CommonFilters) -> dict[str, An
                   b.repo_full_name AS repo_name,
                   {branch_name} AS branch_name,
                   COUNT(*) AS build_count
-                FROM ci_l1_builds b
+                FROM {builds_table}
                 WHERE {where_clause}
                   AND UPPER(COALESCE(b.cloud_phase, '')) IN ('GCP', 'IDC')
                 GROUP BY UPPER(COALESCE(b.cloud_phase, '')), b.repo_full_name, {branch_name}
@@ -527,6 +535,7 @@ def get_migration_runtime_comparison(engine: Engine, filters: CommonFilters) -> 
 
     with engine.begin() as connection:
         where_clause, params = build_common_where(scope_filters, table_alias="b")
+        builds_table = builds_table_expr(connection, scope_filters, alias="b")
         success_where = success_expr("b")
         normalized_job_path = _normalized_job_path_expr(connection, "b")
         anchor_end_date = filters.end_date or _find_latest_gcp_success_date(
@@ -565,7 +574,7 @@ def get_migration_runtime_comparison(engine: Engine, filters: CommonFilters) -> 
                     UPPER(COALESCE(b.cloud_phase, '')) AS cloud_phase,
                     b.start_time,
                     b.run_seconds
-                  FROM ci_l1_builds b
+                  FROM {builds_table}
                   WHERE {where_clause}
                     AND {success_where}
                     AND b.run_seconds IS NOT NULL
@@ -688,7 +697,7 @@ def _find_latest_gcp_success_date(
         text(
             f"""
             SELECT MAX(DATE(b.start_time)) AS anchor_end_date
-            FROM ci_l1_builds b
+            FROM {builds_table_expr(connection, CommonFilters(), alias='b')}
             WHERE {where_clause}
               AND {success_where}
               AND UPPER(COALESCE(b.cloud_phase, '')) = 'GCP'

--- a/ci-dashboard/src/ci_dashboard/api/queries/failures.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/failures.py
@@ -8,7 +8,9 @@ from sqlalchemy.engine import Engine
 from ci_dashboard.api.queries.base import (
     CommonFilters,
     bucket_expr,
+    builds_table_expr,
     build_common_where,
+    failure_like_expr,
     filter_complete_week_rows,
 )
 
@@ -16,19 +18,21 @@ from ci_dashboard.api.queries.base import (
 def get_failure_category_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         bucket = bucket_expr(connection, "b.start_time", filters.granularity)
+        failure_like_where = failure_like_expr("b")
         rows = connection.execute(
             text(
                 f"""
                 SELECT
                   {bucket} AS bucket_start,
-                  SUM(CASE WHEN LOWER(b.state) IN ('failure', 'error', 'timeout', 'timed_out', 'aborted')
+                  SUM(CASE WHEN {failure_like_where}
                              AND b.failure_category = 'FLAKY_TEST'
                            THEN 1 ELSE 0 END) AS flaky_test_count,
-                  SUM(CASE WHEN LOWER(b.state) IN ('failure', 'error', 'timeout', 'timed_out', 'aborted')
+                  SUM(CASE WHEN {failure_like_where}
                              AND b.failure_category IS NULL
                            THEN 1 ELSE 0 END) AS unclassified_count
-                FROM ci_l1_builds b
+                FROM {builds_table}
                 WHERE {where_clause}
                 GROUP BY bucket_start
                 ORDER BY bucket_start
@@ -63,18 +67,20 @@ def get_failure_category_trend(engine: Engine, filters: CommonFilters) -> dict[s
 def get_failure_category_share(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
+        failure_like_where = failure_like_expr("b")
         rows = connection.execute(
             text(
                 f"""
                 SELECT
                   b.cloud_phase,
-                  SUM(CASE WHEN LOWER(b.state) IN ('failure', 'error', 'timeout', 'timed_out', 'aborted')
+                  SUM(CASE WHEN {failure_like_where}
                              AND b.failure_category = 'FLAKY_TEST'
                            THEN 1 ELSE 0 END) AS flaky_test_count,
-                  SUM(CASE WHEN LOWER(b.state) IN ('failure', 'error', 'timeout', 'timed_out', 'aborted')
+                  SUM(CASE WHEN {failure_like_where}
                              AND b.failure_category IS NULL
                            THEN 1 ELSE 0 END) AS unclassified_count
-                FROM ci_l1_builds b
+                FROM {builds_table}
                 WHERE {where_clause}
                 GROUP BY b.cloud_phase
                 ORDER BY b.cloud_phase

--- a/ci-dashboard/src/ci_dashboard/api/queries/filters.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/filters.py
@@ -5,7 +5,12 @@ from datetime import date
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
-from ci_dashboard.api.queries.base import CommonFilters, branch_expr, build_common_where
+from ci_dashboard.api.queries.base import (
+    CommonFilters,
+    branch_expr,
+    builds_table_expr,
+    build_common_where,
+)
 
 
 def list_repos(
@@ -15,14 +20,15 @@ def list_repos(
     end_date: date | None = None,
 ) -> dict[str, object]:
     filters = CommonFilters(start_date=start_date, end_date=end_date)
-    where_clause, params = build_common_where(filters)
+    where_clause, params = build_common_where(filters, table_alias="b")
 
     with engine.begin() as connection:
+        builds_table = builds_table_expr(connection, filters, alias="b")
         rows = connection.execute(
             text(
                 f"""
                 SELECT DISTINCT repo_full_name
-                FROM ci_l1_builds
+                FROM {builds_table}
                 WHERE {where_clause}
                 ORDER BY repo_full_name
                 """
@@ -45,15 +51,16 @@ def list_branches(
     repo: str | None = None,
 ) -> dict[str, object]:
     filters = CommonFilters(repo=repo)
-    where_clause, params = build_common_where(filters)
-    effective_branch = branch_expr()
+    where_clause, params = build_common_where(filters, table_alias="b")
 
     with engine.begin() as connection:
+        builds_table = builds_table_expr(connection, filters, alias="b")
+        effective_branch = branch_expr("b")
         rows = connection.execute(
             text(
                 f"""
                 SELECT DISTINCT {effective_branch} AS branch_name
-                FROM ci_l1_builds
+                FROM {builds_table}
                 WHERE {where_clause}
                   AND {effective_branch} IS NOT NULL
                   AND {effective_branch} <> ''
@@ -79,14 +86,15 @@ def list_jobs(
     branch: str | None = None,
 ) -> dict[str, object]:
     filters = CommonFilters(repo=repo, branch=branch)
-    where_clause, params = build_common_where(filters)
+    where_clause, params = build_common_where(filters, table_alias="b")
 
     with engine.begin() as connection:
+        builds_table = builds_table_expr(connection, filters, alias="b")
         rows = connection.execute(
             text(
                 f"""
                 SELECT DISTINCT job_name
-                FROM ci_l1_builds
+                FROM {builds_table}
                 WHERE {where_clause}
                 ORDER BY job_name
                 """
@@ -104,14 +112,16 @@ def list_jobs(
 
 
 def list_cloud_phases(engine: Engine) -> dict[str, object]:
+    filters = CommonFilters()
     with engine.begin() as connection:
+        builds_table = builds_table_expr(connection, filters, alias="b")
         rows = connection.execute(
             text(
-                """
+                f"""
                 SELECT DISTINCT cloud_phase
-                FROM ci_l1_builds
-                WHERE cloud_phase IS NOT NULL
-                  AND cloud_phase <> ''
+                FROM {builds_table}
+                WHERE b.cloud_phase IS NOT NULL
+                  AND b.cloud_phase <> ''
                 ORDER BY cloud_phase
                 """
             )

--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -9,6 +9,7 @@ from sqlalchemy.engine import Connection, Engine
 from ci_dashboard.api.queries.base import (
     CommonFilters,
     MAX_RANKING_LIMIT,
+    branch_match_expr,
     bucket_expr,
     filter_complete_week_rows,
     failure_like_expr,
@@ -1283,9 +1284,7 @@ def _build_build_where(
         params["repo"] = filters.repo
 
     if filters.branch:
-        conditions.append(
-            f"COALESCE(NULLIF({prefix}target_branch, ''), {prefix}base_ref) = :branch"
-        )
+        conditions.append(branch_match_expr(table_alias))
         params["branch"] = filters.branch
 
     if filters.job_name:

--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import text
@@ -308,6 +308,120 @@ def get_distinct_flaky_case_counts_by_branch(
     }
 
 
+def get_flaky_case_flow_v2(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    """V2: confirm state changes using two consecutive weeks to reduce jitter."""
+    effective_repo = filters.repo or DEFAULT_DISTINCT_CASE_REPO
+    with engine.begin() as connection:
+        presence_rows = _fetch_weekly_flaky_case_presence(connection, filters, effective_repo)
+
+    week_columns = _week_columns(filters.start_date, filters.end_date, presence_rows)
+    presence_by_case: dict[tuple[str, str], set[str]] = {}
+    for row in presence_rows:
+        key = (str(row["branch"]), str(row["case_name"]))
+        presence_by_case.setdefault(key, set()).add(str(row["week_start"]))
+
+    new_by_week = {week: 0 for week in week_columns}
+    resolved_by_week = {week: 0 for week in week_columns}
+    new_by_branch_week: dict[str, dict[str, int]] = {}
+    resolved_by_branch_week: dict[str, dict[str, int]] = {}
+
+    for (branch, _case_name), presence_weeks in presence_by_case.items():
+        presence_bits = [week in presence_weeks for week in week_columns]
+        for index, week in enumerate(week_columns):
+            # Confirm "new" on the 2nd consecutive flaky week.
+            # A missing week before range start is treated as non-flaky.
+            is_new = (
+                index >= 1
+                and presence_bits[index]
+                and presence_bits[index - 1]
+                and (index < 2 or not presence_bits[index - 2])
+            )
+            if is_new:
+                new_by_week[week] += 1
+                new_by_branch_week.setdefault(branch, {}).setdefault(week, 0)
+                new_by_branch_week[branch][week] += 1
+
+            # Confirm "resolved" on the 2nd consecutive non-flaky week
+            # after the case was flaky in the preceding week.
+            is_resolved = (
+                index >= 2
+                and not presence_bits[index]
+                and not presence_bits[index - 1]
+                and presence_bits[index - 2]
+            )
+            if is_resolved:
+                resolved_by_week[week] += 1
+                resolved_by_branch_week.setdefault(branch, {}).setdefault(week, 0)
+                resolved_by_branch_week[branch][week] += 1
+
+    net_by_week = {
+        week: new_by_week.get(week, 0) - resolved_by_week.get(week, 0)
+        for week in week_columns
+    }
+
+    summary_rows = [
+        {
+            "week_start": week,
+            "new_case_count": new_by_week.get(week, 0),
+            "resolved_case_count": resolved_by_week.get(week, 0),
+            "net_case_count": net_by_week.get(week, 0),
+        }
+        for week in week_columns
+    ]
+
+    branch_rows = [
+        {
+            "branch": branch,
+            "new_values": [new_by_branch_week.get(branch, {}).get(week, 0) for week in week_columns],
+            "resolved_values": [
+                resolved_by_branch_week.get(branch, {}).get(week, 0) for week in week_columns
+            ],
+        }
+        for branch in _ordered_branches(
+            {branch for branch, _case_name in presence_by_case.keys()},
+            filters.branch,
+        )
+    ]
+
+    meta = filters.meta()
+    meta.update(
+        {
+            "requested_repo": filters.repo,
+            "effective_repo": effective_repo,
+            "bucket_granularity": "week",
+            "defaulted_repo": filters.repo is None,
+            "confirmation_rule": "2_consecutive_weeks",
+            "week_count": len(week_columns),
+            "case_count_in_scope": len(presence_by_case),
+        }
+    )
+    return {
+        "weeks": week_columns,
+        "series": [
+            {
+                "key": "new_case_count",
+                "label": "New (2-week confirmed)",
+                "type": "bar",
+                "axis": "left",
+                "points": [[week, new_by_week.get(week, 0)] for week in week_columns],
+            },
+            {
+                "key": "resolved_case_count",
+                "label": "Resolved (2-week confirmed)",
+                "type": "bar",
+                "axis": "left",
+                "points": [[week, resolved_by_week.get(week, 0)] for week in week_columns],
+            },
+        ],
+        "summary": summary_rows,
+        "rows": branch_rows,
+        "meta": meta,
+    }
+
+
 def get_issue_filtered_weekly_case_rates(
     engine: Engine,
     filters: CommonFilters,
@@ -409,6 +523,203 @@ def get_issue_filtered_weekly_case_rates(
             "summary": summary_rows,
             "meta": meta,
         },
+        "meta": meta,
+    }
+
+
+def get_issue_lifecycle_snapshot(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    effective_repo = filters.repo or DEFAULT_DISTINCT_CASE_REPO
+    latest_full_week_start = _latest_complete_week_start(filters.end_date)
+    latest_full_week_end = (
+        latest_full_week_start + timedelta(days=6)
+        if latest_full_week_start is not None
+        else None
+    )
+
+    with engine.begin() as connection:
+        issue_rows = _fetch_issue_latest_rows(connection, filters, effective_repo)
+
+    scoped_issue_rows = [
+        row
+        for row in issue_rows
+        if _issue_overlaps_window(
+            row,
+            start_date=filters.start_date,
+            end_date=filters.end_date,
+        )
+    ]
+
+    week_start_dt = (
+        datetime.combine(latest_full_week_start, datetime.min.time())
+        if latest_full_week_start is not None
+        else None
+    )
+    week_end_exclusive_dt = (
+        week_start_dt + timedelta(days=7) if week_start_dt is not None else None
+    )
+
+    created_this_week = [
+        row
+        for row in scoped_issue_rows
+        if week_start_dt is not None
+        and _parse_datetime_value(row.get("issue_created_at")) is not None
+        and week_start_dt
+        <= _parse_datetime_value(row.get("issue_created_at"))
+        < week_end_exclusive_dt
+    ]
+    closed_this_week = [
+        row
+        for row in scoped_issue_rows
+        if week_start_dt is not None
+        and _parse_datetime_value(row.get("issue_closed_at")) is not None
+        and week_start_dt
+        <= _parse_datetime_value(row.get("issue_closed_at"))
+        < week_end_exclusive_dt
+    ]
+    reopened_this_week = [
+        row
+        for row in scoped_issue_rows
+        if int(row.get("reopen_count") or 0) > 0
+        and week_start_dt is not None
+        and _parse_datetime_value(row.get("last_reopened_at")) is not None
+        and week_start_dt
+        <= _parse_datetime_value(row.get("last_reopened_at"))
+        < week_end_exclusive_dt
+    ]
+
+    meta = filters.meta()
+    meta.update(
+        {
+            "requested_repo": filters.repo,
+            "effective_repo": effective_repo,
+            "defaulted_repo": filters.repo is None,
+            "latest_full_week_start": (
+                latest_full_week_start.isoformat() if latest_full_week_start else None
+            ),
+            "latest_full_week_end": (
+                latest_full_week_end.isoformat() if latest_full_week_end else None
+            ),
+            "ignores_issue_status": True,
+        }
+    )
+
+    return {
+        "meta": meta,
+        "scoped_issue_count": len(scoped_issue_rows),
+        "scoped_open_count": sum(
+            1
+            for row in scoped_issue_rows
+            if str(row.get("issue_status") or "").lower() == "open"
+        ),
+        "scoped_closed_count": sum(
+            1
+            for row in scoped_issue_rows
+            if str(row.get("issue_status") or "").lower() == "closed"
+        ),
+        "latest_week_created_count": len(created_this_week),
+        "latest_week_created_open_count": sum(
+            1
+            for row in created_this_week
+            if str(row.get("issue_status") or "").lower() == "open"
+        ),
+        "latest_week_created_closed_count": sum(
+            1
+            for row in created_this_week
+            if str(row.get("issue_status") or "").lower() == "closed"
+        ),
+        "latest_week_closed_count": len(closed_this_week),
+        "latest_week_reopened_count": len(reopened_this_week),
+    }
+
+
+def get_issue_lifecycle_weekly(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    effective_repo = filters.repo or DEFAULT_DISTINCT_CASE_REPO
+    with engine.begin() as connection:
+        issue_rows = _fetch_issue_latest_rows(connection, filters, effective_repo)
+
+    scoped_issue_rows = [
+        row
+        for row in issue_rows
+        if _issue_overlaps_window(
+            row,
+            start_date=filters.start_date,
+            end_date=filters.end_date,
+        )
+    ]
+
+    weeks = _week_columns(
+        filters.start_date,
+        filters.end_date,
+        [
+            {"week_start": _week_start_iso_from_datetime(_parse_datetime_value(row.get("issue_created_at")))}
+            for row in scoped_issue_rows
+            if _parse_datetime_value(row.get("issue_created_at")) is not None
+        ],
+    )
+    created_by_week = {week: 0 for week in weeks}
+    closed_by_week = {week: 0 for week in weeks}
+    reopened_by_week = {week: 0 for week in weeks}
+
+    for row in scoped_issue_rows:
+        created_at = _parse_datetime_value(row.get("issue_created_at"))
+        if created_at is not None:
+            week = _week_start_iso_from_datetime(created_at)
+            if week in created_by_week:
+                created_by_week[week] += 1
+
+        closed_at = _parse_datetime_value(row.get("issue_closed_at"))
+        if closed_at is not None:
+            week = _week_start_iso_from_datetime(closed_at)
+            if week in closed_by_week:
+                closed_by_week[week] += 1
+
+        reopened_at = _parse_datetime_value(row.get("last_reopened_at"))
+        if int(row.get("reopen_count") or 0) > 0 and reopened_at is not None:
+            week = _week_start_iso_from_datetime(reopened_at)
+            if week in reopened_by_week:
+                reopened_by_week[week] += 1
+
+    meta = filters.meta()
+    meta.update(
+        {
+            "requested_repo": filters.repo,
+            "effective_repo": effective_repo,
+            "defaulted_repo": filters.repo is None,
+            "bucket_granularity": "week",
+            "ignores_issue_status": True,
+        }
+    )
+    return {
+        "weeks": weeks,
+        "series": [
+            {
+                "key": "issue_created_count",
+                "label": "Created issues",
+                "type": "bar",
+                "axis": "left",
+                "points": [[week, created_by_week.get(week, 0)] for week in weeks],
+            },
+            {
+                "key": "issue_closed_count",
+                "label": "Closed issues",
+                "type": "bar",
+                "axis": "left",
+                "points": [[week, closed_by_week.get(week, 0)] for week in weeks],
+            },
+            {
+                "key": "issue_reopened_count",
+                "label": "Reopened issues",
+                "type": "bar",
+                "axis": "left",
+                "points": [[week, reopened_by_week.get(week, 0)] for week in weeks],
+            },
+        ],
         "meta": meta,
     }
 
@@ -691,9 +1002,95 @@ def _fetch_issue_weekly_rate_rows(
     return [dict(row) for row in rows]
 
 
+def _fetch_weekly_flaky_case_presence(
+    connection: Connection,
+    filters: CommonFilters,
+    effective_repo: str,
+) -> list[dict[str, Any]]:
+    rows = connection.execute(
+        text(
+            f"""
+            WITH target_prs AS (
+              SELECT DISTINCT repo, pr_number, target_branch
+              FROM ci_l1_pr_events
+              WHERE repo = :repo
+                AND pr_number IS NOT NULL
+                AND target_branch IS NOT NULL
+                AND target_branch <> ''
+                {_optional_clause(filters.branch, "AND target_branch = :branch")}
+            ),
+            build_scope AS (
+              SELECT DISTINCT
+                p.target_branch AS branch,
+                {bucket_expr(connection, "b.start_time", "week")} AS week_start,
+                b.start_time,
+                b.normalized_build_key,
+                UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) AS cloud_phase
+              FROM ci_l1_builds b
+              JOIN target_prs p
+                ON p.repo = b.repo_full_name
+               AND p.pr_number = b.pr_number
+              WHERE b.repo_full_name = :repo
+                AND b.pr_number IS NOT NULL
+                AND b.normalized_build_key IS NOT NULL
+                {_optional_clause(filters.job_name, "AND b.job_name = :job_name")}
+                {_optional_clause(filters.cloud_phase, "AND UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) = :cloud_phase")}
+                {_optional_clause(filters.start_date, "AND b.start_time >= :start_time_from")}
+                {_optional_clause(filters.end_date, "AND b.start_time < :start_time_to")}
+            ),
+            case_runs_raw AS (
+              SELECT
+                pcr.branch,
+                pcr.case_name,
+                {_normalize_case_build_key_expr(connection, "pcr.build_url")} AS build_key,
+                {_case_cloud_phase_expr("pcr.build_url")} AS cloud_phase,
+                pcr.report_time,
+                CASE WHEN pcr.flaky = 1 THEN 1 ELSE 0 END AS flaky_flag
+              FROM problem_case_runs pcr
+              WHERE pcr.repo = :repo
+                AND pcr.branch IS NOT NULL
+                AND pcr.branch <> ''
+                AND pcr.case_name IS NOT NULL
+                AND pcr.case_name <> ''
+                {_optional_clause(filters.branch, "AND pcr.branch = :branch")}
+                {_optional_clause(filters.start_date, "AND pcr.report_time >= :case_report_time_from")}
+                {_optional_clause(filters.end_date, "AND pcr.report_time < :case_report_time_to")}
+            ),
+            case_runs AS (
+              SELECT
+                branch,
+                case_name,
+                build_key,
+                cloud_phase,
+                report_time,
+                MAX(flaky_flag) AS flaky_flag
+              FROM case_runs_raw
+              GROUP BY branch, case_name, build_key, cloud_phase, report_time
+            )
+            SELECT DISTINCT
+              bs.branch,
+              bs.week_start,
+              cr.case_name
+            FROM build_scope bs
+            JOIN case_runs cr
+              ON cr.build_key = bs.normalized_build_key
+             AND cr.branch = bs.branch
+             AND cr.cloud_phase = bs.cloud_phase
+             AND {_case_build_time_match_expr(connection, "cr.report_time", "bs.start_time")}
+            WHERE cr.flaky_flag = 1
+            ORDER BY bs.branch, cr.case_name, bs.week_start
+            """
+        ),
+        _distinct_case_params(filters, effective_repo),
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
 def _build_issue_scope_ctes(
     filters: CommonFilters,
     effective_repo: str,
+    *,
+    include_issue_status: bool = True,
 ) -> tuple[str, dict[str, Any]]:
     conditions = [
         "fi.repo = :repo",
@@ -709,7 +1106,7 @@ def _build_issue_scope_ctes(
         conditions.append("fi.issue_branch IS NOT NULL")
         conditions.append("fi.issue_branch <> ''")
 
-    if filters.issue_status:
+    if include_issue_status and filters.issue_status:
         conditions.append("LOWER(fi.issue_status) = :issue_status")
         params["issue_status"] = filters.issue_status.lower()
 
@@ -763,6 +1160,113 @@ def _build_issue_scope_ctes(
         )
     """
     return ctes, params
+
+
+def _fetch_issue_latest_rows(
+    connection: Connection,
+    filters: CommonFilters,
+    effective_repo: str,
+) -> list[dict[str, Any]]:
+    conditions = [
+        "fi.repo = :repo",
+        "fi.issue_number IS NOT NULL",
+    ]
+    params: dict[str, Any] = {"repo": effective_repo}
+
+    if filters.branch:
+        conditions.append("fi.issue_branch = :branch")
+        params["branch"] = filters.branch
+    else:
+        conditions.append("fi.issue_branch IS NOT NULL")
+        conditions.append("fi.issue_branch <> ''")
+
+    rows = connection.execute(
+        text(
+            f"""
+            WITH ranked_issues AS (
+              SELECT
+                fi.*,
+                ROW_NUMBER() OVER (
+                  PARTITION BY fi.repo, fi.issue_number
+                  ORDER BY fi.issue_updated_at DESC, fi.updated_at DESC, fi.id DESC
+                ) AS rn
+              FROM ci_l1_flaky_issues fi
+              WHERE {' AND '.join(conditions)}
+            )
+            SELECT
+              repo,
+              issue_number,
+              issue_status,
+              issue_branch,
+              issue_created_at,
+              issue_closed_at,
+              last_reopened_at,
+              reopen_count
+            FROM ranked_issues
+            WHERE rn = 1
+            """
+        ),
+        params,
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
+def _latest_complete_week_start(end_date: date | None) -> date | None:
+    if end_date is None:
+        return None
+    week_start = end_date - timedelta(days=end_date.weekday())
+    if end_date >= week_start + timedelta(days=6):
+        return week_start
+    return week_start - timedelta(days=7)
+
+
+def _parse_datetime_value(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    raw = str(value).strip()
+    if raw == "":
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).replace(tzinfo=None)
+    except ValueError:
+        return None
+
+
+def _week_start_iso_from_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    week_start = value.date() - timedelta(days=value.date().weekday())
+    return week_start.isoformat()
+
+
+def _issue_overlaps_window(
+    row: dict[str, Any],
+    *,
+    start_date: date | None,
+    end_date: date | None,
+) -> bool:
+    created_at = _parse_datetime_value(row.get("issue_created_at"))
+    if created_at is None:
+        return False
+
+    start_dt = datetime.combine(start_date, datetime.min.time()) if start_date else None
+    end_exclusive_dt = (
+        datetime.combine(end_date + timedelta(days=1), datetime.min.time())
+        if end_date
+        else None
+    )
+    closed_at = _parse_datetime_value(row.get("issue_closed_at"))
+    status = str(row.get("issue_status") or "").lower()
+
+    if end_exclusive_dt and created_at >= end_exclusive_dt:
+        return False
+    if start_dt:
+        if status != "closed" or closed_at is None:
+            return True
+        return closed_at >= start_dt
+    return True
 
 
 def _build_build_where(

--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -24,6 +24,8 @@ from ci_dashboard.api.queries.filters import list_repos
 from ci_dashboard.api.queries.flaky import (
     get_distinct_flaky_case_counts_by_branch,
     get_flaky_composition,
+    get_issue_lifecycle_snapshot,
+    get_issue_lifecycle_weekly,
     get_flaky_period_comparison,
     get_flaky_top_jobs,
     get_flaky_trend,
@@ -91,10 +93,22 @@ def get_build_trend_page(engine: Engine, filters: CommonFilters) -> dict[str, An
 def get_flaky_page(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     previous_start, previous_end = _get_previous_date_range(filters)
     build_scope_filters = filters.without_issue_status()
+    build_scope_filters_weekly = CommonFilters(
+        repo=build_scope_filters.repo,
+        branch=build_scope_filters.branch,
+        job_name=build_scope_filters.job_name,
+        cloud_phase=build_scope_filters.cloud_phase,
+        issue_status=None,
+        start_date=build_scope_filters.start_date,
+        end_date=build_scope_filters.end_date,
+        granularity="week",
+    )
     issue_case_rates = get_issue_filtered_weekly_case_rates(engine, filters)
     return {
         "scope": filters.meta(),
         "distinct_flaky_case_counts": get_distinct_flaky_case_counts_by_branch(engine, filters),
+        "issue_lifecycle": get_issue_lifecycle_snapshot(engine, filters),
+        "issue_lifecycle_weekly": get_issue_lifecycle_weekly(engine, filters),
         "issue_case_weekly_rates": {
             "weeks": issue_case_rates["weeks"],
             "rows": issue_case_rates["rows"],
@@ -102,7 +116,7 @@ def get_flaky_page(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
         },
         "issue_filtered_weekly_trend": issue_case_rates["trend"],
         "trend": get_flaky_trend(engine, build_scope_filters),
-        "composition": get_flaky_composition(engine, build_scope_filters),
+        "composition": get_flaky_composition(engine, build_scope_filters_weekly),
         "top_jobs": get_flaky_top_jobs(engine, build_scope_filters, limit=8),
         "failure_category_share": get_failure_category_share(engine, build_scope_filters),
         "failure_category_trend": get_failure_category_trend(engine, build_scope_filters),

--- a/ci-dashboard/src/ci_dashboard/api/routes/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/flaky.py
@@ -8,6 +8,7 @@ from sqlalchemy.engine import Engine
 from ci_dashboard.api.dependencies import get_engine
 from ci_dashboard.api.queries.base import CommonFilters, MAX_RANKING_LIMIT
 from ci_dashboard.api.queries.flaky import (
+    get_flaky_case_flow_v2,
     get_distinct_flaky_case_counts_by_branch,
     get_flaky_composition,
     get_flaky_period_comparison,
@@ -43,6 +44,14 @@ def distinct_flaky_case_counts(
     engine: Engine = Depends(get_engine),
 ) -> dict[str, object]:
     return get_distinct_flaky_case_counts_by_branch(engine, filters)
+
+
+@router.get("/case-flow-v2")
+def flaky_case_flow_v2(
+    filters: CommonFilters = Depends(get_common_filters),
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return get_flaky_case_flow_v2(engine, filters)
 
 
 @router.get("/issue-weekly-rates")

--- a/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
@@ -247,7 +247,7 @@ def _get_build_ids_in_time_window(
             SELECT id
             FROM ci_l1_builds
             WHERE start_time >= :start_time_from
-            ORDER BY id
+            ORDER BY start_time, id
             """
         )
         params = {"start_time_from": start_time_from}
@@ -258,7 +258,7 @@ def _get_build_ids_in_time_window(
             FROM ci_l1_builds
             WHERE start_time >= :start_time_from
               AND start_time < :start_time_to
-            ORDER BY id
+            ORDER BY start_time, id
             """
         )
         params = {
@@ -475,6 +475,7 @@ def _phase_a_branch_enrichment(
             FROM ci_l1_builds
             WHERE is_pr_build = 1
               AND pr_number IS NOT NULL
+              AND (target_branch IS NULL OR target_branch = '')
               AND {_build_in_filter(impacted_build_ids, "build_id")}
             """
         ),
@@ -606,8 +607,30 @@ def _phase_c_case_evidence(
     matched_rows = connection.execute(_case_match_query(connection, impacted_build_ids), params).mappings()
     matched_build_ids = {int(row["id"]) for row in matched_rows}
 
-    reset_payload = [{"id": build_id, "has_flaky_case_match": 0} for build_id in impacted_build_ids]
-    if reset_payload:
+    current_rows = connection.execute(
+        text(
+            f"""
+            SELECT id, has_flaky_case_match
+            FROM ci_l1_builds
+            WHERE {_build_in_filter(impacted_build_ids, "current_id")}
+            """
+        ),
+        _build_id_params(impacted_build_ids, "current_id"),
+    ).mappings()
+    current_values = {
+        int(row["id"]): int(row["has_flaky_case_match"] or 0)
+        for row in current_rows
+    }
+
+    update_payload = []
+    for build_id in impacted_build_ids:
+        desired_value = 1 if build_id in matched_build_ids else 0
+        current_value = current_values.get(build_id, 0)
+        if current_value == desired_value:
+            continue
+        update_payload.append({"id": build_id, "has_flaky_case_match": desired_value})
+
+    if update_payload:
         _execute_statement_in_batches(
             connection,
             text(
@@ -617,30 +640,12 @@ def _phase_c_case_evidence(
                 WHERE id = :id
                 """
             ),
-            reset_payload,
+            update_payload,
             batch_size=write_batch_size,
         )
 
-    match_payload = [
-        {"id": build_id, "has_flaky_case_match": 1}
-        for build_id in sorted(matched_build_ids)
-    ]
-    if match_payload:
-        _execute_statement_in_batches(
-            connection,
-            text(
-                """
-                UPDATE ci_l1_builds
-                SET has_flaky_case_match = :has_flaky_case_match
-                WHERE id = :id
-                """
-            ),
-            match_payload,
-            batch_size=write_batch_size,
-        )
-
-    LOG.info("case evidence updated %s matched rows", len(match_payload))
-    return len(match_payload)
+    LOG.info("case evidence updated %s rows", len(update_payload))
+    return len(update_payload)
 
 
 def _phase_d_failure_category(

--- a/ci-dashboard/src/ci_dashboard/jobs/sync_builds.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/sync_builds.py
@@ -347,6 +347,8 @@ def _required(mapping: Mapping[str, Any], *keys: str) -> Any:
 
 def _get_first(mapping: Mapping[str, Any], *keys: str) -> Any:
     for key in keys:
+        if not isinstance(key, str):
+            continue
         if key in mapping:
             return mapping[key]
     return None

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -819,6 +819,124 @@ def test_flaky_top_jobs_and_period_comparison(api_client: TestClient) -> None:
     }
 
 
+def test_flaky_case_flow_v2_two_week_confirmation(sqlite_engine, api_client: TestClient) -> None:
+    weeks = [
+        "2026-03-02",
+        "2026-03-09",
+        "2026-03-16",
+        "2026-03-23",
+        "2026-03-30",
+    ]
+    build_keys = [
+        "/jenkins/job/pingcap/job/tidb/job/job-v2-flow/1001",
+        "/jenkins/job/pingcap/job/tidb/job/job-v2-flow/1002",
+        "/jenkins/job/pingcap/job/tidb/job/job-v2-flow/1003",
+        "/jenkins/job/pingcap/job/tidb/job/job-v2-flow/1004",
+        "/jenkins/job/pingcap/job/tidb/job/job-v2-flow/1005",
+    ]
+
+    for index, week in enumerate(weeks, start=1):
+        _insert_build(
+            sqlite_engine,
+            source_prow_row_id=2000 + index,
+            source_prow_job_id=f"v2-flow-{index}",
+            repo_full_name="pingcap/tidb",
+            target_branch="release-v2-test",
+            base_ref="release-v2-test",
+            job_name="job-v2-flow",
+            state="failure",
+            cloud_phase="GCP",
+            is_flaky=0,
+            is_retry_loop=0,
+            failure_category=None,
+            start_time=f"{week} 08:00:00",
+            pr_number=8800 + index,
+            normalized_build_key=build_keys[index - 1],
+            build_id=f"build-v2-{index}",
+        )
+        _insert_pr_event(
+            sqlite_engine,
+            repo="pingcap/tidb",
+            pr_number=8800 + index,
+            target_branch="release-v2-test",
+            event_key=f"v2-pr-{index}",
+            event_time=f"{week} 07:55:00",
+        )
+
+    # Case A: present in week1 + week2 -> "new" confirmed at week2.
+    _insert_problem_case_run(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        branch="release-v2-test",
+        case_name="CaseA",
+        build_url=f"https://prow.tidb.net{build_keys[0]}",
+        flaky=1,
+        report_time="2026-03-02 08:10:00",
+    )
+    _insert_problem_case_run(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        branch="release-v2-test",
+        case_name="CaseA",
+        build_url=f"https://prow.tidb.net{build_keys[1]}",
+        flaky=1,
+        report_time="2026-03-09 08:10:00",
+    )
+
+    # Case C: present in week2 + week3 then absent in week4 + week5 -> "resolved" at week5.
+    _insert_problem_case_run(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        branch="release-v2-test",
+        case_name="CaseC",
+        build_url=f"https://prow.tidb.net{build_keys[1]}",
+        flaky=1,
+        report_time="2026-03-09 08:11:00",
+    )
+    _insert_problem_case_run(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        branch="release-v2-test",
+        case_name="CaseC",
+        build_url=f"https://prow.tidb.net{build_keys[2]}",
+        flaky=1,
+        report_time="2026-03-16 08:11:00",
+    )
+
+    response = api_client.get(
+        "/api/v1/flaky/case-flow-v2",
+        params={
+            "repo": "pingcap/tidb",
+            "branch": "release-v2-test",
+            "start_date": "2026-03-02",
+            "end_date": "2026-03-30",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["weeks"] == weeks
+
+    series = {item["key"]: item for item in body["series"]}
+    assert series["new_case_count"]["points"] == [
+        ["2026-03-02", 0],
+        ["2026-03-09", 1],
+        ["2026-03-16", 1],
+        ["2026-03-23", 0],
+        ["2026-03-30", 0],
+    ]
+    assert series["resolved_case_count"]["points"] == [
+        ["2026-03-02", 0],
+        ["2026-03-09", 0],
+        ["2026-03-16", 0],
+        ["2026-03-23", 1],
+        ["2026-03-30", 1],
+    ]
+
+    summary_by_week = {row["week_start"]: row for row in body["summary"]}
+    assert summary_by_week["2026-03-09"]["net_case_count"] == 1
+    assert summary_by_week["2026-03-30"]["net_case_count"] == -1
+
+
 def test_case_tables_exclude_cross_cloud_and_stale_build_key_collisions(sqlite_engine) -> None:
     _insert_build(
         sqlite_engine,
@@ -1422,3 +1540,71 @@ def test_weekly_series_skip_partial_boundary_weeks(api_client: TestClient) -> No
         ["2026-03-30", 0],
         ["2026-04-06", 1],
     ]
+
+
+def test_flaky_page_issue_lifecycle_snapshot_ignores_issue_status_filter(
+    sqlite_engine,
+    api_client: TestClient,
+) -> None:
+    _insert_flaky_issue(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        issue_number=70001,
+        case_name="LifecycleCaseOne",
+        issue_branch="master",
+        issue_status="open",
+        issue_created_at="2026-04-13 10:00:00",
+    )
+    _insert_flaky_issue(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        issue_number=70002,
+        case_name="LifecycleCaseTwo",
+        issue_branch="master",
+        issue_status="closed",
+        issue_created_at="2026-04-14 10:00:00",
+        issue_closed_at="2026-04-16 11:00:00",
+    )
+    _insert_flaky_issue(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        issue_number=70003,
+        case_name="LifecycleCaseThree",
+        issue_branch="master",
+        issue_status="open",
+        issue_created_at="2026-04-01 10:00:00",
+        last_reopened_at="2026-04-17 09:00:00",
+        reopen_count=1,
+    )
+
+    response = api_client.get(
+        "/api/v1/pages/flaky",
+        params={
+            "repo": "pingcap/tidb",
+            "branch": "master",
+            "issue_status": "open",
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-20",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    lifecycle = body["issue_lifecycle"]
+    assert lifecycle["meta"]["latest_full_week_start"] == "2026-04-13"
+    assert lifecycle["meta"]["latest_full_week_end"] == "2026-04-19"
+    assert lifecycle["meta"]["ignores_issue_status"] is True
+    assert lifecycle["latest_week_created_count"] == 2
+    assert lifecycle["latest_week_created_open_count"] == 1
+    assert lifecycle["latest_week_created_closed_count"] == 1
+    assert lifecycle["latest_week_closed_count"] == 1
+    assert lifecycle["latest_week_reopened_count"] == 1
+
+    weekly_series = {item["key"]: item["points"] for item in body["issue_lifecycle_weekly"]["series"]}
+    created_by_week = {week: count for week, count in weekly_series["issue_created_count"]}
+    closed_by_week = {week: count for week, count in weekly_series["issue_closed_count"]}
+    reopened_by_week = {week: count for week, count in weekly_series["issue_reopened_count"]}
+
+    assert created_by_week["2026-03-30"] >= 1
+    assert created_by_week["2026-04-13"] >= 2
+    assert closed_by_week["2026-04-13"] >= 1
+    assert reopened_by_week["2026-04-13"] >= 1

--- a/ci-dashboard/tests/jobs/test_cli.py
+++ b/ci-dashboard/tests/jobs/test_cli.py
@@ -29,7 +29,7 @@ def _settings() -> Settings:
 def test_cli_sync_builds_dispatch(monkeypatch) -> None:
     called: dict[str, object] = {}
 
-    monkeypatch.setattr(cli, "get_settings", lambda: _settings())
+    monkeypatch.setattr(cli, "get_settings", _settings)
     monkeypatch.setattr(cli, "build_engine", lambda settings: "engine")
     monkeypatch.setattr(
         cli,
@@ -46,7 +46,7 @@ def test_cli_sync_builds_dispatch(monkeypatch) -> None:
 
 def test_cli_sync_pr_events_dispatch(monkeypatch) -> None:
     called: dict[str, object] = {}
-    monkeypatch.setattr(cli, "get_settings", lambda: _settings())
+    monkeypatch.setattr(cli, "get_settings", _settings)
     monkeypatch.setattr(cli, "build_engine", lambda settings: called.setdefault("engine", "engine"))
     monkeypatch.setattr(cli, "configure_logging", lambda level: None)
     monkeypatch.setattr(
@@ -63,7 +63,7 @@ def test_cli_sync_pr_events_dispatch(monkeypatch) -> None:
 
 def test_cli_sync_flaky_issues_dispatch(monkeypatch) -> None:
     called: dict[str, object] = {}
-    monkeypatch.setattr(cli, "get_settings", lambda: _settings())
+    monkeypatch.setattr(cli, "get_settings", _settings)
     monkeypatch.setattr(cli, "build_engine", lambda settings: called.setdefault("engine", "engine"))
     monkeypatch.setattr(cli, "configure_logging", lambda level: None)
     monkeypatch.setattr(
@@ -83,7 +83,7 @@ def test_cli_sync_flaky_issues_dispatch(monkeypatch) -> None:
 
 def test_cli_refresh_build_derived_dispatch(monkeypatch) -> None:
     called: dict[str, object] = {}
-    monkeypatch.setattr(cli, "get_settings", lambda: _settings())
+    monkeypatch.setattr(cli, "get_settings", _settings)
     monkeypatch.setattr(cli, "build_engine", lambda settings: called.setdefault("engine", "engine"))
     monkeypatch.setattr(cli, "configure_logging", lambda level: None)
     monkeypatch.setattr(
@@ -103,7 +103,7 @@ def test_cli_refresh_build_derived_dispatch(monkeypatch) -> None:
 
 def test_cli_refresh_build_derived_range_dispatch(monkeypatch) -> None:
     called: dict[str, object] = {}
-    monkeypatch.setattr(cli, "get_settings", lambda: _settings())
+    monkeypatch.setattr(cli, "get_settings", _settings)
     monkeypatch.setattr(cli, "build_engine", lambda settings: called.setdefault("engine", "engine"))
     monkeypatch.setattr(cli, "configure_logging", lambda level: None)
     monkeypatch.setattr(
@@ -133,7 +133,7 @@ def test_cli_refresh_build_derived_range_dispatch(monkeypatch) -> None:
 
 def test_cli_refresh_flaky_signals_range_dispatch(monkeypatch) -> None:
     called: dict[str, object] = {}
-    monkeypatch.setattr(cli, "get_settings", lambda: _settings())
+    monkeypatch.setattr(cli, "get_settings", _settings)
     monkeypatch.setattr(cli, "build_engine", lambda settings: called.setdefault("engine", "engine"))
     monkeypatch.setattr(cli, "configure_logging", lambda level: None)
     monkeypatch.setattr(
@@ -163,7 +163,7 @@ def test_cli_refresh_flaky_signals_range_dispatch(monkeypatch) -> None:
 
 def test_cli_backfill_range_dispatch(monkeypatch) -> None:
     called: dict[str, object] = {}
-    monkeypatch.setattr(cli, "get_settings", lambda: _settings())
+    monkeypatch.setattr(cli, "get_settings", _settings)
     monkeypatch.setattr(cli, "build_engine", lambda settings: called.setdefault("engine", "engine"))
     monkeypatch.setattr(cli, "configure_logging", lambda level: None)
     monkeypatch.setattr(

--- a/ci-dashboard/tests/jobs/test_sync_builds.py
+++ b/ci-dashboard/tests/jobs/test_sync_builds.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import pytest
 from sqlalchemy import text
 
-import ci_dashboard.jobs.sync_builds as sync_builds_module
 from ci_dashboard.common.config import DatabaseSettings, JobSettings, Settings
 from ci_dashboard.jobs.state_store import get_job_state
 from ci_dashboard.jobs.sync_builds import (
@@ -382,7 +381,7 @@ def test_sync_builds_marks_failure_state_on_fetch_error(sqlite_engine, monkeypat
     def _boom(*_args, **_kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(sync_builds_module, "fetch_source_rows", _boom)
+    monkeypatch.setattr("ci_dashboard.jobs.sync_builds.fetch_source_rows", _boom)
 
     with pytest.raises(RuntimeError, match="boom"):
         run_sync_builds(sqlite_engine, settings)

--- a/ci-dashboard/tests/test_query_base.py
+++ b/ci-dashboard/tests/test_query_base.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from ci_dashboard.api.queries.base import CommonFilters, build_common_where
+
+
+def _insert_build(
+    sqlite_engine,
+    *,
+    source_prow_row_id: int,
+    source_prow_job_id: str,
+    target_branch: str | None,
+    base_ref: str | None,
+) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_builds (
+                  source_prow_row_id, source_prow_job_id, namespace, job_name, job_type, state,
+                  optional, report, org, repo, repo_full_name, base_ref, pr_number, is_pr_build,
+                  context, url, normalized_build_key, author, retest, event_guid, build_id,
+                  pod_name, pending_time, start_time, completion_time, queue_wait_seconds,
+                  run_seconds, total_seconds, head_sha, target_branch, cloud_phase, is_flaky,
+                  is_retry_loop, has_flaky_case_match, failure_category, failure_subcategory
+                ) VALUES (
+                  :source_prow_row_id, :source_prow_job_id, 'prow', 'unit-test', 'presubmit', 'success',
+                  0, 1, 'pingcap', 'tidb', 'pingcap/tidb', :base_ref, 100, 1,
+                  'unit-test', :url, :normalized_build_key, 'alice', 0, 'guid', '1',
+                  NULL, NULL, '2026-04-20T00:00:00Z', '2026-04-20T00:00:00Z', 0,
+                  0, 0, 'sha', :target_branch, 'GCP', 0,
+                  0, 0, NULL, NULL
+                )
+                """
+            ),
+            {
+                "source_prow_row_id": source_prow_row_id,
+                "source_prow_job_id": source_prow_job_id,
+                "base_ref": base_ref,
+                "url": f"https://prow.tidb.net/jenkins/job/{source_prow_job_id}/display/redirect",
+                "normalized_build_key": f"/jenkins/job/{source_prow_job_id}",
+                "target_branch": target_branch,
+            },
+        )
+
+
+def test_build_common_where_branch_match_preserves_target_branch_fallback(sqlite_engine) -> None:
+    _insert_build(
+        sqlite_engine,
+        source_prow_row_id=1,
+        source_prow_job_id="job-target-match",
+        target_branch="master",
+        base_ref="release-8.5",
+    )
+    _insert_build(
+        sqlite_engine,
+        source_prow_row_id=2,
+        source_prow_job_id="job-null-target",
+        target_branch=None,
+        base_ref="master",
+    )
+    _insert_build(
+        sqlite_engine,
+        source_prow_row_id=3,
+        source_prow_job_id="job-empty-target",
+        target_branch="",
+        base_ref="master",
+    )
+    _insert_build(
+        sqlite_engine,
+        source_prow_row_id=4,
+        source_prow_job_id="job-nonmatching-target",
+        target_branch="main",
+        base_ref="master",
+    )
+
+    where_clause, params = build_common_where(
+        CommonFilters(branch="master"),
+        table_alias="b",
+    )
+
+    with sqlite_engine.begin() as connection:
+        matched_job_ids = connection.execute(
+            text(
+                f"""
+                SELECT source_prow_job_id
+                FROM ci_l1_builds b
+                WHERE {where_clause}
+                ORDER BY source_prow_row_id
+                """
+            ),
+            params,
+        ).scalars().all()
+
+    assert matched_job_ids == [
+        "job-target-match",
+        "job-null-target",
+        "job-empty-target",
+    ]
+
+
+def test_build_common_where_skips_branch_predicate_for_empty_branch() -> None:
+    where_clause, params = build_common_where(
+        CommonFilters(branch=""),
+        table_alias="b",
+    )
+
+    assert where_clause == "1=1"
+    assert params == {}

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -37,6 +37,11 @@ const SERIES_COLORS = {
   flaky_rate_pct: "#d1495b",
   retry_loop_rate_pct: "#e9c46a",
   noisy_rate_pct: "#2a9d8f",
+  new_case_count: "#d1495b",
+  resolved_case_count: "#2a9d8f",
+  issue_created_count: "#d1495b",
+  issue_closed_count: "#2a9d8f",
+  issue_reopened_count: "#e9c46a",
   total_failure_like_count: "#264653",
   issue_filtered_flaky_rate_pct: "#0f7c82",
   FLAKY_TEST: "#d1495b",
@@ -114,6 +119,15 @@ export function TrendChart({
   rightYMax = null,
   bucketAnnotations = null,
   height = 280,
+  compactY = false,
+  stackBars = false,
+  yTickMode = "default",
+  axisLabelSize = 11,
+  bottomLabelSize = 11,
+  annotationLabelSize = 10,
+  barGroupWidthFactor = 0.66,
+  barMaxWidth = 46,
+  leftPadding = 52,
 }) {
   if (!series?.length) {
     return <EmptyState message="No chart data for the current filters." />;
@@ -135,13 +149,35 @@ export function TrendChart({
   );
   const leftSeries = series.filter((item) => item.axis !== "right");
   const rightSeries = series.filter((item) => item.axis === "right");
-  const leftValues = leftSeries.flatMap((item) =>
+  const leftLineSeries = leftSeries.filter((item) => item.type !== "bar");
+  const leftBarSeries = leftSeries.filter((item) => item.type === "bar");
+  const leftLineValues = leftLineSeries.flatMap((item) =>
     labels.map((label) => pointMaps.get(item.key)?.get(label) ?? 0),
   );
+  const leftBarValues = stackBars
+    ? labels.map((label) =>
+        leftBarSeries.reduce(
+          (sum, item) => sum + (pointMaps.get(item.key)?.get(label) ?? 0),
+          0,
+        ),
+      )
+    : leftBarSeries.flatMap((item) =>
+        labels.map((label) => pointMaps.get(item.key)?.get(label) ?? 0),
+      );
+  const leftValues = [...leftLineValues, ...leftBarValues];
   const rightValues = rightSeries.flatMap((item) =>
     labels.map((label) => pointMaps.get(item.key)?.get(label) ?? 0),
   );
-  const leftMaxValue = yMax ?? Math.max(...leftValues, 1);
+  const rawLeftMaxValue = yMax ?? Math.max(...leftValues, 1);
+  let leftMaxValue = rawLeftMaxValue;
+  let leftTickValues = [0, leftMaxValue * 0.25, leftMaxValue * 0.5, leftMaxValue * 0.75, leftMaxValue];
+  if (yTickMode === "thousands-rounded") {
+    const segments = 4;
+    const rawStep = rawLeftMaxValue / segments;
+    const step = Math.max(1000, Math.round(rawStep / 1000) * 1000);
+    leftMaxValue = step * segments;
+    leftTickValues = Array.from({ length: segments + 1 }, (_, index) => index * step);
+  }
   const resolvedRightYMax = rightYMax ?? Math.max(...rightValues, 1);
   const maxBottomLabels = 8;
   const bottomLabelStep =
@@ -153,10 +189,10 @@ export function TrendChart({
     (bucketAnnotations || []).map((annotation) => [annotation.label, annotation.text]),
   );
   const padding = {
-    top: annotationMap.size ? 34 : 20,
+    top: annotationMap.size ? 34 : compactY ? 6 : 20,
     right: hasRightAxis ? 58 : 20,
-    bottom: 42,
-    left: 52,
+    bottom: compactY ? 22 : 42,
+    left: leftPadding,
   };
   const plotWidth = width - padding.left - padding.right;
   const plotHeight = height - padding.top - padding.bottom;
@@ -167,12 +203,11 @@ export function TrendChart({
   return (
     <div className="trend-chart">
       <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Trend chart">
-        {[0, 1, 2, 3, 4].map((grid) => {
-          const ratio = grid / 4;
+        {leftTickValues.map((value) => {
+          const ratio = leftMaxValue > 0 ? value / leftMaxValue : 0;
           const y = padding.top + plotHeight - plotHeight * ratio;
-          const value = leftMaxValue * ratio;
           return (
-            <g key={grid}>
+            <g key={value}>
               <line
                 x1={padding.left}
                 x2={padding.left + plotWidth}
@@ -180,7 +215,13 @@ export function TrendChart({
                 y2={y}
                 className="chart-grid"
               />
-              <text x={padding.left - 8} y={y + 4} textAnchor="end" className="chart-axis-label">
+              <text
+                x={padding.left - 8}
+                y={y + 4}
+                textAnchor="end"
+                className="chart-axis-label"
+                style={{ fontSize: `${axisLabelSize}px` }}
+              >
                 {yFormatter(value)}
               </text>
               {hasRightAxis ? (
@@ -189,6 +230,7 @@ export function TrendChart({
                   y={y + 4}
                   textAnchor="end"
                   className="chart-axis-label"
+                  style={{ fontSize: `${axisLabelSize}px` }}
                 >
                   {rightYFormatter(resolvedRightYMax * ratio)}
                 </text>
@@ -200,13 +242,30 @@ export function TrendChart({
         {barSeries.map((item, seriesIndex) =>
           labels.map((label, index) => {
             const value = pointMaps.get(item.key)?.get(label) ?? 0;
-            const groupWidth = Math.min(46, xStep * 0.66 || 46);
-            const barWidth = Math.max(groupWidth / Math.max(barSeries.length, 1) - 6, 10);
+            const groupWidth = Math.min(barMaxWidth, xStep * barGroupWidthFactor || barMaxWidth);
+            const stackedSeries = stackBars
+              ? barSeries.filter((candidate) => (candidate.axis || "left") === (item.axis || "left"))
+              : [];
+            const axisSeriesIndex = stackBars
+              ? stackedSeries.findIndex((candidate) => candidate.key === item.key)
+              : seriesIndex;
+            const barWidth = stackBars
+              ? Math.max(groupWidth - 4, 10)
+              : Math.max(groupWidth / Math.max(barSeries.length, 1) - 6, 10);
             const groupStart = padding.left + index * xStep - groupWidth / 2;
-            const x = groupStart + seriesIndex * (barWidth + 6);
+            const x = stackBars
+              ? padding.left + index * xStep - barWidth / 2
+              : groupStart + seriesIndex * (barWidth + 6);
             const axisMax = item.axis === "right" ? resolvedRightYMax : leftMaxValue;
-            const barHeight = (value / axisMax) * plotHeight;
-            const y = padding.top + plotHeight - barHeight;
+            const baseValue = stackBars
+              ? stackedSeries
+                  .slice(0, Math.max(axisSeriesIndex, 0))
+                  .reduce((sum, candidate) => sum + (pointMaps.get(candidate.key)?.get(label) ?? 0), 0)
+              : 0;
+            const barHeight = axisMax > 0 ? (value / axisMax) * plotHeight : 0;
+            const y = stackBars
+              ? padding.top + plotHeight - ((baseValue + value) / axisMax) * plotHeight
+              : padding.top + plotHeight - barHeight;
             return (
               <rect
                 key={`${item.key}-${label}`}
@@ -214,7 +273,7 @@ export function TrendChart({
                 y={y}
                 width={barWidth}
                 height={barHeight}
-                rx={6}
+                rx={stackBars ? 2 : 6}
                 fill={seriesColor(item.key)}
                 opacity="0.78"
               />
@@ -284,6 +343,7 @@ export function TrendChart({
               x={x}
               y={annotationY}
               className="chart-axis-label chart-axis-label--annotation"
+              style={{ fontSize: `${annotationLabelSize}px` }}
             >
               {annotation}
             </text>
@@ -291,14 +351,23 @@ export function TrendChart({
         })}
 
         {labels.map((label, index) => {
+          const isFirstLabel = index === 0;
           const isLastLabel = index === labels.length - 1;
           const shouldShowLabel = isLastLabel || index % bottomLabelStep === 0;
           if (!shouldShowLabel) {
             return null;
           }
           const x = padding.left + index * xStep;
+          const textAnchor = isLastLabel ? "end" : isFirstLabel ? "start" : "middle";
           return (
-            <text key={label} x={x} y={height - 14} className="chart-axis-label chart-axis-label--bottom">
+            <text
+              key={label}
+              x={x}
+              y={height - 14}
+              textAnchor={textAnchor}
+              className="chart-axis-label chart-axis-label--bottom"
+              style={{ fontSize: `${bottomLabelSize}px` }}
+            >
               {label}
             </text>
           );

--- a/ci-dashboard/web/src/components/layout.jsx
+++ b/ci-dashboard/web/src/components/layout.jsx
@@ -12,9 +12,8 @@ export function DashboardLayout({
     <div className="app-shell">
       <aside className="sidebar">
         <div className="brand-mark">
-          <span className="brand-mark__eyebrow">CI Metrics</span>
-          <h1>Dashboard Studio</h1>
-          <p>Build health, flaky patterns, and drift across repos and clouds.</p>
+          <h1>CI Dashboard</h1>
+          <p>Build health, flaky patterns, and migration status,</p>
         </div>
 
         <nav className="sidebar-nav" aria-label="Primary">

--- a/ci-dashboard/web/src/lib/api.js
+++ b/ci-dashboard/web/src/lib/api.js
@@ -157,6 +157,17 @@ export function formatCompact(value) {
   }).format(value || 0);
 }
 
+export function formatRoundedThousands(value) {
+  const numeric = Number(value || 0);
+  if (numeric === 0) {
+    return "0";
+  }
+  if (Math.abs(numeric) >= 1000) {
+    return `${Math.round(numeric / 1000)}K`;
+  }
+  return formatNumber(numeric);
+}
+
 export function formatPercent(value) {
   return `${Number(value || 0).toFixed(1)}%`;
 }

--- a/ci-dashboard/web/src/pages/BuildTrendPage.jsx
+++ b/ci-dashboard/web/src/pages/BuildTrendPage.jsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react";
 
 import {
   formatCompact,
+  formatDelta,
   formatPercent,
+  formatRoundedThousands,
   formatSeconds,
   sumSeriesPoints,
   useApiData,
@@ -30,6 +32,18 @@ export default function BuildTrendPage({ filters }) {
   const avgQueue = Number(durationSummary.queue_avg_s || 0);
   const avgRun = Number(durationSummary.run_avg_s || 0);
   const avgTotal = Number(durationSummary.total_avg_s || 0);
+  const successRateDelta = computeSeriesDelta(
+    page.data?.outcome_trend?.series,
+    "success_rate_pct",
+  );
+  const queueDeltaSeconds = computeSeriesDelta(
+    page.data?.duration_trend?.series,
+    "queue_avg_s",
+  );
+  const totalDeltaSeconds = computeSeriesDelta(
+    page.data?.duration_trend?.series,
+    "total_avg_s",
+  );
   const cloudPostureAnnotations = buildCloudPostureAnnotations(page.data?.cloud_posture_trend?.series);
   const cloudRepoShare = page.data?.cloud_repo_share?.clouds || [];
   const gcpRepoShare = limitRepoShareItems(
@@ -73,18 +87,21 @@ export default function BuildTrendPage({ filters }) {
           value={formatPercent(successRate)}
           detail="Counted from build outcomes in the current view"
           tone="teal"
+          delta={successRateDelta == null ? null : formatDelta(successRateDelta + 0, 0, "%")}
         />
         <StatCard
           label="Success avg queue wait"
           value={formatSeconds(avgQueue)}
           detail={`Success avg run time ${formatSeconds(avgRun)}`}
           tone="amber"
+          delta={queueDeltaSeconds == null ? null : formatDelta(queueDeltaSeconds + 0, 0, "s")}
         />
         <StatCard
           label="Success avg total duration"
           value={formatSeconds(avgTotal)}
           detail="Simple average across successful builds"
           tone="default"
+          delta={totalDeltaSeconds == null ? null : formatDelta(totalDeltaSeconds + 0, 0, "s")}
         />
       </section>
 
@@ -114,14 +131,23 @@ export default function BuildTrendPage({ filters }) {
 
       <Panel
         title="Migration status"
-        subtitle="Weekly build counts on IDC versus GCP, with each week labeled by GCP as a share of total builds."
+        subtitle="Weekly build counts on IDC versus GCP. The value shown above each bar is GCP build count % of total builds in that week."
         loading={page.loading}
         error={page.error}
       >
         <TrendChart
           series={page.data?.cloud_posture_trend?.series}
+          yFormatter={formatRoundedThousands}
           bucketAnnotations={cloudPostureAnnotations}
           height={188}
+          stackBars
+          yTickMode="thousands-rounded"
+          axisLabelSize={9}
+          bottomLabelSize={10}
+          annotationLabelSize={9}
+          barGroupWidthFactor={0.3}
+          barMaxWidth={16}
+          leftPadding={64}
         />
       </Panel>
 
@@ -305,4 +331,14 @@ function limitRepoShareItems(cloudShare, maxItems = 10) {
       },
     ],
   };
+}
+
+function computeSeriesDelta(series, key) {
+  const target = series?.find((item) => item.key === key);
+  if (!target?.points || target.points.length < 2) {
+    return null;
+  }
+  const current = Number(target.points[target.points.length - 1][1] || 0);
+  const previous = Number(target.points[target.points.length - 2][1] || 0);
+  return current - previous;
 }

--- a/ci-dashboard/web/src/pages/FlakyPage.jsx
+++ b/ci-dashboard/web/src/pages/FlakyPage.jsx
@@ -20,12 +20,23 @@ import {
 
 export default function FlakyPage({ filters }) {
   const page = useApiData("/api/v1/pages/flaky", filters);
+  const weeklyFlakyTrend = useApiData("/api/v1/flaky/composition", {
+    repo: filters.repo,
+    branch: filters.branch,
+    job_name: filters.job_name,
+    cloud_phase: filters.cloud_phase,
+    issue_status: "",
+    start_date: filters.start_date,
+    end_date: filters.end_date,
+    granularity: "week",
+  });
   const showPanelActions = !page.loading && !page.error;
   const currentPeriod = page.data?.period_comparison?.groups?.find((group) => group.name === "period_a")?.values;
   const previousPeriod = page.data?.period_comparison?.groups?.find((group) => group.name === "period_b")?.values;
   const distinctRows = page.data?.distinct_flaky_case_counts?.rows || [];
   const issueWeeks = page.data?.issue_case_weekly_rates?.weeks || [];
   const issueRows = page.data?.issue_case_weekly_rates?.rows || [];
+  const issueLifecycle = page.data?.issue_lifecycle || {};
   const latestDistinctTotal = distinctRows.reduce(
     (sum, row) => sum + Number(row.values?.[row.values.length - 1] || 0),
     0,
@@ -41,12 +52,8 @@ export default function FlakyPage({ filters }) {
   const latestIssueWeekLabel = issueWeeks[issueWeeks.length - 1] || "latest bucket";
   const failureLikeBuildCount = Number(currentPeriod?.failure_like_build_count || 0);
   const totalPrCount = Number(currentPeriod?.total_pr_count || 0);
-  const unclassifiedFailureCount = Number(
-    (page.data?.failure_category_share?.groups || []).reduce(
-      (sum, group) => sum + (group.values?.[1] || 0),
-      0,
-    ),
-  );
+  const latestFullWeekLabel = issueLifecycle?.meta?.latest_full_week_start || "latest full week";
+  const latestFullWeekDisplay = `${latestFullWeekLabel} week`;
 
   return (
     <div className="page-stack">
@@ -78,6 +85,19 @@ export default function FlakyPage({ filters }) {
           weeks={page.data?.distinct_flaky_case_counts?.weeks}
           rows={page.data?.distinct_flaky_case_counts?.rows}
           scrollClassName="table-scroll--compact-y"
+        />
+      </Panel>
+
+      <Panel
+        title="Issue lifecycle by week"
+        subtitle="Weekly created, closed, and reopened issue counts in the current repo and branch scope."
+        loading={page.loading}
+        error={page.error}
+      >
+        <TrendChart
+          series={page.data?.issue_lifecycle_weekly?.series}
+          yFormatter={formatNumber}
+          height={220}
         />
       </Panel>
 
@@ -210,38 +230,32 @@ export default function FlakyPage({ filters }) {
           }
         />
         <StatCard
-          label="Unclassified failures"
-          value={formatNumber(unclassifiedFailureCount)}
-          detail="A reminder that V1 keeps taxonomy intentionally conservative"
+          label={`Issues created (${latestFullWeekDisplay})`}
+          value={formatNumber(issueLifecycle.latest_week_created_count || 0)}
+          detail={`${formatNumber(issueLifecycle.scoped_open_count || 0)} open now (current status)`}
+          tone="rose"
+        />
+        <StatCard
+          label={`Issues closed (${latestFullWeekDisplay})`}
+          value={formatNumber(issueLifecycle.latest_week_closed_count || 0)}
+          detail={`${formatNumber(issueLifecycle.latest_week_reopened_count || 0)} reopened this week`}
+          tone="teal"
         />
       </section>
 
       <div className="page-grid page-grid--two-column">
         <Panel
           title="Flaky rate trend"
-          subtitle="Flaky rate as flaky builds divided by failure-like builds, alongside total failure-like volume."
-          loading={page.loading}
-          error={page.error}
-        >
-          <TrendChart
-            series={page.data?.trend?.series}
-            rightYFormatter={formatPercent}
-            rightYMax={100}
-          />
-        </Panel>
-
-        <Panel
-          title="Signal composition"
           subtitle="Flaky, blind-retry-loop, and noisy rates together, each using failure-like builds as the denominator."
-          loading={page.loading}
-          error={page.error}
+          loading={weeklyFlakyTrend.loading}
+          error={weeklyFlakyTrend.error}
         >
-          <TrendChart
-            series={page.data?.composition?.series}
-            rightYFormatter={formatPercent}
-            rightYMax={100}
-          />
-        </Panel>
+        <TrendChart
+          series={weeklyFlakyTrend.data?.series}
+          rightYFormatter={formatPercent}
+          compactY
+        />
+      </Panel>
 
         <Panel
           title="Top noisy jobs"

--- a/ci-dashboard/web/src/styles.css
+++ b/ci-dashboard/web/src/styles.css
@@ -599,10 +599,6 @@ select {
   fill: #6a7f89;
 }
 
-.chart-axis-label--bottom {
-  text-anchor: middle;
-}
-
 .chart-axis-label--annotation {
   text-anchor: middle;
   font-size: 10px;


### PR DESCRIPTION
## Summary
- refine flaky/issue metrics behavior and card semantics
- improve chart rendering, labels, and axis behavior for CI status and flaky panels
- tune migration status chart readability (stacked bars, narrower bars, rounded-thousands y-axis ticks)
- include related backend query/route updates and test updates for the new behavior

## Validation
- PYTHONPATH=src /Users/dillon/workspace/ee-apps-worktrees/ci-dashboard-v1/ci-dashboard/.venv/bin/python -m pytest
- cd web && npm run build
