### PR TITLE
fix(ci-dashboard): gate runtime insights tab

### DIFF
--- a/ci-dashboard/README.md
+++ b/ci-dashboard/README.md
@@ -69,7 +69,7 @@ Notes:
 - local development can use `CI_DASHBOARD_DB_URL=sqlite+pysqlite:///./ci-dashboard.sqlite`
 - FastAPI serves the built frontend from `web/dist` after `make web-build`
 - set `CI_DASHBOARD_STATIC_DIR` when the built frontend lives outside the default repo or container layout
-- `CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS` enables the experimental Runtime Insights tab when set to `true`; accepted boolean values include `true`/`false`, `1`/`0`, `yes`/`no`, and it defaults to hidden
+- `CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS` enables the experimental Runtime Insights tab when set to `true`; accepted boolean values include `true`/`false`, `1`/`0`, `yes`/`no`, and `on`/`off`, it defaults to hidden, and invalid values fail startup
 - during UI iteration, run `make api` and `make web-dev` in separate terminals
 - `backfill-range` is stateless and does not update `ci_job_state`, so the same time window can be re-imported safely
 - `CI_DASHBOARD_REFRESH_BUILD_LIMIT` controls how many impacted builds one `refresh-build-derived` run will process before checkpointing and continuing in the next CronJob run; the default is `5000`, valid values are positive integers, and smaller values trade shorter/faster runs for more CronJob passes before backlog catch-up finishes

--- a/ci-dashboard/README.md
+++ b/ci-dashboard/README.md
@@ -69,7 +69,7 @@ Notes:
 - local development can use `CI_DASHBOARD_DB_URL=sqlite+pysqlite:///./ci-dashboard.sqlite`
 - FastAPI serves the built frontend from `web/dist` after `make web-build`
 - set `CI_DASHBOARD_STATIC_DIR` when the built frontend lives outside the default repo or container layout
-- `CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS=true` enables the experimental Runtime Insights tab; it defaults to hidden
+- `CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS` enables the experimental Runtime Insights tab when set to `true`; accepted boolean values include `true`/`false`, `1`/`0`, `yes`/`no`, and it defaults to hidden
 - during UI iteration, run `make api` and `make web-dev` in separate terminals
 - `backfill-range` is stateless and does not update `ci_job_state`, so the same time window can be re-imported safely
 - `CI_DASHBOARD_REFRESH_BUILD_LIMIT` controls how many impacted builds one `refresh-build-derived` run will process before checkpointing and continuing in the next CronJob run; the default is `5000`, valid values are positive integers, and smaller values trade shorter/faster runs for more CronJob passes before backlog catch-up finishes

--- a/ci-dashboard/README.md
+++ b/ci-dashboard/README.md
@@ -69,6 +69,7 @@ Notes:
 - local development can use `CI_DASHBOARD_DB_URL=sqlite+pysqlite:///./ci-dashboard.sqlite`
 - FastAPI serves the built frontend from `web/dist` after `make web-build`
 - set `CI_DASHBOARD_STATIC_DIR` when the built frontend lives outside the default repo or container layout
+- `CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS=true` enables the experimental Runtime Insights tab; it defaults to hidden
 - during UI iteration, run `make api` and `make web-dev` in separate terminals
 - `backfill-range` is stateless and does not update `ci_job_state`, so the same time window can be re-imported safely
 - `CI_DASHBOARD_REFRESH_BUILD_LIMIT` controls how many impacted builds one `refresh-build-derived` run will process before checkpointing and continuing in the next CronJob run; the default is `5000`, valid values are positive integers, and smaller values trade shorter/faster runs for more CronJob passes before backlog catch-up finishes

--- a/ci-dashboard/docs/runtime-insights-design.md
+++ b/ci-dashboard/docs/runtime-insights-design.md
@@ -37,6 +37,10 @@ This document defines the first design for that experimental tab.
 
 Add a standalone dashboard tab named `Runtime Insights`.
 
+The tab is hidden by default in production while the charts are still being
+validated. Operators can expose it by setting
+`CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS=true`.
+
 Purpose:
 - provide an experimental space for pod, Jenkins, and error-classification
   charts

--- a/ci-dashboard/src/ci_dashboard/api/routes/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/pages.py
@@ -14,15 +14,14 @@ from ci_dashboard.api.queries.pages import (
 )
 from ci_dashboard.api.queries.runtime import get_error_builds, get_error_top_jobs
 from ci_dashboard.api.routes.common import get_common_filters
-from ci_dashboard.common.config import get_settings
+from ci_dashboard.common.config import Settings, get_settings
 
 
 router = APIRouter(prefix="/api/v1/pages", tags=["pages"])
 
 
 @router.get("/navigation")
-def navigation_page() -> dict[str, object]:
-    settings = get_settings()
+def navigation_page(settings: Settings = Depends(get_settings)) -> dict[str, object]:
     return {
         "features": {
             "runtime_insights_enabled": settings.features.runtime_insights_enabled,

--- a/ci-dashboard/src/ci_dashboard/api/routes/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/pages.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.engine import Engine
 
 from ci_dashboard.api.dependencies import get_engine
@@ -14,10 +14,20 @@ from ci_dashboard.api.queries.pages import (
 )
 from ci_dashboard.api.queries.runtime import get_error_builds, get_error_top_jobs
 from ci_dashboard.api.routes.common import get_common_filters
-from fastapi import Query
+from ci_dashboard.common.config import get_settings
 
 
 router = APIRouter(prefix="/api/v1/pages", tags=["pages"])
+
+
+@router.get("/navigation")
+def navigation_page() -> dict[str, object]:
+    settings = get_settings()
+    return {
+        "features": {
+            "runtime_insights_enabled": settings.features.runtime_insights_enabled,
+        }
+    }
 
 
 @router.get("/overview")

--- a/ci-dashboard/src/ci_dashboard/common/config.py
+++ b/ci-dashboard/src/ci_dashboard/common/config.py
@@ -24,6 +24,18 @@ def _read_int(environ: Mapping[str, str], key: str, default: int) -> int:
     return value
 
 
+def _read_bool(environ: Mapping[str, str], key: str, default: bool) -> bool:
+    raw = environ.get(key)
+    if raw is None or raw.strip() == "":
+        return default
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "y", "on"}:
+        return True
+    if value in {"0", "false", "no", "n", "off"}:
+        return False
+    raise ValueError(f"{key} must be a boolean, got {raw!r}")
+
+
 def _read_csv(environ: Mapping[str, str], key: str, default: tuple[str, ...]) -> tuple[str, ...]:
     raw = environ.get(key)
     if raw is None:
@@ -90,6 +102,11 @@ class LLMSettings:
 
 
 @dataclass(frozen=True)
+class FeatureSettings:
+    runtime_insights_enabled: bool = False
+
+
+@dataclass(frozen=True)
 class Settings:
     database: DatabaseSettings
     jobs: JobSettings
@@ -98,6 +115,7 @@ class Settings:
     jenkins_ingest: JenkinsIngestSettings = JenkinsIngestSettings()
     archive: ArchiveSettings = ArchiveSettings()
     llm: LLMSettings = LLMSettings()
+    features: FeatureSettings = FeatureSettings()
     log_level: str = "INFO"
 
 
@@ -178,6 +196,13 @@ def load_settings(environ: Mapping[str, str] | None = None) -> Settings:
             api_key=env.get("CI_DASHBOARD_LLM_API_KEY") or None,
             base_url=env.get("CI_DASHBOARD_LLM_BASE_URL") or None,
             reasoning_effort=env.get("CI_DASHBOARD_LLM_REASONING_EFFORT") or None,
+        ),
+        features=FeatureSettings(
+            runtime_insights_enabled=_read_bool(
+                env,
+                "CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS",
+                False,
+            ),
         ),
         log_level=(env.get("CI_DASHBOARD_LOG_LEVEL") or "INFO").upper(),
     )

--- a/ci-dashboard/src/ci_dashboard/common/config.py
+++ b/ci-dashboard/src/ci_dashboard/common/config.py
@@ -33,7 +33,9 @@ def _read_bool(environ: Mapping[str, str], key: str, default: bool) -> bool:
         return True
     if value in {"0", "false", "no", "n", "off"}:
         return False
-    raise ValueError(f"{key} must be a boolean, got {raw!r}")
+    raise ValueError(
+        f"{key} must be a boolean (accepted values: true/false, yes/no, 1/0, on/off), got {raw!r}"
+    )
 
 
 def _read_csv(environ: Mapping[str, str], key: str, default: tuple[str, ...]) -> tuple[str, ...]:

--- a/ci-dashboard/src/ci_dashboard/common/config.py
+++ b/ci-dashboard/src/ci_dashboard/common/config.py
@@ -26,9 +26,11 @@ def _read_int(environ: Mapping[str, str], key: str, default: int) -> int:
 
 def _read_bool(environ: Mapping[str, str], key: str, default: bool) -> bool:
     raw = environ.get(key)
-    if raw is None or raw.strip() == "":
+    if raw is None:
         return default
     value = raw.strip().lower()
+    if value == "":
+        return default
     if value in {"1", "true", "yes", "y", "on"}:
         return True
     if value in {"0", "false", "no", "n", "off"}:

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -715,30 +715,33 @@ def test_frontend_uses_configured_static_dir(tmp_path: Path, monkeypatch) -> Non
     assert response.text == "configured-ok"
 
 
-def test_navigation_page_hides_runtime_insights_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+def _get_navigation_response(monkeypatch: pytest.MonkeyPatch, runtime_insights: str | None = None):
     get_settings.cache_clear()
     monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite+pysqlite:///:memory:")
-    monkeypatch.delenv("CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS", raising=False)
+    if runtime_insights is None:
+        monkeypatch.delenv("CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS", raising=False)
+    else:
+        monkeypatch.setenv("CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS", runtime_insights)
 
-    with TestClient(create_app()) as client:
-        response = client.get("/api/v1/pages/navigation")
+    try:
+        with TestClient(create_app()) as client:
+            return client.get("/api/v1/pages/navigation")
+    finally:
+        get_settings.cache_clear()
+
+
+def test_navigation_page_hides_runtime_insights_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = _get_navigation_response(monkeypatch)
 
     assert response.status_code == 200
     assert response.json()["features"]["runtime_insights_enabled"] is False
-    get_settings.cache_clear()
 
 
 def test_navigation_page_can_enable_runtime_insights(monkeypatch: pytest.MonkeyPatch) -> None:
-    get_settings.cache_clear()
-    monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite+pysqlite:///:memory:")
-    monkeypatch.setenv("CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS", "true")
-
-    with TestClient(create_app()) as client:
-        response = client.get("/api/v1/pages/navigation")
+    response = _get_navigation_response(monkeypatch, "true")
 
     assert response.status_code == 200
     assert response.json()["features"]["runtime_insights_enabled"] is True
-    get_settings.cache_clear()
 
 
 def test_status_and_filter_endpoints(api_client: TestClient, sqlite_engine) -> None:

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -9,7 +10,7 @@ from sqlalchemy import text
 
 from ci_dashboard.api.dependencies import get_engine
 from ci_dashboard.api.main import app, create_app
-from ci_dashboard.common.config import get_settings
+from ci_dashboard.common.config import FeatureSettings, get_settings, load_settings
 from ci_dashboard.jobs.build_url_matcher import normalize_build_url
 
 
@@ -715,30 +716,30 @@ def test_frontend_uses_configured_static_dir(tmp_path: Path, monkeypatch) -> Non
     assert response.text == "configured-ok"
 
 
-def _get_navigation_response(monkeypatch: pytest.MonkeyPatch, runtime_insights: str | None = None):
-    get_settings.cache_clear()
-    monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite+pysqlite:///:memory:")
-    if runtime_insights is None:
-        monkeypatch.delenv("CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS", raising=False)
-    else:
-        monkeypatch.setenv("CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS", runtime_insights)
+def _get_navigation_response(runtime_insights_enabled: bool):
+    settings = replace(
+        load_settings({"CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///:memory:"}),
+        features=FeatureSettings(runtime_insights_enabled=runtime_insights_enabled),
+    )
+    test_app = create_app()
+    test_app.dependency_overrides[get_settings] = lambda: settings
 
     try:
-        with TestClient(create_app()) as client:
+        with TestClient(test_app) as client:
             return client.get("/api/v1/pages/navigation")
     finally:
-        get_settings.cache_clear()
+        test_app.dependency_overrides.clear()
 
 
-def test_navigation_page_hides_runtime_insights_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    response = _get_navigation_response(monkeypatch)
+def test_navigation_page_hides_runtime_insights_by_default() -> None:
+    response = _get_navigation_response(False)
 
     assert response.status_code == 200
     assert response.json()["features"]["runtime_insights_enabled"] is False
 
 
-def test_navigation_page_can_enable_runtime_insights(monkeypatch: pytest.MonkeyPatch) -> None:
-    response = _get_navigation_response(monkeypatch, "true")
+def test_navigation_page_can_enable_runtime_insights() -> None:
+    response = _get_navigation_response(True)
 
     assert response.status_code == 200
     assert response.json()["features"]["runtime_insights_enabled"] is True

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -9,6 +9,7 @@ from sqlalchemy import text
 
 from ci_dashboard.api.dependencies import get_engine
 from ci_dashboard.api.main import app, create_app
+from ci_dashboard.common.config import get_settings
 from ci_dashboard.jobs.build_url_matcher import normalize_build_url
 
 
@@ -712,6 +713,32 @@ def test_frontend_uses_configured_static_dir(tmp_path: Path, monkeypatch) -> Non
 
     assert response.status_code == 200
     assert response.text == "configured-ok"
+
+
+def test_navigation_page_hides_runtime_insights_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_settings.cache_clear()
+    monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.delenv("CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS", raising=False)
+
+    with TestClient(create_app()) as client:
+        response = client.get("/api/v1/pages/navigation")
+
+    assert response.status_code == 200
+    assert response.json()["features"]["runtime_insights_enabled"] is False
+    get_settings.cache_clear()
+
+
+def test_navigation_page_can_enable_runtime_insights(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_settings.cache_clear()
+    monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS", "true")
+
+    with TestClient(create_app()) as client:
+        response = client.get("/api/v1/pages/navigation")
+
+    assert response.status_code == 200
+    assert response.json()["features"]["runtime_insights_enabled"] is True
+    get_settings.cache_clear()
 
 
 def test_status_and_filter_endpoints(api_client: TestClient, sqlite_engine) -> None:

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -77,16 +77,25 @@ def test_load_settings_hides_runtime_insights_by_default() -> None:
     [
         ("1", True),
         ("true", True),
+        (" TRUE ", True),
         ("yes", True),
+        ("Y", True),
         ("on", True),
         ("0", False),
         ("false", False),
+        (" False ", False),
         ("no", False),
+        ("N", False),
         ("off", False),
     ],
 )
 def test_read_bool_accepts_common_boolean_values(raw: str, expected: bool) -> None:
     assert _read_bool({"TEST_FLAG": raw}, "TEST_FLAG", not expected) is expected
+
+
+def test_read_bool_uses_default_for_missing_or_empty_values() -> None:
+    assert _read_bool({}, "TEST_FLAG", True) is True
+    assert _read_bool({"TEST_FLAG": "   "}, "TEST_FLAG", False) is False
 
 
 def test_load_settings_requires_tidb_fields_without_db_url() -> None:
@@ -175,7 +184,7 @@ def test_load_settings_rejects_invalid_archive_limit() -> None:
 def test_load_settings_rejects_invalid_runtime_insights_flag() -> None:
     with pytest.raises(
         ValueError,
-        match=r"CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS must be a boolean, got 'maybe'",
+        match=r"CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS must be a boolean .* got 'maybe'",
     ):
         load_settings(
             {

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -35,6 +35,7 @@ def test_load_settings_supports_db_url() -> None:
             "CI_DASHBOARD_LLM_API_KEY": "test-key",
             "CI_DASHBOARD_LLM_BASE_URL": "https://api-vip.codex-for.me/v1",
             "CI_DASHBOARD_LLM_REASONING_EFFORT": "high",
+            "CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS": "true",
             "CI_DASHBOARD_LOG_LEVEL": "debug",
         }
     )
@@ -62,7 +63,13 @@ def test_load_settings_supports_db_url() -> None:
     assert settings.llm.api_key == "test-key"
     assert settings.llm.base_url == "https://api-vip.codex-for.me/v1"
     assert settings.llm.reasoning_effort == "high"
+    assert settings.features.runtime_insights_enabled is True
     assert settings.log_level == "DEBUG"
+
+
+def test_load_settings_hides_runtime_insights_by_default() -> None:
+    settings = load_settings({"CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db"})
+    assert settings.features.runtime_insights_enabled is False
 
 
 def test_load_settings_requires_tidb_fields_without_db_url() -> None:
@@ -144,6 +151,19 @@ def test_load_settings_rejects_invalid_archive_limit() -> None:
             {
                 "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
                 "CI_DASHBOARD_ARCHIVE_BUILD_LIMIT": "0",
+            }
+        )
+
+
+def test_load_settings_rejects_invalid_runtime_insights_flag() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS must be a boolean, got 'maybe'",
+    ):
+        load_settings(
+            {
+                "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
+                "CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS": "maybe",
             }
         )
 

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from ci_dashboard.common.config import get_settings, load_settings
+from ci_dashboard.common.config import _read_bool, get_settings, load_settings
 from ci_dashboard.common.db import _build_connect_args, build_engine, install_sqlite_functions
 from ci_dashboard.common.logging import configure_logging
 
@@ -70,6 +70,23 @@ def test_load_settings_supports_db_url() -> None:
 def test_load_settings_hides_runtime_insights_by_default() -> None:
     settings = load_settings({"CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db"})
     assert settings.features.runtime_insights_enabled is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+    ],
+)
+def test_read_bool_accepts_common_boolean_values(raw: str, expected: bool) -> None:
+    assert _read_bool({"TEST_FLAG": raw}, "TEST_FLAG", not expected) is expected
 
 
 def test_load_settings_requires_tidb_fields_without_db_url() -> None:

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Route, Routes, useLocation } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { DashboardLayout } from "./components/layout";
 import OverviewPage from "./pages/OverviewPage";
@@ -48,6 +48,14 @@ export default function App() {
   const defaultRange = getDefaultDateRange();
   const location = useLocation();
   const [filters, setFilters] = useState(() => buildDefaultFilters(defaultRange, location.pathname));
+  const navigation = useApiData("/api/v1/pages/navigation");
+  const runtimeInsightsEnabled = navigation.data?.features?.runtime_insights_enabled === true;
+  const runtimeInsightsReady = !navigation.loading;
+  const runtimeInsightsRoute = runtimeInsightsEnabled ? (
+    <RuntimeInsightsPage filters={filters} />
+  ) : runtimeInsightsReady ? (
+    <Navigate to={CI_STATUS_PATH} replace />
+  ) : null;
 
   useEffect(() => {
     if (location.pathname !== "/flaky") {
@@ -139,12 +147,13 @@ export default function App() {
       filters={filters}
       onFilterChange={handleFilterChange}
       filterOptions={filterOptions}
+      features={{ runtimeInsightsEnabled }}
     >
       <Routes>
         <Route path="/" element={<OverviewPage filters={filters} />} />
         <Route path={CI_STATUS_PATH} element={<BuildTrendPage filters={filters} />} />
         <Route path={MIGRATE_STATUS_PATH} element={<MigrateStatusPage filters={filters} />} />
-        <Route path={RUNTIME_INSIGHTS_PATH} element={<RuntimeInsightsPage filters={filters} />} />
+        <Route path={RUNTIME_INSIGHTS_PATH} element={runtimeInsightsRoute} />
         <Route path="/flaky" element={<FlakyPage filters={filters} />} />
       </Routes>
     </DashboardLayout>

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -55,7 +55,9 @@ export default function App() {
     <RuntimeInsightsPage filters={filters} />
   ) : runtimeInsightsReady ? (
     <Navigate to={CI_STATUS_PATH} replace />
-  ) : null;
+  ) : (
+    <div className="empty-state">Loading feature settings...</div>
+  );
 
   useEffect(() => {
     if (location.pathname !== "/flaky") {

--- a/ci-dashboard/web/src/components/layout.jsx
+++ b/ci-dashboard/web/src/components/layout.jsx
@@ -6,9 +6,11 @@ export function DashboardLayout({
   filters,
   onFilterChange,
   filterOptions,
+  features = {},
   children,
 }) {
   const currentVersion = packageInfo.version;
+  const showRuntimeInsights = features.runtimeInsightsEnabled === true;
 
   return (
     <div className="app-shell">
@@ -21,7 +23,13 @@ export function DashboardLayout({
         <nav className="sidebar-nav" aria-label="Primary">
           <NavItem to="/" label="Overview" caption="Signal at a glance" />
           <NavItem to="/ci-status" label="CI Status" caption="Volume and duration" />
-          <NavItem to="/runtime-insights" label="Runtime Insights" caption="Pod and Jenkins diagnosis" />
+          {showRuntimeInsights && (
+            <NavItem
+              to="/runtime-insights"
+              label="Runtime Insights"
+              caption="Pod and Jenkins diagnosis"
+            />
+          )}
           <NavItem to="/flaky" label="Flaky" caption="Noisy failures and blind-retry-loop patterns" />
           <NavItem to="/migrate-status" label="GCP Migration" caption="GCP rollout and runtime drift" />
         </nav>


### PR DESCRIPTION
## Summary
- hide the experimental Runtime Insights sidebar tab by default
- add runtime env flag CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS to expose it when needed
- redirect direct /runtime-insights visits back to CI Status while the feature is disabled

## Testing
- ./.venv/bin/python -m ruff check src tests
- ./.venv/bin/python -m pytest tests/test_config_and_db.py tests/api/test_routes.py
- ./.venv/bin/python -m pytest
- npm run build