### PR TITLE
fix(ci-dashboard): improve refresh-build-derived cronjob performance

### DIFF
--- a/ci-dashboard/README.md
+++ b/ci-dashboard/README.md
@@ -71,6 +71,7 @@ Notes:
 - set `CI_DASHBOARD_STATIC_DIR` when the built frontend lives outside the default repo or container layout
 - during UI iteration, run `make api` and `make web-dev` in separate terminals
 - `backfill-range` is stateless and does not update `ci_job_state`, so the same time window can be re-imported safely
+- `CI_DASHBOARD_REFRESH_BUILD_LIMIT` controls how many impacted builds one `refresh-build-derived` run will process before checkpointing and continuing in the next CronJob run
 - `scripts/render_backfill_job.sh` renders a one-off Kubernetes Job manifest for GKE backfill runs
 - `scripts/render_flaky_issue_sync_cronjob.sh` renders a recurring Kubernetes CronJob manifest for daily flaky issue sync
 

--- a/ci-dashboard/README.md
+++ b/ci-dashboard/README.md
@@ -71,7 +71,7 @@ Notes:
 - set `CI_DASHBOARD_STATIC_DIR` when the built frontend lives outside the default repo or container layout
 - during UI iteration, run `make api` and `make web-dev` in separate terminals
 - `backfill-range` is stateless and does not update `ci_job_state`, so the same time window can be re-imported safely
-- `CI_DASHBOARD_REFRESH_BUILD_LIMIT` controls how many impacted builds one `refresh-build-derived` run will process before checkpointing and continuing in the next CronJob run
+- `CI_DASHBOARD_REFRESH_BUILD_LIMIT` controls how many impacted builds one `refresh-build-derived` run will process before checkpointing and continuing in the next CronJob run; the default is `5000`, valid values are positive integers, and smaller values trade shorter/faster runs for more CronJob passes before backlog catch-up finishes
 - `scripts/render_backfill_job.sh` renders a one-off Kubernetes Job manifest for GKE backfill runs
 - `scripts/render_flaky_issue_sync_cronjob.sh` renders a recurring Kubernetes CronJob manifest for daily flaky issue sync
 

--- a/ci-dashboard/docs/functional-design/domain-entities.md
+++ b/ci-dashboard/docs/functional-design/domain-entities.md
@@ -92,7 +92,7 @@ Watermark shapes:
 
 - `ci-sync-builds`: `{"last_source_prow_row_id": N}`
 - `ci-sync-pr-events`: `{"last_ticket_updated_at": "...", "last_build_source_prow_row_id_seen": N}`
-- `ci-refresh-build-derived`: `{"last_processed_build_id": N, "last_processed_pr_event_updated_at": "...", "last_processed_case_report_time": "..."}`
+- `ci-refresh-build-derived`: `{"last_processed_build_id": N, "last_processed_pr_event_updated_at": "...", "last_processed_case_report_time": "...", "pending_refresh": false, "pending_target_build_id": null, "pending_target_pr_event_updated_at": null, "pending_target_case_report_time": null}`
 
 Current implementation status:
 

--- a/ci-dashboard/src/ci_dashboard/common/config.py
+++ b/ci-dashboard/src/ci_dashboard/common/config.py
@@ -18,9 +18,9 @@ def _read_int(environ: Mapping[str, str], key: str, default: int) -> int:
     try:
         value = int(raw)
     except ValueError as exc:
-        raise ValueError(f"{key} must be an integer") from exc
+        raise ValueError(f"{key} must be an integer, got {raw!r}") from exc
     if value <= 0:
-        raise ValueError(f"{key} must be positive")
+        raise ValueError(f"{key} must be positive, got {raw!r}")
     return value
 
 

--- a/ci-dashboard/src/ci_dashboard/common/config.py
+++ b/ci-dashboard/src/ci_dashboard/common/config.py
@@ -39,6 +39,7 @@ class DatabaseSettings:
 class JobSettings:
     batch_size: int = 1000
     refresh_group_batch_size: int = 25
+    refresh_build_limit: int = 5000
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,11 @@ def load_settings(environ: Mapping[str, str] | None = None) -> Settings:
                 env,
                 "CI_DASHBOARD_REFRESH_GROUP_BATCH_SIZE",
                 25,
+            ),
+            refresh_build_limit=_read_int(
+                env,
+                "CI_DASHBOARD_REFRESH_BUILD_LIMIT",
+                5000,
             ),
         ),
         log_level=(env.get("CI_DASHBOARD_LOG_LEVEL") or "INFO").upper(),

--- a/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 import logging
 from typing import Any, Mapping
@@ -23,6 +24,13 @@ LOG = logging.getLogger(__name__)
 JOB_NAME = "ci-refresh-build-derived"
 REQUIRE_RETEST_FOR_RETRY_LOOP = False
 DEFAULT_WRITE_BATCH_SIZE = 100
+DEFAULT_REFRESH_BUILD_LIMIT = 5000
+
+
+@dataclass(frozen=True)
+class ImpactedBuildSelection:
+    build_ids: list[int]
+    has_more: bool
 
 
 def run_refresh_build_derived(
@@ -37,20 +45,20 @@ def run_refresh_build_derived(
     chunk_size = _resolve_chunk_size(settings)
     group_chunk_size = _resolve_refresh_group_chunk_size(settings)
     write_batch_size = _resolve_write_batch_size(settings)
+    refresh_build_limit = _resolve_refresh_build_limit(settings)
 
     try:
         with engine.begin() as connection:
-            selection_watermarks = _load_selection_watermarks(connection)
-            impacted_build_ids = _get_impacted_build_ids(connection, watermark)
+            selection_watermarks = _resolve_selection_watermarks(connection, watermark)
+            impacted_selection = _get_impacted_build_ids(
+                connection,
+                watermark,
+                selection_watermarks,
+                max_builds=refresh_build_limit,
+            )
+            impacted_build_ids = impacted_selection.build_ids
 
         summary.impacted_builds = len(impacted_build_ids)
-        summary.last_processed_build_id = selection_watermarks["last_processed_build_id"]
-        summary.last_processed_pr_event_updated_at = selection_watermarks[
-            "last_processed_pr_event_updated_at"
-        ]
-        summary.last_processed_case_report_time = selection_watermarks[
-            "last_processed_case_report_time"
-        ]
 
         if impacted_build_ids:
             _apply_refresh_phases(
@@ -62,8 +70,21 @@ def run_refresh_build_derived(
                 write_batch_size=write_batch_size,
             )
 
+        next_watermark = _build_success_watermark(
+            watermark,
+            selection_watermarks,
+            impacted_selection,
+        )
+        summary.last_processed_build_id = int(next_watermark["last_processed_build_id"] or 0)
+        summary.last_processed_pr_event_updated_at = _normalize_optional_string(
+            next_watermark.get("last_processed_pr_event_updated_at")
+        )
+        summary.last_processed_case_report_time = _normalize_optional_string(
+            next_watermark.get("last_processed_case_report_time")
+        )
+
         with engine.begin() as connection:
-            mark_job_succeeded(connection, JOB_NAME, selection_watermarks)
+            mark_job_succeeded(connection, JOB_NAME, next_watermark)
 
         return summary
     except Exception as exc:
@@ -163,13 +184,32 @@ def _load_watermark(connection: Connection) -> dict[str, Any]:
             "last_processed_build_id": 0,
             "last_processed_pr_event_updated_at": None,
             "last_processed_case_report_time": None,
+            "pending_refresh": False,
+            "pending_target_build_id": None,
+            "pending_target_pr_event_updated_at": None,
+            "pending_target_case_report_time": None,
         }
     return {
-        "last_processed_build_id": int(state.watermark.get("last_processed_build_id", 0) or 0),
-        "last_processed_pr_event_updated_at": state.watermark.get(
-            "last_processed_pr_event_updated_at"
+        "last_processed_build_id": _normalize_optional_int(
+            state.watermark.get("last_processed_build_id"),
+            default=0,
         ),
-        "last_processed_case_report_time": state.watermark.get("last_processed_case_report_time"),
+        "last_processed_pr_event_updated_at": _normalize_optional_string(
+            state.watermark.get("last_processed_pr_event_updated_at")
+        ),
+        "last_processed_case_report_time": _normalize_optional_string(
+            state.watermark.get("last_processed_case_report_time")
+        ),
+        "pending_refresh": bool(state.watermark.get("pending_refresh", False)),
+        "pending_target_build_id": _normalize_optional_int(
+            state.watermark.get("pending_target_build_id")
+        ),
+        "pending_target_pr_event_updated_at": _normalize_optional_string(
+            state.watermark.get("pending_target_pr_event_updated_at")
+        ),
+        "pending_target_case_report_time": _normalize_optional_string(
+            state.watermark.get("pending_target_case_report_time")
+        ),
     }
 
 
@@ -191,48 +231,100 @@ def _load_selection_watermarks(connection: Connection) -> dict[str, Any]:
     }
 
 
+def _resolve_selection_watermarks(
+    connection: Connection,
+    watermark: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not bool(watermark.get("pending_refresh", False)):
+        return _load_selection_watermarks(connection)
+
+    return {
+        "last_processed_build_id": _normalize_optional_int(
+            watermark.get("pending_target_build_id"),
+            default=_normalize_optional_int(watermark.get("last_processed_build_id"), default=0),
+        ),
+        "last_processed_pr_event_updated_at": _normalize_optional_string(
+            watermark.get("pending_target_pr_event_updated_at")
+        ),
+        "last_processed_case_report_time": _normalize_optional_string(
+            watermark.get("pending_target_case_report_time")
+        ),
+    }
+
+
 def _get_impacted_build_ids(
     connection: Connection,
     watermark: Mapping[str, Any],
-) -> list[int]:
+    selection_watermarks: Mapping[str, Any],
+    *,
+    max_builds: int,
+) -> ImpactedBuildSelection:
     impacted_ids: set[int] = set()
+    selection_limit = max_builds + 1
+    pending_refresh = bool(watermark.get("pending_refresh", False))
+    last_processed_build_id = _normalize_optional_int(
+        watermark.get("last_processed_build_id"),
+        default=0,
+    )
+    has_more = False
 
-    rows = connection.execute(
-        text("SELECT id FROM ci_l1_builds WHERE id > :last_processed_build_id"),
-        {"last_processed_build_id": watermark["last_processed_build_id"]},
-    ).mappings()
-    impacted_ids.update(int(row["id"]) for row in rows)
+    new_build_ids = _fetch_new_build_ids(
+        connection,
+        lower_build_id=last_processed_build_id,
+        upper_build_id=_normalize_optional_int(
+            selection_watermarks.get("last_processed_build_id"),
+            default=last_processed_build_id,
+        ),
+        selection_limit=selection_limit,
+    )
+    if len(new_build_ids) == selection_limit:
+        has_more = True
+    impacted_ids.update(new_build_ids)
 
-    last_pr_event_updated_at = watermark.get("last_processed_pr_event_updated_at")
-    if last_pr_event_updated_at:
-        rows = connection.execute(
-            text(
-                """
-                SELECT DISTINCT b.id
-                FROM ci_l1_builds b
-                JOIN ci_l1_pr_events e
-                  ON e.repo = b.repo_full_name
-                 AND e.pr_number = b.pr_number
-                WHERE b.is_pr_build = 1
-                  AND e.updated_at > :last_processed_pr_event_updated_at
-                """
-            ),
-            {"last_processed_pr_event_updated_at": last_pr_event_updated_at},
-        ).mappings()
-        impacted_ids.update(int(row["id"]) for row in rows)
+    pr_event_build_ids = _fetch_pr_event_impacted_build_ids(
+        connection,
+        last_processed_pr_event_updated_at=_normalize_optional_string(
+            watermark.get("last_processed_pr_event_updated_at")
+        ),
+        target_pr_event_updated_at=_normalize_optional_string(
+            selection_watermarks.get("last_processed_pr_event_updated_at")
+        ),
+        upper_build_id=_normalize_optional_int(
+            selection_watermarks.get("last_processed_build_id"),
+            default=last_processed_build_id,
+        ),
+        after_build_id=last_processed_build_id if pending_refresh else 0,
+        selection_limit=selection_limit,
+    )
+    if len(pr_event_build_ids) == selection_limit:
+        has_more = True
+    impacted_ids.update(pr_event_build_ids)
 
-    last_case_report_time = watermark.get("last_processed_case_report_time")
-    if last_case_report_time:
-        rows = connection.execute(
-            _case_impact_query(connection, last_case_report_time),
-            {"last_processed_case_report_time": last_case_report_time},
-        ).mappings()
-        impacted_ids.update(int(row["id"]) for row in rows)
-    else:
-        rows = connection.execute(_case_impact_query(connection, None)).mappings()
-        impacted_ids.update(int(row["id"]) for row in rows)
+    case_build_ids = _fetch_case_impacted_build_ids(
+        connection,
+        last_processed_case_report_time=_normalize_optional_string(
+            watermark.get("last_processed_case_report_time")
+        ),
+        target_case_report_time=_normalize_optional_string(
+            selection_watermarks.get("last_processed_case_report_time")
+        ),
+        upper_build_id=_normalize_optional_int(
+            selection_watermarks.get("last_processed_build_id"),
+            default=last_processed_build_id,
+        ),
+        after_build_id=last_processed_build_id if pending_refresh else 0,
+        selection_limit=selection_limit,
+    )
+    if len(case_build_ids) == selection_limit:
+        has_more = True
+    impacted_ids.update(case_build_ids)
 
-    return sorted(impacted_ids)
+    build_ids = sorted(impacted_ids)
+    if len(build_ids) > max_builds:
+        has_more = True
+        build_ids = build_ids[:max_builds]
+
+    return ImpactedBuildSelection(build_ids=build_ids, has_more=has_more)
 
 
 def _get_build_ids_in_time_window(
@@ -435,6 +527,12 @@ def _resolve_refresh_group_chunk_size(settings: Settings | None) -> int:
     return max(1, min(settings.jobs.batch_size, settings.jobs.refresh_group_batch_size))
 
 
+def _resolve_refresh_build_limit(settings: Settings | None) -> int:
+    if settings is None:
+        return DEFAULT_REFRESH_BUILD_LIMIT
+    return settings.jobs.refresh_build_limit
+
+
 def _resolve_write_batch_size(settings: Settings | None) -> int:
     if settings is None:
         return DEFAULT_WRITE_BATCH_SIZE
@@ -460,6 +558,63 @@ def _assign_failure_category_rows_updated(
     rows_updated: int,
 ) -> None:
     summary.failure_category_rows_updated += rows_updated
+
+
+def _build_success_watermark(
+    watermark: Mapping[str, Any],
+    selection_watermarks: Mapping[str, Any],
+    impacted_selection: ImpactedBuildSelection,
+) -> dict[str, Any]:
+    if impacted_selection.has_more and impacted_selection.build_ids:
+        return {
+            "last_processed_build_id": impacted_selection.build_ids[-1],
+            "last_processed_pr_event_updated_at": _normalize_optional_string(
+                watermark.get("last_processed_pr_event_updated_at")
+            ),
+            "last_processed_case_report_time": _normalize_optional_string(
+                watermark.get("last_processed_case_report_time")
+            ),
+            "pending_refresh": True,
+            "pending_target_build_id": _normalize_optional_int(
+                selection_watermarks.get("last_processed_build_id")
+            ),
+            "pending_target_pr_event_updated_at": _normalize_optional_string(
+                selection_watermarks.get("last_processed_pr_event_updated_at")
+            ),
+            "pending_target_case_report_time": _normalize_optional_string(
+                selection_watermarks.get("last_processed_case_report_time")
+            ),
+        }
+
+    return {
+        "last_processed_build_id": _normalize_optional_int(
+            selection_watermarks.get("last_processed_build_id"),
+            default=0,
+        ),
+        "last_processed_pr_event_updated_at": _normalize_optional_string(
+            selection_watermarks.get("last_processed_pr_event_updated_at")
+        ),
+        "last_processed_case_report_time": _normalize_optional_string(
+            selection_watermarks.get("last_processed_case_report_time")
+        ),
+        "pending_refresh": False,
+        "pending_target_build_id": None,
+        "pending_target_pr_event_updated_at": None,
+        "pending_target_case_report_time": None,
+    }
+
+
+def _normalize_optional_int(value: Any, *, default: int | None = None) -> int | None:
+    if value is None or value == "":
+        return default
+    return int(value)
+
+
+def _normalize_optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
 
 
 def _phase_a_branch_enrichment(
@@ -652,38 +807,133 @@ def _phase_d_failure_category(
     if not build_ids:
         return 0
 
-    rows = connection.execute(
+    connection.execute(
         text(
             f"""
-            SELECT id, is_flaky, is_retry_loop
-            FROM ci_l1_builds
+            UPDATE ci_l1_builds
+            SET failure_category = CASE
+                WHEN COALESCE(is_flaky, 0) = 1 OR COALESCE(is_retry_loop, 0) = 1 THEN 'FLAKY_TEST'
+                ELSE NULL
+            END
             WHERE {_build_in_filter(build_ids, "failure_id")}
             """
         ),
         _build_id_params(build_ids, "failure_id"),
+    )
+
+    LOG.info("failure category refreshed for %s rows", len(build_ids))
+    return len(build_ids)
+
+
+def _fetch_new_build_ids(
+    connection: Connection,
+    *,
+    lower_build_id: int,
+    upper_build_id: int,
+    selection_limit: int,
+) -> list[int]:
+    if upper_build_id <= lower_build_id:
+        return []
+
+    rows = connection.execute(
+        text(
+            """
+            SELECT id
+            FROM ci_l1_builds
+            WHERE id > :lower_build_id
+              AND id <= :upper_build_id
+            ORDER BY id
+            LIMIT :selection_limit
+            """
+        ),
+        {
+            "lower_build_id": lower_build_id,
+            "upper_build_id": upper_build_id,
+            "selection_limit": selection_limit,
+        },
     ).mappings()
+    return [int(row["id"]) for row in rows]
 
-    payload = []
-    for row in rows:
-        category = "FLAKY_TEST" if int(row["is_flaky"] or 0) == 1 or int(row["is_retry_loop"] or 0) == 1 else None
-        payload.append({"id": int(row["id"]), "failure_category": category})
 
-    if payload:
-        _execute_statement_in_batches(
+def _fetch_pr_event_impacted_build_ids(
+    connection: Connection,
+    *,
+    last_processed_pr_event_updated_at: str | None,
+    target_pr_event_updated_at: str | None,
+    upper_build_id: int,
+    after_build_id: int,
+    selection_limit: int,
+) -> list[int]:
+    if target_pr_event_updated_at is None or target_pr_event_updated_at == last_processed_pr_event_updated_at:
+        return []
+
+    params: dict[str, Any] = {
+        "target_pr_event_updated_at": target_pr_event_updated_at,
+        "upper_build_id": upper_build_id,
+        "selection_limit": selection_limit,
+    }
+    lower_bound_clause = ""
+    if last_processed_pr_event_updated_at is not None:
+        lower_bound_clause = "AND e.updated_at > :last_processed_pr_event_updated_at"
+        params["last_processed_pr_event_updated_at"] = last_processed_pr_event_updated_at
+
+    build_cursor_clause = ""
+    if after_build_id > 0:
+        build_cursor_clause = "AND b.id > :after_build_id"
+        params["after_build_id"] = after_build_id
+
+    rows = connection.execute(
+        text(
+            f"""
+            SELECT DISTINCT b.id
+            FROM ci_l1_builds b
+            JOIN ci_l1_pr_events e
+              ON e.repo = b.repo_full_name
+             AND e.pr_number = b.pr_number
+            WHERE b.is_pr_build = 1
+              AND b.id <= :upper_build_id
+              AND e.updated_at <= :target_pr_event_updated_at
+              {lower_bound_clause}
+              {build_cursor_clause}
+            ORDER BY b.id
+            LIMIT :selection_limit
+            """
+        ),
+        params,
+    ).mappings()
+    return [int(row["id"]) for row in rows]
+
+
+def _fetch_case_impacted_build_ids(
+    connection: Connection,
+    *,
+    last_processed_case_report_time: str | None,
+    target_case_report_time: str | None,
+    upper_build_id: int,
+    after_build_id: int,
+    selection_limit: int,
+) -> list[int]:
+    if target_case_report_time is None or target_case_report_time == last_processed_case_report_time:
+        return []
+
+    rows = connection.execute(
+        _case_impact_query(
             connection,
-            text(
-                """
-                UPDATE ci_l1_builds
-                SET failure_category = :failure_category
-                WHERE id = :id
-                """
-            ),
-            payload,
-            batch_size=write_batch_size,
-        )
-
-    LOG.info("failure category refreshed for %s rows", len(payload))
-    return len(payload)
+            last_processed_case_report_time=last_processed_case_report_time,
+            target_case_report_time=target_case_report_time,
+            upper_build_id=upper_build_id,
+            after_build_id=after_build_id,
+            selection_limit=selection_limit,
+        ),
+        _case_impact_query_params(
+            last_processed_case_report_time=last_processed_case_report_time,
+            target_case_report_time=target_case_report_time,
+            upper_build_id=upper_build_id,
+            after_build_id=after_build_id,
+            selection_limit=selection_limit,
+        ),
+    ).mappings()
+    return [int(row["id"]) for row in rows]
 
 
 def _fetch_snapshot_rows(
@@ -807,11 +1057,22 @@ def _fetch_retest_times(
 
 def _case_impact_query(
     connection: Connection,
-    last_case_report_time: str | None,
+    *,
+    last_processed_case_report_time: str | None,
+    target_case_report_time: str,
+    upper_build_id: int,
+    after_build_id: int,
+    selection_limit: int,
 ) -> Any:
-    where_clause = ""
-    if last_case_report_time is not None:
-        where_clause = "WHERE p.report_time > :last_processed_case_report_time"
+    where_clauses = [
+        "p.report_time <= :target_case_report_time",
+        "b.id <= :upper_build_id",
+    ]
+    if last_processed_case_report_time is not None:
+        where_clauses.append("p.report_time > :last_processed_case_report_time")
+    if after_build_id > 0:
+        where_clauses.append("b.id > :after_build_id")
+    where_clause = "WHERE " + " AND ".join(where_clauses)
 
     if connection.dialect.name == "sqlite":
         return text(
@@ -824,6 +1085,8 @@ def _case_impact_query(
              AND {_sqlite_normalized_build_url_sql('p.build_url')} = b.normalized_build_key
              AND p.report_time BETWEEN b.start_time AND datetime(b.start_time, '+24 hours')
             {where_clause}
+            ORDER BY b.id
+            LIMIT :selection_limit
             """
         )
 
@@ -837,8 +1100,30 @@ def _case_impact_query(
          AND {_mysql_normalized_build_url_sql('p.build_url')} = b.normalized_build_key
          AND p.report_time BETWEEN b.start_time AND b.start_time + INTERVAL 24 HOUR
         {where_clause}
+        ORDER BY b.id
+        LIMIT :selection_limit
         """
     )
+
+
+def _case_impact_query_params(
+    *,
+    last_processed_case_report_time: str | None,
+    target_case_report_time: str,
+    upper_build_id: int,
+    after_build_id: int,
+    selection_limit: int,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "target_case_report_time": target_case_report_time,
+        "upper_build_id": upper_build_id,
+        "selection_limit": selection_limit,
+    }
+    if last_processed_case_report_time is not None:
+        params["last_processed_case_report_time"] = last_processed_case_report_time
+    if after_build_id > 0:
+        params["after_build_id"] = after_build_id
+    return params
 
 
 def _case_match_query(connection: Connection, impacted_build_ids: list[int]) -> Any:

--- a/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
@@ -189,28 +189,31 @@ def _load_watermark(connection: Connection) -> dict[str, Any]:
             "pending_target_pr_event_updated_at": None,
             "pending_target_case_report_time": None,
         }
-    return {
-        "last_processed_build_id": _normalize_optional_int(
-            state.watermark.get("last_processed_build_id"),
-            default=0,
-        ),
-        "last_processed_pr_event_updated_at": _normalize_optional_string(
-            state.watermark.get("last_processed_pr_event_updated_at")
-        ),
-        "last_processed_case_report_time": _normalize_optional_string(
-            state.watermark.get("last_processed_case_report_time")
-        ),
-        "pending_refresh": bool(state.watermark.get("pending_refresh", False)),
-        "pending_target_build_id": _normalize_optional_int(
-            state.watermark.get("pending_target_build_id")
-        ),
-        "pending_target_pr_event_updated_at": _normalize_optional_string(
-            state.watermark.get("pending_target_pr_event_updated_at")
-        ),
-        "pending_target_case_report_time": _normalize_optional_string(
-            state.watermark.get("pending_target_case_report_time")
-        ),
-    }
+    try:
+        return {
+            "last_processed_build_id": _normalize_optional_int(
+                state.watermark.get("last_processed_build_id"),
+                default=0,
+            ),
+            "last_processed_pr_event_updated_at": _normalize_optional_string(
+                state.watermark.get("last_processed_pr_event_updated_at")
+            ),
+            "last_processed_case_report_time": _normalize_optional_string(
+                state.watermark.get("last_processed_case_report_time")
+            ),
+            "pending_refresh": bool(state.watermark.get("pending_refresh", False)),
+            "pending_target_build_id": _normalize_optional_int(
+                state.watermark.get("pending_target_build_id")
+            ),
+            "pending_target_pr_event_updated_at": _normalize_optional_string(
+                state.watermark.get("pending_target_pr_event_updated_at")
+            ),
+            "pending_target_case_report_time": _normalize_optional_string(
+                state.watermark.get("pending_target_case_report_time")
+            ),
+        }
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid {JOB_NAME} watermark: {state.watermark!r}") from exc
 
 
 def _load_selection_watermarks(connection: Connection) -> dict[str, Any]:

--- a/ci-dashboard/tests/jobs/test_refresh_build_derived.py
+++ b/ci-dashboard/tests/jobs/test_refresh_build_derived.py
@@ -16,7 +16,7 @@ from ci_dashboard.jobs.refresh_build_derived import (
 from ci_dashboard.jobs.state_store import get_job_state
 
 
-def _settings(*, batch_size: int = 100) -> Settings:
+def _settings(*, batch_size: int = 100, refresh_build_limit: int = 5000) -> Settings:
     return Settings(
         database=DatabaseSettings(
             url="sqlite+pysqlite:///:memory:",
@@ -27,7 +27,10 @@ def _settings(*, batch_size: int = 100) -> Settings:
             database=None,
             ssl_ca=None,
         ),
-        jobs=JobSettings(batch_size=batch_size),
+        jobs=JobSettings(
+            batch_size=batch_size,
+            refresh_build_limit=refresh_build_limit,
+        ),
         log_level="INFO",
     )
 
@@ -319,6 +322,95 @@ def test_refresh_build_derived_end_to_end(sqlite_engine) -> None:
     assert state is not None
     assert state.last_status == "succeeded"
     assert state.watermark["last_processed_build_id"] == next_sha
+
+
+def test_refresh_build_derived_slices_large_backlog_and_freezes_selection_window(sqlite_engine) -> None:
+    first_id = _insert_build(
+        sqlite_engine,
+        source_prow_job_id="prow-job-200",
+        normalized_build_key="/jenkins/job/prow-job-200",
+        start_time="2026-04-13 09:00:00",
+    )
+    second_id = _insert_build(
+        sqlite_engine,
+        source_prow_job_id="prow-job-201",
+        normalized_build_key="/jenkins/job/prow-job-201",
+        start_time="2026-04-13 09:05:00",
+    )
+    third_id = _insert_build(
+        sqlite_engine,
+        source_prow_job_id="prow-job-202",
+        normalized_build_key="/jenkins/job/prow-job-202",
+        start_time="2026-04-13 09:10:00",
+    )
+    _insert_pr_snapshot(
+        sqlite_engine,
+        pr_number=101,
+        target_branch="master",
+        updated_at="2026-04-13 09:30:00",
+    )
+
+    settings = _settings(batch_size=10, refresh_build_limit=2)
+
+    first_summary = run_refresh_build_derived(sqlite_engine, settings)
+    assert first_summary.impacted_builds == 2
+
+    fourth_id = _insert_build(
+        sqlite_engine,
+        source_prow_job_id="prow-job-203",
+        normalized_build_key="/jenkins/job/prow-job-203",
+        start_time="2026-04-13 09:15:00",
+    )
+
+    second_summary = run_refresh_build_derived(sqlite_engine, settings)
+    assert second_summary.impacted_builds == 1
+
+    with sqlite_engine.begin() as connection:
+        rows = list(
+            connection.execute(
+                text(
+                    """
+                    SELECT id, target_branch
+                    FROM ci_l1_builds
+                    WHERE id IN (:first_id, :second_id, :third_id, :fourth_id)
+                    ORDER BY id
+                    """
+                ),
+                {
+                    "first_id": first_id,
+                    "second_id": second_id,
+                    "third_id": third_id,
+                    "fourth_id": fourth_id,
+                },
+            ).mappings()
+        )
+        state_after_second_run = get_job_state(connection, "ci-refresh-build-derived")
+
+    assert [row["target_branch"] for row in rows[:3]] == ["master", "master", "master"]
+    assert rows[3]["target_branch"] is None
+    assert state_after_second_run is not None
+    assert state_after_second_run.watermark["pending_refresh"] is False
+    assert state_after_second_run.watermark["last_processed_build_id"] == third_id
+
+    third_summary = run_refresh_build_derived(sqlite_engine, settings)
+    assert third_summary.impacted_builds == 1
+
+    with sqlite_engine.begin() as connection:
+        final_row = connection.execute(
+            text(
+                """
+                SELECT target_branch
+                FROM ci_l1_builds
+                WHERE id = :id
+                """
+            ),
+            {"id": fourth_id},
+        ).mappings().one()
+        final_state = get_job_state(connection, "ci-refresh-build-derived")
+
+    assert final_row["target_branch"] == "master"
+    assert final_state is not None
+    assert final_state.watermark["last_processed_build_id"] == fourth_id
 
 
 def test_refresh_build_derived_picks_up_new_case_rows_incrementally(sqlite_engine) -> None:

--- a/ci-dashboard/tests/jobs/test_refresh_build_derived.py
+++ b/ci-dashboard/tests/jobs/test_refresh_build_derived.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pytest
 from sqlalchemy import text
 
 from ci_dashboard.common.config import DatabaseSettings, JobSettings, Settings
@@ -411,6 +412,77 @@ def test_refresh_build_derived_slices_large_backlog_and_freezes_selection_window
     assert final_row["target_branch"] == "master"
     assert final_state is not None
     assert final_state.watermark["last_processed_build_id"] == fourth_id
+
+
+def test_refresh_build_derived_clears_pending_refresh_when_slice_is_empty(sqlite_engine) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_job_state (
+                  job_name, watermark_json, last_status
+                ) VALUES (
+                  :job_name, :watermark_json, 'succeeded'
+                )
+                """
+            ),
+            {
+                "job_name": "ci-refresh-build-derived",
+                "watermark_json": """
+                {
+                  "last_processed_build_id": 2,
+                  "last_processed_pr_event_updated_at": "2026-04-13 09:00:00",
+                  "last_processed_case_report_time": "2026-04-13 09:05:00",
+                  "pending_refresh": true,
+                  "pending_target_build_id": 5,
+                  "pending_target_pr_event_updated_at": "2026-04-13 10:00:00",
+                  "pending_target_case_report_time": "2026-04-13 10:05:00"
+                }
+                """,
+            },
+        )
+
+    summary = run_refresh_build_derived(sqlite_engine, _settings(refresh_build_limit=2))
+
+    assert summary.impacted_builds == 0
+    assert summary.last_processed_build_id == 5
+    assert summary.last_processed_pr_event_updated_at == "2026-04-13 10:00:00"
+    assert summary.last_processed_case_report_time == "2026-04-13 10:05:00"
+
+    with sqlite_engine.begin() as connection:
+        state = get_job_state(connection, "ci-refresh-build-derived")
+
+    assert state is not None
+    assert state.last_status == "succeeded"
+    assert state.watermark["pending_refresh"] is False
+    assert state.watermark["last_processed_build_id"] == 5
+    assert state.watermark["last_processed_pr_event_updated_at"] == "2026-04-13 10:00:00"
+    assert state.watermark["last_processed_case_report_time"] == "2026-04-13 10:05:00"
+
+
+def test_refresh_build_derived_rejects_corrupted_watermark(sqlite_engine) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_job_state (
+                  job_name, watermark_json, last_status
+                ) VALUES (
+                  :job_name, :watermark_json, 'succeeded'
+                )
+                """
+            ),
+            {
+                "job_name": "ci-refresh-build-derived",
+                "watermark_json": '{"last_processed_build_id": "oops"}',
+            },
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid ci-refresh-build-derived watermark",
+    ):
+        run_refresh_build_derived(sqlite_engine, _settings())
 
 
 def test_refresh_build_derived_picks_up_new_case_rows_incrementally(sqlite_engine) -> None:

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -15,6 +15,7 @@ def test_load_settings_supports_db_url() -> None:
             "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
             "CI_DASHBOARD_BATCH_SIZE": "12",
             "CI_DASHBOARD_REFRESH_GROUP_BATCH_SIZE": "7",
+            "CI_DASHBOARD_REFRESH_BUILD_LIMIT": "3456",
             "CI_DASHBOARD_LOG_LEVEL": "debug",
         }
     )
@@ -23,6 +24,7 @@ def test_load_settings_supports_db_url() -> None:
     assert settings.database.host is None
     assert settings.jobs.batch_size == 12
     assert settings.jobs.refresh_group_batch_size == 7
+    assert settings.jobs.refresh_build_limit == 3456
     assert settings.log_level == "DEBUG"
 
 
@@ -47,6 +49,16 @@ def test_load_settings_rejects_invalid_refresh_group_batch_size() -> None:
             {
                 "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
                 "CI_DASHBOARD_REFRESH_GROUP_BATCH_SIZE": "abc",
+            }
+        )
+
+
+def test_load_settings_rejects_invalid_refresh_build_limit() -> None:
+    with pytest.raises(ValueError, match="CI_DASHBOARD_REFRESH_BUILD_LIMIT"):
+        load_settings(
+            {
+                "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
+                "CI_DASHBOARD_REFRESH_BUILD_LIMIT": "abc",
             }
         )
 

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -34,7 +34,10 @@ def test_load_settings_requires_tidb_fields_without_db_url() -> None:
 
 
 def test_load_settings_rejects_invalid_integer() -> None:
-    with pytest.raises(ValueError, match="CI_DASHBOARD_BATCH_SIZE"):
+    with pytest.raises(
+        ValueError,
+        match=r"CI_DASHBOARD_BATCH_SIZE must be an integer, got 'abc'",
+    ):
         load_settings(
             {
                 "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
@@ -44,7 +47,10 @@ def test_load_settings_rejects_invalid_integer() -> None:
 
 
 def test_load_settings_rejects_invalid_refresh_group_batch_size() -> None:
-    with pytest.raises(ValueError, match="CI_DASHBOARD_REFRESH_GROUP_BATCH_SIZE"):
+    with pytest.raises(
+        ValueError,
+        match=r"CI_DASHBOARD_REFRESH_GROUP_BATCH_SIZE must be an integer, got 'abc'",
+    ):
         load_settings(
             {
                 "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
@@ -54,11 +60,27 @@ def test_load_settings_rejects_invalid_refresh_group_batch_size() -> None:
 
 
 def test_load_settings_rejects_invalid_refresh_build_limit() -> None:
-    with pytest.raises(ValueError, match="CI_DASHBOARD_REFRESH_BUILD_LIMIT"):
+    with pytest.raises(
+        ValueError,
+        match=r"CI_DASHBOARD_REFRESH_BUILD_LIMIT must be an integer, got 'abc'",
+    ):
         load_settings(
             {
                 "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
                 "CI_DASHBOARD_REFRESH_BUILD_LIMIT": "abc",
+            }
+        )
+
+
+def test_load_settings_rejects_non_positive_refresh_build_limit() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"CI_DASHBOARD_REFRESH_BUILD_LIMIT must be positive, got '0'",
+    ):
+        load_settings(
+            {
+                "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
+                "CI_DASHBOARD_REFRESH_BUILD_LIMIT": "0",
             }
         )
 


### PR DESCRIPTION
## Summary
- checkpoint refresh-build-derived progress with a per-run impacted build limit
- freeze the selection window in ci_job_state so backlog processing resumes without re-scanning everything
- batch failure_category refresh and document the new watermark fields / env knob

## Testing
- /Users/dillon/workspace/ee-apps-worktrees/ci-dashboard-round2/ci-dashboard/.venv/bin/python -m pytest -q
- /Users/dillon/workspace/ee-apps-worktrees/ci-dashboard-round2/ci-dashboard/.venv/bin/python -m ruff check src tests