### PR TITLE
feat(tibuild-v2): support new tidbx hotfix bump tag rules

### DIFF
--- a/experiments/tibuild-v2/internal/service/impl/hotfix_tidbx.go
+++ b/experiments/tibuild-v2/internal/service/impl/hotfix_tidbx.go
@@ -20,6 +20,12 @@ type tidbxGitTagMeta struct {
 	Meta   *hotfix.TiDBxBumpTagMeta `json:"meta,omitempty"`
 }
 
+var (
+	legacyTidbxTagPattern        = regexp.MustCompile(`^v(\d+\.\d+\.\d+)-nextgen\.(\d{6})\.(\d+)$`)
+	alphaTidbxTagPattern         = regexp.MustCompile(`^(v\d+\.\d+\.\d+)-alpha$`)
+	releaseNextgenBranchPattern  = regexp.MustCompile(`^release-nextgen-(\d{4})(\d{2})(?:\d{2})?$`)
+)
+
 // BumpTagForTidbx creates a hot fix git tag for a GitHub repository.
 func (s *hotfixsrvc) BumpTagForTidbx(ctx context.Context, p *hotfix.BumpTagForTidbxPayload) (*hotfix.HotfixTagResult, error) {
 	l := s.logger.With().
@@ -58,7 +64,7 @@ func (s *hotfixsrvc) BumpTagForTidbx(ctx context.Context, p *hotfix.BumpTagForTi
 	l.Info().Msg("Verified commit exists")
 
 	// Step 2: Compute the tag name (and fail if commit already has a tidbx-style tag)
-	tagName, err := s.computeNewTagNameForTidbx(ctx, owner, repo, commitSHA)
+	tagName, err := s.computeNewTagNameForTidbx(ctx, owner, repo, commitSHA, p.Branch)
 	if err != nil {
 		l.Err(err).Msg("Failed to compute tag name")
 		return nil, err
@@ -149,11 +155,9 @@ func (s *hotfixsrvc) QueryTagOfTidbx(ctx context.Context, p *hotfix.QueryTagOfTi
 	return ret, nil
 }
 
-// computeNewTagNameForTidbx computes the next tag name based on existing tags,
+// computeNewTagNameForTidbx computes the next tag name based on existing tags
 // and fails if the provided commit already has a tidbx-style tag.
-// Tags use the new plain semver flow starting at v26.0.0 and fall back to the
-// legacy vX.Y.Z-nextgen.YYYYMM.N pattern for older repositories.
-func (s *hotfixsrvc) computeNewTagNameForTidbx(ctx context.Context, owner, repo, commitSHA string) (string, error) {
+func (s *hotfixsrvc) computeNewTagNameForTidbx(ctx context.Context, owner, repo, commitSHA string, branch *string) (string, error) {
 	// Get all tags from the repository
 	var allTags []*github.RepositoryTag
 	opts := &github.ListOptions{PerPage: 100}
@@ -173,15 +177,21 @@ func (s *hotfixsrvc) computeNewTagNameForTidbx(ctx context.Context, owner, repo,
 		opts.Page = resp.NextPage
 	}
 
-	// Parse and filter both the new >=v26.0.0 semver tags and the legacy nextgen tags.
-	legacyPattern := regexp.MustCompile(`^v(\d+\.\d+\.\d+)-nextgen\.(\d{6})\.(\d+)$`)
+	// Parse and filter three kinds of tags:
+	// 1) new GA tags: vX.Y.Z
+	// 2) new alpha tags: vX.Y.Z-alpha
+	// 3) legacy tags: vX.Y.Z-nextgen.YYYYMM.N
 	var legacyTags []tagInfo
 	var newTags []string
+	var alphaTags []string
 
 	for _, tag := range allTags {
 		name := tag.GetName()
+		baseAlphaTag, isAlphaTag := parseTidbxAlphaTag(name)
 
-		if (legacyPattern.MatchString(name) || isNewTidbxGitTag(name)) &&
+		// Keep "already tagged" guard for GA and legacy tags.
+		// For alpha tags, we allow promotion on the same commit (vX.Y.Z-alpha -> vX.Y.Z).
+		if (legacyTidbxTagPattern.MatchString(name) || isNewTidbxGitTag(name)) &&
 			tag.Commit != nil && tag.Commit.SHA != nil && *tag.Commit.SHA == commitSHA {
 			return "", &hotfix.HTTPError{
 				Code:    http.StatusBadRequest,
@@ -194,7 +204,12 @@ func (s *hotfixsrvc) computeNewTagNameForTidbx(ctx context.Context, owner, repo,
 			continue
 		}
 
-		matches := legacyPattern.FindStringSubmatch(name)
+		if isAlphaTag {
+			alphaTags = append(alphaTags, baseAlphaTag)
+			continue
+		}
+
+		matches := legacyTidbxTagPattern.FindStringSubmatch(name)
 		if len(matches) == 4 {
 			seq, err := strconv.Atoi(matches[3])
 			if err != nil {
@@ -240,40 +255,109 @@ func (s *hotfixsrvc) computeNewTagNameForTidbx(ctx context.Context, owner, repo,
 		return fmt.Sprintf("v%s.%s.%d", parts[0], parts[1], patch+1), nil
 	}
 
-	// If no matching tags exist, we cannot determine the version to use.
-	if len(legacyTags) == 0 {
-		return "", &hotfix.HTTPError{
-			Code:    http.StatusBadRequest,
-			Message: "no existing tags found matching pattern >=v26.0.0 or vX.Y.Z-nextgen.YYYYMM.N, cannot determine version to use",
+	// If there is no GA new-style tag, but there is alpha tag, promote the latest
+	// alpha tag to its first GA tag (vX.Y.Z-alpha -> vX.Y.Z).
+	if len(alphaTags) > 0 {
+		sort.Slice(alphaTags, func(i, j int) bool {
+			return semver.Compare(alphaTags[i], alphaTags[j]) > 0
+		})
+
+		latestAlphaBase := alphaTags[0]
+		latestAlphaTag := latestAlphaBase + "-alpha"
+		comparison, _, err := s.ghClient.Repositories.CompareCommits(ctx, owner, repo, latestAlphaTag, commitSHA, nil)
+		if err != nil {
+			return "", &hotfix.HTTPError{
+				Code:    http.StatusInternalServerError,
+				Message: fmt.Sprintf("failed to compare commits: %v", err),
+			}
+		}
+		if comparison.GetStatus() == "behind" {
+			return "", &hotfix.HTTPError{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("commit %s is behind existing tidbx-style tag %s; cannot create new tag on an outdated commit", commitSHA, latestAlphaTag),
+			}
+		}
+
+		return latestAlphaBase, nil
+	}
+
+	// If only legacy tags exist, keep legacy bump behavior.
+	if len(legacyTags) > 0 {
+		sort.Slice(legacyTags, func(i, j int) bool {
+			if legacyTags[i].yearMonth != legacyTags[j].yearMonth {
+				return legacyTags[i].yearMonth > legacyTags[j].yearMonth
+			}
+			return legacyTags[i].sequence > legacyTags[j].sequence
+		})
+
+		latest := legacyTags[0]
+
+		// Check if the commit is behind the latest existing tidbx-style tag
+		comparison, _, err := s.ghClient.Repositories.CompareCommits(ctx, owner, repo, latest.name, commitSHA, nil)
+		if err != nil {
+			return "", &hotfix.HTTPError{
+				Code:    http.StatusInternalServerError,
+				Message: fmt.Sprintf("failed to compare commits: %v", err),
+			}
+		}
+
+		if comparison.GetStatus() == "behind" {
+			return "", &hotfix.HTTPError{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("commit %s is behind existing tidbx-style tag %s; cannot create new tag on an outdated commit", commitSHA, latest.name),
+			}
+		}
+
+		// Always increment sequence based on the latest tag's month found in the repository.
+		return fmt.Sprintf("v%s-nextgen.%s.%d", latest.version, latest.yearMonth, latest.sequence+1), nil
+	}
+
+	// If there are no tags, and caller provides a release-nextgen branch in new style,
+	// bootstrap the first patch version: vYY.M.0.
+	if branch != nil {
+		if bootstrapTag, ok := buildBootstrapTagFromReleaseBranch(*branch); ok {
+			return bootstrapTag, nil
 		}
 	}
 
-	// Sort tags to find the latest legacy tag.
-	sort.Slice(legacyTags, func(i, j int) bool {
-		if legacyTags[i].yearMonth != legacyTags[j].yearMonth {
-			return legacyTags[i].yearMonth > legacyTags[j].yearMonth
-		}
-		return legacyTags[i].sequence > legacyTags[j].sequence
-	})
+	return "", &hotfix.HTTPError{
+		Code:    http.StatusBadRequest,
+		Message: "no existing tags found matching new-style/legacy patterns, and branch does not match bootstrap rule release-nextgen-YYYYMM[/DD]",
+	}
+}
 
-	latest := legacyTags[0]
+func parseTidbxAlphaTag(tag string) (string, bool) {
+	matches := alphaTidbxTagPattern.FindStringSubmatch(tag)
+	if len(matches) != 2 {
+		return "", false
+	}
+	base := matches[1]
+	if !isNewTidbxGitTag(base) {
+		return "", false
+	}
 
-	// Check if the commit is behind the latest existing tidbx-style tag
-	comparison, _, err := s.ghClient.Repositories.CompareCommits(ctx, owner, repo, latest.name, commitSHA, nil)
+	return base, true
+}
+
+func buildBootstrapTagFromReleaseBranch(branch string) (string, bool) {
+	matches := releaseNextgenBranchPattern.FindStringSubmatch(branch)
+	if len(matches) != 3 {
+		return "", false
+	}
+
+	year, err := strconv.Atoi(matches[1])
 	if err != nil {
-		return "", &hotfix.HTTPError{
-			Code:    http.StatusInternalServerError,
-			Message: fmt.Sprintf("failed to compare commits: %v", err),
-		}
+		return "", false
+	}
+	month, err := strconv.Atoi(matches[2])
+	if err != nil || month < 1 || month > 12 {
+		return "", false
 	}
 
-	if comparison.GetStatus() == "behind" {
-		return "", &hotfix.HTTPError{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("commit %s is behind existing tidbx-style tag %s; cannot create new tag on an outdated commit", commitSHA, latest.name),
-		}
+	shortYear := year % 100
+	if shortYear <= 25 {
+		return "", false
 	}
 
-	// Always increment sequence based on the latest tag's month found in the repository
-	return fmt.Sprintf("v%s-nextgen.%s.%d", latest.version, latest.yearMonth, latest.sequence+1), nil
+	return fmt.Sprintf("v%d.%d.0", shortYear, month), true
 }

--- a/experiments/tibuild-v2/internal/service/impl/hotfix_tidbx_test.go
+++ b/experiments/tibuild-v2/internal/service/impl/hotfix_tidbx_test.go
@@ -132,16 +132,16 @@ func TestComputeNewTagNameForTidbx(t *testing.T) {
 			name: "AlphaPromoteToGA",
 			pages: [][]string{
 				{
-					"v26.4.2-alpha",
+					"v26.4.0-alpha",
 				},
 			},
-			expected: "v26.4.2",
+			expected: "v26.4.0",
 		},
 		{
 			name: "AlphaPromoteToGACommitBehind",
 			pages: [][]string{
 				{
-					"v26.4.2-alpha",
+					"v26.4.2",
 				},
 			},
 			compareStatus: "behind",

--- a/experiments/tibuild-v2/internal/service/impl/hotfix_tidbx_test.go
+++ b/experiments/tibuild-v2/internal/service/impl/hotfix_tidbx_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-github/v69/github"
@@ -25,17 +24,20 @@ func newServiceWithClient(client *github.Client) *hotfixsrvc {
 
 func TestComputeNewTagNameForTidbx(t *testing.T) {
 	type testCase struct {
-		name            string
-		pages           [][]string
-		expected        string
-		taggedCommitSHA string
-		behindCommitSHA string
-		expectErr       bool
-		errCode         int
+		name             string
+		pages            [][]string
+		branch           *string
+		expected         string
+		taggedCommitTag  string
+		compareStatus    string
+		expectErr        bool
+		errCode          int
 	}
 
 	testCommitSHA := "a9814602ed087838d71095efd35bd221ab0bf5a9"
-	behindCommitSHA := "bbbb1234567890abcdef1234567890abcdef1234"
+	bootstrapBranch := "release-nextgen-202604"
+	bootstrapBranchWithDate := "release-nextgen-20260415"
+	invalidBootstrapBranch := "release-nextgen-202512"
 	cases := []testCase{
 		{
 			name: "LastMonthIncrement",
@@ -99,7 +101,7 @@ func TestComputeNewTagNameForTidbx(t *testing.T) {
 					"v8.5.4-nextgen.202510.2",
 				},
 			},
-			taggedCommitSHA: testCommitSHA,
+			taggedCommitTag: "v8.5.4-nextgen.202510.1",
 			expectErr:       true,
 			errCode:         http.StatusBadRequest,
 		},
@@ -111,9 +113,59 @@ func TestComputeNewTagNameForTidbx(t *testing.T) {
 					"v8.5.4-nextgen.202510.2",
 				},
 			},
-			behindCommitSHA: behindCommitSHA,
-			expectErr:       true,
-			errCode:         http.StatusBadRequest,
+			compareStatus: "behind",
+			expectErr:     true,
+			errCode:       http.StatusBadRequest,
+		},
+		{
+			name: "NewStyleBump",
+			pages: [][]string{
+				{
+					"v25.12.9",
+					"v26.4.1",
+					"v26.4.2",
+				},
+			},
+			expected: "v26.4.3",
+		},
+		{
+			name: "AlphaPromoteToGA",
+			pages: [][]string{
+				{
+					"v26.4.2-alpha",
+				},
+			},
+			expected: "v26.4.2",
+		},
+		{
+			name: "AlphaPromoteToGACommitBehind",
+			pages: [][]string{
+				{
+					"v26.4.2-alpha",
+				},
+			},
+			compareStatus: "behind",
+			expectErr:     true,
+			errCode:       http.StatusBadRequest,
+		},
+		{
+			name:     "BootstrapFromReleaseNextgenYYYYMM",
+			pages:    [][]string{{}},
+			branch:   &bootstrapBranch,
+			expected: "v26.4.0",
+		},
+		{
+			name:     "BootstrapFromReleaseNextgenYYYYMMDD",
+			pages:    [][]string{{}},
+			branch:   &bootstrapBranchWithDate,
+			expected: "v26.4.0",
+		},
+		{
+			name:      "BootstrapRejectOldYear",
+			pages:     [][]string{{}},
+			branch:    &invalidBootstrapBranch,
+			expectErr: true,
+			errCode:   http.StatusBadRequest,
 		},
 	}
 
@@ -126,39 +178,30 @@ func TestComputeNewTagNameForTidbx(t *testing.T) {
 				tags := make([]*github.RepositoryTag, len(names))
 				for j, name := range names {
 					tags[j] = &github.RepositoryTag{Name: github.Ptr(name)}
-					// For the CommitAlreadyTagged case, attach the commit SHA to the first tidbx-style tag
-					if j == 0 && tc.taggedCommitSHA != "" && strings.HasPrefix(name, "v") && strings.Contains(name, "-nextgen.") {
-						tags[j].Commit = &github.Commit{SHA: &tc.taggedCommitSHA}
+					// For CommitAlreadyTagged, attach commit SHA to specific tag.
+					if tc.taggedCommitTag == name {
+						tags[j].Commit = &github.Commit{SHA: github.Ptr(testCommitSHA)}
 					}
 				}
 				tagPages = append(tagPages, tags)
 			}
 			resp := mock.WithRequestMatchPages(mock.GetReposTagsByOwnerByRepo, tagPages...)
 
-			// Mock CompareCommits for the CommitBehindExistingTag case
-			var comparisonResponse *github.CommitsComparison
-			if tc.behindCommitSHA != "" {
-				comparisonResponse = &github.CommitsComparison{
-					Status:   github.Ptr("behind"),
-					BehindBy: github.Ptr(1),
-				}
-			} else {
-				comparisonResponse = &github.CommitsComparison{
-					Status:   github.Ptr("identical"),
-					BehindBy: github.Ptr(0),
-				}
+			compareStatus := tc.compareStatus
+			if compareStatus == "" {
+				compareStatus = "identical"
 			}
-			compareMock := mock.WithRequestMatch(mock.GetReposCompareByOwnerByRepoByBasehead, comparisonResponse)
+			compareMock := mock.WithRequestMatch(
+				mock.GetReposCompareByOwnerByRepoByBasehead,
+				&github.CommitsComparison{
+					Status: github.Ptr(compareStatus),
+				},
+			)
 
 			ghClient := github.NewClient(mock.NewMockedHTTPClient(resp, compareMock))
 			svc := newServiceWithClient(ghClient)
 
-			commitSHA := testCommitSHA
-			if tc.behindCommitSHA != "" {
-				commitSHA = tc.behindCommitSHA
-			}
-
-			tag, err := svc.computeNewTagNameForTidbx(context.Background(), "owner", "repo", commitSHA)
+			tag, err := svc.computeNewTagNameForTidbx(context.Background(), "owner", "repo", testCommitSHA, tc.branch)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -180,58 +223,6 @@ func TestComputeNewTagNameForTidbx(t *testing.T) {
 				t.Fatalf("expected %s, got %s", tc.expected, tag)
 			}
 		})
-	}
-}
-
-func TestComputeNewTagNameForTidbxCalendarStyle(t *testing.T) {
-	resp := mock.WithRequestMatchPages(
-		mock.GetReposTagsByOwnerByRepo,
-		[]*github.RepositoryTag{
-			{Name: github.Ptr("v25.12.9")},
-			{Name: github.Ptr("v26.0.0")},
-			{Name: github.Ptr("v26.3.1")},
-			{Name: github.Ptr("v26.3.3")},
-			{Name: github.Ptr("v26.2.9")},
-		},
-	)
-	compareMock := mock.WithRequestMatch(
-		mock.GetReposCompareByOwnerByRepoByBasehead,
-		&github.CommitsComparison{Status: github.Ptr("identical")},
-	)
-
-	ghClient := github.NewClient(mock.NewMockedHTTPClient(resp, compareMock))
-	svc := newServiceWithClient(ghClient)
-
-	tag, err := svc.computeNewTagNameForTidbx(context.Background(), "owner", "repo", "a9814602ed087838d71095efd35bd221ab0bf5a9")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if tag != "v26.3.4" {
-		t.Fatalf("expected v26.3.4, got %s", tag)
-	}
-}
-
-func TestComputeNewTagNameForTidbxCalendarStylePatchStartsAtZero(t *testing.T) {
-	resp := mock.WithRequestMatchPages(
-		mock.GetReposTagsByOwnerByRepo,
-		[]*github.RepositoryTag{
-			{Name: github.Ptr("v26.0.0")},
-		},
-	)
-	compareMock := mock.WithRequestMatch(
-		mock.GetReposCompareByOwnerByRepoByBasehead,
-		&github.CommitsComparison{Status: github.Ptr("identical")},
-	)
-
-	ghClient := github.NewClient(mock.NewMockedHTTPClient(resp, compareMock))
-	svc := newServiceWithClient(ghClient)
-
-	tag, err := svc.computeNewTagNameForTidbx(context.Background(), "owner", "repo", "a9814602ed087838d71095efd35bd221ab0bf5a9")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if tag != "v26.0.1" {
-		t.Fatalf("expected v26.0.1, got %s", tag)
 	}
 }
 
@@ -380,6 +371,69 @@ func TestBumpTagForTidbx_PaginationFlow(t *testing.T) {
 				t.Fatalf("expected tag %s, got %s", test.expectTag, result.Tag)
 			}
 		})
+	}
+}
+
+func TestBumpTagForTidbx_BootstrapFromReleaseBranch(t *testing.T) {
+	fullRepo := "owner/repo"
+	branch := "release-nextgen-202604"
+	commit := "abc123"
+	expectedTag := "v26.4.0"
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchPages(
+			mock.GetReposTagsByOwnerByRepo,
+			[]*github.RepositoryTag{},
+		),
+		mock.WithRequestMatch(
+			mock.GetReposBranchesByOwnerByRepoByBranch,
+			&github.Branch{
+				Name: github.Ptr(branch),
+				Commit: &github.RepositoryCommit{
+					SHA: github.Ptr(commit),
+				},
+			},
+		),
+		mock.WithRequestMatch(
+			mock.PostReposGitTagsByOwnerByRepo,
+			&github.Tag{
+				Tag: github.Ptr(expectedTag),
+				Object: &github.GitObject{
+					Type: github.Ptr("commit"),
+					SHA:  github.Ptr(commit),
+				},
+				SHA: github.Ptr(commit),
+			},
+		),
+		mock.WithRequestMatch(
+			mock.PostReposGitRefsByOwnerByRepo,
+			&github.Reference{
+				Ref: github.Ptr("refs/tags/" + expectedTag),
+				Object: &github.GitObject{
+					SHA: github.Ptr(commit),
+				},
+			},
+		),
+	)
+	svc := newServiceWithClient(github.NewClient(httpClient))
+
+	res, err := svc.BumpTagForTidbx(context.Background(), &hotfix.BumpTagForTidbxPayload{
+		Repo:   fullRepo,
+		Author: "tester",
+		Branch: &branch,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if res.Repo != fullRepo {
+		t.Fatalf("expected repo %s, got %s", fullRepo, res.Repo)
+	}
+	if res.Commit != commit {
+		t.Fatalf("expected commit %s, got %s", commit, res.Commit)
+	}
+	if res.Tag != expectedTag {
+		t.Fatalf("expected tag %s, got %s", expectedTag, res.Tag)
 	}
 }
 


### PR DESCRIPTION
## Summary
- support GA new-style tidbx tag bump (`vX.Y.Z`) by incrementing patch
- support alpha promotion (`vX.Y.Z-alpha` -> `vX.Y.Z`) when no GA new-style tag exists
- preserve legacy `vX.Y.Z-nextgen.YYYYMM.N` bump flow when only legacy tags exist
- support bootstrap from `release-nextgen-YYYYMM`/`release-nextgen-YYYYMMDD` to first new-style tag `vYY.M.0`
- add/refresh unit tests for new logic and bootstrap flow

## Test
- go test not run in this runtime (`go` toolchain unavailable)