### PR TITLE
fix(ci-dashboard): raise default llm timeout

### DIFF
--- a/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
@@ -9,7 +9,7 @@ import httpx
 from ci_dashboard.common.config import LLMSettings
 from ci_dashboard.common.models import ErrorClassification
 
-DEFAULT_LLM_TIMEOUT_SECONDS = 60
+DEFAULT_LLM_TIMEOUT_SECONDS = 180
 DEFAULT_LLM_MAX_INPUT_CHARS = 24000
 
 

--- a/ci-dashboard/tests/jobs/test_llm_classifier.py
+++ b/ci-dashboard/tests/jobs/test_llm_classifier.py
@@ -199,6 +199,7 @@ def test_build_llm_classifier_passes_reasoning_effort() -> None:
     assert isinstance(classifier, OpenAICompatibleLLMClassifier)
     assert classifier.model == "gpt-5.4"
     assert classifier.reasoning_effort == "high"
+    assert classifier.timeout_seconds == 180
 
 
 def test_build_llm_classifier_rejects_invalid_reasoning_effort() -> None:


### PR DESCRIPTION
## Summary
- raise the default OpenAI-compatible LLM timeout from 60s to 180s
- keep the change minimal and cover the default timeout in the existing classifier test

## Why
- the GKE analyze-errors smoke against the real streaming provider succeeded overall, but one request hit httpx.ReadTimeout at the 60s default
- increasing the default timeout reduces false negatives during high-reasoning LLM classifications

## Testing
- PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests/jobs/test_llm_classifier.py
- PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests
- cd ci-dashboard && ruff check src tests