### PR TITLE
fix(ci-dashboard): retry llm rate limits

### DIFF
--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -43,3 +43,9 @@ src = ["src", "tests"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["src/ci_dashboard"]
+
+[tool.coverage.report]
+fail_under = 90

--- a/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import logging
+import time
 from dataclasses import dataclass
 from typing import Any, Iterator, Mapping, Protocol
 
@@ -9,8 +11,13 @@ import httpx
 from ci_dashboard.common.config import LLMSettings
 from ci_dashboard.common.models import ErrorClassification
 
+LOG = logging.getLogger(__name__)
+
 DEFAULT_LLM_TIMEOUT_SECONDS = 180
 DEFAULT_LLM_MAX_INPUT_CHARS = 24000
+DEFAULT_LLM_RATE_LIMIT_RETRIES = 4
+DEFAULT_LLM_RATE_LIMIT_BACKOFF_SECONDS = 5.0
+MAX_LLM_RATE_LIMIT_BACKOFF_SECONDS = 60.0
 
 
 class LLMClassifier(Protocol):
@@ -77,9 +84,31 @@ class OpenAICompatibleLLMClassifier:
             timeout=self.timeout_seconds,
             transport=self.transport,
         ) as client:
-            with client.stream("POST", endpoint, headers=headers, json=request_payload) as response:
-                response.raise_for_status()
-                return _collect_stream_content(response)
+            for attempt in range(DEFAULT_LLM_RATE_LIMIT_RETRIES + 1):
+                try:
+                    with client.stream(
+                        "POST",
+                        endpoint,
+                        headers=headers,
+                        json=request_payload,
+                    ) as response:
+                        response.raise_for_status()
+                        return _collect_stream_content(response)
+                except httpx.HTTPStatusError as exc:
+                    if not _should_retry_rate_limit(exc.response, attempt=attempt):
+                        raise
+                    delay_seconds = _resolve_rate_limit_backoff_seconds(exc.response, attempt=attempt)
+                    LOG.warning(
+                        "LLM provider rate limited classification request; retrying",
+                        extra={
+                            "provider_name": self.provider_name,
+                            "model": self.model,
+                            "attempt": attempt + 1,
+                            "delay_seconds": delay_seconds,
+                        },
+                    )
+                    time.sleep(delay_seconds)
+        raise RuntimeError("LLM classification request retries exhausted")
 
 
 def build_llm_classifier(
@@ -181,6 +210,35 @@ def _normalize_reasoning_effort(value: str | None) -> str | None:
             "CI_DASHBOARD_LLM_REASONING_EFFORT must be one of: minimal, low, medium, high"
         )
     return resolved
+
+
+def _should_retry_rate_limit(response: httpx.Response, *, attempt: int) -> bool:
+    return (
+        response.status_code == httpx.codes.TOO_MANY_REQUESTS
+        and attempt < DEFAULT_LLM_RATE_LIMIT_RETRIES
+    )
+
+
+def _resolve_rate_limit_backoff_seconds(response: httpx.Response, *, attempt: int) -> float:
+    retry_after = _parse_retry_after_seconds(response.headers.get("Retry-After"))
+    if retry_after is not None:
+        return retry_after
+    return min(
+        DEFAULT_LLM_RATE_LIMIT_BACKOFF_SECONDS * (2**attempt),
+        MAX_LLM_RATE_LIMIT_BACKOFF_SECONDS,
+    )
+
+
+def _parse_retry_after_seconds(value: str | None) -> float | None:
+    if value is None:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        return max(float(raw), 0.0)
+    except ValueError:
+        return None
 
 
 def _collect_stream_content(response: httpx.Response) -> str:

--- a/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/llm_classifier.py
@@ -95,8 +95,13 @@ class OpenAICompatibleLLMClassifier:
                         response.raise_for_status()
                         return _collect_stream_content(response)
                 except httpx.HTTPStatusError as exc:
-                    if not _should_retry_rate_limit(exc.response, attempt=attempt):
+                    if exc.response.status_code != httpx.codes.TOO_MANY_REQUESTS:
                         raise
+                    if attempt >= DEFAULT_LLM_RATE_LIMIT_RETRIES:
+                        raise RuntimeError(
+                            "LLM classification request retries exhausted "
+                            f"after {DEFAULT_LLM_RATE_LIMIT_RETRIES + 1} attempts"
+                        ) from exc
                     delay_seconds = _resolve_rate_limit_backoff_seconds(exc.response, attempt=attempt)
                     LOG.warning(
                         "LLM provider rate limited classification request; retrying",
@@ -108,7 +113,7 @@ class OpenAICompatibleLLMClassifier:
                         },
                     )
                     time.sleep(delay_seconds)
-        raise RuntimeError("LLM classification request retries exhausted")
+        raise AssertionError("unreachable")
 
 
 def build_llm_classifier(

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -12,6 +12,27 @@ from ci_dashboard.api.main import app, create_app
 from ci_dashboard.jobs.build_url_matcher import normalize_build_url
 
 
+def test_get_engine_dependency_caches_underlying_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    from ci_dashboard.api import dependencies as dependencies_module
+
+    sentinel = object()
+    calls = {"count": 0}
+
+    dependencies_module._cached_engine.cache_clear()
+
+    def fake_build_engine():
+        calls["count"] += 1
+        return sentinel
+
+    monkeypatch.setattr("ci_dashboard.api.dependencies.build_engine", fake_build_engine)
+
+    assert get_engine() is sentinel
+    assert get_engine() is sentinel
+    assert calls["count"] == 1
+
+    dependencies_module._cached_engine.cache_clear()
+
+
 def _insert_build(
     sqlite_engine,
     *,

--- a/ci-dashboard/tests/jobs/test_build_merge.py
+++ b/ci-dashboard/tests/jobs/test_build_merge.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from ci_dashboard.jobs.build_merge import resolve_merge_target_id
+from ci_dashboard.jobs.build_merge import fetch_existing_build_targets, resolve_merge_target_id
 
 
 def _candidate(candidate_id: int, normalized_build_url: str, source_prow_job_id: str | None):
@@ -86,3 +86,70 @@ def test_resolve_merge_target_id_without_source_prow_job_id_still_rejects_confli
             existing_by_prow_job_id={},
             existing_by_build_url=existing_by_build_url,
         )
+
+
+def test_fetch_existing_build_targets_returns_empty_maps_without_inputs(sqlite_engine) -> None:
+    with sqlite_engine.begin() as connection:
+        existing_by_prow_job_id, existing_by_build_url = fetch_existing_build_targets(
+            connection,
+            normalized_build_urls=[],
+            source_prow_job_ids=[],
+        )
+
+    assert existing_by_prow_job_id == {}
+    assert existing_by_build_url == {}
+
+
+def test_resolve_merge_target_id_returns_none_without_build_url_or_candidates() -> None:
+    assert (
+        resolve_merge_target_id(
+            normalized_build_url=None,
+            source_prow_job_id="prow-job-5",
+            existing_by_prow_job_id={},
+            existing_by_build_url={},
+        )
+        is None
+    )
+
+
+def test_resolve_merge_target_id_without_source_prefers_single_candidate_or_unresolved_row() -> None:
+    normalized_build_url = "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/5/"
+    resolved = _candidate(501, normalized_build_url, "prow-job-5")
+    unresolved = _candidate(502, normalized_build_url, None)
+
+    assert (
+        resolve_merge_target_id(
+            normalized_build_url=normalized_build_url,
+            source_prow_job_id=None,
+            existing_by_prow_job_id={},
+            existing_by_build_url={normalized_build_url: [resolved]},
+        )
+        == 501
+    )
+    assert (
+        resolve_merge_target_id(
+            normalized_build_url=normalized_build_url,
+            source_prow_job_id=None,
+            existing_by_prow_job_id={},
+            existing_by_build_url={normalized_build_url: [resolved, unresolved]},
+        )
+        == 502
+    )
+
+
+def test_resolve_merge_target_id_chooses_oldest_unresolved_row_when_multiple_exist(caplog: pytest.LogCaptureFixture) -> None:
+    normalized_build_url = "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/6/"
+    first_unresolved = _candidate(601, normalized_build_url, None)
+    second_unresolved = _candidate(602, normalized_build_url, None)
+
+    with caplog.at_level("WARNING"):
+        target_id = resolve_merge_target_id(
+            normalized_build_url=normalized_build_url,
+            source_prow_job_id="prow-job-6",
+            existing_by_prow_job_id={},
+            existing_by_build_url={normalized_build_url: [first_unresolved, second_unresolved]},
+            log_context={"worker": "jenkins"},
+        )
+
+    assert target_id == 601
+    assert "multiple canonical build rows share normalized_build_url" in caplog.text

--- a/ci-dashboard/tests/jobs/test_build_url_matcher.py
+++ b/ci-dashboard/tests/jobs/test_build_url_matcher.py
@@ -22,6 +22,20 @@ def test_normalize_build_url_handles_none_and_blank() -> None:
     assert normalize_build_url("   ") is None
 
 
+def test_normalize_build_url_supports_relative_paths_and_internal_jenkins_host() -> None:
+    assert (
+        normalize_build_url("/job/pingcap/job/tidb/job/ghpr_unit_test/299/display/redirect")
+        == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/299/"
+    )
+    assert (
+        normalize_build_url(
+            "http://jenkins.jenkins.svc.cluster.local/job/pingcap/job/tidb/job/ghpr_unit_test/299/"
+        )
+        == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/299/"
+    )
+    assert normalize_build_url("https://example.test/not-a-build") is None
+
+
 def test_classify_cloud_phase_uses_host_prefix() -> None:
     assert classify_cloud_phase("https://prow.tidb.net/jenkins/job/example") == "GCP"
     assert classify_cloud_phase("https://prow.tidb.net/view/gs/prow-tidb-logs/job/example") == "GCP"
@@ -44,6 +58,14 @@ def test_build_job_url_uses_cloud_phase_host() -> None:
         build_job_url("/jenkins/job/pingcap/job/tidb/job/nightly", "IDC")
         == "https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/nightly"
     )
+    assert build_job_url("https://prow.tidb.net/jenkins/job/example", "GCP") == "https://prow.tidb.net/jenkins/job/example/"
+    assert build_job_url("   ", "GCP") is None
+    assert build_job_url(None, "GCP") is None
+
+
+def test_classify_build_system_handles_missing_url() -> None:
+    assert classify_build_system(None) == "UNKNOWN"
+    assert classify_build_system("") == "UNKNOWN"
 
 
 def test_normalized_job_path_from_key_strips_only_numeric_build_suffix() -> None:
@@ -52,3 +74,5 @@ def test_normalized_job_path_from_key_strips_only_numeric_build_suffix() -> None
         == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/"
     )
     assert normalized_job_path_from_key("https://prow.tidb.net/jenkins/job/job-4/") == "https://prow.tidb.net/jenkins/job/job-4/"
+    assert normalized_job_path_from_key(None) is None
+    assert normalized_job_path_from_key("https://example.test/not-a-build") is None

--- a/ci-dashboard/tests/jobs/test_flaky.py
+++ b/ci-dashboard/tests/jobs/test_flaky.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+from datetime import timezone
 
-from ci_dashboard.jobs.flaky import BuildAttempt, classify_state, compute_group_flags
+from ci_dashboard.jobs.flaky import BuildAttempt, classify_state, compute_group_flags, has_retest_between, parse_datetime
 
 
 def test_classify_state_keeps_abort_out_of_flaky_logic() -> None:
@@ -39,3 +40,59 @@ def test_compute_group_flags_marks_retry_loop_only_on_redundant_reruns() -> None
     assert flags[1].is_retry_loop == 0
     assert flags[2].is_retry_loop == 1
     assert flags[3].is_retry_loop == 0
+
+
+def test_parse_datetime_supports_datetime_strings_and_aware_values() -> None:
+    aware = datetime(2026, 4, 13, 10, 0, 0, tzinfo=timezone.utc)
+    assert parse_datetime(None) is None
+    assert parse_datetime("   ") is None
+    assert parse_datetime(aware) == datetime(2026, 4, 13, 10, 0, 0)
+    assert parse_datetime("2026-04-13T10:00:00Z") == datetime(2026, 4, 13, 10, 0, 0)
+    assert parse_datetime(123) is None
+
+
+def test_has_retest_between_checks_window_boundaries() -> None:
+    retest_times = [
+        datetime(2026, 4, 13, 10, 0, 0),
+        datetime(2026, 4, 13, 10, 30, 0),
+    ]
+    assert has_retest_between(retest_times, datetime(2026, 4, 13, 9, 0, 0), datetime(2026, 4, 13, 10, 15, 0)) is True
+    assert has_retest_between(retest_times, datetime(2026, 4, 13, 10, 31, 0), datetime(2026, 4, 13, 10, 40, 0)) is False
+    assert has_retest_between([], datetime(2026, 4, 13, 9, 0, 0), datetime(2026, 4, 13, 10, 15, 0)) is False
+
+
+def test_compute_group_flags_marks_flaky_when_failure_is_followed_by_pass() -> None:
+    flags = compute_group_flags(
+        [
+            BuildAttempt(build_id=1, sha="sha-1", state="failure", created_at=datetime(2026, 4, 13, 10, 0, 0)),
+            BuildAttempt(build_id=2, sha="sha-1", state="success", created_at=datetime(2026, 4, 13, 10, 1, 0)),
+            BuildAttempt(build_id=3, sha="sha-1", state="pending", created_at=datetime(2026, 4, 13, 10, 2, 0)),
+        ]
+    )
+
+    assert flags[1].is_flaky == 1
+    assert flags[2].is_flaky == 0
+    assert flags[3].is_flaky == 0
+
+
+def test_compute_group_flags_requires_retest_signal_before_marking_retry_loop() -> None:
+    attempts = [
+        BuildAttempt(build_id=11, sha="sha-1", state="failure", created_at=datetime(2026, 4, 13, 10, 0, 0)),
+        BuildAttempt(build_id=12, sha="sha-1", state="failure", created_at=datetime(2026, 4, 13, 10, 5, 0)),
+        BuildAttempt(build_id=13, sha="sha-2", state="failure", created_at=datetime(2026, 4, 13, 10, 10, 0)),
+    ]
+
+    without_retest = compute_group_flags(attempts, require_retest=True, retest_times=[])
+    with_retest = compute_group_flags(
+        attempts,
+        require_retest=True,
+        retest_times=[datetime(2026, 4, 13, 10, 3, 0)],
+    )
+
+    assert without_retest[12].is_retry_loop == 0
+    assert with_retest[12].is_retry_loop == 1
+
+
+def test_compute_group_flags_returns_empty_for_no_attempts_and_ignores_unknown_state() -> None:
+    assert compute_group_flags([]) == {}
+    assert classify_state("mystery-state") == "ignore"

--- a/ci-dashboard/tests/jobs/test_gcs_client.py
+++ b/ci-dashboard/tests/jobs/test_gcs_client.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import builtins
+from types import SimpleNamespace
+
+import pytest
+
+from ci_dashboard.jobs.gcs_client import (
+    GCSObjectRef,
+    GCSReader,
+    GCSUploader,
+    _build_storage_client,
+    parse_gcs_uri,
+)
+
+
+class _FakeBlob:
+    def __init__(self) -> None:
+        self.upload_calls: list[tuple[str, str]] = []
+        self.download_result = "downloaded-text"
+
+    def upload_from_string(self, text: str, *, content_type: str) -> None:
+        self.upload_calls.append((text, content_type))
+
+    def download_as_text(self, *, encoding: str) -> str:
+        return f"{self.download_result}:{encoding}"
+
+
+class _FakeBucket:
+    def __init__(self, blob: _FakeBlob) -> None:
+        self._blob = blob
+        self.requested_names: list[str] = []
+
+    def blob(self, object_name: str) -> _FakeBlob:
+        self.requested_names.append(object_name)
+        return self._blob
+
+
+class _FakeClient:
+    def __init__(self, bucket: _FakeBucket) -> None:
+        self._bucket = bucket
+        self.requested_buckets: list[str] = []
+
+    def bucket(self, bucket_name: str) -> _FakeBucket:
+        self.requested_buckets.append(bucket_name)
+        return self._bucket
+
+
+def test_gcs_object_ref_builds_uri() -> None:
+    assert GCSObjectRef(bucket="ci-logs", object_name="202604/build-1.log").uri == "gcs://ci-logs/202604/build-1.log"
+
+
+def test_gcs_uploader_and_reader_delegate_to_storage_client() -> None:
+    blob = _FakeBlob()
+    bucket = _FakeBucket(blob)
+    client = _FakeClient(bucket)
+
+    uploader = GCSUploader(client=client)
+    reader = GCSReader(client=client)
+
+    uri = uploader.upload_text(
+        bucket="ci-logs",
+        object_name="202604/build-1.log",
+        text="hello world",
+        content_type="text/plain",
+    )
+    content = reader.download_text(
+        bucket="ci-logs",
+        object_name="202604/build-1.log",
+        encoding="utf-16",
+    )
+
+    assert uri == "gcs://ci-logs/202604/build-1.log"
+    assert client.requested_buckets == ["ci-logs", "ci-logs"]
+    assert bucket.requested_names == ["202604/build-1.log", "202604/build-1.log"]
+    assert blob.upload_calls == [("hello world", "text/plain")]
+    assert content == "downloaded-text:utf-16"
+
+
+def test_parse_gcs_uri_accepts_valid_uri_and_rejects_invalid_values() -> None:
+    assert parse_gcs_uri("gcs://ci-logs/202604/build-1.log") == GCSObjectRef(
+        bucket="ci-logs",
+        object_name="202604/build-1.log",
+    )
+    assert parse_gcs_uri(None) is None
+    assert parse_gcs_uri("") is None
+    assert parse_gcs_uri("https://storage.googleapis.com/ci-logs/build.log") is None
+    assert parse_gcs_uri("gcs://ci-logs") is None
+    assert parse_gcs_uri("gcs:///missing-bucket") is None
+    assert parse_gcs_uri("gcs://ci-logs/") is None
+
+
+def test_build_storage_client_raises_clear_error_when_dependency_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "google.cloud":
+            raise ImportError("missing google.cloud")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(RuntimeError, match="google-cloud-storage is required"):
+        _build_storage_client()
+
+
+def test_build_storage_client_returns_google_storage_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_storage = SimpleNamespace(Client=lambda: "fake-storage-client")
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "google.cloud":
+            return SimpleNamespace(storage=fake_storage)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert _build_storage_client() == "fake-storage-client"

--- a/ci-dashboard/tests/jobs/test_llm_classifier.py
+++ b/ci-dashboard/tests/jobs/test_llm_classifier.py
@@ -8,7 +8,19 @@ import pytest
 import ci_dashboard.jobs.llm_classifier as llm_classifier_module
 from ci_dashboard.common.config import LLMSettings
 from ci_dashboard.jobs.llm_classifier import (
+    NoopLLMClassifier,
     OpenAICompatibleLLMClassifier,
+    _build_chat_payload,
+    _collect_stream_content,
+    _coerce_message_content,
+    _extract_json_object,
+    _extract_stream_choice_content,
+    _normalize_reasoning_effort,
+    _parse_retry_after_seconds,
+    _resolve_rate_limit_backoff_seconds,
+    _should_retry_rate_limit,
+    _truncate_log_text,
+    _validate_classification,
     _iter_sse_data_payloads,
     build_llm_classifier,
 )
@@ -261,6 +273,178 @@ def test_build_llm_classifier_rejects_invalid_reasoning_effort() -> None:
                 base_url="https://api-vip.codex-for.me/v1",
                 reasoning_effort="extreme",
             ),
+            default_l1_category="OTHERS",
+            default_l2_subcategory="UNCLASSIFIED",
+            allowed_classifications=(("OTHERS", "UNCLASSIFIED"),),
+        )
+
+
+def test_noop_llm_classifier_returns_default_classification() -> None:
+    classifier = NoopLLMClassifier(
+        default_l1_category="OTHERS",
+        default_l2_subcategory="UNCLASSIFIED",
+    )
+
+    result = classifier.classify(log_text="ignored", build={"job_name": "job"})
+
+    assert result.l1_category == "OTHERS"
+    assert result.l2_subcategory == "UNCLASSIFIED"
+    assert result.source == "llm:noop"
+
+
+def test_llm_helper_functions_cover_validation_and_truncation() -> None:
+    assert _truncate_log_text("short", max_chars=10) == "short"
+    assert _truncate_log_text("abcdefghijklmnopqrstuvwxyz", max_chars=5) == "[TRUNCATED TO LAST 5 CHARS]\nvwxyz"
+    assert _normalize_reasoning_effort(None) is None
+    assert _normalize_reasoning_effort(" HIGH ") == "high"
+    assert _parse_retry_after_seconds(None) is None
+    assert _parse_retry_after_seconds("   ") is None
+    assert _parse_retry_after_seconds("7.5") == 7.5
+    assert _parse_retry_after_seconds("-3") == 0.0
+    assert _parse_retry_after_seconds("not-a-number") is None
+    assert _resolve_rate_limit_backoff_seconds(httpx.Response(429, headers={}), attempt=0) == 5.0
+    assert _resolve_rate_limit_backoff_seconds(httpx.Response(429, headers={}), attempt=4) == 60.0
+    assert _resolve_rate_limit_backoff_seconds(httpx.Response(429, headers={"Retry-After": "12"}), attempt=0) == 12.0
+    assert _should_retry_rate_limit(httpx.Response(429), attempt=0) is True
+    assert _should_retry_rate_limit(httpx.Response(429), attempt=4) is False
+    assert _should_retry_rate_limit(httpx.Response(500), attempt=0) is False
+
+
+def test_chat_payload_and_content_parsing_helpers() -> None:
+    payload = _build_chat_payload(
+        model="gpt-5.4",
+        reasoning_effort=None,
+        allowed_classifications=(("INFRA", "NETWORK"), ("OTHERS", "UNCLASSIFIED")),
+        default_l1_category="OTHERS",
+        default_l2_subcategory="UNCLASSIFIED",
+        log_text="tail",
+        build={},
+    )
+    assert payload["model"] == "gpt-5.4"
+    assert "reasoning_effort" not in payload
+    assert "<unknown>" in payload["messages"][1]["content"]
+
+    assert _extract_stream_choice_content({"choices": [{"delta": {"content": "hello"}}]}) == ["hello"]
+    assert _extract_stream_choice_content({"choices": [{"delta": {"content": [{"text": "line-1"}, {"text": "line-2"}]}}]}) == [
+        "line-1\nline-2"
+    ]
+    assert _extract_stream_choice_content({"choices": [{"delta": {"content": None}}, "bad"]}) == []
+    assert _extract_stream_choice_content({"choices": "bad"}) == []
+    assert _coerce_message_content("text") == "text"
+    with pytest.raises(ValueError, match="empty"):
+        _coerce_message_content([])
+
+
+def test_json_object_helpers_accept_fenced_json_and_reject_bad_payloads() -> None:
+    assert _extract_json_object('```json\n{"l1":"INFRA","l2":"NETWORK"}\n```') == {
+        "l1": "INFRA",
+        "l2": "NETWORK",
+    }
+    assert _extract_json_object('prefix {"l1":"INFRA","l2":"NETWORK"} suffix') == {
+        "l1": "INFRA",
+        "l2": "NETWORK",
+    }
+    with pytest.raises(ValueError, match="did not contain a JSON object"):
+        _extract_json_object("no json here")
+    with pytest.raises(ValueError, match="did not contain a JSON object"):
+        _extract_json_object("[1,2,3]")
+
+    classification = _validate_classification(
+        {"l1": " infra ", "l2": " network "},
+        allowed_classifications=(("INFRA", "NETWORK"),),
+        provider_name="codex",
+    )
+    assert classification.l1_category == "INFRA"
+    assert classification.l2_subcategory == "NETWORK"
+    with pytest.raises(ValueError, match="unsupported classification"):
+        _validate_classification(
+            {"l1": "APP", "l2": "BUG"},
+            allowed_classifications=(("INFRA", "NETWORK"),),
+            provider_name="codex",
+        )
+
+
+def test_collect_stream_content_rejects_empty_or_non_object_events() -> None:
+    with pytest.raises(ValueError, match="must be an object"):
+        _collect_stream_content(
+            httpx.Response(
+                200,
+                text='data: ["bad"]\n\n',
+            )
+        )
+
+    with pytest.raises(ValueError, match="did not contain content"):
+        _collect_stream_content(
+            httpx.Response(
+                200,
+                text='data: {"choices":[{"delta":{"reasoning_content":"only-thoughts"}}]}\n\ndata: [DONE]\n\n',
+            )
+        )
+
+
+def test_openai_compatible_llm_classifier_rate_limit_failures_surface_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+    attempts = {"count": 0}
+
+    def retry_forever(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(429, request=request, text="rate limited")
+
+    classifier = OpenAICompatibleLLMClassifier(
+        provider_name="codex",
+        base_url="https://api-vip.codex-for.me/v1",
+        model="gpt-5-codex",
+        api_key="test-key",
+        reasoning_effort=None,
+        default_l1_category="OTHERS",
+        default_l2_subcategory="UNCLASSIFIED",
+        allowed_classifications=(("OTHERS", "UNCLASSIFIED"),),
+        transport=httpx.MockTransport(retry_forever),
+    )
+    monkeypatch.setattr(llm_classifier_module.time, "sleep", sleep_calls.append)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        classifier.classify(log_text="rate limited", build={})
+
+    assert attempts["count"] == 5
+    assert sleep_calls == [5.0, 10.0, 20.0, 40.0]
+
+
+def test_openai_compatible_llm_classifier_does_not_retry_non_429_errors() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, request=request, text="server error")
+
+    classifier = OpenAICompatibleLLMClassifier(
+        provider_name="codex",
+        base_url="https://api-vip.codex-for.me/v1",
+        model="gpt-5-codex",
+        api_key="test-key",
+        reasoning_effort=None,
+        default_l1_category="OTHERS",
+        default_l2_subcategory="UNCLASSIFIED",
+        allowed_classifications=(("OTHERS", "UNCLASSIFIED"),),
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        classifier.classify(log_text="server error", build={})
+
+
+def test_build_llm_classifier_supports_noop_aliases_and_rejects_unknown_provider() -> None:
+    assert isinstance(
+        build_llm_classifier(
+            LLMSettings(provider=" none "),
+            default_l1_category="OTHERS",
+            default_l2_subcategory="UNCLASSIFIED",
+            allowed_classifications=(("OTHERS", "UNCLASSIFIED"),),
+        ),
+        NoopLLMClassifier,
+    )
+    with pytest.raises(ValueError, match="unsupported CI_DASHBOARD_LLM_PROVIDER"):
+        build_llm_classifier(
+            LLMSettings(provider="gemini"),
             default_l1_category="OTHERS",
             default_l2_subcategory="UNCLASSIFIED",
             allowed_classifications=(("OTHERS", "UNCLASSIFIED"),),

--- a/ci-dashboard/tests/jobs/test_llm_classifier.py
+++ b/ci-dashboard/tests/jobs/test_llm_classifier.py
@@ -5,6 +5,7 @@ import json
 import httpx
 import pytest
 
+import ci_dashboard.jobs.llm_classifier as llm_classifier_module
 from ci_dashboard.common.config import LLMSettings
 from ci_dashboard.jobs.llm_classifier import (
     OpenAICompatibleLLMClassifier,
@@ -151,6 +152,54 @@ def test_openai_compatible_llm_classifier_ignores_reasoning_only_chunks() -> Non
 
     assert result.l1_category == "OTHERS"
     assert result.l2_subcategory == "UNCLASSIFIED"
+
+
+def test_openai_compatible_llm_classifier_retries_on_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+    sleep_calls: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(
+                429,
+                request=request,
+                headers={"Retry-After": "7"},
+                text="rate limited",
+            )
+        return httpx.Response(
+            200,
+            request=request,
+            headers={"Content-Type": "text/event-stream"},
+            text=(
+                'data: {"choices":[{"delta":{"content":"{\\"l1\\":\\"OTHERS\\",\\"l2\\":\\"UNCLASSIFIED\\"}"}}]}\n\n'
+                "data: [DONE]\n\n"
+            ),
+        )
+
+    monkeypatch.setattr(llm_classifier_module.time, "sleep", sleep_calls.append)
+
+    classifier = OpenAICompatibleLLMClassifier(
+        provider_name="codex",
+        base_url="https://api-vip.codex-for.me/v1",
+        model="gpt-5-codex",
+        api_key="test-key",
+        reasoning_effort=None,
+        default_l1_category="OTHERS",
+        default_l2_subcategory="UNCLASSIFIED",
+        allowed_classifications=(("INFRA", "NETWORK"), ("OTHERS", "UNCLASSIFIED")),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = classifier.classify(log_text="unknown failure", build={})
+
+    assert result.l1_category == "OTHERS"
+    assert result.l2_subcategory == "UNCLASSIFIED"
+    assert attempts == 2
+    assert sleep_calls == [7.0]
 
 
 def test_iter_sse_data_payloads_preserves_significant_whitespace() -> None:

--- a/ci-dashboard/tests/jobs/test_llm_classifier.py
+++ b/ci-dashboard/tests/jobs/test_llm_classifier.py
@@ -405,11 +405,12 @@ def test_openai_compatible_llm_classifier_rate_limit_failures_surface_cleanly(
     )
     monkeypatch.setattr(llm_classifier_module.time, "sleep", sleep_calls.append)
 
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(RuntimeError, match="retries exhausted after 5 attempts") as exc_info:
         classifier.classify(log_text="rate limited", build={})
 
     assert attempts["count"] == 5
     assert sleep_calls == [5.0, 10.0, 20.0, 40.0]
+    assert isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
 
 
 def test_openai_compatible_llm_classifier_does_not_retry_non_429_errors() -> None:

--- a/ci-dashboard/tests/jobs/test_sync_flaky_issues.py
+++ b/ci-dashboard/tests/jobs/test_sync_flaky_issues.py
@@ -1,12 +1,29 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
+from types import SimpleNamespace
+from urllib import error as urllib_error
 
+import pytest
 from sqlalchemy import text
 
 from ci_dashboard.common.config import DatabaseSettings, JobSettings, Settings
 from ci_dashboard.jobs.state_store import get_job_state
 from ci_dashboard.jobs.sync_flaky_issues import (
+    _build_flaky_issue_row,
+    _build_upsert_statement,
+    _extract_issue_lifecycle,
+    _fallback_issue_branch,
+    _fetch_github_api_json,
+    _normalize_issue_comments,
+    _parse_case_name,
+    _parse_datetime,
+    _parse_timeline,
+    _resolve_issue_branch,
+    _reuse_existing_issue_branch_if_fresh,
+    _upsert_flaky_issues,
+    fetch_issue_details_via_github_api,
     parse_issue_branch,
     parse_issue_branch_from_comments,
     run_sync_flaky_issues,
@@ -348,3 +365,148 @@ def test_parse_issue_branch_from_comments_prefers_latest_bot_comment() -> None:
         {"author": "ti-chi-bot", "body": "Automated flaky test report update.\n- Branch: release-8.5\n"},
     ]
     assert parse_issue_branch_from_comments(comments) == "release-8.5"
+
+
+def test_sync_flaky_issue_helpers_cover_fallbacks_and_payload_shapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert parse_issue_branch_from_comments(None) is None
+    assert parse_issue_branch_from_comments("not-json") is None
+    assert parse_issue_branch_from_comments([{"user": {"login": "someone"}, "body": "- Branch: release-9.0"}]) == "release-9.0"
+
+    assert _normalize_issue_comments(None) == []
+    assert _normalize_issue_comments('[{"body":"ok"},{"bad":1},3]') == [{"body": "ok"}, {"bad": 1}]
+    with pytest.raises(ValueError, match="Unsupported issue comments payload"):
+        _normalize_issue_comments(123)
+
+    assert _parse_case_name("Flaky test: TestCase in nightly") == "TestCase"
+    assert _parse_case_name("Flaky test: TestCase") == "TestCase"
+    assert _parse_case_name("Plain title") == "Plain title"
+    assert _parse_timeline(None) == []
+    assert _parse_timeline('[{"event":"closed"},"bad"]') == [{"event": "closed"}]
+    with pytest.raises(ValueError, match="Unsupported issue timeline payload"):
+        _parse_timeline(123)
+
+    closed_at, reopened_at, reopen_count = _extract_issue_lifecycle(
+        [
+            {"event": "closed", "created_at": "2026-04-11T08:00:00Z"},
+            {"event": "reopened", "createdAt": "2026-04-12T08:00:00Z"},
+            {"event": "ignored"},
+        ]
+    )
+    assert str(closed_at).startswith("2026-04-11 08:00:00")
+    assert str(reopened_at).startswith("2026-04-12 08:00:00")
+    assert reopen_count == 1
+
+    now = datetime(2026, 4, 15, 9, 0, 0)
+    assert _parse_datetime(now) == now
+    assert _parse_datetime("2026-04-15T09:00:00Z") == datetime.fromisoformat("2026-04-15T09:00:00+00:00")
+    with pytest.raises(ValueError, match="Unsupported datetime value"):
+        _parse_datetime(123)
+
+    row = _build_flaky_issue_row(
+        {
+            "id": 1,
+            "repo": "pingcap/tidb",
+            "number": 70002,
+            "title": "Flaky test: TestBranchFallback in nightly",
+            "state": "open",
+            "created_at": "2026-04-10T08:00:00Z",
+            "updated_at": "2026-04-15T09:00:00Z",
+            "timeline": [],
+        },
+        issue_branch="master",
+        branch_source="ticket_body",
+    )
+    assert row.case_name == "TestBranchFallback"
+    assert row.issue_branch == "master"
+    assert row.branch_source == "ticket_body"
+
+    existing = {
+        "issue_branch": "release-8.5",
+        "branch_source": "github_api_body",
+        "source_ticket_updated_at": "2026-04-15T09:00:00Z",
+    }
+    assert _reuse_existing_issue_branch_if_fresh(
+        {"updated_at": "2026-04-15T09:00:00Z"},
+        existing,
+    ) == ("release-8.5", "github_api_body")
+    assert _reuse_existing_issue_branch_if_fresh(
+        {"updated_at": "2026-04-16T09:00:00Z"},
+        existing,
+    ) == (None, "")
+    assert _fallback_issue_branch(existing) == ("release-8.5", "github_api_body")
+    assert _fallback_issue_branch(None) == (None, "unknown")
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.fetch_issue_details_via_github_api",
+        lambda **_: ("body without branch", []),
+    )
+    assert _resolve_issue_branch(
+        {"repo": "pingcap/tidb", "number": 1, "body": None, "comments": None, "updated_at": "2026-04-16T09:00:00Z"},
+        existing,
+    ) == ("release-8.5", "github_api_body", True, False)
+
+
+def test_fetch_github_api_json_and_issue_details_wrap_http_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Response:
+        def __init__(self, payload: str) -> None:
+            self._payload = payload.encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            return self._payload
+
+    responses = iter(
+        [
+            _Response(
+                json.dumps(
+                    {
+                        "body": "hello",
+                        "comments_url": "https://api.github.com/comments/1",
+                        "comments": 1,
+                    }
+                )
+            ),
+            _Response(json.dumps([{"body": "- Branch: master"}])),
+        ]
+    )
+    monkeypatch.setattr("ci_dashboard.jobs.sync_flaky_issues.urllib_request.urlopen", lambda request, timeout=0: next(responses))
+
+    body, comments = fetch_issue_details_via_github_api(repo="pingcap/tidb", issue_number=1)
+
+    assert body == "hello"
+    assert comments == [{"body": "- Branch: master"}]
+
+    class _HTTPError(urllib_error.HTTPError):
+        def __init__(self) -> None:
+            super().__init__("https://api.github.com", 403, "forbidden", hdrs=None, fp=None)
+
+        def read(self) -> bytes:
+            return b'{"message":"forbidden"}'
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.urllib_request.urlopen",
+        lambda request, timeout=0: (_ for _ in ()).throw(_HTTPError()),
+    )
+    with pytest.raises(RuntimeError, match="HTTP 403"):
+        _fetch_github_api_json("https://api.github.com/repos/pingcap/tidb/issues/1")
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.urllib_request.urlopen",
+        lambda request, timeout=0: (_ for _ in ()).throw(urllib_error.URLError("timeout")),
+    )
+    with pytest.raises(RuntimeError, match="timeout"):
+        _fetch_github_api_json("https://api.github.com/repos/pingcap/tidb/issues/1")
+
+
+def test_upsert_flaky_issues_accepts_empty_rows_and_tidb_statement(sqlite_engine) -> None:
+    with sqlite_engine.begin() as connection:
+        _upsert_flaky_issues(connection, [])
+
+    tidb_connection = SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
+    statement = _build_upsert_statement(tidb_connection)
+    assert "ON DUPLICATE KEY UPDATE" in str(statement)

--- a/ci-dashboard/tests/jobs/test_sync_pods.py
+++ b/ci-dashboard/tests/jobs/test_sync_pods.py
@@ -1,21 +1,51 @@
 from __future__ import annotations
 
+import io
+import json
 from datetime import datetime
+from datetime import UTC
+from types import SimpleNamespace
 from urllib import error as urllib_error
 
 import pytest
 from sqlalchemy import text
 
-from ci_dashboard.jobs.sync_pods import _load_target_namespaces
-
 from ci_dashboard.common.config import DatabaseSettings, JobSettings, Settings
 from ci_dashboard.jobs.state_store import get_job_state
 from ci_dashboard.jobs.sync_pods import (
+    JenkinsPodNameBuildRef,
     PodMetadataSnapshot,
+    _build_ci_job_from_build_metadata,
+    _build_requested_pods_relation,
+    _build_jenkins_url_from_label_and_ci_job,
+    _coerce_str_mapping,
+    _compute_start_from,
+    _decode_json_object,
+    _extract_normalized_build_url_from_metadata,
+    _extract_normalized_build_url_from_pod_name,
+    _extract_project_from_log_name,
     _extract_build_number_from_jenkins_label,
+    _fetch_pod_event_entries,
+    _format_rfc3339,
     _get_json,
+    _get_kubernetes_api_ca_file,
+    _get_kubernetes_api_token,
+    _get_kubernetes_api_url,
+    _infer_pod_build_system,
+    _json_dumps_or_none,
+    _list_namespace_pod_metadata,
     _load_jenkins_pod_name_url_prefix_map,
+    _load_target_namespaces,
+    _max_receive_timestamp,
+    _normalize_logging_entry,
+    _normalize_jenkins_runtime_url,
+    _null_safe_equals_sql,
+    _parse_jenkins_pod_name_build_ref,
     _post_json,
+    _read_int_env,
+    _request_json,
+    _resolve_jenkins_build_metadata,
+    _upsert_pod_events,
     run_reconcile_pod_linkage_for_time_window,
     run_sync_pods,
 )
@@ -142,6 +172,305 @@ def test_load_target_namespaces_uses_env_override(sqlite_engine, monkeypatch) ->
         namespaces = _load_target_namespaces(connection)
 
     assert namespaces == ["prow-test-pods", "custom-ns"]
+
+
+def test_sync_pod_helper_functions_cover_common_edge_cases(sqlite_engine, monkeypatch) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_builds (
+                  source_prow_row_id, source_prow_job_id, namespace, job_name, job_type, state,
+                  optional, report, org, repo, repo_full_name, url, pod_name, start_time, normalized_build_url, build_system
+                ) VALUES (
+                  101, 'prow-job-extra', 'custom-ns', 'job-a', 'presubmit', 'success',
+                  0, 1, 'pingcap', 'tidb', 'pingcap/tidb',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/job-a/101/',
+                  'pod-a', '2026-04-20T12:00:00Z',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/job-a/101/',
+                  'JENKINS'
+                )
+                """
+            )
+        )
+        assert _load_target_namespaces(connection) == [
+            "prow-test-pods",
+            "jenkins-tidb",
+            "jenkins-tiflow",
+            "custom-ns",
+        ]
+        _upsert_pod_events(connection, [])
+
+    monkeypatch.delenv("CI_DASHBOARD_POD_SYNC_OVERLAP_MINUTES", raising=False)
+    monkeypatch.delenv("CI_DASHBOARD_POD_SYNC_LOOKBACK_MINUTES", raising=False)
+    assert _compute_start_from({}, datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)) == datetime(2026, 4, 20, 10, 0, 0, tzinfo=UTC)
+    assert _compute_start_from({"last_receive_timestamp": "invalid"}, datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)) == datetime(
+        2026, 4, 20, 10, 0, 0, tzinfo=UTC
+    )
+
+    monkeypatch.setenv("TEST_INT_ENV", "")
+    assert _read_int_env("TEST_INT_ENV", 9) == 9
+    monkeypatch.setenv("TEST_INT_ENV", "oops")
+    assert _read_int_env("TEST_INT_ENV", 9) == 9
+    monkeypatch.setenv("TEST_INT_ENV", "0")
+    assert _read_int_env("TEST_INT_ENV", 9) == 9
+    monkeypatch.setenv("TEST_INT_ENV", "12")
+    assert _read_int_env("TEST_INT_ENV", 9) == 12
+
+    assert _extract_project_from_log_name("projects/pingcap-testing-account/logs/events") == "pingcap-testing-account"
+    assert _extract_project_from_log_name("bad-log-name") is None
+    assert _coerce_str_mapping({"a": " 1 ", "": "bad", "b": None, 3: "x"}) == {"a": "1", "3": "x"}
+    assert _json_dumps_or_none({}) is None
+    assert _json_dumps_or_none({"b": "2", "a": "1"}) == '{"a":"1","b":"2"}'
+    assert _format_rfc3339(datetime(2026, 4, 20, 12, 0, 0)) == "2026-04-20T12:00:00Z"
+    assert _max_receive_timestamp([]) is None
+    assert _null_safe_equals_sql("a", "b", "sqlite") == "a IS b"
+    assert _null_safe_equals_sql("a", "b", "mysql") == "a <=> b"
+    relation_sql, params = _build_requested_pods_relation([("p1", "ns", "uid", "pod")])
+    assert "UNION ALL" not in relation_sql
+    assert params == {
+        "source_project_0": "p1",
+        "namespace_name_0": "ns",
+        "pod_uid_0": "uid",
+        "pod_name_0": "pod",
+    }
+
+
+def test_sync_pods_http_and_kubernetes_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _decode_json_object(b'{"ok": true}', error_context="Logging API") == {"ok": True}
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        _decode_json_object(b"<html>bad</html>", error_context="Logging API")
+    with pytest.raises(RuntimeError, match="response is not an object"):
+        _decode_json_object(b"[1,2,3]", error_context="Logging API")
+
+    class _RetryHTTPError(urllib_error.HTTPError):
+        def __init__(self, code: int, body: str) -> None:
+            super().__init__("https://example.test", code, "error", hdrs=None, fp=io.BytesIO(body.encode("utf-8")))
+            self._body = body.encode("utf-8")
+
+        def read(self) -> bytes:
+            return self._body
+
+    attempts = {"count": 0}
+
+    def fake_urlopen_retry(request, timeout=0, context=None):
+        del request, timeout, context
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise _RetryHTTPError(503, "retry me")
+        return _FakeHTTPResponse('{"ok": true}')
+
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods.urllib_request.urlopen", fake_urlopen_retry)
+    request = __import__("urllib.request", fromlist=["Request"]).Request("https://example.test")
+    assert _request_json(request, timeout=1, error_context="Logging API") == {"ok": True}
+    assert attempts["count"] == 2
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_pods.urllib_request.urlopen",
+        lambda request, timeout=0, context=None: (_ for _ in ()).throw(urllib_error.URLError("down")),
+    )
+    with pytest.raises(RuntimeError, match="down"):
+        _request_json(request, timeout=1, error_context="Logging API")
+
+    monkeypatch.setenv("CI_DASHBOARD_GCP_PROJECT", "pingcap-testing-account")
+    monkeypatch.setenv("CI_DASHBOARD_GCP_ACCESS_TOKEN", "token")
+    pages = iter(
+        [
+            {"entries": [{"id": 1}], "nextPageToken": "next"},
+            {"entries": [{"id": 2}]},
+        ]
+    )
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods._post_json", lambda *args, **kwargs: next(pages))
+    assert _fetch_pod_event_entries(
+        start_from=datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC),
+        end_time=datetime(2026, 4, 20, 13, 0, 0, tzinfo=UTC),
+        namespaces=["prow-test-pods"],
+    ) == [{"id": 1}, {"id": 2}]
+
+    monkeypatch.setenv("CI_DASHBOARD_KUBERNETES_API_URL", "https://k8s.internal/")
+    assert _get_kubernetes_api_url() == "https://k8s.internal"
+    monkeypatch.delenv("CI_DASHBOARD_KUBERNETES_API_URL", raising=False)
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT_HTTPS", "6443")
+    assert _get_kubernetes_api_url() == "https://10.0.0.1:6443"
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    with pytest.raises(RuntimeError, match="Unable to resolve Kubernetes API host"):
+        _get_kubernetes_api_url()
+
+    monkeypatch.setenv("CI_DASHBOARD_KUBERNETES_BEARER_TOKEN", "inline-token")
+    assert _get_kubernetes_api_token() == "inline-token"
+    monkeypatch.delenv("CI_DASHBOARD_KUBERNETES_BEARER_TOKEN", raising=False)
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods._read_text_file", lambda path: "file-token")
+    assert _get_kubernetes_api_token() == "file-token"
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods._read_text_file", lambda path: (_ for _ in ()).throw(OSError("missing")))
+    with pytest.raises(RuntimeError, match="Unable to read Kubernetes service account token"):
+        _get_kubernetes_api_token()
+
+    monkeypatch.setenv("CI_DASHBOARD_KUBERNETES_CA_FILE", "/tmp/ca.pem")
+    assert _get_kubernetes_api_ca_file() == "/tmp/ca.pem"
+    monkeypatch.delenv("CI_DASHBOARD_KUBERNETES_CA_FILE", raising=False)
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods.os.path.exists", lambda path: False)
+    assert _get_kubernetes_api_ca_file() is None
+
+
+def test_sync_pods_build_matching_helpers_cover_jenkins_paths(sqlite_engine, monkeypatch) -> None:
+    assert _normalize_jenkins_runtime_url("https://do.pingcap.net/jenkins/job/a/1/") is None
+    assert _normalize_jenkins_runtime_url("https://prow.tidb.net/jenkins/job/a/1/") == "https://prow.tidb.net/jenkins/job/a/1/"
+    assert _infer_pod_build_system("jenkins-tidb") == "JENKINS"
+    assert _infer_pod_build_system("prow-test-pods") == "PROW_NATIVE"
+    assert _infer_pod_build_system("apps") == "UNKNOWN"
+
+    assert _parse_jenkins_pod_name_build_ref("jenkins-agent-1413-abcd") == JenkinsPodNameBuildRef(
+        pod_prefix="jenkins-agent",
+        build_number="1413",
+    )
+    assert _parse_jenkins_pod_name_build_ref("jenkins-agent-a-b") is None
+    assert _extract_normalized_build_url_from_pod_name(
+        "jenkins-agent-1413-abcd",
+        {"jenkins-agent": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test/"},
+    ) == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test/1413/"
+
+    metadata = _pod_metadata(
+        annotations={"buildUrl": "http://jenkins.jenkins.svc.cluster.local/job/pingcap/job/tidb/job/test/1413/"},
+    )
+    assert (
+        _extract_normalized_build_url_from_metadata(metadata)
+        == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test/1413/"
+    )
+    metadata_from_label = _pod_metadata(
+        labels={"org": "pingcap", "repo": "tidb", "jenkins/label": "ghpr-unit-test_1413-abcd"},
+        annotations={"ci_job": "pingcap/tidb/ghpr_unit_test"},
+    )
+    assert (
+        _extract_normalized_build_url_from_metadata(metadata_from_label)
+        == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/1413/"
+    )
+    assert _build_jenkins_url_from_label_and_ci_job(org=None, repo="tidb", ci_job="pingcap/tidb/job", jenkins_label="x_1-a") is None
+    assert _build_jenkins_url_from_label_and_ci_job(org="pingcap", repo="tidb", ci_job="other/job", jenkins_label="x_1-a") is None
+    assert _build_jenkins_url_from_label_and_ci_job(org="pingcap", repo="tidb", ci_job="pingcap/tidb/", jenkins_label="x_1-a") is None
+    assert _extract_build_number_from_jenkins_label(None) is None
+    assert _extract_build_number_from_jenkins_label("only-one-segment") is None
+
+    assert _build_ci_job_from_build_metadata({"job_name": "ghpr_unit_test", "repo_full_name": "pingcap/tidb"}) == "pingcap/tidb/ghpr_unit_test"
+    assert _build_ci_job_from_build_metadata({"job_name": "pingcap/tidb/ghpr_unit_test"}) == "pingcap/tidb/ghpr_unit_test"
+    assert _build_ci_job_from_build_metadata({"job_name": "ghpr_unit_test"}) is None
+
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_builds (
+                  source_prow_row_id, source_prow_job_id, namespace, job_name, job_type, state,
+                  optional, report, org, repo, repo_full_name, url, pod_name, start_time, normalized_build_url, build_system
+                ) VALUES
+                (
+                  201, 'prow-job-201', 'jenkins-tidb', 'test-a', 'presubmit', 'success',
+                  0, 1, 'pingcap', 'tidb', 'pingcap/tidb',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/1413/',
+                  'jenkins-agent-1413-abcd', '2026-04-20T12:00:00Z',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/1413/',
+                  'JENKINS'
+                ),
+                (
+                  202, 'prow-job-202', 'jenkins-tidb', 'test-a', 'presubmit', 'success',
+                  0, 1, 'pingcap', 'tidb', 'pingcap/tidb',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/1414/',
+                  'jenkins-agent-1413-abcd', '2026-04-19T12:00:00Z',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/1414/',
+                  'JENKINS'
+                )
+                """
+            )
+        )
+        prefix_map = _load_jenkins_pod_name_url_prefix_map(connection)
+
+    assert prefix_map["jenkins-agent"] == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/"
+    resolved = _resolve_jenkins_build_metadata(
+        scheduled_at=datetime(2026, 4, 20, 12, 1, 0),
+        candidate_urls=[
+            "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/1413/",
+            "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/9999/",
+        ],
+        build_candidates_by_url={
+            "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/1413/": [
+                {
+                    "source_prow_job_id": "prow-job-201",
+                    "org": "pingcap",
+                    "repo": "tidb",
+                    "repo_full_name": "pingcap/tidb",
+                    "job_name": "test-a",
+                    "author": "alice",
+                    "start_time": "2026-04-20T12:00:00Z",
+                }
+            ]
+        },
+    )
+    assert resolved["source_prow_job_id"] == "prow-job-201"
+    assert _resolve_jenkins_build_metadata(
+        scheduled_at=None,
+        candidate_urls=["https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/1413/"],
+        build_candidates_by_url={},
+    ) == {
+        "build_system": "JENKINS",
+        "normalized_build_url": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/test-a/1413/",
+    }
+
+
+def test_sync_pods_metadata_fetch_and_logging_entry_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _normalize_logging_entry({"logName": "projects/a/logs/events"}) is None
+    assert _normalize_logging_entry({"insertId": "1", "logName": "projects/a/logs/events", "jsonPayload": {}}) is None
+    normalized = _normalize_logging_entry(
+        {
+            "insertId": "ins-1",
+            "logName": "projects/pingcap-testing-account/logs/events",
+            "receiveTimestamp": "2026-04-20T12:53:54Z",
+            "resource": {"labels": {"namespace_name": "prow-test-pods", "pod_name": "pod-a"}},
+            "jsonPayload": {
+                "reason": "Scheduled",
+                "type": "Normal",
+                "message": "assigned",
+                "involvedObject": {"uid": "uid-a"},
+                "lastTimestamp": "2026-04-20T12:53:49Z",
+            },
+        }
+    )
+    assert normalized is not None
+    assert normalized.source_project == "pingcap-testing-account"
+    assert normalized.event_timestamp == datetime(2026, 4, 20, 12, 53, 49)
+
+    observed_at = datetime(2026, 4, 20, 13, 0, 0)
+    pages = iter(
+        [
+            {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "pod-a",
+                            "uid": "uid-a",
+                            "labels": {"author": "alice"},
+                            "annotations": {"ci_job": "pingcap/tidb/test-a"},
+                        }
+                    },
+                    "ignore-me",
+                ],
+                "metadata": {"continue": "next"},
+            },
+            {"items": [], "metadata": {}},
+        ]
+    )
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods._get_json", lambda *args, **kwargs: next(pages))
+    snapshots = _list_namespace_pod_metadata(
+        namespace_name="jenkins-tidb",
+        requested_pod_names={"pod-a"},
+        base_url="https://k8s.internal",
+        token="token",
+        ca_file=None,
+        observed_at=observed_at,
+    )
+    assert snapshots["pod-a"].pod_uid == "uid-a"
+    assert snapshots["pod-a"].labels == {"author": "alice"}
+    assert snapshots["pod-a"].annotations == {"ci_job": "pingcap/tidb/test-a"}
 
 
 def test_sync_pods_end_to_end_and_idempotent(sqlite_engine, monkeypatch) -> None:

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 
 import pytest
 
 from ci_dashboard.common.config import get_settings, load_settings
-from ci_dashboard.common.db import build_engine
+from ci_dashboard.common.db import _build_connect_args, build_engine, install_sqlite_functions
 from ci_dashboard.common.logging import configure_logging
 
 
@@ -151,6 +152,75 @@ def test_build_engine_supports_sqlite_url() -> None:
     settings = load_settings({"CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///:memory:"})
     engine = build_engine(settings)
     assert engine.dialect.name == "sqlite"
+    with engine.begin() as connection:
+        assert (
+            connection.exec_driver_sql(
+                "SELECT normalize_build_url('https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/1/display/redirect')"
+            ).scalar_one()
+            == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/1/"
+        )
+        assert (
+            connection.exec_driver_sql(
+                "SELECT normalized_job_path_from_key('https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/1/')"
+            ).scalar_one()
+            == "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/unit/"
+        )
+
+
+def test_build_connect_args_supports_optional_ssl_ca() -> None:
+    without_ssl = load_settings({"CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///:memory:"})
+    assert _build_connect_args(without_ssl.database) == {}
+
+    with_ssl = load_settings(
+        {
+            "TIDB_HOST": "db.example.com",
+            "TIDB_PORT": "4000",
+            "TIDB_USER": "ci",
+            "TIDB_PASSWORD": "secret",
+            "TIDB_DB": "dashboard",
+            "TIDB_SSL_CA": "/etc/certs/ca.pem",
+        }
+    )
+    assert _build_connect_args(with_ssl.database) == {"ssl": {"ca": "/etc/certs/ca.pem"}}
+
+
+def test_install_sqlite_functions_is_noop_for_non_sqlite_engine() -> None:
+    install_sqlite_functions(SimpleNamespace(dialect=SimpleNamespace(name="mysql")))
+
+
+def test_build_engine_builds_mysql_url_and_ssl_connect_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_engine(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
+
+    install_calls: list[object] = []
+    monkeypatch.setattr("ci_dashboard.common.db.create_engine", fake_create_engine)
+    monkeypatch.setattr("ci_dashboard.common.db.install_sqlite_functions", install_calls.append)
+
+    settings = load_settings(
+        {
+            "TIDB_HOST": "db.example.com",
+            "TIDB_PORT": "4000",
+            "TIDB_USER": "ci",
+            "TIDB_PASSWORD": "secret",
+            "TIDB_DB": "dashboard",
+            "TIDB_SSL_CA": "/etc/certs/ca.pem",
+        }
+    )
+
+    engine = build_engine(settings)
+
+    assert engine.dialect.name == "mysql"
+    assert str(captured["url"]) == "mysql+pymysql://ci:***@db.example.com:4000/dashboard?charset=utf8mb4"
+    assert captured["kwargs"] == {
+        "pool_pre_ping": True,
+        "future": True,
+        "connect_args": {"ssl": {"ca": "/etc/certs/ca.pem"}},
+    }
+    assert install_calls == [engine]
 
 
 def test_configure_logging_sets_root_level() -> None:

--- a/ci-dashboard/tests/test_query_base.py
+++ b/ci-dashboard/tests/test_query_base.py
@@ -1,8 +1,23 @@
 from __future__ import annotations
 
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+
 from sqlalchemy import text
 
-from ci_dashboard.api.queries.base import CommonFilters, build_common_where
+from ci_dashboard.api.queries.base import (
+    CommonFilters,
+    branch_expr,
+    bucket_expr,
+    builds_table_expr,
+    complete_week_bounds,
+    filter_complete_week_rows,
+    isoformat_utc,
+    rate_pct,
+    to_number,
+    build_common_where,
+)
 
 
 def _insert_build(
@@ -108,3 +123,92 @@ def test_build_common_where_skips_branch_predicate_for_empty_branch() -> None:
 
     assert where_clause == "1=1"
     assert params == {}
+
+
+def test_build_common_where_supports_job_repo_cloud_and_date_filters() -> None:
+    where_clause, params = build_common_where(
+        CommonFilters(
+            repo="pingcap/tidb",
+            branch="master",
+            job_name="ghpr_unit_test",
+            cloud_phase="GCP",
+            start_date=date(2026, 4, 1),
+            end_date=date(2026, 4, 7),
+        ),
+        table_alias="b",
+    )
+
+    assert "b.repo_full_name = :repo" in where_clause
+    assert "b.job_name = :job_name" in where_clause
+    assert "b.cloud_phase = :cloud_phase" in where_clause
+    assert "b.start_time >= :start_time_from" in where_clause
+    assert "b.start_time < :start_time_to" in where_clause
+    assert params["repo"] == "pingcap/tidb"
+    assert params["job_name"] == "ghpr_unit_test"
+    assert params["cloud_phase"] == "GCP"
+    assert params["start_time_from"] == datetime(2026, 4, 1, 0, 0, 0)
+    assert params["start_time_to"] == datetime(2026, 4, 8, 0, 0, 0)
+
+
+def test_query_base_helpers_cover_tidb_and_week_filters() -> None:
+    sqlite_connection = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    tidb_connection = SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
+
+    assert branch_expr("b") == "COALESCE(NULLIF(b.target_branch, ''), b.base_ref)"
+    assert bucket_expr(sqlite_connection, "start_time", "day") == "DATE(start_time)"
+    assert "strftime('%w'" in bucket_expr(sqlite_connection, "start_time", "week")
+    assert bucket_expr(tidb_connection, "start_time", "week") == "DATE_SUB(DATE(start_time), INTERVAL WEEKDAY(start_time) DAY)"
+
+    assert builds_table_expr(sqlite_connection, CommonFilters(repo="pingcap/tidb")) == "ci_l1_builds b"
+    assert (
+        builds_table_expr(
+            tidb_connection,
+            CommonFilters(repo="pingcap/tidb", start_date=date(2026, 4, 1)),
+        )
+        == "ci_l1_builds b FORCE INDEX(idx_ci_l1_builds_repo_time)"
+    )
+    assert (
+        builds_table_expr(
+            tidb_connection,
+            CommonFilters(start_date=date(2026, 4, 1)),
+        )
+        == "ci_l1_builds b FORCE INDEX(idx_ci_l1_builds_start_time_id)"
+    )
+    assert builds_table_expr(tidb_connection, CommonFilters()) == "ci_l1_builds b"
+
+
+def test_week_filters_and_numeric_helpers_cover_edge_cases() -> None:
+    rows = [
+        {"bucket_start": "2026-04-06", "value": 1},
+        {"bucket_start": "2026-04-13", "value": 2},
+        {"bucket_start": "not-a-date", "value": 3},
+        {"bucket_start": None, "value": 4},
+    ]
+
+    assert complete_week_bounds(date(2026, 4, 8), date(2026, 4, 10)) == (None, None)
+    assert complete_week_bounds(date(2026, 4, 6), date(2026, 4, 19)) == (
+        date(2026, 4, 6),
+        date(2026, 4, 13),
+    )
+    assert filter_complete_week_rows(rows, start_date=None, end_date=date(2026, 4, 19)) == rows
+    assert filter_complete_week_rows(rows, start_date=date(2026, 4, 8), end_date=date(2026, 4, 10)) == []
+    assert filter_complete_week_rows(rows, start_date=date(2026, 4, 6), end_date=date(2026, 4, 19)) == [
+        {"bucket_start": "2026-04-06", "value": 1},
+        {"bucket_start": "2026-04-13", "value": 2},
+    ]
+
+    assert to_number(Decimal("12")) == 12
+    assert to_number(Decimal("12.5")) == 12.5
+    assert to_number(4.0) == 4
+    assert to_number(4.567) == 4.57
+    assert to_number("7") == 7
+    assert to_number("7.129") == 7.13
+    assert to_number("not-a-number") is None
+    assert rate_pct(1, 4) == 25.0
+    assert rate_pct(1, 0) == 0.0
+    assert isoformat_utc(None) is None
+    assert isoformat_utc(datetime(2026, 4, 1, 0, 0, 0)) == "2026-04-01T00:00:00Z"
+    assert (
+        isoformat_utc(datetime(2026, 4, 1, 8, 0, 0, tzinfo=timezone.utc))
+        == "2026-04-01T08:00:00Z"
+    )

--- a/ci-dashboard/tests/test_status_query.py
+++ b/ci-dashboard/tests/test_status_query.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+from ci_dashboard.api.queries.status import _parse_datetime, get_freshness
+
+
+def test_parse_datetime_supports_naive_aware_and_string_values() -> None:
+    aware = datetime(2026, 4, 29, 8, 0, 0, tzinfo=timezone.utc)
+    assert _parse_datetime(None) is None
+    assert _parse_datetime(aware) == aware
+    assert _parse_datetime(datetime(2026, 4, 29, 8, 0, 0)) == aware
+    assert _parse_datetime("2026-04-29T08:00:00Z") == aware
+    assert _parse_datetime(123) is None
+
+
+def test_get_freshness_clamps_negative_lag_and_serializes_datetimes(sqlite_engine, monkeypatch) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_job_state (
+                  job_name,
+                  watermark_json,
+                  last_started_at,
+                  last_succeeded_at,
+                  last_status,
+                  last_error
+                ) VALUES
+                ('job-a', '{}', '2026-04-29T08:00:00Z', '2026-04-29T08:05:00Z', 'succeeded', NULL),
+                ('job-b', '{}', '2026-04-29T08:00:00Z', '2026-04-29 08:30:00', 'running', NULL),
+                ('job-c', '{}', '2026-04-29T08:00:00Z', NULL, 'never', NULL)
+                """
+            )
+        )
+
+    monkeypatch.setattr(
+        "ci_dashboard.api.queries.status.utcnow",
+        lambda: datetime(2026, 4, 29, 8, 20, 0, tzinfo=timezone.utc),
+    )
+
+    payload = get_freshness(sqlite_engine)
+
+    assert payload["generated_at"] == "2026-04-29T08:20:00Z"
+    assert payload["jobs"] == [
+        {
+            "job_name": "job-a",
+            "last_status": "succeeded",
+            "last_succeeded_at": "2026-04-29T08:05:00Z",
+            "lag_minutes": 15,
+        },
+        {
+            "job_name": "job-b",
+            "last_status": "running",
+            "last_succeeded_at": "2026-04-29T08:30:00Z",
+            "lag_minutes": 0,
+        },
+        {
+            "job_name": "job-c",
+            "last_status": "never",
+            "last_succeeded_at": None,
+            "lag_minutes": None,
+        },
+    ]


### PR DESCRIPTION
## Summary
- retry OpenAI-compatible LLM requests when the provider returns HTTP 429
- honor Retry-After when present and otherwise use a simple exponential backoff
- cover the rate-limit retry flow in the classifier tests
- improve test coverage upto 90%

## Why
- the live analyze-errors validation showed that long-running batches no longer time out, but they can hit provider-side 429 rate limiting
- without retries, each rate-limited build is marked failed immediately

## Testing
- PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests/jobs/test_llm_classifier.py
- PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests
- cd ci-dashboard && ruff check src tests