### PR TITLE
fix(ci-dashboard): support streaming llm providers

### DIFF
--- a/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Mapping, Protocol
+from typing import Any, Iterator, Mapping, Protocol
 
 import httpx
 
@@ -198,14 +198,12 @@ def _collect_stream_content(response: httpx.Response) -> str:
     return content
 
 
-def _iter_sse_data_payloads(response: httpx.Response) -> list[str]:
-    payloads: list[str] = []
+def _iter_sse_data_payloads(response: httpx.Response) -> Iterator[str]:
     data_lines: list[str] = []
-    for raw_line in response.iter_lines():
-        line = raw_line.strip()
+    for line in response.iter_lines():
         if not line:
             if data_lines:
-                payloads.append("\n".join(data_lines))
+                yield "\n".join(data_lines)
                 data_lines = []
             continue
         if line.startswith(":"):
@@ -217,8 +215,7 @@ def _iter_sse_data_payloads(response: httpx.Response) -> list[str]:
             data_line = data_line[1:]
         data_lines.append(data_line)
     if data_lines:
-        payloads.append("\n".join(data_lines))
-    return payloads
+        yield "\n".join(data_lines)
 
 
 def _extract_stream_choice_content(payload: Mapping[str, Any]) -> list[str]:

--- a/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
@@ -47,7 +47,7 @@ class OpenAICompatibleLLMClassifier:
     transport: httpx.BaseTransport | None = None
 
     def classify(self, *, log_text: str, build: Mapping[str, Any]) -> ErrorClassification:
-        response_payload = self._post_chat_completion(
+        response_content = self._post_chat_completion(
             _build_chat_payload(
                 model=self.model,
                 reasoning_effort=self.reasoning_effort,
@@ -58,26 +58,28 @@ class OpenAICompatibleLLMClassifier:
                 build=build,
             )
         )
-        parsed = _parse_classification_response(response_payload)
+        parsed = _extract_json_object(response_content)
         return _validate_classification(
             parsed,
             allowed_classifications=self.allowed_classifications,
             provider_name=self.provider_name,
         )
 
-    def _post_chat_completion(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    def _post_chat_completion(self, payload: Mapping[str, Any]) -> str:
         endpoint = f"{self.base_url.rstrip('/')}/chat/completions"
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
+        request_payload = dict(payload)
+        request_payload["stream"] = True
         with httpx.Client(
             timeout=self.timeout_seconds,
             transport=self.transport,
         ) as client:
-            response = client.post(endpoint, headers=headers, json=payload)
-            response.raise_for_status()
-            return response.json()
+            with client.stream("POST", endpoint, headers=headers, json=request_payload) as response:
+                response.raise_for_status()
+                return _collect_stream_content(response)
 
 
 def build_llm_classifier(
@@ -181,18 +183,60 @@ def _normalize_reasoning_effort(value: str | None) -> str | None:
     return resolved
 
 
-def _parse_classification_response(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+def _collect_stream_content(response: httpx.Response) -> str:
+    parts: list[str] = []
+    for event_payload in _iter_sse_data_payloads(response):
+        if event_payload == "[DONE]":
+            continue
+        parsed = json.loads(event_payload)
+        if not isinstance(parsed, Mapping):
+            raise ValueError("LLM stream event JSON must be an object")
+        parts.extend(_extract_stream_choice_content(parsed))
+    content = "".join(parts).strip()
+    if not content:
+        raise ValueError("LLM stream did not contain content")
+    return content
+
+
+def _iter_sse_data_payloads(response: httpx.Response) -> list[str]:
+    payloads: list[str] = []
+    data_lines: list[str] = []
+    for raw_line in response.iter_lines():
+        line = raw_line.strip()
+        if not line:
+            if data_lines:
+                payloads.append("\n".join(data_lines))
+                data_lines = []
+            continue
+        if line.startswith(":"):
+            continue
+        if not line.startswith("data:"):
+            continue
+        data_line = line[5:]
+        if data_line.startswith(" "):
+            data_line = data_line[1:]
+        data_lines.append(data_line)
+    if data_lines:
+        payloads.append("\n".join(data_lines))
+    return payloads
+
+
+def _extract_stream_choice_content(payload: Mapping[str, Any]) -> list[str]:
     choices = payload.get("choices")
-    if not isinstance(choices, list) or not choices:
-        raise ValueError("LLM response did not contain choices")
-    first_choice = choices[0]
-    if not isinstance(first_choice, Mapping):
-        raise ValueError("LLM response choice is malformed")
-    message = first_choice.get("message")
-    if not isinstance(message, Mapping):
-        raise ValueError("LLM response message is missing")
-    content = _coerce_message_content(message.get("content"))
-    return _extract_json_object(content)
+    if not isinstance(choices, list):
+        return []
+    parts: list[str] = []
+    for choice in choices:
+        if not isinstance(choice, Mapping):
+            continue
+        delta = choice.get("delta")
+        if not isinstance(delta, Mapping):
+            continue
+        content = delta.get("content")
+        if content is None:
+            continue
+        parts.append(_coerce_message_content(content))
+    return parts
 
 
 def _coerce_message_content(content: Any) -> str:

--- a/ci-dashboard/tests/jobs/test_llm_classifier.py
+++ b/ci-dashboard/tests/jobs/test_llm_classifier.py
@@ -6,7 +6,11 @@ import httpx
 import pytest
 
 from ci_dashboard.common.config import LLMSettings
-from ci_dashboard.jobs.llm_classifier import OpenAICompatibleLLMClassifier, build_llm_classifier
+from ci_dashboard.jobs.llm_classifier import (
+    OpenAICompatibleLLMClassifier,
+    _iter_sse_data_payloads,
+    build_llm_classifier,
+)
 
 
 def test_openai_compatible_llm_classifier_posts_to_configured_base_url() -> None:
@@ -147,6 +151,20 @@ def test_openai_compatible_llm_classifier_ignores_reasoning_only_chunks() -> Non
 
     assert result.l1_category == "OTHERS"
     assert result.l2_subcategory == "UNCLASSIFIED"
+
+
+def test_iter_sse_data_payloads_preserves_significant_whitespace() -> None:
+    response = httpx.Response(
+        200,
+        text=(
+            ": keep-alive\n"
+            "data:  first line  \n"
+            "data: second line\n\n"
+            "data: [DONE]\n\n"
+        ),
+    )
+
+    assert list(_iter_sse_data_payloads(response)) == [" first line  \nsecond line", "[DONE]"]
 
 
 def test_build_llm_classifier_requires_base_url_for_codex() -> None:

--- a/ci-dashboard/tests/jobs/test_llm_classifier.py
+++ b/ci-dashboard/tests/jobs/test_llm_classifier.py
@@ -18,15 +18,14 @@ def test_openai_compatible_llm_classifier_posts_to_configured_base_url() -> None
         captured["body"] = json.loads(request.content.decode("utf-8"))
         return httpx.Response(
             200,
-            json={
-                "choices": [
-                    {
-                        "message": {
-                            "content": '{"l1":"INFRA","l2":"NETWORK"}',
-                        }
-                    }
-                ]
-            },
+            headers={"Content-Type": "text/event-stream"},
+            text=(
+                'data: {"choices":[{"delta":{"reasoning_content":"checking failure"}}]}\n\n'
+                'data: {"choices":[{"delta":{"content":"{\\"l1\\":\\"INFRA\\","}}]}\n\n'
+                'data: {"choices":[{"delta":{"content":"\\"l2\\":\\"NETWORK\\"}"}}]}\n\n'
+                'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+                "data: [DONE]\n\n"
+            ),
         )
 
     classifier = OpenAICompatibleLLMClassifier(
@@ -60,6 +59,7 @@ def test_openai_compatible_llm_classifier_posts_to_configured_base_url() -> None
     assert captured["body"] == {
         "model": "gpt-5-codex",
         "reasoning_effort": "high",
+        "stream": True,
         "messages": [
             {
                 "role": "system",
@@ -94,15 +94,11 @@ def test_openai_compatible_llm_classifier_rejects_unknown_label() -> None:
         del request
         return httpx.Response(
             200,
-            json={
-                "choices": [
-                    {
-                        "message": {
-                            "content": '{"l1":"NEW","l2":"CATEGORY"}',
-                        }
-                    }
-                ]
-            },
+            headers={"Content-Type": "text/event-stream"},
+            text=(
+                'data: {"choices":[{"delta":{"content":"{\\"l1\\":\\"NEW\\",\\"l2\\":\\"CATEGORY\\"}"}}]}\n\n'
+                "data: [DONE]\n\n"
+            ),
         )
 
     classifier = OpenAICompatibleLLMClassifier(
@@ -119,6 +115,38 @@ def test_openai_compatible_llm_classifier_rejects_unknown_label() -> None:
 
     with pytest.raises(ValueError, match="unsupported classification"):
         classifier.classify(log_text="unknown failure", build={})
+
+
+def test_openai_compatible_llm_classifier_ignores_reasoning_only_chunks() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "text/event-stream"},
+            text=(
+                'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n\n'
+                'data: {"choices":[{"delta":{"reasoning_content":"still thinking"}}]}\n\n'
+                'data: {"choices":[{"delta":{"content":"{\\"l1\\":\\"OTHERS\\",\\"l2\\":\\"UNCLASSIFIED\\"}"}}]}\n\n'
+                "data: [DONE]\n\n"
+            ),
+        )
+
+    classifier = OpenAICompatibleLLMClassifier(
+        provider_name="codex",
+        base_url="https://api-vip.codex-for.me/v1",
+        model="gpt-5-codex",
+        api_key="test-key",
+        reasoning_effort=None,
+        default_l1_category="OTHERS",
+        default_l2_subcategory="UNCLASSIFIED",
+        allowed_classifications=(("INFRA", "NETWORK"), ("OTHERS", "UNCLASSIFIED")),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = classifier.classify(log_text="unknown failure", build={})
+
+    assert result.l1_category == "OTHERS"
+    assert result.l2_subcategory == "UNCLASSIFIED"
 
 
 def test_build_llm_classifier_requires_base_url_for_codex() -> None:


### PR DESCRIPTION
## Summary
- switch the Codex/OpenAI-compatible classifier to 
- parse SSE chunks and concatenate only 
- ignore reasoning-only chunks and cover the stream flow in tests

## Testing
- PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests/jobs/test_llm_classifier.py
- PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests
- cd ci-dashboard && ruff check src tests