### PR TITLE
chore (ci-dashboard): improve dashboard slow sql and release 0.1.2

### DIFF
--- a/charts/ci-dashboard/Chart.yaml
+++ b/charts/ci-dashboard/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ci-dashboard
 description: CI dashboard application for prow.tidb.net/dashboard/.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.2
+appVersion: "0.1.2"

--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-dashboard"
-version = "0.1.1"
+version = "0.1.2"
 description = "CI dashboard jobs and API scaffold"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
+++ b/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: ci-dashboard
-Version: 0.1.0
+Version: 0.1.2
 Summary: CI dashboard jobs and API scaffold
 Requires-Python: >=3.11
 Description-Content-Type: text/markdown

--- a/ci-dashboard/src/ci_dashboard/__init__.py
+++ b/ci-dashboard/src/ci_dashboard/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.2"

--- a/ci-dashboard/src/ci_dashboard/api/main.py
+++ b/ci-dashboard/src/ci_dashboard/api/main.py
@@ -71,7 +71,7 @@ def _attach_frontend(app: FastAPI) -> None:
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="CI Dashboard", version="0.1.0")
+    app = FastAPI(title="CI Dashboard", version="0.1.2")
 
     app.include_router(status_router)
     app.include_router(filters_router)

--- a/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
@@ -11,6 +11,7 @@ from sqlalchemy.engine import Connection, Engine
 from ci_dashboard.common.config import Settings
 from ci_dashboard.common.models import RefreshBuildDerivedSummary
 from ci_dashboard.common.sql_helpers import chunked
+from ci_dashboard.jobs.build_url_matcher import classify_cloud_phase, normalize_build_url
 from ci_dashboard.jobs.flaky import BuildAttempt, compute_group_flags, parse_datetime
 from ci_dashboard.jobs.state_store import (
     get_job_state,
@@ -25,6 +26,7 @@ JOB_NAME = "ci-refresh-build-derived"
 REQUIRE_RETEST_FOR_RETRY_LOOP = False
 DEFAULT_WRITE_BATCH_SIZE = 100
 DEFAULT_REFRESH_BUILD_LIMIT = 5000
+CASE_RUN_DERIVED_WATERMARK_KEY = "last_processed_case_run_derived_id"
 
 
 @dataclass(frozen=True)
@@ -49,6 +51,15 @@ def run_refresh_build_derived(
 
     try:
         with engine.begin() as connection:
+            case_run_derived_watermark = _refresh_problem_case_run_derived_columns(
+                connection,
+                last_processed_case_run_derived_id=_normalize_optional_int(
+                    watermark.get(CASE_RUN_DERIVED_WATERMARK_KEY),
+                    default=0,
+                ),
+                batch_size=chunk_size,
+                write_batch_size=write_batch_size,
+            )
             selection_watermarks = _resolve_selection_watermarks(connection, watermark)
             impacted_selection = _get_impacted_build_ids(
                 connection,
@@ -74,6 +85,7 @@ def run_refresh_build_derived(
             watermark,
             selection_watermarks,
             impacted_selection,
+            case_run_derived_watermark=case_run_derived_watermark,
         )
         summary.last_processed_build_id = int(next_watermark["last_processed_build_id"] or 0)
         summary.last_processed_pr_event_updated_at = _normalize_optional_string(
@@ -184,6 +196,7 @@ def _load_watermark(connection: Connection) -> dict[str, Any]:
             "last_processed_build_id": 0,
             "last_processed_pr_event_updated_at": None,
             "last_processed_case_report_time": None,
+            CASE_RUN_DERIVED_WATERMARK_KEY: 0,
             "pending_refresh": False,
             "pending_target_build_id": None,
             "pending_target_pr_event_updated_at": None,
@@ -200,6 +213,10 @@ def _load_watermark(connection: Connection) -> dict[str, Any]:
             ),
             "last_processed_case_report_time": _normalize_optional_string(
                 state.watermark.get("last_processed_case_report_time")
+            ),
+            CASE_RUN_DERIVED_WATERMARK_KEY: _normalize_optional_int(
+                state.watermark.get(CASE_RUN_DERIVED_WATERMARK_KEY),
+                default=0,
             ),
             "pending_refresh": bool(state.watermark.get("pending_refresh", False)),
             "pending_target_build_id": _normalize_optional_int(
@@ -567,6 +584,8 @@ def _build_success_watermark(
     watermark: Mapping[str, Any],
     selection_watermarks: Mapping[str, Any],
     impacted_selection: ImpactedBuildSelection,
+    *,
+    case_run_derived_watermark: int,
 ) -> dict[str, Any]:
     if impacted_selection.has_more and impacted_selection.build_ids:
         return {
@@ -587,6 +606,7 @@ def _build_success_watermark(
             "pending_target_case_report_time": _normalize_optional_string(
                 selection_watermarks.get("last_processed_case_report_time")
             ),
+            CASE_RUN_DERIVED_WATERMARK_KEY: case_run_derived_watermark,
         }
 
     return {
@@ -604,6 +624,7 @@ def _build_success_watermark(
         "pending_target_build_id": None,
         "pending_target_pr_event_updated_at": None,
         "pending_target_case_report_time": None,
+        CASE_RUN_DERIVED_WATERMARK_KEY: case_run_derived_watermark,
     }
 
 
@@ -618,6 +639,74 @@ def _normalize_optional_string(value: Any) -> str | None:
         return None
     normalized = str(value).strip()
     return normalized or None
+
+
+def _refresh_problem_case_run_derived_columns(
+    connection: Connection,
+    *,
+    last_processed_case_run_derived_id: int,
+    batch_size: int,
+    write_batch_size: int,
+) -> int:
+    rows = list(
+        connection.execute(
+            text(
+                """
+                SELECT id, build_url
+                FROM problem_case_runs
+                WHERE id > :after_id
+                  AND (
+                    normalized_build_key IS NULL
+                    OR normalized_build_key = ''
+                    OR cloud_phase IS NULL
+                    OR cloud_phase = ''
+                  )
+                ORDER BY id
+                LIMIT :batch_size
+                """
+            ),
+            {"after_id": last_processed_case_run_derived_id, "batch_size": batch_size},
+        ).mappings()
+    )
+    if not rows:
+        max_problem_case_run_id = connection.execute(
+            text("SELECT COALESCE(MAX(id), 0) FROM problem_case_runs")
+        ).scalar_one()
+        return int(max_problem_case_run_id or last_processed_case_run_derived_id)
+
+    payload: list[dict[str, Any]] = []
+    next_watermark = last_processed_case_run_derived_id
+    for row in rows:
+        problem_case_run_id = int(row["id"])
+        raw_build_url = _normalize_optional_string(row["build_url"])
+        payload.append(
+            {
+                "id": problem_case_run_id,
+                "normalized_build_key": normalize_build_url(raw_build_url),
+                "cloud_phase": classify_cloud_phase(raw_build_url),
+            }
+        )
+        next_watermark = problem_case_run_id
+
+    _execute_statement_in_batches(
+        connection,
+        text(
+            """
+            UPDATE problem_case_runs
+            SET normalized_build_key = :normalized_build_key,
+                cloud_phase = :cloud_phase
+            WHERE id = :id
+            """
+        ),
+        payload,
+        batch_size=write_batch_size,
+    )
+    LOG.info(
+        "problem_case_runs derived columns updated %s rows up to id %s",
+        len(payload),
+        next_watermark,
+    )
+    return next_watermark
 
 
 def _phase_a_branch_enrichment(

--- a/ci-dashboard/tests/conftest.py
+++ b/ci-dashboard/tests/conftest.py
@@ -139,6 +139,8 @@ def _create_test_schema(engine: Engine) -> None:
           timecost_ms INTEGER NULL,
           report_time TEXT NULL,
           build_url TEXT NULL,
+          normalized_build_key TEXT NULL,
+          cloud_phase TEXT NULL,
           reason TEXT NULL
         )
         """,

--- a/ci-dashboard/tests/jobs/test_refresh_build_derived.py
+++ b/ci-dashboard/tests/jobs/test_refresh_build_derived.py
@@ -225,6 +225,43 @@ def test_fetch_group_builds_for_groups_batches_and_buckets_rows(sqlite_engine) -
     ] == [third_id]
 
 
+def test_refresh_build_derived_enriches_problem_case_run_derived_columns(sqlite_engine) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO problem_case_runs (
+                  repo, branch, suite_name, case_name, flaky, timecost_ms, report_time, build_url, reason
+                ) VALUES (
+                  'pingcap/tidb', 'master', 'unit', 'case-a', 1, 10, '2026-04-13 10:15:00',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/123/display/redirect',
+                  'flake'
+                )
+                """
+            )
+        )
+
+    summary = run_refresh_build_derived(sqlite_engine, _settings(batch_size=5))
+
+    with sqlite_engine.begin() as connection:
+        row = connection.execute(
+            text(
+                """
+                SELECT normalized_build_key, cloud_phase
+                FROM problem_case_runs
+                WHERE case_name = 'case-a'
+                """
+            )
+        ).mappings().one()
+        state = get_job_state(connection, "ci-refresh-build-derived")
+
+    assert summary.impacted_builds == 0
+    assert row["normalized_build_key"] == "/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/123"
+    assert row["cloud_phase"] == "GCP"
+    assert state is not None
+    assert int(state.watermark["last_processed_case_run_derived_id"]) > 0
+
+
 def test_refresh_build_derived_end_to_end(sqlite_engine) -> None:
     _insert_build(
         sqlite_engine,

--- a/ci-dashboard/web/package-lock.json
+++ b/ci-dashboard/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-dashboard-web",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump ci-dashboard release metadata to 0.1.2 across the Python package, FastAPI app version, frontend package metadata, and Helm chart
- enrich `problem_case_runs` inside `ci-refresh-build-derived` by backfilling `normalized_build_key` and `cloud_phase` for rows that are still missing those derived values
- persist a dedicated `last_processed_case_run_derived_id` watermark so the new source-table enrichment phase resumes incrementally and remains idempotent

## Context
- the previously merged refresh-build-derived performance work is already on `main` via `#415` and `#420`
- this PR only contains the remaining delta that is not yet in `main`

## Validation
- `./.venv/bin/python -m pytest -q tests/jobs/test_refresh_build_derived.py`
- `./.venv/bin/python -m ruff check src tests`
- `python3 -m compileall ci-dashboard/src`

## Notes
- local `helm` is not installed in this environment, so `helm lint charts/ci-dashboard` was not run locally