### PR TITLE
fix(cloudevents-server): ignore unmapped Jenkins cdevents

### DIFF
--- a/cloudevents-server/configs/example-config.yaml
+++ b/cloudevents-server/configs/example-config.yaml
@@ -31,7 +31,8 @@ kafka:
   #   user: username
   #   password: password
   producer:
-    topic_mapping: {}
+    topic_mapping:
+      dev.cdevents.pipelinerun.finished.0.1.0: jenkins-event
     default_topic: test-topic
   consumer:
     group_id: consumer-group-1

--- a/cloudevents-server/pkg/events/handler/jenkins_routing.go
+++ b/cloudevents-server/pkg/events/handler/jenkins_routing.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+const jenkinsCloudEventTypePrefix = "dev.cdevents."
+
+func (eb *EventProducer) resolveTopic(eventType string) (string, bool) {
+	if topic, ok := eb.topicMapping[eventType]; ok {
+		return topic, false
+	}
+
+	if strings.HasPrefix(eventType, jenkinsCloudEventTypePrefix) {
+		return "", true
+	}
+
+	log.Debug().Str("event-type", eventType).Msg("No topic found for event type, using default topic")
+	return eb.unknowEventTopic, false
+}

--- a/cloudevents-server/pkg/events/handler/jenkins_routing_test.go
+++ b/cloudevents-server/pkg/events/handler/jenkins_routing_test.go
@@ -16,9 +16,9 @@ func TestResolveTopic(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		eventType string
-		wantTopic string
+		name       string
+		eventType  string
+		wantTopic  string
 		wantIgnore bool
 	}{
 		{

--- a/cloudevents-server/pkg/events/handler/kafka.go
+++ b/cloudevents-server/pkg/events/handler/kafka.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -70,8 +69,6 @@ type EventProducer struct {
 	topicMapping     map[string]string // Map event type to Kafka topic
 }
 
-const jenkinsCloudEventTypePrefix = "dev.cdevents."
-
 func (eb *EventProducer) HandleCloudEvent(ctx context.Context, event cloudevents.Event) cloudevents.Result {
 	eventType := event.Type()
 	topic, ignore := eb.resolveTopic(eventType)
@@ -104,19 +101,6 @@ func (eb *EventProducer) HandleCloudEvent(ctx context.Context, event cloudevents
 		Dur("duration", time.Since(startTime)).
 		Msg("message written to Kafka")
 	return cloudevents.ResultACK
-}
-
-func (eb *EventProducer) resolveTopic(eventType string) (string, bool) {
-	if topic, ok := eb.topicMapping[eventType]; ok {
-		return topic, false
-	}
-
-	if strings.HasPrefix(eventType, jenkinsCloudEventTypePrefix) {
-		return "", true
-	}
-
-	log.Debug().Str("event-type", eventType).Msg("No topic found for event type, using default topic")
-	return eb.unknowEventTopic, false
 }
 
 type EventConsumerGroup map[string]*EventConsumer

--- a/cloudevents-server/pkg/events/handler/kafka.go
+++ b/cloudevents-server/pkg/events/handler/kafka.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -69,14 +70,14 @@ type EventProducer struct {
 	topicMapping     map[string]string // Map event type to Kafka topic
 }
 
+const jenkinsCloudEventTypePrefix = "dev.cdevents."
+
 func (eb *EventProducer) HandleCloudEvent(ctx context.Context, event cloudevents.Event) cloudevents.Result {
 	eventType := event.Type()
-	topic, ok := eb.topicMapping[eventType]
-
-	// Use default topic if not found in mapping
-	if !ok {
-		log.Debug().Str("event-type", eventType).Msg("No topic found for event type, using default topic")
-		topic = eb.unknowEventTopic
+	topic, ignore := eb.resolveTopic(eventType)
+	if ignore {
+		log.Debug().Str("event-type", eventType).Msg("Ignoring unsupported Jenkins CDEvent type")
+		return cloudevents.ResultACK
 	}
 
 	cloudEventBytes, err := event.MarshalJSON()
@@ -103,6 +104,19 @@ func (eb *EventProducer) HandleCloudEvent(ctx context.Context, event cloudevents
 		Dur("duration", time.Since(startTime)).
 		Msg("message written to Kafka")
 	return cloudevents.ResultACK
+}
+
+func (eb *EventProducer) resolveTopic(eventType string) (string, bool) {
+	if topic, ok := eb.topicMapping[eventType]; ok {
+		return topic, false
+	}
+
+	if strings.HasPrefix(eventType, jenkinsCloudEventTypePrefix) {
+		return "", true
+	}
+
+	log.Debug().Str("event-type", eventType).Msg("No topic found for event type, using default topic")
+	return eb.unknowEventTopic, false
 }
 
 type EventConsumerGroup map[string]*EventConsumer

--- a/cloudevents-server/pkg/events/handler/kafka.go
+++ b/cloudevents-server/pkg/events/handler/kafka.go
@@ -73,7 +73,7 @@ func (eb *EventProducer) HandleCloudEvent(ctx context.Context, event cloudevents
 	eventType := event.Type()
 	topic, ignore := eb.resolveTopic(eventType)
 	if ignore {
-		log.Debug().Str("event-type", eventType).Msg("Ignoring unsupported Jenkins CDEvent type")
+		log.Debug().Str("event-type", eventType).Str("ce-id", event.ID()).Msg("Ignoring unsupported Jenkins CDEvent type")
 		return cloudevents.ResultACK
 	}
 

--- a/cloudevents-server/pkg/events/handler/kafka_test.go
+++ b/cloudevents-server/pkg/events/handler/kafka_test.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+func TestResolveTopic(t *testing.T) {
+	producer := &EventProducer{
+		unknowEventTopic: "cloudevents-default-channel",
+		topicMapping: map[string]string{
+			"dev.cdevents.pipelinerun.finished.0.1.0": "jenkins-event",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		eventType string
+		wantTopic string
+		wantIgnore bool
+	}{
+		{
+			name:       "mapped Jenkins pipeline run finished event",
+			eventType:  "dev.cdevents.pipelinerun.finished.0.1.0",
+			wantTopic:  "jenkins-event",
+			wantIgnore: false,
+		},
+		{
+			name:       "unmapped Jenkins event is ignored",
+			eventType:  "dev.cdevents.taskrun.finished.0.1.0",
+			wantTopic:  "",
+			wantIgnore: true,
+		},
+		{
+			name:       "non Jenkins event falls back to default topic",
+			eventType:  "dev.tekton.event.taskrun.failed.v1",
+			wantTopic:  "cloudevents-default-channel",
+			wantIgnore: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTopic, gotIgnore := producer.resolveTopic(tt.eventType)
+			if gotTopic != tt.wantTopic {
+				t.Fatalf("resolveTopic() topic = %q, want %q", gotTopic, tt.wantTopic)
+			}
+			if gotIgnore != tt.wantIgnore {
+				t.Fatalf("resolveTopic() ignore = %v, want %v", gotIgnore, tt.wantIgnore)
+			}
+		})
+	}
+}
+
+func TestHandleCloudEventIgnoresUnsupportedJenkinsCDEvent(t *testing.T) {
+	producer := &EventProducer{
+		unknowEventTopic: "cloudevents-default-channel",
+		topicMapping: map[string]string{
+			"dev.cdevents.pipelinerun.finished.0.1.0": "jenkins-event",
+		},
+	}
+
+	event := cloudevents.NewEvent()
+	event.SetID("test-id")
+	event.SetSource("job/example/1/")
+	event.SetType("dev.cdevents.taskrun.finished.0.1.0")
+
+	result := producer.HandleCloudEvent(context.Background(), event)
+	if !cloudevents.IsACK(result) {
+		t.Fatalf("HandleCloudEvent() result = %v, want ACK", result)
+	}
+}


### PR DESCRIPTION
## Summary
- ignore unmapped Jenkins CDEvents (`dev.cdevents.*`) at the ingress routing layer
- keep mapped Jenkins events routable through Kafka `producer.topic_mapping`
- document the Jenkins `pipelinerun.finished -> jenkins-event` mapping in `configs/example-config.yaml`
- isolate the Jenkins ingress routing policy into its own file instead of mixing it into the generic Kafka producer flow

## Behavior
- `dev.cdevents.pipelinerun.finished.0.1.0` is routed by `producer.topic_mapping`
- other `dev.cdevents.*` event types are acknowledged and dropped
- non-Jenkins CloudEvents still fall back to `default_topic` when not explicitly mapped

## Testing
- `cd cloudevents-server && go test ./pkg/events/handler`
- `cd cloudevents-server && go test ./cmd/server`
