### PR TITLE
fix(dashboard):  improves the dashboard's performance

### DIFF
--- a/ci-dashboard/src/ci_dashboard/api/queries/builds.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/builds.py
@@ -529,7 +529,7 @@ def get_migration_runtime_comparison(engine: Engine, filters: CommonFilters) -> 
         cloud_phase=None,
         issue_status=None,
         start_date=None,
-        end_date=None,
+        end_date=filters.end_date,
         granularity=filters.granularity,
     )
 
@@ -579,6 +579,7 @@ def get_migration_runtime_comparison(engine: Engine, filters: CommonFilters) -> 
                     AND {success_where}
                     AND b.run_seconds IS NOT NULL
                     AND b.start_time < :anchor_end_exclusive
+                    AND UPPER(COALESCE(b.cloud_phase, '')) IN ('GCP', 'IDC')
                     AND {normalized_job_path} IS NOT NULL
                 ),
                 first_gcp AS (
@@ -720,10 +721,19 @@ def _normalized_job_path_expr(connection, table_alias: str = "") -> str:
     if connection.dialect.name == "sqlite":
         return f"normalized_job_path_from_key({base_key})"
 
+    trimmed_key = f"TRIM(TRAILING '/' FROM {base_key})"
+    last_segment = f"SUBSTRING_INDEX({trimmed_key}, '/', -1)"
+    job_path = (
+        "CASE "
+        f"WHEN {last_segment} REGEXP '^[0-9]+$' "
+        f"THEN LEFT({trimmed_key}, CHAR_LENGTH({trimmed_key}) - CHAR_LENGTH({last_segment}) - 1) "
+        f"ELSE {trimmed_key} "
+        "END"
+    )
     return (
         "CASE "
         f"WHEN {base_key} IS NULL THEN NULL "
-        f"ELSE CONCAT(NULLIF(REGEXP_REPLACE(REGEXP_REPLACE({base_key}, '/[0-9]+/?$', ''), '/+$', ''), ''), '/') "
+        f"ELSE CONCAT(NULLIF({job_path}, ''), '/') "
         "END"
     )
 

--- a/ci-dashboard/src/ci_dashboard/api/queries/filters.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/filters.py
@@ -84,8 +84,15 @@ def list_jobs(
     *,
     repo: str | None = None,
     branch: str | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
 ) -> dict[str, object]:
-    filters = CommonFilters(repo=repo, branch=branch)
+    filters = CommonFilters(
+        repo=repo,
+        branch=branch,
+        start_date=start_date,
+        end_date=end_date,
+    )
     where_clause, params = build_common_where(filters, table_alias="b")
 
     with engine.begin() as connection:
@@ -111,8 +118,23 @@ def list_jobs(
     return {"items": items}
 
 
-def list_cloud_phases(engine: Engine) -> dict[str, object]:
-    filters = CommonFilters()
+def list_cloud_phases(
+    engine: Engine,
+    *,
+    repo: str | None = None,
+    branch: str | None = None,
+    job_name: str | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> dict[str, object]:
+    filters = CommonFilters(
+        repo=repo,
+        branch=branch,
+        job_name=job_name,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    where_clause, params = build_common_where(filters, table_alias="b")
     with engine.begin() as connection:
         builds_table = builds_table_expr(connection, filters, alias="b")
         rows = connection.execute(
@@ -120,11 +142,13 @@ def list_cloud_phases(engine: Engine) -> dict[str, object]:
                 f"""
                 SELECT DISTINCT cloud_phase
                 FROM {builds_table}
-                WHERE b.cloud_phase IS NOT NULL
+                WHERE {where_clause}
+                  AND b.cloud_phase IS NOT NULL
                   AND b.cloud_phase <> ''
                 ORDER BY cloud_phase
                 """
-            )
+            ),
+            params,
         ).mappings()
 
         items = [

--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -10,6 +10,7 @@ from ci_dashboard.api.queries.base import (
     CommonFilters,
     MAX_RANKING_LIMIT,
     branch_match_expr,
+    builds_table_expr,
     bucket_expr,
     filter_complete_week_rows,
     failure_like_expr,
@@ -79,22 +80,24 @@ def get_flaky_top_jobs(
     limit: int = 10,
 ) -> dict[str, Any]:
     effective_limit = min(limit, MAX_RANKING_LIMIT)
-    where_clause, params = _build_build_where(filters, table_alias="b")
     failure_like = failure_like_expr("b")
 
     with engine.begin() as connection:
+        where_clause, params = _build_build_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         rows = connection.execute(
             text(
                 f"""
                 WITH job_stats AS (
                   SELECT
                     b.job_name,
-                    SUM(CASE WHEN {failure_like} THEN 1 ELSE 0 END) AS failure_like_build_count,
-                    SUM(CASE WHEN {failure_like} AND b.is_flaky = 1 THEN 1 ELSE 0 END) AS flaky_build_count,
-                    SUM(CASE WHEN {failure_like} AND b.is_retry_loop = 1 THEN 1 ELSE 0 END) AS retry_loop_build_count,
-                    SUM(CASE WHEN {failure_like} AND (b.is_flaky = 1 OR b.is_retry_loop = 1) THEN 1 ELSE 0 END) AS noisy_build_count
-                  FROM ci_l1_builds b
+                    COUNT(*) AS failure_like_build_count,
+                    SUM(CASE WHEN b.is_flaky = 1 THEN 1 ELSE 0 END) AS flaky_build_count,
+                    SUM(CASE WHEN b.is_retry_loop = 1 THEN 1 ELSE 0 END) AS retry_loop_build_count,
+                    SUM(CASE WHEN b.is_flaky = 1 OR b.is_retry_loop = 1 THEN 1 ELSE 0 END) AS noisy_build_count
+                  FROM {builds_table}
                   WHERE {where_clause}
+                    AND {failure_like}
                   GROUP BY b.job_name
                 )
                 SELECT
@@ -733,17 +736,19 @@ def _query_bucketed_flaky_metrics(
         where_clause, params = _build_build_where(filters, table_alias="b")
         bucket = bucket_expr(connection, "b.start_time", filters.granularity)
         failure_like = failure_like_expr("b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
         rows = connection.execute(
             text(
                 f"""
                 SELECT
                   {bucket} AS bucket_start,
-                  SUM(CASE WHEN {failure_like} THEN 1 ELSE 0 END) AS total_failure_like_count,
-                  SUM(CASE WHEN {failure_like} AND b.is_flaky = 1 THEN 1 ELSE 0 END) AS flaky_build_count,
-                  SUM(CASE WHEN {failure_like} AND b.is_retry_loop = 1 THEN 1 ELSE 0 END) AS retry_loop_build_count,
-                  SUM(CASE WHEN {failure_like} AND (b.is_flaky = 1 OR b.is_retry_loop = 1) THEN 1 ELSE 0 END) AS noisy_build_count
-                FROM ci_l1_builds b
+                  COUNT(*) AS total_failure_like_count,
+                  SUM(CASE WHEN b.is_flaky = 1 THEN 1 ELSE 0 END) AS flaky_build_count,
+                  SUM(CASE WHEN b.is_retry_loop = 1 THEN 1 ELSE 0 END) AS retry_loop_build_count,
+                  SUM(CASE WHEN b.is_flaky = 1 OR b.is_retry_loop = 1 THEN 1 ELSE 0 END) AS noisy_build_count
+                FROM {builds_table}
                 WHERE {where_clause}
+                  AND {failure_like}
                 GROUP BY bucket_start
                 ORDER BY bucket_start
                 """
@@ -766,7 +771,8 @@ def _query_period_summary(
 ) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = _build_build_where(filters, table_alias="b")
-        summary = _fetch_period_summary(connection, where_clause, params)
+        builds_table = builds_table_expr(connection, filters, alias="b")
+        summary = _fetch_period_summary(connection, builds_table, where_clause, params)
 
     total_build_count = int(summary["total_build_count"] or 0)
     failure_like_build_count = int(summary["failure_like_build_count"] or 0)
@@ -793,6 +799,7 @@ def _query_period_summary(
 
 def _fetch_period_summary(
     connection: Connection,
+    builds_table: str,
     where_clause: str,
     params: dict[str, Any],
 ) -> dict[str, Any]:
@@ -811,7 +818,7 @@ def _fetch_period_summary(
               COUNT(DISTINCT CASE
                 WHEN b.pr_number IS NOT NULL AND (b.is_flaky = 1 OR b.is_retry_loop = 1) THEN {distinct_pr_key}
               END) AS affected_pr_count
-            FROM ci_l1_builds b
+            FROM {builds_table}
             WHERE {where_clause}
             """
         ),

--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, timedelta
-from typing import Any
+from typing import Any, Callable
 
 from sqlalchemy.engine import Engine
 
@@ -36,33 +37,39 @@ from ci_dashboard.api.queries.status import get_freshness
 
 def get_overview_page(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     previous_start, previous_end = _get_previous_date_range(filters)
+    sections = _resolve_page_sections(
+        engine,
+        {
+            "freshness": lambda: get_freshness(engine),
+            "repos": lambda: list_repos(
+                engine,
+                start_date=filters.start_date,
+                end_date=filters.end_date,
+            ),
+            "outcome_trend": lambda: get_outcome_trend(engine, filters),
+            "top_noisy_jobs": lambda: get_flaky_top_jobs(engine, filters, limit=5),
+            "failure_category_share": lambda: get_failure_category_share(engine, filters),
+            "cloud_comparison": lambda: get_cloud_comparison(engine, filters),
+            "period_comparison": (
+                lambda: get_flaky_period_comparison(
+                    engine,
+                    repo=filters.repo,
+                    branch=filters.branch,
+                    job_name=filters.job_name,
+                    cloud_phase=filters.cloud_phase,
+                    period_a_start=filters.start_date,
+                    period_a_end=filters.end_date,
+                    period_b_start=previous_start,
+                    period_b_end=previous_end,
+                )
+                if previous_start and previous_end and filters.start_date and filters.end_date
+                else {"groups": [], "meta": filters.meta()}
+            ),
+        }
+    )
     return {
         "scope": filters.meta(),
-        "freshness": get_freshness(engine),
-        "repos": list_repos(
-            engine,
-            start_date=filters.start_date,
-            end_date=filters.end_date,
-        ),
-        "outcome_trend": get_outcome_trend(engine, filters),
-        "top_noisy_jobs": get_flaky_top_jobs(engine, filters, limit=5),
-        "failure_category_share": get_failure_category_share(engine, filters),
-        "cloud_comparison": get_cloud_comparison(engine, filters),
-        "period_comparison": (
-            get_flaky_period_comparison(
-                engine,
-                repo=filters.repo,
-                branch=filters.branch,
-                job_name=filters.job_name,
-                cloud_phase=filters.cloud_phase,
-                period_a_start=filters.start_date,
-                period_a_end=filters.end_date,
-                period_b_start=previous_start,
-                period_b_end=previous_end,
-            )
-            if previous_start and previous_end and filters.start_date and filters.end_date
-            else {"groups": [], "meta": filters.meta()}
-        ),
+        **sections,
     }
 
 
@@ -78,15 +85,24 @@ def get_build_trend_page(engine: Engine, filters: CommonFilters) -> dict[str, An
         end_date=filters.end_date,
         granularity=filters.granularity,
     )
+    sections = _resolve_page_sections(
+        engine,
+        {
+            "outcome_trend": lambda: get_outcome_trend(engine, filters),
+            "duration_trend": lambda: get_duration_trend(engine, filters),
+            "cloud_posture_trend": lambda: get_cloud_posture_trend(engine, filters),
+            "longest_avg_success_jobs": lambda: get_longest_avg_success_jobs(engine, filters),
+            "lowest_success_rate_jobs": lambda: get_lowest_success_rate_jobs(engine, filters),
+            "migration_runtime_comparison": lambda: get_migration_runtime_comparison(
+                engine,
+                migration_filters,
+            ),
+            "cloud_repo_share": lambda: get_cloud_repo_share(engine, repo_share_filters),
+        }
+    )
     return {
         "scope": filters.meta(),
-        "outcome_trend": get_outcome_trend(engine, filters),
-        "duration_trend": get_duration_trend(engine, filters),
-        "cloud_posture_trend": get_cloud_posture_trend(engine, filters),
-        "longest_avg_success_jobs": get_longest_avg_success_jobs(engine, filters),
-        "lowest_success_rate_jobs": get_lowest_success_rate_jobs(engine, filters),
-        "migration_runtime_comparison": get_migration_runtime_comparison(engine, migration_filters),
-        "cloud_repo_share": get_cloud_repo_share(engine, repo_share_filters),
+        **sections,
     }
 
 
@@ -103,38 +119,54 @@ def get_flaky_page(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
         end_date=build_scope_filters.end_date,
         granularity="week",
     )
-    issue_case_rates = get_issue_filtered_weekly_case_rates(engine, filters)
+    sections = _resolve_page_sections(
+        engine,
+        {
+            "distinct_flaky_case_counts": lambda: get_distinct_flaky_case_counts_by_branch(
+                engine,
+                filters,
+            ),
+            "issue_lifecycle": lambda: get_issue_lifecycle_snapshot(engine, filters),
+            "issue_lifecycle_weekly": lambda: get_issue_lifecycle_weekly(engine, filters),
+            "issue_case_rates": lambda: get_issue_filtered_weekly_case_rates(engine, filters),
+            "trend": lambda: get_flaky_trend(engine, build_scope_filters),
+            "composition": lambda: get_flaky_composition(engine, build_scope_filters_weekly),
+            "top_jobs": lambda: get_flaky_top_jobs(engine, build_scope_filters, limit=8),
+            "failure_category_share": lambda: get_failure_category_share(
+                engine,
+                build_scope_filters,
+            ),
+            "failure_category_trend": lambda: get_failure_category_trend(
+                engine,
+                build_scope_filters,
+            ),
+            "period_comparison": (
+                lambda: get_flaky_period_comparison(
+                    engine,
+                    repo=build_scope_filters.repo,
+                    branch=build_scope_filters.branch,
+                    job_name=build_scope_filters.job_name,
+                    cloud_phase=build_scope_filters.cloud_phase,
+                    period_a_start=build_scope_filters.start_date,
+                    period_a_end=build_scope_filters.end_date,
+                    period_b_start=previous_start,
+                    period_b_end=previous_end,
+                )
+                if previous_start and previous_end and filters.start_date and filters.end_date
+                else {"groups": [], "meta": filters.meta()}
+            ),
+        }
+    )
+    issue_case_rates = sections.pop("issue_case_rates")
     return {
         "scope": filters.meta(),
-        "distinct_flaky_case_counts": get_distinct_flaky_case_counts_by_branch(engine, filters),
-        "issue_lifecycle": get_issue_lifecycle_snapshot(engine, filters),
-        "issue_lifecycle_weekly": get_issue_lifecycle_weekly(engine, filters),
+        **sections,
         "issue_case_weekly_rates": {
             "weeks": issue_case_rates["weeks"],
             "rows": issue_case_rates["rows"],
             "meta": issue_case_rates["meta"],
         },
         "issue_filtered_weekly_trend": issue_case_rates["trend"],
-        "trend": get_flaky_trend(engine, build_scope_filters),
-        "composition": get_flaky_composition(engine, build_scope_filters_weekly),
-        "top_jobs": get_flaky_top_jobs(engine, build_scope_filters, limit=8),
-        "failure_category_share": get_failure_category_share(engine, build_scope_filters),
-        "failure_category_trend": get_failure_category_trend(engine, build_scope_filters),
-        "period_comparison": (
-            get_flaky_period_comparison(
-                engine,
-                repo=build_scope_filters.repo,
-                branch=build_scope_filters.branch,
-                job_name=build_scope_filters.job_name,
-                cloud_phase=build_scope_filters.cloud_phase,
-                period_a_start=build_scope_filters.start_date,
-                period_a_end=build_scope_filters.end_date,
-                period_b_start=previous_start,
-                period_b_end=previous_end,
-            )
-            if previous_start and previous_end and filters.start_date and filters.end_date
-            else {"groups": [], "meta": filters.meta()}
-        ),
     }
 
 
@@ -146,3 +178,15 @@ def _get_previous_date_range(filters: CommonFilters) -> tuple[date | None, date 
     previous_end = filters.start_date - timedelta(days=1)
     previous_start = previous_end - timedelta(days=span_days - 1)
     return previous_start, previous_end
+
+
+def _resolve_page_sections(
+    engine: Engine,
+    tasks: dict[str, Callable[[], Any]],
+) -> dict[str, Any]:
+    if engine.dialect.name == "sqlite" or len(tasks) <= 1:
+        return {name: task() for name, task in tasks.items()}
+
+    with ThreadPoolExecutor(max_workers=min(len(tasks), 4)) as executor:
+        futures = {name: executor.submit(task) for name, task in tasks.items()}
+        return {name: future.result() for name, future in futures.items()}

--- a/ci-dashboard/src/ci_dashboard/api/routes/filters.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/filters.py
@@ -38,11 +38,33 @@ def branches(
 def jobs(
     repo: str | None = None,
     branch: str | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
     engine: Engine = Depends(get_engine),
 ) -> dict[str, object]:
-    return list_jobs(engine, repo=repo, branch=branch)
+    return list_jobs(
+        engine,
+        repo=repo,
+        branch=branch,
+        start_date=start_date,
+        end_date=end_date,
+    )
 
 
 @router.get("/cloud-phases")
-def cloud_phases(engine: Engine = Depends(get_engine)) -> dict[str, object]:
-    return list_cloud_phases(engine)
+def cloud_phases(
+    repo: str | None = None,
+    branch: str | None = None,
+    job_name: str | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return list_cloud_phases(
+        engine,
+        repo=repo,
+        branch=branch,
+        job_name=job_name,
+        start_date=start_date,
+        end_date=end_date,
+    )

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -80,11 +80,24 @@ export default function App() {
     });
   }, [location.pathname]);
 
-  const jobs = useApiData("/api/v1/filters/jobs", {
+  const shouldLoadJobs = Boolean(filters.repo);
+  const jobs = useApiData(
+    "/api/v1/filters/jobs",
+    {
+      repo: filters.repo,
+      branch: filters.branch,
+      start_date: filters.start_date,
+      end_date: filters.end_date,
+    },
+    shouldLoadJobs,
+  );
+  const cloudPhases = useApiData("/api/v1/filters/cloud-phases", {
     repo: filters.repo,
     branch: filters.branch,
+    job_name: filters.job_name,
+    start_date: filters.start_date,
+    end_date: filters.end_date,
   });
-  const cloudPhases = useApiData("/api/v1/filters/cloud-phases");
 
   function handleFilterChange(key, value) {
     setFilters((current) => {

--- a/ci-dashboard/web/src/lib/api.js
+++ b/ci-dashboard/web/src/lib/api.js
@@ -85,14 +85,23 @@ export async function fetchJson(path, params = {}, signal) {
   return response.json();
 }
 
-export function useApiData(path, params = {}) {
+export function useApiData(path, params = {}, enabled = true) {
   const [state, setState] = useState({
     data: null,
-    loading: true,
+    loading: enabled,
     error: null,
   });
 
   useEffect(() => {
+    if (!enabled) {
+      setState({
+        data: null,
+        loading: false,
+        error: null,
+      });
+      return undefined;
+    }
+
     const controller = new AbortController();
     setState((current) => ({
       data: current.data,
@@ -120,7 +129,7 @@ export function useApiData(path, params = {}) {
       });
 
     return () => controller.abort();
-  }, [path, JSON.stringify(params)]);
+  }, [enabled, path, JSON.stringify(params)]);
 
   return state;
 }


### PR DESCRIPTION
## Summary
- narrow filter option queries to the active dashboard scope instead of scanning the full builds table
- force flaky aggregations onto the existing time/repo-time indexes and skip non-failure rows for noisy-rate panels
- parallelize page assembly queries so overview / ci-status / flaky wall-clock time tracks the slowest section instead of the sum of all sections
- tighten migration runtime comparison to the selected end date, GCP/IDC rows only, and cheaper normalized job-path extraction

## Validation
- `python3.12 -m pytest tests/api/test_routes.py -q`
- prod DB local smoke with current code + `apps/ci-dashboard-eq-prd-insight-db` credentials:
  - `overview`: `7.051s`
  - `ci-status`: `5.215s`
  - `flaky`: `9.25s`
  - `filters/jobs` (`repo=pingcap/tidb`, `branch=master`, `2026-03-23..2026-04-24`): `4.613s`
  - `filters/cloud-phases` (`2026-03-23..2026-04-24`): `0.843s`

## Context
Current prod app was timing out behind the gateway and returning `Could not load panel: 504`. Before this patch, direct prod-DB timing on the same code path was roughly:
- `overview`: `10.649s`
- `ci-status`: `33.213s`
- `flaky`: `33.555s`

The main hot spots were:
- serial page assembly of independent section queries
- full-scan / unhinted flaky page aggregations
- unscoped filter-option queries
