### PR TITLE
fix(ci-dashboard): parse real Jenkins cd events

### DIFF
--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -1347,20 +1347,47 @@ def _normalize_case_build_key_expr(connection: Connection, column_name: str) -> 
 
     trimmed = f"TRIM(COALESCE({column_name}, ''))"
     without_redirect = f"REPLACE({trimmed}, '/display/redirect', '')"
-    canonical = (
+    canonical_host = (
         "CASE "
         f"WHEN {without_redirect} = '' THEN NULL "
-        f"WHEN {without_redirect} LIKE 'https://do.pingcap.net/%' "
-        f"THEN CONCAT('https://prow.tidb.net', SUBSTRING({without_redirect}, CHAR_LENGTH('https://do.pingcap.net') + 1)) "
-        f"WHEN {without_redirect} LIKE 'https://prow.tidb.net/%' THEN {without_redirect} "
+        f"WHEN {without_redirect} LIKE 'https://prow.tidb.net/%' THEN 'https://prow.tidb.net' "
+        f"WHEN {without_redirect} LIKE 'https://do.pingcap.net/%' THEN 'https://do.pingcap.net' "
+        f"WHEN {without_redirect} REGEXP '^https?://jenkins\\\\.jenkins\\\\.svc\\\\.cluster\\\\.local(:[0-9]+)?/' THEN 'https://prow.tidb.net' "
+        f"WHEN {without_redirect} NOT REGEXP '^https?://' THEN 'https://prow.tidb.net' "
+        "ELSE NULL "
+        "END"
+    )
+    stripped_known_host = (
+        "CASE "
+        f"WHEN {without_redirect} = '' THEN NULL "
+        f"WHEN {without_redirect} REGEXP '^https?://prow\\\\.tidb\\\\.net/' "
+        f"THEN REGEXP_REPLACE({without_redirect}, '^https?://prow\\\\.tidb\\\\.net', '') "
+        f"WHEN {without_redirect} REGEXP '^https?://do\\\\.pingcap\\\\.net/' "
+        f"THEN REGEXP_REPLACE({without_redirect}, '^https?://do\\\\.pingcap\\\\.net', '') "
+        f"WHEN {without_redirect} REGEXP '^https?://jenkins\\\\.jenkins\\\\.svc\\\\.cluster\\\\.local(:[0-9]+)?/' "
+        f"THEN REGEXP_REPLACE({without_redirect}, '^https?://jenkins\\\\.jenkins\\\\.svc\\\\.cluster\\\\.local(:[0-9]+)?', '') "
         f"ELSE {without_redirect} "
+        "END"
+    )
+    normalized_path = (
+        "CASE "
+        f"WHEN {stripped_known_host} IS NULL OR {stripped_known_host} = '' THEN NULL "
+        f"WHEN LEFT({stripped_known_host}, 1) = '/' THEN {stripped_known_host} "
+        f"ELSE CONCAT('/', TRIM(LEADING '/' FROM {stripped_known_host})) "
+        "END"
+    )
+    canonical_path = (
+        "CASE "
+        f"WHEN {normalized_path} IS NULL THEN NULL "
+        f"WHEN {normalized_path} LIKE '/job/%' THEN CONCAT('/jenkins', {normalized_path}) "
+        f"ELSE {normalized_path} "
         "END"
     )
     return (
         "CASE "
-        f"WHEN {canonical} IS NULL OR {canonical} = '' THEN NULL "
-        f"WHEN RIGHT({canonical}, 1) = '/' THEN {canonical} "
-        f"ELSE CONCAT({canonical}, '/') "
+        f"WHEN {canonical_path} IS NULL OR {canonical_path} = '' OR {canonical_host} IS NULL THEN NULL "
+        f"WHEN RIGHT({canonical_path}, 1) = '/' THEN CONCAT({canonical_host}, {canonical_path}) "
+        f"ELSE CONCAT({canonical_host}, {canonical_path}, '/') "
         "END"
     )
 

--- a/ci-dashboard/src/ci_dashboard/jobs/build_merge.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/build_merge.py
@@ -63,11 +63,12 @@ def resolve_merge_target_id(
     if not candidates:
         return None
 
+    unresolved_candidates = [candidate for candidate in candidates if not candidate.get("source_prow_job_id")]
+
     if source_prow_job_id is None:
         if len(candidates) == 1:
             return int(candidates[0]["id"])
 
-        unresolved_candidates = [candidate for candidate in candidates if not candidate.get("source_prow_job_id")]
         if len(unresolved_candidates) == 1:
             return int(unresolved_candidates[0]["id"])
 
@@ -80,13 +81,6 @@ def resolve_merge_target_id(
         for candidate in candidates
         if candidate.get("source_prow_job_id") not in {None, source_prow_job_id}
     )
-    if conflicting_source_ids:
-        raise ValueError(
-            "normalized_build_url already belongs to a different source_prow_job_id: "
-            f"{normalized_build_url} -> {conflicting_source_ids}"
-        )
-
-    unresolved_candidates = [candidate for candidate in candidates if not candidate.get("source_prow_job_id")]
     if len(unresolved_candidates) == 1:
         return int(unresolved_candidates[0]["id"])
     if len(unresolved_candidates) > 1:
@@ -104,6 +98,25 @@ def resolve_merge_target_id(
             extra=extra,
         )
         return int(chosen["id"])
+
+    if conflicting_source_ids:
+        if source_prow_job_id is not None:
+            extra = {
+                "normalized_build_url": normalized_build_url,
+                "existing_source_prow_job_ids": conflicting_source_ids,
+                "incoming_source_prow_job_id": source_prow_job_id,
+            }
+            if log_context:
+                extra.update(log_context)
+            LOG.warning(
+                "normalized_build_url is reused by multiple source_prow_job_id values; inserting a new canonical row",
+                extra=extra,
+            )
+            return None
+        raise ValueError(
+            "normalized_build_url already belongs to a different source_prow_job_id: "
+            f"{normalized_build_url} -> {conflicting_source_ids}"
+        )
 
     return None
 

--- a/ci-dashboard/src/ci_dashboard/jobs/build_url_matcher.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/build_url_matcher.py
@@ -4,6 +4,7 @@ import re
 from urllib import parse as urllib_parse
 
 GCP_HOST = "https://prow.tidb.net"
+IDC_HOST = "https://do.pingcap.net"
 PROW_NATIVE_PREFIX = "https://prow.tidb.net/view/gs/"
 JENKINS_PREFIXES = (
     "https://prow.tidb.net/jenkins/",
@@ -24,9 +25,17 @@ def normalize_build_url(url: str | None) -> str | None:
     normalized = url.strip()
     if normalized == "":
         return None
+    canonical_host: str | None = None
     if normalized.startswith(("http://", "https://")):
         parsed = urllib_parse.urlparse(normalized)
+        host = (parsed.hostname or "").lower()
         path = parsed.path or ""
+        if host == "prow.tidb.net":
+            canonical_host = GCP_HOST
+        elif host == "do.pingcap.net":
+            canonical_host = IDC_HOST
+        elif host == "jenkins.jenkins.svc.cluster.local":
+            canonical_host = GCP_HOST
     else:
         path = normalized
 
@@ -40,12 +49,10 @@ def normalize_build_url(url: str | None) -> str | None:
     if path.startswith("/job/"):
         path = f"/jenkins{path}"
     if path.startswith(CANONICAL_JENKINS_PATH_PREFIX) or path.startswith(CANONICAL_PROW_PATH_PREFIX):
-        return _canonical_full_url(path)
+        return _canonical_full_url(path, canonical_host=canonical_host or GCP_HOST)
 
-    if any(normalized.startswith(prefix) for prefix in INTERNAL_JENKINS_HOST_PREFIXES) and path.startswith(
-        CANONICAL_JENKINS_PATH_PREFIX
-    ):
-        return _canonical_full_url(path)
+    if any(normalized.startswith(prefix) for prefix in INTERNAL_JENKINS_HOST_PREFIXES) and path.startswith(CANONICAL_JENKINS_PATH_PREFIX):
+        return _canonical_full_url(path, canonical_host=GCP_HOST)
     return None
 
 
@@ -88,12 +95,12 @@ def build_job_url(normalized_job_path: str | None, cloud_phase: str | None) -> s
         return path if path.endswith("/") else f"{path}/"
     if not path.startswith("/"):
         path = f"/{path}"
-    host = GCP_HOST if str(cloud_phase or "").upper() == "GCP" else "https://do.pingcap.net"
+    host = GCP_HOST if str(cloud_phase or "").upper() == "GCP" else IDC_HOST
     return f"{host}{path}"
 
 
-def _canonical_full_url(path: str) -> str:
+def _canonical_full_url(path: str, *, canonical_host: str) -> str:
     normalized_path = path.rstrip("/")
     if normalized_path == "":
-        return f"{GCP_HOST}/"
-    return f"{GCP_HOST}{normalized_path}/"
+        return f"{canonical_host}/"
+    return f"{canonical_host}{normalized_path}/"

--- a/ci-dashboard/src/ci_dashboard/jobs/jenkins_worker.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/jenkins_worker.py
@@ -171,7 +171,8 @@ INSERT_BUILD_FROM_JENKINS = text(
 UPDATE_BUILD_FROM_JENKINS = text(
     """
     UPDATE ci_l1_builds
-    SET state = :state,
+    SET source_prow_job_id = COALESCE(source_prow_job_id, :source_prow_job_id),
+        state = :state,
         url = COALESCE(url, :url),
         normalized_build_url = COALESCE(normalized_build_url, :normalized_build_url),
         job_name = COALESCE(job_name, :job_name),
@@ -222,6 +223,7 @@ class ParsedJenkinsFinishedEvent:
     event_time: datetime | None
     build_url: str
     normalized_build_url: str
+    source_prow_job_id: str | None
     jenkins_result: str | None
     state: str
     job_name: str | None
@@ -248,7 +250,7 @@ class ParsedJenkinsFinishedEvent:
         return {
             "id": None,
             "source_prow_row_id": None,
-            "source_prow_job_id": None,
+            "source_prow_job_id": self.source_prow_job_id,
             "namespace": None,
             "job_name": self.job_name,
             "job_type": self.job_type,
@@ -517,6 +519,7 @@ def parse_jenkins_finished_event(
     if start_time is None and completion_time is not None and duration_seconds is not None:
         start_time = completion_time - timedelta(seconds=duration_seconds)
     total_seconds = _duration_seconds(start_time, completion_time) or duration_seconds
+    source_prow_job_id = _extract_source_prow_job_id(custom_data, job_spec)
     build_id = _first_non_empty_str(
         custom_data.get("build_id"),
         custom_data.get("buildId"),
@@ -530,6 +533,7 @@ def parse_jenkins_finished_event(
         event_time=envelope.event_time,
         build_url=build_url,
         normalized_build_url=normalized_build_url,
+        source_prow_job_id=source_prow_job_id,
         jenkins_result=jenkins_result,
         state=state,
         job_name=job_name,
@@ -583,11 +587,11 @@ def _upsert_build_from_jenkins_event(connection: Connection, parsed: ParsedJenki
     existing_by_prow_job_id, existing_by_build_url = fetch_existing_build_targets(
         connection,
         normalized_build_urls=[parsed.normalized_build_url],
-        source_prow_job_ids=[],
+        source_prow_job_ids=[parsed.source_prow_job_id] if parsed.source_prow_job_id else [],
     )
     target_id = resolve_merge_target_id(
         normalized_build_url=parsed.normalized_build_url,
-        source_prow_job_id=None,
+        source_prow_job_id=parsed.source_prow_job_id,
         existing_by_prow_job_id=existing_by_prow_job_id,
         existing_by_build_url=existing_by_build_url,
         log_context={"job_name": JOB_NAME},
@@ -748,6 +752,18 @@ def _extract_job_spec(custom_data: Mapping[str, Any]) -> dict[str, Any] | None:
     if not isinstance(parsed, Mapping):
         return None
     return dict(parsed)
+
+
+def _extract_source_prow_job_id(
+    custom_data: Mapping[str, Any],
+    job_spec: Mapping[str, Any] | None,
+) -> str | None:
+    return _first_non_empty_str(
+        custom_data.get("PROW_JOB_ID"),
+        custom_data.get("prow_job_id"),
+        _nested_get(custom_data, "build", "parameters", "PROW_JOB_ID"),
+        job_spec.get("prowjobid") if job_spec else None,
+    )
 
 
 def _first_mapping(value: Any) -> dict[str, Any]:

--- a/ci-dashboard/src/ci_dashboard/jobs/jenkins_worker.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/jenkins_worker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping
 from urllib.parse import urlsplit
 
@@ -430,12 +430,22 @@ def parse_jenkins_finished_event(
     normalized_build_url = normalize_build_url(build_url)
     if normalized_build_url is None:
         raise ValueError(f"failed to normalize Jenkins build URL: {build_url!r}")
+    if not build_url.startswith(("http://", "https://")):
+        build_url = normalized_build_url
 
     build_url_org, build_url_repo = _extract_repo_from_build_url(normalized_build_url)
+    job_spec = _extract_job_spec(custom_data)
+    job_spec_refs = _as_mapping(job_spec.get("refs")) if job_spec else {}
+    job_spec_first_pull = _first_mapping(job_spec_refs.get("pulls"))
+    job_spec_org = _first_non_empty_str(job_spec_refs.get("org"), build_url_org)
+    job_spec_repo = _first_non_empty_str(job_spec_refs.get("repo"), build_url_repo)
     job_name = _first_non_empty_str(
         custom_data.get("job_name"),
         custom_data.get("jobName"),
+        custom_data.get("name"),
+        custom_data.get("displayName"),
         custom_data.get("pipelineName"),
+        _nested_get(data, "subject", "content", "pipelineName"),
         _extract_job_name_from_build_url(normalized_build_url),
     )
 
@@ -446,6 +456,7 @@ def parse_jenkins_finished_event(
         custom_data.get("org"),
         custom_data.get("github_org"),
         custom_data.get("ghprbGhRepositoryOwner"),
+        job_spec_org,
         build_url_org,
     )
     repo_candidate = _first_non_empty_str(
@@ -453,12 +464,14 @@ def parse_jenkins_finished_event(
         custom_data.get("github_repo"),
         custom_data.get("ghprbGhRepositoryName"),
         custom_data.get("repository"),
+        job_spec_repo,
         build_url_repo,
     )
     repo_full_name = _first_non_empty_str(
         custom_data.get("repo_full_name"),
         custom_data.get("github_repo_full_name"),
         custom_data.get("ghprbGhRepository"),
+        f"{job_spec_org}/{job_spec_repo}" if job_spec_org and job_spec_repo else None,
     )
     org, repo, repo_full_name = _normalize_repo_fields(org, repo_candidate, repo_full_name)
     if repo_full_name is None and org and repo:
@@ -468,12 +481,14 @@ def parse_jenkins_finished_event(
         custom_data.get("target_branch"),
         custom_data.get("branch"),
         custom_data.get("ghprbTargetBranch"),
+        job_spec_refs.get("base_ref"),
     )
     pr_number = _first_non_empty_int(
         custom_data.get("pr_number"),
         custom_data.get("pr"),
         custom_data.get("pull"),
         custom_data.get("ghprbPullId"),
+        _nested_get(job_spec_first_pull, "number"),
     )
     start_time = _parse_datetime(
         _first_non_none(
@@ -498,10 +513,15 @@ def parse_jenkins_finished_event(
             envelope.event_time,
         )
     )
-    total_seconds = _duration_seconds(start_time, completion_time)
+    duration_seconds = _extract_duration_seconds(data, custom_data)
+    if start_time is None and completion_time is not None and duration_seconds is not None:
+        start_time = completion_time - timedelta(seconds=duration_seconds)
+    total_seconds = _duration_seconds(start_time, completion_time) or duration_seconds
     build_id = _first_non_empty_str(
         custom_data.get("build_id"),
         custom_data.get("buildId"),
+        _nested_get(custom_data, "build", "parameters", "BUILD_ID"),
+        job_spec.get("buildid") if job_spec else None,
         _extract_build_number_from_url(normalized_build_url),
     )
     return ParsedJenkinsFinishedEvent(
@@ -513,15 +533,19 @@ def parse_jenkins_finished_event(
         jenkins_result=jenkins_result,
         state=state,
         job_name=job_name,
-        job_type=None,
+        job_type=_first_non_empty_str(custom_data.get("job_type"), custom_data.get("jobType"), job_spec.get("type") if job_spec else None),
         org=org,
         repo=repo,
         repo_full_name=repo_full_name,
         base_ref=target_branch,
         pr_number=pr_number,
         is_pr_build=pr_number is not None,
-        context=_first_non_empty_str(custom_data.get("context")),
-        author=_first_non_empty_str(custom_data.get("author"), custom_data.get("triggered_by")),
+        context=_first_non_empty_str(custom_data.get("context"), job_spec.get("job") if job_spec else None),
+        author=_first_non_empty_str(
+            custom_data.get("author"),
+            custom_data.get("triggered_by"),
+            _nested_get(job_spec_first_pull, "author"),
+        ),
         build_id=build_id,
         start_time=start_time,
         completion_time=completion_time,
@@ -533,10 +557,11 @@ def parse_jenkins_finished_event(
             custom_data.get("commit"),
             custom_data.get("ghprbActualCommit"),
             custom_data.get("ghprbPullActualCommit"),
+            _nested_get(job_spec_first_pull, "sha"),
         ),
         target_branch=target_branch,
-        cloud_phase=classify_cloud_phase(build_url),
-        build_system=classify_build_system(build_url),
+        cloud_phase=classify_cloud_phase(normalized_build_url),
+        build_system=classify_build_system(normalized_build_url),
     )
 
 
@@ -652,11 +677,16 @@ def _extract_build_url(
 ) -> str | None:
     for candidate in (
         payload.get("subject"),
+        payload.get("source"),
         data.get("url"),
         data.get("buildUrl"),
         data.get("buildURL"),
         data.get("runURL"),
         data.get("runUrl"),
+        _nested_get(data, "context", "source"),
+        _nested_get(custom_data, "build", "url"),
+        _nested_get(custom_data, "build", "buildUrl"),
+        _nested_get(custom_data, "build", "buildURL"),
         custom_data.get("url"),
         custom_data.get("buildUrl"),
         custom_data.get("buildURL"),
@@ -682,7 +712,52 @@ def _extract_result(data: Mapping[str, Any], custom_data: Mapping[str, Any]) -> 
         custom_data.get("outcome"),
         custom_data.get("status"),
         _nested_get(data, "pipelineRun", "result"),
+        _nested_get(data, "subject", "content", "outcome"),
+        _nested_get(data, "subject", "content", "result"),
     )
+
+
+def _extract_duration_seconds(data: Mapping[str, Any], custom_data: Mapping[str, Any]) -> int | None:
+    duration_millis = _first_non_empty_int(
+        data.get("durationMillis"),
+        data.get("duration_ms"),
+        data.get("duration"),
+        _nested_get(custom_data, "build", "durationMillis"),
+        _nested_get(custom_data, "build", "duration_ms"),
+        _nested_get(custom_data, "build", "duration"),
+    )
+    if duration_millis is None:
+        return None
+    if duration_millis < 0:
+        return None
+    return duration_millis // 1000
+
+
+def _extract_job_spec(custom_data: Mapping[str, Any]) -> dict[str, Any] | None:
+    raw_job_spec = _first_non_empty_str(
+        custom_data.get("JOB_SPEC"),
+        custom_data.get("job_spec"),
+        _nested_get(custom_data, "build", "parameters", "JOB_SPEC"),
+    )
+    if raw_job_spec is None:
+        return None
+    try:
+        parsed = json.loads(raw_job_spec)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, Mapping):
+        return None
+    return dict(parsed)
+
+
+def _first_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, Mapping):
+                return dict(item)
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
 
 
 def _extract_repo_from_build_url(normalized_build_url: str) -> tuple[str | None, str | None]:

--- a/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/refresh_build_derived.py
@@ -1283,6 +1283,16 @@ def _sqlite_normalized_build_url_sql(column_name: str) -> str:
 def _mysql_normalized_build_url_sql(column_name: str) -> str:
     trimmed = f"TRIM(COALESCE({column_name}, ''))"
     without_redirect = f"REPLACE({trimmed}, '/display/redirect', '')"
+    canonical_host = (
+        "CASE "
+        f"WHEN {without_redirect} = '' THEN NULL "
+        f"WHEN {without_redirect} REGEXP '^https?://prow\\\\.tidb\\\\.net/' THEN 'https://prow.tidb.net' "
+        f"WHEN {without_redirect} REGEXP '^https?://do\\\\.pingcap\\\\.net/' THEN 'https://do.pingcap.net' "
+        f"WHEN {without_redirect} REGEXP '^https?://jenkins\\\\.jenkins\\\\.svc\\\\.cluster\\\\.local(:[0-9]+)?/' THEN 'https://prow.tidb.net' "
+        f"WHEN {without_redirect} NOT REGEXP '^https?://' THEN 'https://prow.tidb.net' "
+        "ELSE NULL "
+        "END"
+    )
     stripped_known_host = (
         "CASE "
         f"WHEN {without_redirect} = '' THEN NULL "
@@ -1311,9 +1321,9 @@ def _mysql_normalized_build_url_sql(column_name: str) -> str:
     )
     return (
         "CASE "
-        f"WHEN {canonical_path} IS NULL OR {canonical_path} = '' THEN NULL "
+        f"WHEN {canonical_path} IS NULL OR {canonical_path} = '' OR {canonical_host} IS NULL THEN NULL "
         f"WHEN {canonical_path} LIKE '/jenkins/job/%' OR {canonical_path} LIKE '/view/gs/%' "
-        f"THEN CONCAT('https://prow.tidb.net', REGEXP_REPLACE({canonical_path}, '/+$', ''), '/') "
+        f"THEN CONCAT({canonical_host}, REGEXP_REPLACE({canonical_path}, '/+$', ''), '/') "
         "ELSE NULL "
         "END"
     )

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -1047,7 +1047,7 @@ def test_case_tables_exclude_cross_cloud_and_stale_build_key_collisions(sqlite_e
         failure_category=None,
         start_time="2026-04-10 14:00:00",
         pr_number=902,
-        normalized_build_url="https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_unit_test_next_gen/945/",
+        normalized_build_url="https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/pull_unit_test_next_gen/945/",
         build_id="prow-ghost-time",
     )
     _insert_pr_event(

--- a/ci-dashboard/tests/jobs/test_build_merge.py
+++ b/ci-dashboard/tests/jobs/test_build_merge.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from ci_dashboard.jobs.build_merge import resolve_merge_target_id
+
+
+def _candidate(candidate_id: int, normalized_build_url: str, source_prow_job_id: str | None):
+    return {
+        "id": candidate_id,
+        "normalized_build_url": normalized_build_url,
+        "source_prow_job_id": source_prow_job_id,
+    }
+
+
+def test_resolve_merge_target_id_prefers_exact_prow_job_match() -> None:
+    normalized_build_url = "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/1/"
+    existing_by_prow_job_id = {
+        "prow-job-1": _candidate(101, normalized_build_url, "prow-job-1"),
+        "prow-job-2": _candidate(102, normalized_build_url, "prow-job-2"),
+    }
+    existing_by_build_url = {
+        normalized_build_url: [
+            existing_by_prow_job_id["prow-job-1"],
+            existing_by_prow_job_id["prow-job-2"],
+        ]
+    }
+
+    target_id = resolve_merge_target_id(
+        normalized_build_url=normalized_build_url,
+        source_prow_job_id="prow-job-2",
+        existing_by_prow_job_id=existing_by_prow_job_id,
+        existing_by_build_url=existing_by_build_url,
+    )
+
+    assert target_id == 102
+
+
+def test_resolve_merge_target_id_allows_new_row_when_url_is_reused_by_another_prow_job() -> None:
+    normalized_build_url = "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/2/"
+    existing_by_prow_job_id = {
+        "old-prow-job": _candidate(201, normalized_build_url, "old-prow-job"),
+    }
+    existing_by_build_url = {
+        normalized_build_url: [existing_by_prow_job_id["old-prow-job"]],
+    }
+
+    target_id = resolve_merge_target_id(
+        normalized_build_url=normalized_build_url,
+        source_prow_job_id="new-prow-job",
+        existing_by_prow_job_id=existing_by_prow_job_id,
+        existing_by_build_url=existing_by_build_url,
+    )
+
+    assert target_id is None
+
+
+def test_resolve_merge_target_id_still_merges_into_single_unresolved_row() -> None:
+    normalized_build_url = "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/3/"
+    unresolved = _candidate(301, normalized_build_url, None)
+    existing_by_build_url = {normalized_build_url: [unresolved]}
+
+    target_id = resolve_merge_target_id(
+        normalized_build_url=normalized_build_url,
+        source_prow_job_id="prow-job-3",
+        existing_by_prow_job_id={},
+        existing_by_build_url=existing_by_build_url,
+    )
+
+    assert target_id == 301
+
+
+def test_resolve_merge_target_id_without_source_prow_job_id_still_rejects_conflicts() -> None:
+    normalized_build_url = "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/4/"
+    existing_by_build_url = {
+        normalized_build_url: [
+            _candidate(401, normalized_build_url, "prow-job-4a"),
+            _candidate(402, normalized_build_url, "prow-job-4b"),
+        ]
+    }
+
+    with pytest.raises(ValueError, match="normalized_build_url already belongs"):
+        resolve_merge_target_id(
+            normalized_build_url=normalized_build_url,
+            source_prow_job_id=None,
+            existing_by_prow_job_id={},
+            existing_by_build_url=existing_by_build_url,
+        )

--- a/ci-dashboard/tests/jobs/test_build_url_matcher.py
+++ b/ci-dashboard/tests/jobs/test_build_url_matcher.py
@@ -12,6 +12,11 @@ def test_normalize_build_url_strips_known_prefix_and_redirect() -> None:
     assert normalize_build_url(raw) == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/299/"
 
 
+def test_normalize_build_url_preserves_public_host() -> None:
+    raw = "https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/299/display/redirect"
+    assert normalize_build_url(raw) == "https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/299/"
+
+
 def test_normalize_build_url_handles_none_and_blank() -> None:
     assert normalize_build_url(None) is None
     assert normalize_build_url("   ") is None

--- a/ci-dashboard/tests/jobs/test_jenkins_worker.py
+++ b/ci-dashboard/tests/jobs/test_jenkins_worker.py
@@ -56,6 +56,71 @@ def _finished_event_payload(*, event_id: str = "evt-1") -> dict[str, object]:
     }
 
 
+def _real_jenkins_plugin_finished_event_payload(*, event_id: str = "evt-real-1") -> dict[str, object]:
+    return {
+        "specversion": "0.3",
+        "id": event_id,
+        "source": "job/pingcap/job/tidb/job/pull_mysql_client_test/1816/",
+        "type": "dev.cdevents.pipelinerun.finished.0.1.0",
+        "datacontenttype": "application/json",
+        "time": "2026-04-27T13:09:00.499612608Z",
+        "data": {
+            "context": {
+                "id": "ff67a5de-f3b1-403e-9c0a-d41b2103a108",
+                "type": "dev.cdevents.pipelinerun.finished.0.1.0",
+                "source": "job/pingcap/job/tidb/job/pull_mysql_client_test/1816/",
+                "version": "0.1.2",
+                "timestamp": "2026-04-27T13:09:00Z",
+            },
+            "customData": {
+                "name": "pull_mysql_client_test",
+                "displayName": "pull_mysql_client_test",
+                "url": "job/pingcap/job/tidb/job/pull_mysql_client_test/",
+                "build": {
+                    "number": 1816,
+                    "queueId": 202018,
+                    "duration": 566556,
+                    "url": "job/pingcap/job/tidb/job/pull_mysql_client_test/1816/",
+                    "parameters": {
+                        "BUILD_ID": "2048748867029045251",
+                        "JOB_SPEC": json.dumps(
+                            {
+                                "type": "presubmit",
+                                "job": "pingcap/tidb/pull_mysql_client_test",
+                                "buildid": "2048748867029045251",
+                                "prowjobid": "3bfe389c-e361-4a6d-a1d6-679fb87b0e13",
+                                "refs": {
+                                    "org": "pingcap",
+                                    "repo": "tidb",
+                                    "base_ref": "master",
+                                    "pulls": [
+                                        {
+                                            "number": 65626,
+                                            "author": "terry1purcell",
+                                            "sha": "e6030436c2093b30da167ca295887b8df8eaeb07",
+                                        }
+                                    ],
+                                },
+                            }
+                        ),
+                        "PROW_JOB_ID": "3bfe389c-e361-4a6d-a1d6-679fb87b0e13",
+                    },
+                },
+            },
+            "customDataContentType": "application/json",
+            "subject": {
+                "id": "1816",
+                "type": "PIPELINERUN",
+                "content": {
+                    "pipelineName": "pingcap » tidb » pull_mysql_client_test",
+                    "outcome": "SUCCESS",
+                    "errors": "",
+                },
+            },
+        },
+    }
+
+
 def test_parse_jenkins_finished_event_extracts_canonical_fields() -> None:
     parsed = parse_jenkins_finished_event(_finished_event_payload(), _settings())
 
@@ -72,6 +137,32 @@ def test_parse_jenkins_finished_event_extracts_canonical_fields() -> None:
     assert parsed.total_seconds == 1200
     assert parsed.start_time == datetime(2026, 4, 24, 10, 0, 0)
     assert parsed.completion_time == datetime(2026, 4, 24, 10, 20, 0)
+
+
+def test_parse_jenkins_finished_event_supports_real_plugin_payload() -> None:
+    parsed = parse_jenkins_finished_event(_real_jenkins_plugin_finished_event_payload(), _settings())
+
+    assert parsed.build_url == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
+    assert parsed.normalized_build_url == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
+    assert parsed.jenkins_result == "SUCCESS"
+    assert parsed.state == "success"
+    assert parsed.job_name == "pull_mysql_client_test"
+    assert parsed.job_type == "presubmit"
+    assert parsed.org == "pingcap"
+    assert parsed.repo == "tidb"
+    assert parsed.repo_full_name == "pingcap/tidb"
+    assert parsed.base_ref == "master"
+    assert parsed.pr_number == 65626
+    assert parsed.is_pr_build is True
+    assert parsed.author == "terry1purcell"
+    assert parsed.head_sha == "e6030436c2093b30da167ca295887b8df8eaeb07"
+    assert parsed.build_id == "2048748867029045251"
+    assert parsed.build_system == "JENKINS"
+    assert parsed.cloud_phase == "GCP"
+    assert parsed.run_seconds == 566
+    assert parsed.total_seconds == 566
+    assert parsed.start_time is not None
+    assert parsed.completion_time is not None
 
 
 def test_process_jenkins_event_message_inserts_build_and_audit(sqlite_engine) -> None:
@@ -108,6 +199,45 @@ def test_process_jenkins_event_message_inserts_build_and_audit(sqlite_engine) ->
     assert audit["processing_status"] == "PROCESSED"
     assert audit["normalized_build_url"] == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/301/"
     assert audit["result"] == "FAILURE"
+
+
+def test_process_jenkins_event_message_inserts_real_plugin_payload(sqlite_engine) -> None:
+    result = process_jenkins_event_message(sqlite_engine, _settings(), _real_jenkins_plugin_finished_event_payload())
+
+    assert result == "processed"
+
+    with sqlite_engine.begin() as connection:
+        build = connection.execute(
+            text(
+                """
+                SELECT state, url, normalized_build_url, job_type, repo_full_name, pr_number, author, head_sha, build_system, cloud_phase
+                FROM ci_l1_builds
+                """
+            )
+        ).mappings().one()
+        audit = connection.execute(
+            text(
+                """
+                SELECT event_id, processing_status, normalized_build_url, result
+                FROM ci_l1_jenkins_build_events
+                """
+            )
+        ).mappings().one()
+
+    assert build["state"] == "success"
+    assert build["url"] == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
+    assert build["normalized_build_url"] == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
+    assert build["job_type"] == "presubmit"
+    assert build["repo_full_name"] == "pingcap/tidb"
+    assert build["pr_number"] == 65626
+    assert build["author"] == "terry1purcell"
+    assert build["head_sha"] == "e6030436c2093b30da167ca295887b8df8eaeb07"
+    assert build["build_system"] == "JENKINS"
+    assert build["cloud_phase"] == "GCP"
+    assert audit["event_id"] == "evt-real-1"
+    assert audit["processing_status"] == "PROCESSED"
+    assert audit["normalized_build_url"] == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
+    assert audit["result"] == "SUCCESS"
 
 
 def test_process_jenkins_event_message_enriches_existing_prow_row_without_clearing_it(sqlite_engine) -> None:

--- a/ci-dashboard/tests/jobs/test_jenkins_worker.py
+++ b/ci-dashboard/tests/jobs/test_jenkins_worker.py
@@ -144,6 +144,7 @@ def test_parse_jenkins_finished_event_supports_real_plugin_payload() -> None:
 
     assert parsed.build_url == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
     assert parsed.normalized_build_url == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
+    assert parsed.source_prow_job_id == "3bfe389c-e361-4a6d-a1d6-679fb87b0e13"
     assert parsed.jenkins_result == "SUCCESS"
     assert parsed.state == "success"
     assert parsed.job_name == "pull_mysql_client_test"
@@ -210,7 +211,7 @@ def test_process_jenkins_event_message_inserts_real_plugin_payload(sqlite_engine
         build = connection.execute(
             text(
                 """
-                SELECT state, url, normalized_build_url, job_type, repo_full_name, pr_number, author, head_sha, build_system, cloud_phase
+                SELECT source_prow_job_id, state, url, normalized_build_url, job_type, repo_full_name, pr_number, author, head_sha, build_system, cloud_phase
                 FROM ci_l1_builds
                 """
             )
@@ -224,6 +225,7 @@ def test_process_jenkins_event_message_inserts_real_plugin_payload(sqlite_engine
             )
         ).mappings().one()
 
+    assert build["source_prow_job_id"] == "3bfe389c-e361-4a6d-a1d6-679fb87b0e13"
     assert build["state"] == "success"
     assert build["url"] == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
     assert build["normalized_build_url"] == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/"
@@ -288,6 +290,64 @@ def test_process_jenkins_event_message_enriches_existing_prow_row_without_cleari
     assert row["job_type"] == "presubmit"
     assert row["repo_full_name"] == "pingcap/tidb"
     assert row["state"] == "failure"
+
+
+def test_process_jenkins_event_message_uses_prow_job_id_to_resolve_duplicate_build_urls(sqlite_engine) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_builds (
+                  source_prow_row_id, source_prow_job_id, namespace, job_name, job_type, state,
+                  optional, report, org, repo, repo_full_name, base_ref, pr_number, is_pr_build,
+                  context, url, normalized_build_url, author, start_time, completion_time,
+                  total_seconds, head_sha, target_branch, cloud_phase, build_system
+                ) VALUES
+                (
+                  111, 'different-prow-job', 'prow', 'pull_mysql_client_test', 'presubmit', 'aborted',
+                  0, 1, 'pingcap', 'tidb', 'pingcap/tidb', 'master', 65626, 1,
+                  'unit', 'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/display/redirect',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/',
+                  'alice', '2026-04-27 13:00:00', '2026-04-27 13:05:00',
+                  300, 'deadbeef', 'master', 'GCP', 'JENKINS'
+                ),
+                (
+                  222, '3bfe389c-e361-4a6d-a1d6-679fb87b0e13', 'prow', 'pull_mysql_client_test', 'presubmit', 'pending',
+                  0, 1, 'pingcap', 'tidb', 'pingcap/tidb', 'master', 65626, 1,
+                  'unit', 'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/display/redirect',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/1816/',
+                  'terry1purcell', '2026-04-27 13:00:00', NULL,
+                  NULL, 'e6030436c2093b30da167ca295887b8df8eaeb07', 'master', 'IDC', 'UNKNOWN'
+                )
+                """
+            )
+        )
+
+    result = process_jenkins_event_message(sqlite_engine, _settings(), _real_jenkins_plugin_finished_event_payload())
+
+    assert result == "processed"
+
+    with sqlite_engine.begin() as connection:
+        rows = list(
+            connection.execute(
+                text(
+                    """
+                    SELECT source_prow_row_id, source_prow_job_id, state, completion_time, build_system, cloud_phase
+                    FROM ci_l1_builds
+                    ORDER BY source_prow_row_id
+                    """
+                )
+            ).mappings()
+        )
+
+    assert len(rows) == 2
+    assert rows[0]["source_prow_job_id"] == "different-prow-job"
+    assert rows[0]["state"] == "aborted"
+    assert rows[1]["source_prow_job_id"] == "3bfe389c-e361-4a6d-a1d6-679fb87b0e13"
+    assert rows[1]["state"] == "success"
+    assert rows[1]["completion_time"] is not None
+    assert rows[1]["build_system"] == "JENKINS"
+    assert rows[1]["cloud_phase"] == "GCP"
 
 
 def test_process_jenkins_event_message_skips_duplicate_processed_event(sqlite_engine) -> None:

--- a/ci-dashboard/tests/jobs/test_sync_builds.py
+++ b/ci-dashboard/tests/jobs/test_sync_builds.py
@@ -126,6 +126,7 @@ def test_map_build_row_allows_missing_optional_status_fields() -> None:
 
     build = map_build_row(row)
 
+    assert build.normalized_build_url == "https://do.pingcap.net/jenkins/job/abc/"
     assert build.build_id is None
     assert build.pod_name is None
     assert build.cloud_phase == "IDC"
@@ -306,7 +307,7 @@ def test_sync_builds_end_to_end_with_sqlite(sqlite_engine) -> None:
     assert rows[0]["build_system"] == "JENKINS"
     assert rows[1]["cloud_phase"] == "IDC"
     assert rows[1]["build_system"] == "JENKINS"
-    assert rows[1]["normalized_build_url"] == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/nightly/2/"
+    assert rows[1]["normalized_build_url"] == "https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/nightly/2/"
     assert state is not None
     assert state.last_status == "succeeded"
     assert state.watermark == {"last_source_prow_row_id": 2}


### PR DESCRIPTION
## Summary
- parse real Jenkins CDEvents payloads that use relative job URLs
- extract outcome and JOB_SPEC metadata into canonical build fields
- classify Jenkins builds with canonical full URLs and add regression tests

## Test
- PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests/jobs/test_jenkins_worker.py
- PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests/jobs/test_archive_error_logs.py ci-dashboard/tests/jobs/test_jenkins_worker.py ci-dashboard/tests/jobs/test_jenkins_client.py ci-dashboard/tests/jobs/test_sync_builds.py ci-dashboard/tests/jobs/test_cli.py ci-dashboard/tests/test_config_and_db.py