### PR TITLE
refactor(ci-dashboard): simplify archived log object layout

### DIFF
--- a/ci-dashboard/k8s/cronjobs/README.md
+++ b/ci-dashboard/k8s/cronjobs/README.md
@@ -196,7 +196,8 @@ Useful overrides:
 - `--schedule "35 * * * *"` keeps the default hourly archive cadence.
 - `--build-limit 100` caps one run's Jenkins and GCS load.
 - `--log-tail-bytes 262144` keeps the default tail size at 256 KiB.
-- `--gcs-prefix ci-dashboard/v3/jenkins-logs` keeps artifacts under one dedicated prefix.
+- default object layout is `YYMM/<build_id>.log`, for example `2604/1682039.log`.
+- `--gcs-prefix ci-dashboard/jenkins` is optional if we later want an extra stable prefix in front of the month folder.
 - `--jenkins-secret <secret>` enables server-side Jenkins auth if console access is later restricted.
 - `--suspend true` is recommended until GCS write permission is confirmed.
 

--- a/ci-dashboard/scripts/render_archive_error_logs_cronjob.sh
+++ b/ci-dashboard/scripts/render_archive_error_logs_cronjob.sh
@@ -8,7 +8,7 @@ schedule="35 * * * *"
 time_zone="Asia/Shanghai"
 db_secret="ci-dashboard-db"
 gcs_bucket=""
-gcs_prefix="ci-dashboard/v3/jenkins-logs"
+gcs_prefix=""
 jenkins_internal_base_url=""
 build_limit="100"
 log_tail_bytes="262144"
@@ -47,7 +47,7 @@ Optional:
   --time-zone TZ                  CronJob timeZone. Default: Asia/Shanghai
   --db-secret NAME                Secret containing TIDB_* or CI_DASHBOARD_DB_URL. Default: ci-dashboard-db
   --gcs-bucket NAME               GCS bucket for archived logs. Required.
-  --gcs-prefix PATH               GCS object prefix. Default: ci-dashboard/v3/jenkins-logs
+  --gcs-prefix PATH               Optional GCS object prefix. Default: empty.
   --jenkins-internal-base-url URL Internal Jenkins base URL. Required.
   --build-limit N                 Max builds archived per run. Default: 100
   --log-tail-bytes N              Tail byte cap. Default: 262144
@@ -279,6 +279,15 @@ EOF
 )
 fi
 
+gcs_prefix_env_block=""
+if [[ -n "${gcs_prefix}" ]]; then
+  gcs_prefix_env_block=$(cat <<EOF
+                - name: CI_DASHBOARD_GCS_PREFIX
+                  value: ${gcs_prefix}
+EOF
+)
+fi
+
 cat <<EOF
 apiVersion: batch/v1
 kind: CronJob
@@ -326,8 +335,7 @@ ${service_account_block}
                   value: ${log_level}
                 - name: CI_DASHBOARD_GCS_BUCKET
                   value: ${gcs_bucket}
-                - name: CI_DASHBOARD_GCS_PREFIX
-                  value: ${gcs_prefix}
+${gcs_prefix_env_block}
                 - name: CI_DASHBOARD_ARCHIVE_LOG_TAIL_BYTES
                   value: "${log_tail_bytes}"
                 - name: CI_DASHBOARD_JENKINS_INTERNAL_BASE_URL

--- a/ci-dashboard/src/ci_dashboard/common/config.py
+++ b/ci-dashboard/src/ci_dashboard/common/config.py
@@ -77,7 +77,7 @@ class ArchiveSettings:
     build_limit: int = 100
     log_tail_bytes: int = 262144
     gcs_bucket: str | None = None
-    gcs_prefix: str = "ci-dashboard/v3/jenkins-logs"
+    gcs_prefix: str = ""
 
 
 @dataclass(frozen=True)
@@ -160,9 +160,7 @@ def load_settings(environ: Mapping[str, str] | None = None) -> Settings:
             build_limit=_read_int(env, "CI_DASHBOARD_ARCHIVE_BUILD_LIMIT", 100),
             log_tail_bytes=_read_int(env, "CI_DASHBOARD_ARCHIVE_LOG_TAIL_BYTES", 262144),
             gcs_bucket=env.get("CI_DASHBOARD_GCS_BUCKET") or None,
-            gcs_prefix=(
-                (env.get("CI_DASHBOARD_GCS_PREFIX") or "ci-dashboard/v3/jenkins-logs").strip("/")
-            ),
+            gcs_prefix=(env.get("CI_DASHBOARD_GCS_PREFIX") or "").strip("/"),
         ),
         log_level=(env.get("CI_DASHBOARD_LOG_LEVEL") or "INFO").upper(),
     )

--- a/ci-dashboard/src/ci_dashboard/jobs/archive_error_logs.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/archive_error_logs.py
@@ -168,7 +168,7 @@ def parse_archive_timestamp(value: Any) -> datetime | None:
     raw = str(value).strip()
     if not raw:
         return None
-    normalized = raw.replace("Z", "+00:00").replace(" ", "T")
+    normalized = raw.replace("Z", "+00:00")
     try:
         return datetime.fromisoformat(normalized)
     except ValueError as exc:

--- a/ci-dashboard/src/ci_dashboard/jobs/archive_error_logs.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/archive_error_logs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 import re
 from typing import Any, Mapping
@@ -18,7 +19,8 @@ FAILURE_LIKE_STATES = ("failure", "error", "timeout", "timed_out", "aborted")
 
 FETCH_CANDIDATE_BUILDS = text(
     """
-    SELECT id, url, normalized_build_url, log_gcs_uri, state, build_system
+    SELECT id, url, normalized_build_url, log_gcs_uri, state, build_system,
+           start_time, completion_time
     FROM ci_l1_builds
     WHERE build_system = 'JENKINS'
       AND state IN :failure_states
@@ -136,10 +138,41 @@ def build_archive_object_ref(
     existing = parse_gcs_uri(build.get("log_gcs_uri"))
     if force and existing is not None:
         return existing.bucket, existing.object_name
+    archive_folder = resolve_archive_month_folder(build)
+    archive_file_name = f"{int(build['id'])}.log"
+    object_name = "/".join(
+        part
+        for part in (settings.archive.gcs_prefix, archive_folder, archive_file_name)
+        if part
+    )
     return (
         settings.archive.gcs_bucket or "",
-        f"{settings.archive.gcs_prefix}/build-{int(build['id'])}.log",
+        object_name,
     )
+
+
+def resolve_archive_month_folder(build: Mapping[str, Any]) -> str:
+    timestamp = parse_archive_timestamp(build.get("start_time")) or parse_archive_timestamp(
+        build.get("completion_time")
+    )
+    if timestamp is None:
+        raise ValueError(f"build {build['id']} is missing both start_time and completion_time")
+    return timestamp.strftime("%y%m")
+
+
+def parse_archive_timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    raw = str(value).strip()
+    if not raw:
+        return None
+    normalized = raw.replace("Z", "+00:00").replace(" ", "T")
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"unsupported archive timestamp value: {value!r}") from exc
 
 
 def _archive_single_build(

--- a/ci-dashboard/tests/jobs/test_archive_error_logs.py
+++ b/ci-dashboard/tests/jobs/test_archive_error_logs.py
@@ -11,6 +11,7 @@ from ci_dashboard.common.config import (
 )
 from ci_dashboard.jobs.archive_error_logs import (
     build_archive_object_ref,
+    parse_archive_timestamp,
     redact_console_log,
     run_archive_error_logs,
 )
@@ -123,6 +124,13 @@ def test_redact_console_log_masks_common_secrets() -> None:
     assert "[EMAIL]" in redacted
     assert "[INTERNAL_IP]" in redacted
     assert "/home/[USER]/" in redacted
+
+
+def test_parse_archive_timestamp_supports_space_before_timezone_offset() -> None:
+    parsed = parse_archive_timestamp("2026-04-24 10:00:00 +00:00")
+
+    assert parsed is not None
+    assert parsed.isoformat() == "2026-04-24T10:00:00+00:00"
 
 
 def test_run_archive_error_logs_archives_failed_jenkins_build(sqlite_engine) -> None:

--- a/ci-dashboard/tests/jobs/test_archive_error_logs.py
+++ b/ci-dashboard/tests/jobs/test_archive_error_logs.py
@@ -33,7 +33,7 @@ def _settings() -> Settings:
             build_limit=20,
             log_tail_bytes=1024,
             gcs_bucket="ci-dashboard-test",
-            gcs_prefix="ci-dashboard/v3/jenkins-logs",
+            gcs_prefix="",
         ),
         log_level="INFO",
     )
@@ -145,7 +145,7 @@ def test_run_archive_error_logs_archives_failed_jenkins_build(sqlite_engine) -> 
         ("https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/101/display/redirect", 1024)
     ]
     assert uploader.calls[0][0] == "ci-dashboard-test"
-    assert uploader.calls[0][1] == "ci-dashboard/v3/jenkins-logs/build-101.log"
+    assert uploader.calls[0][1] == "2604/101.log"
     assert "abc123" not in uploader.calls[0][2]
 
     with sqlite_engine.begin() as connection:
@@ -153,14 +153,14 @@ def test_run_archive_error_logs_archives_failed_jenkins_build(sqlite_engine) -> 
             text("SELECT log_gcs_uri FROM ci_l1_builds WHERE id = 101")
         ).mappings().one()
 
-    assert row["log_gcs_uri"] == "gcs://ci-dashboard-test/ci-dashboard/v3/jenkins-logs/build-101.log"
+    assert row["log_gcs_uri"] == "gcs://ci-dashboard-test/2604/101.log"
 
 
 def test_run_archive_error_logs_skips_existing_archive_without_force(sqlite_engine) -> None:
     _insert_build(
         sqlite_engine,
         build_id=201,
-        log_gcs_uri="gcs://ci-dashboard-test/ci-dashboard/v3/jenkins-logs/build-201.log",
+        log_gcs_uri="gcs://ci-dashboard-test/2604/201.log",
     )
     fetcher = _FakeFetcher("failure line\n")
     uploader = _FakeUploader()
@@ -216,4 +216,32 @@ def test_build_archive_object_ref_reuses_existing_uri_on_force(sqlite_engine) ->
     assert build_archive_object_ref(build, _settings(), force=True) == (
         "ci-dashboard-test",
         "custom/path/build-401.log",
+    )
+
+
+def test_build_archive_object_ref_supports_optional_prefix(sqlite_engine) -> None:
+    _insert_build(sqlite_engine, build_id=501)
+
+    with sqlite_engine.begin() as connection:
+        build = connection.execute(
+            text("SELECT id, start_time, completion_time, log_gcs_uri FROM ci_l1_builds WHERE id = 501")
+        ).mappings().one()
+
+    settings = _settings()
+    settings = Settings(
+        database=settings.database,
+        jobs=settings.jobs,
+        jenkins=settings.jenkins,
+        archive=ArchiveSettings(
+            build_limit=settings.archive.build_limit,
+            log_tail_bytes=settings.archive.log_tail_bytes,
+            gcs_bucket=settings.archive.gcs_bucket,
+            gcs_prefix="ci-dashboard/jenkins",
+        ),
+        log_level=settings.log_level,
+    )
+
+    assert build_archive_object_ref(build, settings, force=False) == (
+        "ci-dashboard-test",
+        "ci-dashboard/jenkins/2604/501.log",
     )

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -28,7 +28,7 @@ def test_load_settings_supports_db_url() -> None:
             "CI_DASHBOARD_ARCHIVE_BUILD_LIMIT": "77",
             "CI_DASHBOARD_ARCHIVE_LOG_TAIL_BYTES": "65536",
             "CI_DASHBOARD_GCS_BUCKET": "ci-dashboard-prod",
-            "CI_DASHBOARD_GCS_PREFIX": "ci-dashboard/v3/custom-prefix",
+            "CI_DASHBOARD_GCS_PREFIX": "ci-dashboard/custom-prefix",
             "CI_DASHBOARD_LOG_LEVEL": "debug",
         }
     )
@@ -50,7 +50,7 @@ def test_load_settings_supports_db_url() -> None:
     assert settings.archive.build_limit == 77
     assert settings.archive.log_tail_bytes == 65536
     assert settings.archive.gcs_bucket == "ci-dashboard-prod"
-    assert settings.archive.gcs_prefix == "ci-dashboard/v3/custom-prefix"
+    assert settings.archive.gcs_prefix == "ci-dashboard/custom-prefix"
     assert settings.log_level == "DEBUG"
 
 


### PR DESCRIPTION
## Summary
- store archived Jenkins console logs as `YYMM/<build_id>.log` by default
- keep optional `CI_DASHBOARD_GCS_PREFIX` support, but make it empty by default
- update archive tests and rendering docs to match the new layout

## Validation
- `PYTHONPATH=src python -m pytest tests/jobs/test_archive_error_logs.py tests/test_config_and_db.py`
- verified object key helper returns `2604/1682039.log` for build `1682039`

## Notes
- current truncation logic is unchanged in this PR: we still fetch the last `CI_DASHBOARD_ARCHIVE_LOG_TAIL_BYTES` bytes via Jenkins progressiveText, default `262144` bytes