### PR TITLE
feat(ci-dashboard): add pod lifecycle watcher

### DIFF
--- a/ci-dashboard/docs/pod-watcher-design.md
+++ b/ci-dashboard/docs/pod-watcher-design.md
@@ -1,0 +1,137 @@
+# CI Dashboard Pod Watcher Design
+
+Status: Draft v0.1
+
+Last updated: 2026-05-01
+
+## 1. Problem
+
+The current pod ingestion path combines two imperfect sources:
+
+- Cloud Logging Kubernetes events have better historical coverage, but they do not carry the full Pod object metadata. In particular, Cloud Logging `Created` is a container-created event, not the Pod `metadata.creationTimestamp`, so it must not be used as pod creation time.
+- Ad hoc Kubernetes API lookup has complete Pod metadata, labels, annotations, and `metadata.creationTimestamp`, but it can only read Pods that still exist when the sync job runs. Short-lived CI Pods are often gone by then.
+
+This makes scheduling metrics unreliable. We can safely show lifecycle metrics only when we have the actual Pod creation time and the `Scheduled` event for the same Pod identity.
+
+## 2. Goal
+
+Run a long-lived watcher inside the cluster so CI Dashboard sees Pods while they are alive.
+
+The watcher should:
+
+- watch target namespaces for Pod `ADDED` and `MODIFIED` events
+- persist full Pod labels, annotations, uid, and `metadata.creationTimestamp`
+- watch Kubernetes Events for lifecycle reasons such as `Scheduled`, `Pulling`, `Pulled`, `Created`, `Started`, `ErrImagePull`, and `ImagePullBackOff`
+- upsert existing `ci_l1_pod_events` and `ci_l1_pod_lifecycle` rows idempotently
+- keep the dashboard's scheduling wait definition strict: `scheduled_at - pod_created_at`
+
+## 3. Non-Goals
+
+- Do not create a new dashboard tab in this change.
+- Do not invent historical pod creation time from Cloud Logging.
+- Do not replace Jenkins build ingestion or error classification.
+- Do not backfill Pods that were deleted before the watcher rollout. Old data can stay incomplete.
+
+## 4. Data Contract
+
+The source of truth for Pod creation time is Kubernetes Pod `metadata.creationTimestamp`.
+
+The source of truth for lifecycle milestones is Kubernetes Event reason timestamps:
+
+- `Scheduled`: scheduler accepted the Pod onto a Node
+- `Pulling` / `Pulled`: image pull start and completion
+- `Created` / `Started`: container creation and start, not Pod creation
+- `FailedScheduling`: intermediate retry signal, not final CI failure
+- `ErrImagePull` / `ImagePullBackOff`: image pull failure/backoff signal
+
+Rows remain keyed by the existing lifecycle identity:
+
+```text
+(source_project, namespace_name, pod_uid, pod_name)
+```
+
+The watcher writes the existing tables:
+
+- `ci_l1_pod_events`
+- `ci_l1_pod_lifecycle`
+- `ci_job_state`
+
+## 5. Runtime Shape
+
+The watcher is a Deployment, not a CronJob.
+
+Recommended first deployment:
+
+- namespace: `apps`
+- replicas: `1`
+- service account: `ci-dashboard`
+- target namespaces: `prow-test-pods,jenkins-tidb,jenkins-tiflow`
+- RBAC: `get`, `list`, `watch` on `pods` and `events` in target namespaces
+
+The watcher uses Kubernetes watch streams. On startup it first lists current Pods in each namespace, then starts watches from the returned `resourceVersion`. If a watch stream disconnects or the resource version expires, the worker relists and resumes from a fresh resource version.
+
+Rollout precondition: migration `017_alter_ci_l1_pod_lifecycle_add_pod_created_at.sql`
+must be applied before `watch-pods` starts, otherwise metadata writes will fail because the
+watcher persists Pod `metadata.creationTimestamp` into `ci_l1_pod_lifecycle.pod_created_at`.
+
+## 6. Health And Self-Healing
+
+The watcher exposes HTTP health endpoints from the same process:
+
+- `/livez`: returns success only when every registered Pod/Event watch stream has a recent heartbeat
+- `/readyz`: uses the same stream-heartbeat check so the Pod does not receive traffic until every namespace stream has completed at least one successful list/watch cycle
+
+Each namespace has two registered streams:
+
+- `<namespace>/pods`
+- `<namespace>/events`
+
+The heartbeat is updated after each successful list and after each watch response, including Kubernetes watch bookmarks. The Kubernetes watch request also sets `allowWatchBookmarks=true` and `timeoutSeconds`, so healthy long connections are expected to either receive events/bookmarks or reconnect periodically. If a stream is stuck beyond `CI_DASHBOARD_POD_WATCH_STALE_AFTER_SECONDS`, `/livez` fails and Kubernetes restarts the Pod.
+
+Recommended first probe settings:
+
+- health port: `8081`
+- watch timeout: `300s`
+- stale-after: `720s`
+- startup probe: `/livez`, up to 3 minutes
+- liveness probe: `/livez`
+- readiness probe: `/readyz`
+
+## 7. Dashboard Semantics
+
+Scheduling wait should only use rows where:
+
+- `pod_created_at IS NOT NULL`
+- `scheduled_at IS NOT NULL`
+- `scheduled_at >= pod_created_at`
+
+`FailedScheduling` should not be displayed as a CI failure rate. It is useful as a debug signal, but in an autoscaled GKE cluster it is commonly an intermediate retry event. The high-level dashboard should emphasize:
+
+- final unscheduled Pods, if any
+- scheduling wait distribution
+- image pull latency distribution
+- image pull error/backoff counts
+
+## 8. Failure Handling
+
+Writes are idempotent:
+
+- pod events are deduped by `(source_project, source_insert_id)`
+- lifecycle rows are upserted by `(source_project, namespace_name, pod_uid, pod_name)`
+
+The worker records a job state under `ci-watch-pods`. A restart is safe because the startup relist refreshes current Pod metadata and new watch streams continue from Kubernetes resource versions.
+
+Watch streams are not a durable historical log. If the watcher is down while short-lived Pods are created and deleted, those Pods can still be missed. This is an operational reliability problem, so alerts should eventually watch for worker restarts and DB write failures.
+
+## 9. Rollout Plan
+
+1. Deploy with `replicas=1` and a narrow namespace list.
+2. Validate that fresh lifecycle rows have `pod_created_at`, labels, annotations, and `Scheduled`.
+3. Compare new rows against existing Cloud Logging rows for a recent window.
+4. Update dashboard cards to count scheduling wait only for watcher-backed rows.
+5. Keep `sync-pods` temporarily as a compatibility/backfill path, but do not use Cloud Logging `Created` as Pod creation time.
+
+## 10. Open Follow-Ups
+
+- Add a small freshness monitor: latest `metadata_observed_at` by namespace.
+- Consider a dedicated `ci_l1_pod_watch_state` table only if Kubernetes resource versions need to survive restarts more precisely than startup relist.

--- a/ci-dashboard/docs/pod-watcher-design.md
+++ b/ci-dashboard/docs/pod-watcher-design.md
@@ -6,12 +6,12 @@ Last updated: 2026-05-01
 
 ## 1. Problem
 
-The current pod ingestion path combines two imperfect sources:
-
-- Cloud Logging Kubernetes events have better historical coverage, but they do not carry the full Pod object metadata. In particular, Cloud Logging `Created` is a container-created event, not the Pod `metadata.creationTimestamp`, so it must not be used as pod creation time.
-- Ad hoc Kubernetes API lookup has complete Pod metadata, labels, annotations, and `metadata.creationTimestamp`, but it can only read Pods that still exist when the sync job runs. Short-lived CI Pods are often gone by then.
-
-This makes scheduling metrics unreliable. We can safely show lifecycle metrics only when we have the actual Pod creation time and the `Scheduled` event for the same Pod identity.
+The current pod ingestion path has two incomplete sources: Cloud Logging covers
+more history but lacks full Pod metadata and true Pod creation time, while ad hoc
+Kubernetes API lookup has full metadata but misses short-lived Pods after they
+are deleted. Cloud Logging `Created` is a container-created event, not Pod
+`metadata.creationTimestamp`, so scheduling wait must not use it as Pod creation
+time.
 
 ## 2. Goal
 
@@ -27,10 +27,10 @@ The watcher should:
 
 ## 3. Non-Goals
 
-- Do not create a new dashboard tab in this change.
-- Do not invent historical pod creation time from Cloud Logging.
-- Do not replace Jenkins build ingestion or error classification.
-- Do not backfill Pods that were deleted before the watcher rollout. Old data can stay incomplete.
+- no dashboard UI changes in this slice
+- no invented historical Pod creation time from Cloud Logging
+- no Jenkins build ingestion or error-classification replacement
+- no backfill for Pods deleted before watcher rollout
 
 ## 4. Data Contract
 
@@ -68,7 +68,9 @@ Recommended first deployment:
 - target namespaces: `prow-test-pods,jenkins-tidb,jenkins-tiflow`
 - RBAC: `get`, `list`, `watch` on `pods` and `events` in target namespaces
 
-The watcher uses Kubernetes watch streams. On startup it first lists current Pods in each namespace, then starts watches from the returned `resourceVersion`. If a watch stream disconnects or the resource version expires, the worker relists and resumes from a fresh resource version.
+On startup, each namespace is listed once and then watched from the returned
+`resourceVersion`. If the stream disconnects or the resource version expires,
+the worker relists and resumes.
 
 Rollout precondition: migration `017_alter_ci_l1_pod_lifecycle_add_pod_created_at.sql`
 must be applied before `watch-pods` starts, otherwise metadata writes will fail because the
@@ -76,17 +78,12 @@ watcher persists Pod `metadata.creationTimestamp` into `ci_l1_pod_lifecycle.pod_
 
 ## 6. Health And Self-Healing
 
-The watcher exposes HTTP health endpoints from the same process:
-
-- `/livez`: returns success only when every registered Pod/Event watch stream has a recent heartbeat
-- `/readyz`: uses the same stream-heartbeat check so the Pod does not receive traffic until every namespace stream has completed at least one successful list/watch cycle
-
-Each namespace has two registered streams:
-
-- `<namespace>/pods`
-- `<namespace>/events`
-
-The heartbeat is updated after each successful list and after each watch response, including Kubernetes watch bookmarks. The Kubernetes watch request also sets `allowWatchBookmarks=true` and `timeoutSeconds`, so healthy long connections are expected to either receive events/bookmarks or reconnect periodically. If a stream is stuck beyond `CI_DASHBOARD_POD_WATCH_STALE_AFTER_SECONDS`, `/livez` fails and Kubernetes restarts the Pod.
+The watcher exposes `/livez` and `/readyz` from the same process. Each watched
+namespace registers two heartbeat streams, `<namespace>/pods` and
+`<namespace>/events`. Heartbeats update after each successful list and watch
+response, including bookmarks. If any stream is stale beyond
+`CI_DASHBOARD_POD_WATCH_STALE_AFTER_SECONDS`, health checks fail and Kubernetes
+restarts the Pod.
 
 Recommended first probe settings:
 
@@ -105,7 +102,8 @@ Scheduling wait should only use rows where:
 - `scheduled_at IS NOT NULL`
 - `scheduled_at >= pod_created_at`
 
-`FailedScheduling` should not be displayed as a CI failure rate. It is useful as a debug signal, but in an autoscaled GKE cluster it is commonly an intermediate retry event. The high-level dashboard should emphasize:
+`FailedScheduling` should not be displayed as a CI failure rate. In autoscaled
+GKE it is often an intermediate retry signal. The dashboard should emphasize:
 
 - final unscheduled Pods, if any
 - scheduling wait distribution
@@ -119,19 +117,20 @@ Writes are idempotent:
 - pod events are deduped by `(source_project, source_insert_id)`
 - lifecycle rows are upserted by `(source_project, namespace_name, pod_uid, pod_name)`
 
-The worker records a job state under `ci-watch-pods`. A restart is safe because the startup relist refreshes current Pod metadata and new watch streams continue from Kubernetes resource versions.
-
-Watch streams are not a durable historical log. If the watcher is down while short-lived Pods are created and deleted, those Pods can still be missed. This is an operational reliability problem, so alerts should eventually watch for worker restarts and DB write failures.
+The worker records job state under `ci-watch-pods`. Restart is safe because
+writes are idempotent and startup relist refreshes current Pod metadata. Watch
+streams are not a durable historical log, so Pods created and deleted while the
+watcher is down can still be missed.
 
 ## 9. Rollout Plan
 
-1. Deploy with `replicas=1` and a narrow namespace list.
-2. Validate that fresh lifecycle rows have `pod_created_at`, labels, annotations, and `Scheduled`.
-3. Compare new rows against existing Cloud Logging rows for a recent window.
-4. Update dashboard cards to count scheduling wait only for watcher-backed rows.
-5. Keep `sync-pods` temporarily as a compatibility/backfill path, but do not use Cloud Logging `Created` as Pod creation time.
+1. Deploy with `replicas=1`.
+2. Validate fresh rows have `pod_created_at`, labels, annotations, and `Scheduled`.
+3. Compare watcher rows against existing Cloud Logging rows for a recent window.
+4. Update dashboard cards to count scheduling wait only for complete watcher-backed rows.
+5. Keep `sync-pods` temporarily, but never use Cloud Logging `Created` as Pod creation time.
 
 ## 10. Open Follow-Ups
 
-- Add a small freshness monitor: latest `metadata_observed_at` by namespace.
-- Consider a dedicated `ci_l1_pod_watch_state` table only if Kubernetes resource versions need to survive restarts more precisely than startup relist.
+- add a freshness monitor for latest `metadata_observed_at` by namespace
+- add durable watch state only if startup relist is not precise enough

--- a/ci-dashboard/docs/pod-watcher-design.md
+++ b/ci-dashboard/docs/pod-watcher-design.md
@@ -76,12 +76,32 @@ Rollout precondition: migration `017_alter_ci_l1_pod_lifecycle_add_pod_created_a
 must be applied before `watch-pods` starts, otherwise metadata writes will fail because the
 watcher persists Pod `metadata.creationTimestamp` into `ci_l1_pod_lifecycle.pod_created_at`.
 
-## 6. Health And Self-Healing
+## 6. Runtime Configuration
+
+Required:
+
+- `CI_DASHBOARD_GCP_PROJECT` or `CI_DASHBOARD_POD_WATCH_SOURCE_PROJECT`: source project stored in pod tables.
+- `CI_DASHBOARD_POD_EVENT_NAMESPACES`: comma-separated namespaces to watch.
+
+Recommended defaults:
+
+- `CI_DASHBOARD_POD_WATCH_TIMEOUT_SECONDS=300`
+- `CI_DASHBOARD_POD_WATCH_RETRY_DELAY_SECONDS=5`
+- `CI_DASHBOARD_POD_WATCH_HEALTH_PORT=8081`
+- `CI_DASHBOARD_POD_WATCH_STALE_AFTER_SECONDS=720`
+- `CI_DASHBOARD_JENKINS_POD_NAME_PREFIX_CACHE_SECONDS=900`
+
+Optional metadata:
+
+- `CI_DASHBOARD_KUBERNETES_CLUSTER_NAME`
+- `CI_DASHBOARD_KUBERNETES_LOCATION`
+
+## 7. Health And Self-Healing
 
 The watcher exposes `/livez` and `/readyz` from the same process. Each watched
 namespace registers two heartbeat streams, `<namespace>/pods` and
-`<namespace>/events`. Heartbeats update after each successful list and watch
-response, including bookmarks. If any stream is stale beyond
+`<namespace>/events`. Heartbeats update after each successful list, watch
+response, and persistence batch. If any stream is stale beyond
 `CI_DASHBOARD_POD_WATCH_STALE_AFTER_SECONDS`, health checks fail and Kubernetes
 restarts the Pod.
 
@@ -94,7 +114,7 @@ Recommended first probe settings:
 - liveness probe: `/livez`
 - readiness probe: `/readyz`
 
-## 7. Dashboard Semantics
+## 8. Dashboard Semantics
 
 Scheduling wait should only use rows where:
 
@@ -110,7 +130,7 @@ GKE it is often an intermediate retry signal. The dashboard should emphasize:
 - image pull latency distribution
 - image pull error/backoff counts
 
-## 8. Failure Handling
+## 9. Failure Handling
 
 Writes are idempotent:
 
@@ -119,10 +139,12 @@ Writes are idempotent:
 
 The worker records job state under `ci-watch-pods`. Restart is safe because
 writes are idempotent and startup relist refreshes current Pod metadata. Watch
-streams are not a durable historical log, so Pods created and deleted while the
-watcher is down can still be missed.
+`410 Gone` / expired resource-version events relist immediately; other watch
+errors reconnect after the retry delay. Watch streams are not a durable
+historical log, so Pods created and deleted while the watcher is down can still
+be missed.
 
-## 9. Rollout Plan
+## 10. Rollout Plan
 
 1. Deploy with `replicas=1`.
 2. Validate fresh rows have `pod_created_at`, labels, annotations, and `Scheduled`.
@@ -130,7 +152,7 @@ watcher is down can still be missed.
 4. Update dashboard cards to count scheduling wait only for complete watcher-backed rows.
 5. Keep `sync-pods` temporarily, but never use Cloud Logging `Created` as Pod creation time.
 
-## 10. Open Follow-Ups
+## 11. Open Follow-Ups
 
 - add a freshness monitor for latest `metadata_observed_at` by namespace
 - add durable watch state only if startup relist is not precise enough

--- a/ci-dashboard/k8s/cronjobs/README.md
+++ b/ci-dashboard/k8s/cronjobs/README.md
@@ -56,6 +56,80 @@ Notes:
   - Kafka bootstrap service: `cluster-cd-kafka-bootstrap:9092`
   - Jenkins service DNS for internal callers: `http://jenkins.jenkins.svc.cluster.local`
 
+## Pod Watcher
+
+`watch-pods` is the long-running pod lifecycle collector. It watches live
+Kubernetes Pods and Events so `ci_l1_pod_lifecycle.pod_created_at` comes from
+Pod `metadata.creationTimestamp`, not from Cloud Logging container events.
+
+The Deployment runs in the `apps` namespace by default.
+
+Before smoke or rollout, make sure migration `017_alter_ci_l1_pod_lifecycle_add_pod_created_at.sql`
+has been applied to the target database.
+
+Render and apply the least-privilege RBAC first:
+
+```bash
+cd ci-dashboard
+./scripts/render_pod_watcher_rbac.sh \
+  --service-account-namespace apps \
+  --service-account-name ci-dashboard \
+  --target-namespaces prow-test-pods,jenkins-tidb,jenkins-tiflow \
+  | kubectl apply -f -
+```
+
+Render a Deployment manifest:
+
+```bash
+cd ci-dashboard
+./scripts/render_pod_watcher_deployment.sh \
+  --image ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:<tag> \
+  --db-secret ci-dashboard-db \
+  --ca-secret ci-dashboard-ca \
+  --gcp-project pingcap-testing-account \
+  --service-account ci-dashboard \
+  --cluster-name prow \
+  --location us-central1-c \
+  > /tmp/ci-dashboard-pod-watcher.yaml
+```
+
+Apply it:
+
+```bash
+kubectl apply -f /tmp/ci-dashboard-pod-watcher.yaml
+```
+
+Recommended first bring-up:
+
+```bash
+kubectl -n apps rollout status deployment/ci-dashboard-pod-watcher
+kubectl -n apps logs deployment/ci-dashboard-pod-watcher --follow
+```
+
+Useful overrides:
+
+- `--pod-event-namespaces prow-test-pods,jenkins-tidb,jenkins-tiflow` pins the watched CI namespaces.
+- `--watch-timeout-seconds 300` controls Kubernetes watch reconnect cadence.
+- `--retry-delay-seconds 5` controls retry delay after watch/API errors.
+- `--health-port 8081` exposes `/livez` and `/readyz` from the watcher process.
+- `--stale-after-seconds 720` fails health checks when any Pod/Event stream stops heartbeating.
+- `--replicas 1` keeps exactly one writer during the first rollout.
+
+Validation:
+
+```bash
+kubectl -n apps get deployment ci-dashboard-pod-watcher
+kubectl -n apps get pods -l app.kubernetes.io/name=ci-dashboard-pod-watcher
+kubectl -n apps logs deployment/ci-dashboard-pod-watcher --tail=200
+```
+
+Notes:
+
+- The service account needs `get`, `list`, and `watch` on `pods` and `events` in the target namespaces.
+- The worker is safe to restart because pod events and lifecycle rows are upserted idempotently.
+- Liveness/readiness probes use stream heartbeats, so a stuck Kubernetes watch connection should trigger Pod self-healing.
+- See `../../docs/pod-watcher-design.md` for the scheduling-wait data contract.
+
 ## Hourly Pod Sync
 
 `sync-pods` incrementally reads Cloud Logging `k8s_pod` events and writes:

--- a/ci-dashboard/k8s/cronjobs/README.md
+++ b/ci-dashboard/k8s/cronjobs/README.md
@@ -58,16 +58,13 @@ Notes:
 
 ## Pod Watcher
 
-`watch-pods` is the long-running pod lifecycle collector. It watches live
-Kubernetes Pods and Events so `ci_l1_pod_lifecycle.pod_created_at` comes from
-Pod `metadata.creationTimestamp`, not from Cloud Logging container events.
+`watch-pods` is the long-running pod lifecycle collector. It runs in `apps` by
+default and records Pod `metadata.creationTimestamp` as `pod_created_at`.
 
-The Deployment runs in the `apps` namespace by default.
+Preconditions:
 
-Before smoke or rollout, make sure migration `017_alter_ci_l1_pod_lifecycle_add_pod_created_at.sql`
-has been applied to the target database.
-
-Render and apply the least-privilege RBAC first:
+- apply `017_alter_ci_l1_pod_lifecycle_add_pod_created_at.sql`
+- grant `apps/ci-dashboard` `get/list/watch` on `pods` and `events` in watched namespaces
 
 ```bash
 cd ci-dashboard
@@ -78,10 +75,9 @@ cd ci-dashboard
   | kubectl apply -f -
 ```
 
-Render a Deployment manifest:
+Render and apply the Deployment:
 
 ```bash
-cd ci-dashboard
 ./scripts/render_pod_watcher_deployment.sh \
   --image ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:<tag> \
   --db-secret ci-dashboard-db \
@@ -91,29 +87,9 @@ cd ci-dashboard
   --cluster-name prow \
   --location us-central1-c \
   > /tmp/ci-dashboard-pod-watcher.yaml
-```
-
-Apply it:
-
-```bash
 kubectl apply -f /tmp/ci-dashboard-pod-watcher.yaml
-```
-
-Recommended first bring-up:
-
-```bash
 kubectl -n apps rollout status deployment/ci-dashboard-pod-watcher
-kubectl -n apps logs deployment/ci-dashboard-pod-watcher --follow
 ```
-
-Useful overrides:
-
-- `--pod-event-namespaces prow-test-pods,jenkins-tidb,jenkins-tiflow` pins the watched CI namespaces.
-- `--watch-timeout-seconds 300` controls Kubernetes watch reconnect cadence.
-- `--retry-delay-seconds 5` controls retry delay after watch/API errors.
-- `--health-port 8081` exposes `/livez` and `/readyz` from the watcher process.
-- `--stale-after-seconds 720` fails health checks when any Pod/Event stream stops heartbeating.
-- `--replicas 1` keeps exactly one writer during the first rollout.
 
 Validation:
 
@@ -122,13 +98,6 @@ kubectl -n apps get deployment ci-dashboard-pod-watcher
 kubectl -n apps get pods -l app.kubernetes.io/name=ci-dashboard-pod-watcher
 kubectl -n apps logs deployment/ci-dashboard-pod-watcher --tail=200
 ```
-
-Notes:
-
-- The service account needs `get`, `list`, and `watch` on `pods` and `events` in the target namespaces.
-- The worker is safe to restart because pod events and lifecycle rows are upserted idempotently.
-- Liveness/readiness probes use stream heartbeats, so a stuck Kubernetes watch connection should trigger Pod self-healing.
-- See `../../docs/pod-watcher-design.md` for the scheduling-wait data contract.
 
 ## Hourly Pod Sync
 

--- a/ci-dashboard/scripts/render_pod_watcher_deployment.sh
+++ b/ci-dashboard/scripts/render_pod_watcher_deployment.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+namespace="apps"
+image="ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:latest"
+deployment_name="ci-dashboard-pod-watcher"
+replicas="1"
+db_secret="ci-dashboard-db"
+gcp_project=""
+pod_event_namespaces="prow-test-pods,jenkins-tidb,jenkins-tiflow"
+cluster_name=""
+location=""
+watch_timeout_seconds="300"
+retry_delay_seconds="5"
+health_port="8081"
+stale_after_seconds="720"
+log_level="INFO"
+image_pull_policy="IfNotPresent"
+service_account=""
+ca_secret=""
+ca_key="ca.crt"
+cpu_request="500m"
+memory_request="1Gi"
+cpu_limit="1"
+memory_limit="2Gi"
+
+usage() {
+  cat <<'EOF'
+Render a Kubernetes Deployment manifest for the CI Dashboard Pod watcher.
+
+Usage:
+  render_pod_watcher_deployment.sh [options]
+
+Optional:
+  --namespace NAME              Kubernetes namespace. Default: apps
+  --image IMAGE                 Jobs image. Default: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:latest
+  --deployment-name NAME        Deployment name. Default: ci-dashboard-pod-watcher
+  --replicas N                  Replica count. Default: 1
+  --db-secret NAME              Secret containing TIDB_* or CI_DASHBOARD_DB_URL. Default: ci-dashboard-db
+  --gcp-project PROJECT         Source project stored in pod tables. Required.
+  --pod-event-namespaces CSV    Watched namespaces. Default: prow-test-pods,jenkins-tidb,jenkins-tiflow
+  --cluster-name NAME           Optional cluster name stored in pod tables.
+  --location NAME               Optional cluster location stored in pod tables.
+  --watch-timeout-seconds N     Kubernetes watch timeoutSeconds. Default: 300
+  --retry-delay-seconds N       Delay before reconnect after a watch error. Default: 5
+  --health-port N               HTTP health port exposed by watch-pods. Default: 8081
+  --stale-after-seconds N       Mark watch streams unhealthy after no heartbeat. Default: 720
+  --log-level LEVEL             CI_DASHBOARD_LOG_LEVEL override. Default: INFO
+  --image-pull-policy P         Image pull policy. Default: IfNotPresent
+  --service-account NAME        Optional service account name.
+  --ca-secret NAME              Optional secret containing CA file for TIDB SSL.
+  --ca-key NAME                 Key inside CA secret. Default: ca.crt
+  --cpu-request VALUE           CPU request. Default: 500m
+  --memory-request VALUE        Memory request. Default: 1Gi
+  --cpu-limit VALUE             CPU limit. Default: 1
+  --memory-limit VALUE          Memory limit. Default: 2Gi
+  --help                        Show this help text.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      namespace="${2:-}"
+      shift 2
+      ;;
+    --image)
+      image="${2:-}"
+      shift 2
+      ;;
+    --deployment-name)
+      deployment_name="${2:-}"
+      shift 2
+      ;;
+    --replicas)
+      replicas="${2:-}"
+      shift 2
+      ;;
+    --db-secret)
+      db_secret="${2:-}"
+      shift 2
+      ;;
+    --gcp-project)
+      gcp_project="${2:-}"
+      shift 2
+      ;;
+    --pod-event-namespaces)
+      pod_event_namespaces="${2:-}"
+      shift 2
+      ;;
+    --cluster-name)
+      cluster_name="${2:-}"
+      shift 2
+      ;;
+    --location)
+      location="${2:-}"
+      shift 2
+      ;;
+    --watch-timeout-seconds)
+      watch_timeout_seconds="${2:-}"
+      shift 2
+      ;;
+    --retry-delay-seconds)
+      retry_delay_seconds="${2:-}"
+      shift 2
+      ;;
+    --health-port)
+      health_port="${2:-}"
+      shift 2
+      ;;
+    --stale-after-seconds)
+      stale_after_seconds="${2:-}"
+      shift 2
+      ;;
+    --log-level)
+      log_level="${2:-}"
+      shift 2
+      ;;
+    --image-pull-policy)
+      image_pull_policy="${2:-}"
+      shift 2
+      ;;
+    --service-account)
+      service_account="${2:-}"
+      shift 2
+      ;;
+    --ca-secret)
+      ca_secret="${2:-}"
+      shift 2
+      ;;
+    --ca-key)
+      ca_key="${2:-}"
+      shift 2
+      ;;
+    --cpu-request)
+      cpu_request="${2:-}"
+      shift 2
+      ;;
+    --memory-request)
+      memory_request="${2:-}"
+      shift 2
+      ;;
+    --cpu-limit)
+      cpu_limit="${2:-}"
+      shift 2
+      ;;
+    --memory-limit)
+      memory_limit="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${gcp_project}" ]]; then
+  echo "--gcp-project is required" >&2
+  exit 1
+fi
+
+service_account_block=""
+if [[ -n "${service_account}" ]]; then
+  service_account_block=$(cat <<EOF
+      serviceAccountName: ${service_account}
+EOF
+)
+fi
+
+cluster_env_block=""
+if [[ -n "${cluster_name}" ]]; then
+  cluster_env_block="${cluster_env_block}            - name: CI_DASHBOARD_KUBERNETES_CLUSTER_NAME
+              value: ${cluster_name}
+"
+fi
+if [[ -n "${location}" ]]; then
+  cluster_env_block="${cluster_env_block}            - name: CI_DASHBOARD_KUBERNETES_LOCATION
+              value: ${location}
+"
+fi
+
+ca_env_block=""
+ca_mount_block=""
+ca_volume_block=""
+if [[ -n "${ca_secret}" ]]; then
+  ca_env_block=$(cat <<EOF
+            - name: TIDB_SSL_CA
+              value: /var/run/ci-dashboard/ssl/${ca_key}
+EOF
+)
+  ca_mount_block=$(cat <<EOF
+          volumeMounts:
+            - name: tidb-ca
+              mountPath: /var/run/ci-dashboard/ssl
+              readOnly: true
+EOF
+)
+  ca_volume_block=$(cat <<EOF
+      volumes:
+        - name: tidb-ca
+          secret:
+            secretName: ${ca_secret}
+            items:
+              - key: ${ca_key}
+                path: ${ca_key}
+EOF
+)
+fi
+
+cat <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${deployment_name}
+  namespace: ${namespace}
+  labels:
+    app.kubernetes.io/name: ci-dashboard-pod-watcher
+    app.kubernetes.io/part-of: ci-dashboard
+spec:
+  replicas: ${replicas}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ci-dashboard-pod-watcher
+      app.kubernetes.io/part-of: ci-dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ci-dashboard-pod-watcher
+        app.kubernetes.io/part-of: ci-dashboard
+    spec:
+${service_account_block}
+      restartPolicy: Always
+      containers:
+        - name: pod-watcher
+          image: ${image}
+          imagePullPolicy: ${image_pull_policy}
+          args: ["watch-pods"]
+          ports:
+            - name: health
+              containerPort: ${health_port}
+          envFrom:
+            - secretRef:
+                name: ${db_secret}
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: CI_DASHBOARD_LOG_LEVEL
+              value: ${log_level}
+            - name: CI_DASHBOARD_GCP_PROJECT
+              value: ${gcp_project}
+            - name: CI_DASHBOARD_POD_EVENT_NAMESPACES
+              value: ${pod_event_namespaces}
+            - name: CI_DASHBOARD_POD_WATCH_TIMEOUT_SECONDS
+              value: "${watch_timeout_seconds}"
+            - name: CI_DASHBOARD_POD_WATCH_RETRY_DELAY_SECONDS
+              value: "${retry_delay_seconds}"
+            - name: CI_DASHBOARD_POD_WATCH_HEALTH_PORT
+              value: "${health_port}"
+            - name: CI_DASHBOARD_POD_WATCH_STALE_AFTER_SECONDS
+              value: "${stale_after_seconds}"
+${cluster_env_block}${ca_env_block}
+          startupProbe:
+            httpGet:
+              path: /livez
+              port: health
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 18
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "${cpu_request}"
+              memory: ${memory_request}
+            limits:
+              cpu: "${cpu_limit}"
+              memory: ${memory_limit}
+${ca_mount_block}
+${ca_volume_block}
+EOF

--- a/ci-dashboard/scripts/render_pod_watcher_deployment.sh
+++ b/ci-dashboard/scripts/render_pod_watcher_deployment.sh
@@ -14,6 +14,7 @@ watch_timeout_seconds="300"
 retry_delay_seconds="5"
 health_port="8081"
 stale_after_seconds="720"
+jenkins_prefix_cache_seconds="900"
 log_level="INFO"
 image_pull_policy="IfNotPresent"
 service_account=""
@@ -45,6 +46,8 @@ Optional:
   --retry-delay-seconds N       Delay before reconnect after a watch error. Default: 5
   --health-port N               HTTP health port exposed by watch-pods. Default: 8081
   --stale-after-seconds N       Mark watch streams unhealthy after no heartbeat. Default: 720
+  --jenkins-prefix-cache-seconds N
+                                Cache Jenkins pod-name prefix lookup for N seconds. Default: 900
   --log-level LEVEL             CI_DASHBOARD_LOG_LEVEL override. Default: INFO
   --image-pull-policy P         Image pull policy. Default: IfNotPresent
   --service-account NAME        Optional service account name.
@@ -110,6 +113,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --stale-after-seconds)
       stale_after_seconds="${2:-}"
+      shift 2
+      ;;
+    --jenkins-prefix-cache-seconds)
+      jenkins_prefix_cache_seconds="${2:-}"
       shift 2
       ;;
     --log-level)
@@ -264,6 +271,8 @@ ${service_account_block}
               value: "${health_port}"
             - name: CI_DASHBOARD_POD_WATCH_STALE_AFTER_SECONDS
               value: "${stale_after_seconds}"
+            - name: CI_DASHBOARD_JENKINS_POD_NAME_PREFIX_CACHE_SECONDS
+              value: "${jenkins_prefix_cache_seconds}"
 ${cluster_env_block}${ca_env_block}
           startupProbe:
             httpGet:

--- a/ci-dashboard/scripts/render_pod_watcher_rbac.sh
+++ b/ci-dashboard/scripts/render_pod_watcher_rbac.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+name="ci-dashboard-pod-watcher"
+service_account_namespace="apps"
+service_account_name="ci-dashboard"
+target_namespaces="prow-test-pods,jenkins-tidb,jenkins-tiflow"
+
+usage() {
+  cat <<'EOF'
+Render Kubernetes RBAC for the CI Dashboard Pod watcher.
+
+The rendered RBAC grants get/list/watch on pods and events only in the target
+namespaces by binding a shared ClusterRole with namespace-scoped RoleBindings.
+
+Usage:
+  render_pod_watcher_rbac.sh [options]
+
+Optional:
+  --name NAME                     RBAC resource name. Default: ci-dashboard-pod-watcher
+  --service-account-namespace NS  ServiceAccount namespace. Default: apps
+  --service-account-name NAME     ServiceAccount name. Default: ci-dashboard
+  --target-namespaces CSV         Namespaces to watch. Default: prow-test-pods,jenkins-tidb,jenkins-tiflow
+  --help                          Show this help text.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      name="${2:-}"
+      shift 2
+      ;;
+    --service-account-namespace)
+      service_account_namespace="${2:-}"
+      shift 2
+      ;;
+    --service-account-name)
+      service_account_name="${2:-}"
+      shift 2
+      ;;
+    --target-namespaces)
+      target_namespaces="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${name}" ]]; then
+  echo "--name must not be empty" >&2
+  exit 1
+fi
+if [[ -z "${service_account_namespace}" ]]; then
+  echo "--service-account-namespace must not be empty" >&2
+  exit 1
+fi
+if [[ -z "${service_account_name}" ]]; then
+  echo "--service-account-name must not be empty" >&2
+  exit 1
+fi
+if [[ -z "${target_namespaces}" ]]; then
+  echo "--target-namespaces must not be empty" >&2
+  exit 1
+fi
+
+cat <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ${name}
+  labels:
+    app.kubernetes.io/name: ci-dashboard-pod-watcher
+    app.kubernetes.io/part-of: ci-dashboard
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "events"]
+    verbs: ["get", "list", "watch"]
+EOF
+
+IFS=',' read -r -a namespaces <<< "${target_namespaces}"
+for raw_namespace in "${namespaces[@]}"; do
+  namespace="$(echo "${raw_namespace}" | xargs)"
+  if [[ -z "${namespace}" ]]; then
+    continue
+  fi
+  cat <<EOF
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+  labels:
+    app.kubernetes.io/name: ci-dashboard-pod-watcher
+    app.kubernetes.io/part-of: ci-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ${name}
+subjects:
+  - kind: ServiceAccount
+    name: ${service_account_name}
+    namespace: ${service_account_namespace}
+EOF
+done

--- a/ci-dashboard/src/ci_dashboard/common/models.py
+++ b/ci-dashboard/src/ci_dashboard/common/models.py
@@ -127,6 +127,16 @@ class SyncPodsSummary:
 
 
 @dataclass
+class WatchPodsSummary:
+    pod_snapshots_seen: int = 0
+    event_rows_seen: int = 0
+    event_rows_written: int = 0
+    lifecycle_rows_upserted: int = 0
+    pods_touched: int = 0
+    watch_restarts: int = 0
+
+
+@dataclass
 class ConsumeJenkinsEventsSummary:
     messages_polled: int = 0
     events_processed: int = 0

--- a/ci-dashboard/src/ci_dashboard/jobs/cli.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/cli.py
@@ -25,6 +25,7 @@ from ci_dashboard.jobs.sync_flaky_issues import (
     run_backfill_flaky_issue_pr_links,
     run_sync_flaky_issues,
 )
+from ci_dashboard.jobs.pod_watcher import run_watch_pods
 from ci_dashboard.jobs.sync_pods import run_reconcile_pod_linkage_for_time_window, run_sync_pods
 
 
@@ -70,6 +71,15 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser(
         "sync-pods",
         help="Sync Kubernetes pod lifecycle events into ci_l1_pod_* tables",
+    )
+    watch_pods_parser = subparsers.add_parser(
+        "watch-pods",
+        help="Watch live Kubernetes pods/events into ci_l1_pod_* tables",
+    )
+    watch_pods_parser.add_argument(
+        "--max-events",
+        type=int,
+        help="Stop after observing this many pod snapshots or Kubernetes events",
     )
     subparsers.add_parser(
         "repair-job-names",
@@ -259,6 +269,17 @@ def main() -> int:
         summary = run_sync_pods(engine, settings)
         logging.getLogger(__name__).info(
             "sync-pods finished",
+            extra={"summary": summary.__dict__},
+        )
+        return 0
+
+    if args.command == "watch-pods":
+        if args.max_events is not None and args.max_events <= 0:
+            parser.error("--max-events must be positive")
+        engine = build_engine(settings)
+        summary = run_watch_pods(engine, settings, max_events=args.max_events)
+        logging.getLogger(__name__).info(
+            "watch-pods finished",
             extra={"summary": summary.__dict__},
         )
         return 0

--- a/ci-dashboard/src/ci_dashboard/jobs/pod_watcher.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/pod_watcher.py
@@ -1,0 +1,975 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import ssl
+import threading
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Iterable
+from urllib import error as urllib_error
+from urllib import parse as urllib_parse
+from urllib import request as urllib_request
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+
+from ci_dashboard.common.config import Settings
+from ci_dashboard.common.models import WatchPodsSummary
+from ci_dashboard.common.sql_helpers import chunked
+from ci_dashboard.jobs.build_url_matcher import canonicalize_job_name
+from ci_dashboard.jobs.state_store import mark_job_failed, mark_job_started, mark_job_succeeded
+from ci_dashboard.jobs.sync_pods import (
+    POD_EVENT_REASONS,
+    NormalizedPodEvent,
+    PodMetadataSnapshot,
+    _build_lifecycle_rows,
+    _build_requested_pods_relation,
+    _coerce_str,
+    _coerce_str_mapping,
+    _decode_json_object,
+    _get_json,
+    _get_kubernetes_api_ca_file,
+    _get_kubernetes_api_token,
+    _get_kubernetes_api_url,
+    _infer_pod_build_system,
+    _json_loads_str_mapping,
+    _load_build_metadata_map,
+    _load_target_namespaces,
+    _null_safe_equals_sql,
+    _parse_datetime,
+    _pod_identity_from_values,
+    _read_int_env,
+    _supplement_jenkins_pod_fields_from_build_metadata,
+    _upsert_pod_events,
+    _upsert_pod_lifecycle,
+)
+
+JOB_NAME = "ci-watch-pods"
+WATCH_USER_AGENT = "ci-dashboard-watch-pods"
+DEFAULT_WATCH_TIMEOUT_SECONDS = 300
+DEFAULT_WATCH_RETRY_DELAY_SECONDS = 5
+DEFAULT_HEALTH_PORT = 8081
+DEFAULT_HEALTH_STALE_AFTER_SECONDS = 720
+POD_WATCH_TYPES = frozenset({"ADDED", "MODIFIED"})
+EVENT_WATCH_TYPES = frozenset({"ADDED", "MODIFIED"})
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WatchRuntimeContext:
+    source_project: str
+    cluster_name: str | None
+    location: str | None
+
+
+@dataclass(frozen=True)
+class WatchedPodSnapshot:
+    source_project: str
+    cluster_name: str | None
+    location: str | None
+    namespace_name: str
+    pod_name: str
+    pod_uid: str
+    snapshot: PodMetadataSnapshot
+
+    @property
+    def identity(self) -> tuple[str, str | None, str | None, str | None]:
+        return _pod_identity_from_values(
+            source_project=self.source_project,
+            namespace_name=self.namespace_name,
+            pod_uid=self.pod_uid,
+            pod_name=self.pod_name,
+        )
+
+
+class WatchHealthState:
+    def __init__(self, *, stale_after_seconds: int) -> None:
+        self._stale_after_seconds = stale_after_seconds
+        self._streams: dict[str, float | None] = {}
+        self._lock = threading.Lock()
+
+    def register(self, stream_key: str) -> None:
+        with self._lock:
+            self._streams.setdefault(stream_key, None)
+
+    def heartbeat(self, stream_key: str) -> None:
+        with self._lock:
+            self._streams[stream_key] = time.monotonic()
+
+    def snapshot(self) -> dict[str, Any]:
+        now = time.monotonic()
+        with self._lock:
+            streams = {
+                key: {
+                    "age_seconds": None if value is None else round(now - value, 3),
+                    "healthy": value is not None and now - value <= self._stale_after_seconds,
+                }
+                for key, value in sorted(self._streams.items())
+            }
+        healthy = bool(streams) and all(item["healthy"] for item in streams.values())
+        return {
+            "healthy": healthy,
+            "stale_after_seconds": self._stale_after_seconds,
+            "streams": streams,
+        }
+
+
+class _ProgressRecorder:
+    def __init__(
+        self,
+        summary: WatchPodsSummary,
+        *,
+        max_events: int | None,
+        stop_event: threading.Event,
+    ) -> None:
+        self._summary = summary
+        self._max_events = max_events
+        self._stop_event = stop_event
+        self._lock = threading.Lock()
+
+    def add(
+        self,
+        *,
+        pod_snapshots_seen: int = 0,
+        event_rows_seen: int = 0,
+        event_rows_written: int = 0,
+        lifecycle_rows_upserted: int = 0,
+        pods_touched: int = 0,
+        watch_restarts: int = 0,
+    ) -> None:
+        with self._lock:
+            self._summary.pod_snapshots_seen += pod_snapshots_seen
+            self._summary.event_rows_seen += event_rows_seen
+            self._summary.event_rows_written += event_rows_written
+            self._summary.lifecycle_rows_upserted += lifecycle_rows_upserted
+            self._summary.pods_touched += pods_touched
+            self._summary.watch_restarts += watch_restarts
+            processed = self._summary.pod_snapshots_seen + self._summary.event_rows_seen
+            if self._max_events is not None and processed >= self._max_events:
+                self._stop_event.set()
+
+
+class _KubernetesClient:
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        token: str,
+        ca_file: str | None,
+        watch_timeout_seconds: int,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._token = token
+        self._ca_file = ca_file
+        self._watch_timeout_seconds = watch_timeout_seconds
+
+    def list_collection(self, *, namespace_name: str, resource: str) -> tuple[list[dict[str, Any]], str | None]:
+        items: list[dict[str, Any]] = []
+        continue_token: str | None = None
+        resource_version: str | None = None
+        while True:
+            query = {"limit": "500"}
+            if continue_token:
+                query["continue"] = continue_token
+            response = _get_json(
+                self._collection_url(namespace_name=namespace_name, resource=resource, query=query),
+                headers={"Authorization": f"Bearer {self._token}"},
+                ca_file=self._ca_file,
+            )
+            raw_items = response.get("items")
+            if isinstance(raw_items, list):
+                items.extend(item for item in raw_items if isinstance(item, dict))
+
+            metadata = response.get("metadata")
+            continue_token = None
+            if isinstance(metadata, dict):
+                continue_token = _coerce_str(metadata.get("continue"))
+                resource_version = _coerce_str(metadata.get("resourceVersion")) or resource_version
+            if continue_token is None:
+                return items, resource_version
+
+    def stream_collection(
+        self,
+        *,
+        namespace_name: str,
+        resource: str,
+        resource_version: str | None,
+    ) -> Iterable[dict[str, Any]]:
+        query = {
+            "watch": "true",
+            "allowWatchBookmarks": "true",
+            "timeoutSeconds": str(self._watch_timeout_seconds),
+        }
+        if resource_version:
+            query["resourceVersion"] = resource_version
+        url = self._collection_url(namespace_name=namespace_name, resource=resource, query=query)
+        yield from _stream_watch_json(
+            url,
+            token=self._token,
+            ca_file=self._ca_file,
+            timeout_seconds=self._watch_timeout_seconds + 30,
+        )
+
+    def _collection_url(self, *, namespace_name: str, resource: str, query: dict[str, str]) -> str:
+        namespace = urllib_parse.quote(namespace_name, safe="")
+        encoded_query = urllib_parse.urlencode(query)
+        return f"{self._base_url}/api/v1/namespaces/{namespace}/{resource}?{encoded_query}"
+
+
+def run_watch_pods(
+    engine: Engine,
+    settings: Settings,
+    *,
+    max_events: int | None = None,
+) -> WatchPodsSummary:
+    if max_events is not None and max_events <= 0:
+        raise ValueError("max_events must be positive")
+
+    summary = WatchPodsSummary()
+    stop_event = threading.Event()
+    recorder = _ProgressRecorder(summary, max_events=max_events, stop_event=stop_event)
+    worker_errors: queue.Queue[BaseException] = queue.Queue()
+    context = _load_runtime_context()
+    watch_timeout_seconds = _read_int_env(
+        "CI_DASHBOARD_POD_WATCH_TIMEOUT_SECONDS",
+        DEFAULT_WATCH_TIMEOUT_SECONDS,
+    )
+    health_state = WatchHealthState(
+        stale_after_seconds=_read_int_env(
+            "CI_DASHBOARD_POD_WATCH_STALE_AFTER_SECONDS",
+            max(DEFAULT_HEALTH_STALE_AFTER_SECONDS, watch_timeout_seconds * 2 + 120),
+        )
+    )
+    client = _KubernetesClient(
+        base_url=_get_kubernetes_api_url(),
+        token=_get_kubernetes_api_token(),
+        ca_file=_get_kubernetes_api_ca_file(),
+        watch_timeout_seconds=watch_timeout_seconds,
+    )
+
+    with engine.begin() as connection:
+        namespaces = _load_target_namespaces(connection)
+        watermark = {
+            "namespaces": namespaces,
+            "source_project": context.source_project,
+        }
+        mark_job_started(connection, JOB_NAME, watermark)
+
+    threads: list[threading.Thread] = []
+    for namespace_name in namespaces:
+        pod_stream_key = _stream_key(namespace_name, "pods")
+        event_stream_key = _stream_key(namespace_name, "events")
+        health_state.register(pod_stream_key)
+        health_state.register(event_stream_key)
+        threads.append(
+            threading.Thread(
+                target=_worker_guard,
+                name=f"pod-watch:{namespace_name}:pods",
+                kwargs={
+                    "worker_errors": worker_errors,
+                    "stop_event": stop_event,
+                    "target": _run_pod_worker,
+                    "target_kwargs": {
+                        "engine": engine,
+                        "settings": settings,
+                        "client": client,
+                        "context": context,
+                        "namespace_name": namespace_name,
+                        "stream_key": pod_stream_key,
+                        "health_state": health_state,
+                        "recorder": recorder,
+                        "stop_event": stop_event,
+                    },
+                },
+                daemon=True,
+            )
+        )
+        threads.append(
+            threading.Thread(
+                target=_worker_guard,
+                name=f"pod-watch:{namespace_name}:events",
+                kwargs={
+                    "worker_errors": worker_errors,
+                    "stop_event": stop_event,
+                    "target": _run_event_worker,
+                    "target_kwargs": {
+                        "engine": engine,
+                        "settings": settings,
+                        "client": client,
+                        "context": context,
+                        "namespace_name": namespace_name,
+                        "stream_key": event_stream_key,
+                        "health_state": health_state,
+                        "recorder": recorder,
+                        "stop_event": stop_event,
+                    },
+                },
+                daemon=True,
+            )
+        )
+
+    health_server = _start_health_server(health_state)
+    for thread in threads:
+        thread.start()
+
+    try:
+        while any(thread.is_alive() for thread in threads):
+            if max_events is not None and stop_event.is_set():
+                break
+            try:
+                raise worker_errors.get(timeout=1)
+            except queue.Empty:
+                continue
+
+        stop_event.set()
+        for thread in threads:
+            thread.join(timeout=5)
+        if health_server is not None:
+            health_server.shutdown()
+            health_server.server_close()
+
+        if not worker_errors.empty():
+            raise worker_errors.get()
+
+        with engine.begin() as connection:
+            mark_job_succeeded(connection, JOB_NAME, {"namespaces": namespaces})
+        return summary
+    except Exception as exc:
+        stop_event.set()
+        if health_server is not None:
+            health_server.shutdown()
+            health_server.server_close()
+        with engine.begin() as connection:
+            mark_job_failed(connection, JOB_NAME, {"namespaces": namespaces}, str(exc))
+        raise
+
+
+def _worker_guard(
+    *,
+    worker_errors: queue.Queue[BaseException],
+    stop_event: threading.Event,
+    target,
+    target_kwargs: dict[str, Any],
+) -> None:
+    try:
+        target(**target_kwargs)
+    except BaseException as exc:
+        worker_errors.put(exc)
+        stop_event.set()
+
+
+def _run_pod_worker(
+    *,
+    engine: Engine,
+    settings: Settings,
+    client: _KubernetesClient,
+    context: WatchRuntimeContext,
+    namespace_name: str,
+    stream_key: str,
+    health_state: WatchHealthState,
+    recorder: _ProgressRecorder,
+    stop_event: threading.Event,
+) -> None:
+    while not stop_event.is_set():
+        try:
+            items, resource_version = client.list_collection(
+                namespace_name=namespace_name,
+                resource="pods",
+            )
+            health_state.heartbeat(stream_key)
+            snapshots = [
+                snapshot
+                for snapshot in (
+                    _normalize_pod_object(item, context=context) for item in items
+                )
+                if snapshot is not None
+            ]
+            lifecycle_count = _persist_pod_snapshots(
+                engine,
+                settings,
+                snapshots,
+            )
+            recorder.add(
+                pod_snapshots_seen=len(snapshots),
+                lifecycle_rows_upserted=lifecycle_count,
+                pods_touched=len(snapshots),
+            )
+
+            for watch_event in client.stream_collection(
+                namespace_name=namespace_name,
+                resource="pods",
+                resource_version=resource_version,
+            ):
+                if stop_event.is_set():
+                    break
+                health_state.heartbeat(stream_key)
+                event_type = _coerce_str(watch_event.get("type"))
+                if event_type == "ERROR":
+                    raise RuntimeError(_format_watch_error(watch_event))
+                if event_type not in POD_WATCH_TYPES:
+                    continue
+                pod_object = watch_event.get("object")
+                if not isinstance(pod_object, dict):
+                    continue
+                snapshot = _normalize_pod_object(pod_object, context=context)
+                if snapshot is None:
+                    continue
+                lifecycle_count = _persist_pod_snapshots(
+                    engine,
+                    settings,
+                    [snapshot],
+                )
+                recorder.add(
+                    pod_snapshots_seen=1,
+                    lifecycle_rows_upserted=lifecycle_count,
+                    pods_touched=1,
+                )
+        except Exception as exc:
+            if stop_event.is_set():
+                break
+            recorder.add(watch_restarts=1)
+            logger.warning(
+                "pod watch stream restarted for namespace %s: %s",
+                namespace_name,
+                exc,
+            )
+            _sleep_until_retry(stop_event)
+
+
+def _run_event_worker(
+    *,
+    engine: Engine,
+    settings: Settings,
+    client: _KubernetesClient,
+    context: WatchRuntimeContext,
+    namespace_name: str,
+    stream_key: str,
+    health_state: WatchHealthState,
+    recorder: _ProgressRecorder,
+    stop_event: threading.Event,
+) -> None:
+    while not stop_event.is_set():
+        try:
+            items, resource_version = client.list_collection(
+                namespace_name=namespace_name,
+                resource="events",
+            )
+            health_state.heartbeat(stream_key)
+            normalized_rows = [
+                row
+                for row in (
+                    _normalize_kubernetes_event(item, context=context) for item in items
+                )
+                if row is not None
+            ]
+            event_count, lifecycle_count, pods_touched = _persist_pod_events(
+                engine,
+                settings,
+                normalized_rows,
+            )
+            recorder.add(
+                event_rows_seen=len(normalized_rows),
+                event_rows_written=event_count,
+                lifecycle_rows_upserted=lifecycle_count,
+                pods_touched=pods_touched,
+            )
+
+            for watch_event in client.stream_collection(
+                namespace_name=namespace_name,
+                resource="events",
+                resource_version=resource_version,
+            ):
+                if stop_event.is_set():
+                    break
+                health_state.heartbeat(stream_key)
+                event_type = _coerce_str(watch_event.get("type"))
+                if event_type == "ERROR":
+                    raise RuntimeError(_format_watch_error(watch_event))
+                if event_type not in EVENT_WATCH_TYPES:
+                    continue
+                event_object = watch_event.get("object")
+                if not isinstance(event_object, dict):
+                    continue
+                normalized = _normalize_kubernetes_event(event_object, context=context)
+                if normalized is None:
+                    continue
+                event_count, lifecycle_count, pods_touched = _persist_pod_events(
+                    engine,
+                    settings,
+                    [normalized],
+                )
+                recorder.add(
+                    event_rows_seen=1,
+                    event_rows_written=event_count,
+                    lifecycle_rows_upserted=lifecycle_count,
+                    pods_touched=pods_touched,
+                )
+        except Exception as exc:
+            if stop_event.is_set():
+                break
+            recorder.add(watch_restarts=1)
+            logger.warning(
+                "event watch stream restarted for namespace %s: %s",
+                namespace_name,
+                exc,
+            )
+            _sleep_until_retry(stop_event)
+
+
+def _persist_pod_snapshots(
+    engine: Engine,
+    settings: Settings,
+    snapshots: list[WatchedPodSnapshot],
+) -> int:
+    if not snapshots:
+        return 0
+
+    rows_written = 0
+    for batch in chunked(snapshots, settings.jobs.batch_size):
+        with engine.begin() as connection:
+            lifecycle_rows = _build_lifecycle_rows_for_snapshots(connection, list(batch))
+            if lifecycle_rows:
+                _upsert_pod_lifecycle(connection, lifecycle_rows)
+                rows_written += len(lifecycle_rows)
+    return rows_written
+
+
+def _persist_pod_events(
+    engine: Engine,
+    settings: Settings,
+    rows: list[NormalizedPodEvent],
+) -> tuple[int, int, int]:
+    if not rows:
+        return 0, 0, 0
+
+    event_rows_written = 0
+    lifecycle_rows_written = 0
+    touched_pods: set[tuple[str, str | None, str | None, str | None]] = set()
+    for batch in chunked(rows, settings.jobs.batch_size):
+        batch_identities = {
+            _pod_identity_from_values(
+                source_project=row.source_project,
+                namespace_name=row.namespace_name,
+                pod_uid=row.pod_uid,
+                pod_name=row.pod_name,
+            )
+            for row in batch
+            if row.namespace_name is not None and row.pod_name is not None
+        }
+        with engine.begin() as connection:
+            _upsert_pod_events(connection, [row.as_db_params() for row in batch])
+            event_rows_written += len(batch)
+
+            pod_metadata_by_identity = _load_existing_pod_metadata_snapshots(
+                connection,
+                _sort_identities(batch_identities),
+            )
+            lifecycle_rows = _build_lifecycle_rows(
+                connection,
+                _sort_identities(batch_identities),
+                pod_metadata_by_identity=pod_metadata_by_identity,
+            )
+            if lifecycle_rows:
+                _upsert_pod_lifecycle(connection, lifecycle_rows)
+                lifecycle_rows_written += len(lifecycle_rows)
+        touched_pods.update(batch_identities)
+    return event_rows_written, lifecycle_rows_written, len(touched_pods)
+
+
+def _build_lifecycle_rows_for_snapshots(
+    connection: Connection,
+    snapshots: list[WatchedPodSnapshot],
+) -> list[dict[str, Any]]:
+    snapshot_by_identity = {snapshot.identity: snapshot.snapshot for snapshot in snapshots}
+    identities = _sort_identities(snapshot_by_identity)
+    event_rows = _build_lifecycle_rows(
+        connection,
+        identities,
+        pod_metadata_by_identity=snapshot_by_identity,
+    )
+    event_rows_by_identity = {
+        _pod_identity_from_values(
+            source_project=_coerce_str(row.get("source_project")) or "",
+            namespace_name=_coerce_str(row.get("namespace_name")),
+            pod_uid=_coerce_str(row.get("pod_uid")),
+            pod_name=_coerce_str(row.get("pod_name")),
+        ): row
+        for row in event_rows
+    }
+
+    metadata_only_rows = [
+        _base_lifecycle_row_for_snapshot(snapshot)
+        for snapshot in snapshots
+        if snapshot.identity not in event_rows_by_identity
+    ]
+    build_metadata_by_identity = _load_build_metadata_map(
+        connection,
+        metadata_only_rows,
+        pod_metadata_by_identity=snapshot_by_identity,
+    )
+
+    rows = list(event_rows)
+    for row in metadata_only_rows:
+        identity = _pod_identity_from_values(
+            source_project=_coerce_str(row.get("source_project")) or "",
+            namespace_name=_coerce_str(row.get("namespace_name")),
+            pod_uid=_coerce_str(row.get("pod_uid")),
+            pod_name=_coerce_str(row.get("pod_name")),
+        )
+        build_meta = build_metadata_by_identity.get(identity, {})
+        namespace_name = _coerce_str(row.get("namespace_name"))
+        row.update(
+            {
+                "build_system": build_meta.get("build_system")
+                or _infer_pod_build_system(namespace_name),
+                "source_prow_job_id": build_meta.get("source_prow_job_id"),
+                "normalized_build_url": build_meta.get("normalized_build_url"),
+                "repo_full_name": build_meta.get("repo_full_name"),
+                "job_name": canonicalize_job_name(
+                    _coerce_str(build_meta.get("job_name")),
+                    repo_full_name=_coerce_str(build_meta.get("repo_full_name")),
+                ),
+            }
+        )
+        _supplement_jenkins_pod_fields_from_build_metadata(
+            row,
+            build_meta,
+            build_system=_coerce_str(row.get("build_system")),
+        )
+        rows.append(row)
+    return rows
+
+
+def _base_lifecycle_row_for_snapshot(snapshot: WatchedPodSnapshot) -> dict[str, Any]:
+    return {
+        "source_project": snapshot.source_project,
+        "cluster_name": snapshot.cluster_name,
+        "location": snapshot.location,
+        "namespace_name": snapshot.namespace_name,
+        "pod_name": snapshot.pod_name,
+        "pod_uid": snapshot.pod_uid,
+        "build_system": _infer_pod_build_system(snapshot.namespace_name),
+        **snapshot.snapshot.as_lifecycle_fields(),
+        "source_prow_job_id": None,
+        "normalized_build_url": None,
+        "repo_full_name": None,
+        "job_name": None,
+        "scheduled_at": None,
+        "first_pulling_at": None,
+        "first_pulled_at": None,
+        "first_created_at": None,
+        "first_started_at": None,
+        "last_failed_scheduling_at": None,
+        "failed_scheduling_count": 0,
+        "last_event_at": None,
+        "schedule_to_started_seconds": None,
+    }
+
+
+def _load_existing_pod_metadata_snapshots(
+    connection: Connection,
+    identities: list[tuple[str, str | None, str | None, str | None]],
+) -> dict[tuple[str, str | None, str | None, str | None], PodMetadataSnapshot]:
+    if not identities:
+        return {}
+    requested_pods_sql, params = _build_requested_pods_relation(identities)
+    rows = connection.execute(
+        text(
+            f"""
+            WITH requested_pods AS (
+              {requested_pods_sql}
+            )
+            SELECT
+              lifecycle.source_project,
+              lifecycle.namespace_name,
+              lifecycle.pod_uid,
+              lifecycle.pod_name,
+              lifecycle.pod_labels_json,
+              lifecycle.pod_annotations_json,
+              lifecycle.metadata_observed_at,
+              lifecycle.pod_created_at
+            FROM ci_l1_pod_lifecycle AS lifecycle
+            JOIN requested_pods AS requested
+              ON lifecycle.source_project = requested.source_project
+             AND {_null_safe_equals_sql('lifecycle.namespace_name', 'requested.namespace_name', connection.dialect.name)}
+             AND {_null_safe_equals_sql('lifecycle.pod_uid', 'requested.pod_uid', connection.dialect.name)}
+             AND {_null_safe_equals_sql('lifecycle.pod_name', 'requested.pod_name', connection.dialect.name)}
+            """
+        ),
+        params,
+    ).mappings()
+
+    snapshots: dict[tuple[str, str | None, str | None, str | None], PodMetadataSnapshot] = {}
+    for row in rows:
+        labels = _json_loads_str_mapping(row.get("pod_labels_json"))
+        annotations = _json_loads_str_mapping(row.get("pod_annotations_json"))
+        creation_timestamp = _parse_datetime(row.get("pod_created_at"))
+        if not labels and not annotations and creation_timestamp is None:
+            continue
+        identity = _pod_identity_from_values(
+            source_project=_coerce_str(row.get("source_project")) or "",
+            namespace_name=_coerce_str(row.get("namespace_name")),
+            pod_uid=_coerce_str(row.get("pod_uid")),
+            pod_name=_coerce_str(row.get("pod_name")),
+        )
+        snapshots[identity] = PodMetadataSnapshot(
+            pod_uid=_coerce_str(row.get("pod_uid")),
+            labels=labels,
+            annotations=annotations,
+            observed_at=_parse_datetime(row.get("metadata_observed_at"))
+            or datetime.now(UTC).replace(tzinfo=None),
+            creation_timestamp=creation_timestamp,
+        )
+    return snapshots
+
+
+def _normalize_pod_object(
+    pod_object: dict[str, Any],
+    *,
+    context: WatchRuntimeContext,
+) -> WatchedPodSnapshot | None:
+    metadata = pod_object.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    namespace_name = _coerce_str(metadata.get("namespace"))
+    pod_name = _coerce_str(metadata.get("name"))
+    pod_uid = _coerce_str(metadata.get("uid"))
+    if namespace_name is None or pod_name is None or pod_uid is None:
+        return None
+
+    observed_at = datetime.now(UTC).replace(tzinfo=None)
+    return WatchedPodSnapshot(
+        source_project=context.source_project,
+        cluster_name=context.cluster_name,
+        location=context.location,
+        namespace_name=namespace_name,
+        pod_name=pod_name,
+        pod_uid=pod_uid,
+        snapshot=PodMetadataSnapshot(
+            pod_uid=pod_uid,
+            labels=_coerce_str_mapping(metadata.get("labels")),
+            annotations=_coerce_str_mapping(metadata.get("annotations")),
+            observed_at=observed_at,
+            creation_timestamp=_parse_datetime(metadata.get("creationTimestamp")),
+        ),
+    )
+
+
+def _normalize_kubernetes_event(
+    event_object: dict[str, Any],
+    *,
+    context: WatchRuntimeContext,
+) -> NormalizedPodEvent | None:
+    metadata = event_object.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    involved_object = event_object.get("involvedObject")
+    if not isinstance(involved_object, dict):
+        return None
+    if _coerce_str(involved_object.get("kind")) != "Pod":
+        return None
+
+    event_reason = _coerce_str(event_object.get("reason"))
+    if event_reason not in POD_EVENT_REASONS:
+        return None
+
+    event_timestamp = (
+        _parse_datetime(event_object.get("eventTime"))
+        or _parse_datetime(event_object.get("lastTimestamp"))
+        or _parse_datetime(event_object.get("firstTimestamp"))
+        or _parse_datetime(metadata.get("creationTimestamp"))
+    )
+    if event_timestamp is None:
+        return None
+
+    namespace_name = _coerce_str(involved_object.get("namespace")) or _coerce_str(
+        metadata.get("namespace")
+    )
+    pod_name = _coerce_str(involved_object.get("name"))
+    pod_uid = _coerce_str(involved_object.get("uid"))
+    if namespace_name is None or pod_name is None:
+        return None
+
+    source_insert_id = _build_event_source_insert_id(event_object)
+    if source_insert_id is None:
+        return None
+
+    source = event_object.get("source")
+    source_component = None
+    source_host = None
+    if isinstance(source, dict):
+        source_component = _coerce_str(source.get("component"))
+        source_host = _coerce_str(source.get("host"))
+
+    return NormalizedPodEvent(
+        source_project=context.source_project,
+        cluster_name=context.cluster_name,
+        location=context.location,
+        namespace_name=namespace_name,
+        pod_name=pod_name,
+        pod_uid=pod_uid,
+        event_reason=event_reason,
+        event_type=_coerce_str(event_object.get("type")),
+        event_message=_coerce_str(event_object.get("message")),
+        event_timestamp=event_timestamp,
+        receive_timestamp=datetime.now(UTC).replace(tzinfo=None),
+        first_timestamp=_parse_datetime(event_object.get("firstTimestamp")),
+        last_timestamp=_parse_datetime(event_object.get("lastTimestamp")),
+        reporting_component=_coerce_str(event_object.get("reportingComponent"))
+        or source_component,
+        reporting_instance=_coerce_str(event_object.get("reportingInstance")) or source_host,
+        source_insert_id=source_insert_id,
+    )
+
+
+def _build_event_source_insert_id(event_object: dict[str, Any]) -> str | None:
+    metadata = event_object.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    uid = _coerce_str(metadata.get("uid"))
+    resource_version = _coerce_str(metadata.get("resourceVersion"))
+    if uid is not None and resource_version is not None:
+        return f"kubernetes-event:{uid}:{resource_version}"
+    if uid is not None:
+        return f"kubernetes-event:{uid}"
+
+    namespace_name = _coerce_str(metadata.get("namespace"))
+    name = _coerce_str(metadata.get("name"))
+    if namespace_name and name and resource_version:
+        return f"kubernetes-event:{namespace_name}:{name}:{resource_version}"
+    return None
+
+
+def _stream_watch_json(
+    url: str,
+    *,
+    token: str,
+    ca_file: str | None,
+    timeout_seconds: int,
+) -> Iterable[dict[str, Any]]:
+    request = urllib_request.Request(
+        url,
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": WATCH_USER_AGENT,
+        },
+    )
+    context = ssl.create_default_context(cafile=ca_file) if ca_file else None
+    try:
+        with urllib_request.urlopen(request, timeout=timeout_seconds, context=context) as response:
+            while True:
+                line = response.readline()
+                if line == b"":
+                    break
+                if not line.strip():
+                    continue
+                yield _decode_json_object(line, error_context="Kubernetes watch")
+    except urllib_error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Kubernetes watch failed: HTTP {exc.code}: {body}") from exc
+    except urllib_error.URLError as exc:
+        raise RuntimeError(f"Kubernetes watch failed: {exc.reason}") from exc
+
+
+def _start_health_server(health_state: WatchHealthState) -> ThreadingHTTPServer | None:
+    port = _read_non_negative_int_env("CI_DASHBOARD_POD_WATCH_HEALTH_PORT", DEFAULT_HEALTH_PORT)
+    if port == 0:
+        return None
+    server = ThreadingHTTPServer(("0.0.0.0", port), _build_health_handler(health_state))
+    thread = threading.Thread(
+        target=server.serve_forever,
+        name="pod-watch:health",
+        daemon=True,
+    )
+    thread.start()
+    return server
+
+
+def _build_health_handler(health_state: WatchHealthState):
+    class _HealthHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            path = self.path.split("?", 1)[0]
+            if path in {"/livez", "/readyz", "/healthz"}:
+                self._send_health(health_state.snapshot())
+                return
+            self.send_error(HTTPStatus.NOT_FOUND, "not found")
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def _send_health(self, payload: dict[str, Any]) -> None:
+            status = HTTPStatus.OK if payload["healthy"] else HTTPStatus.SERVICE_UNAVAILABLE
+            encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+    return _HealthHandler
+
+
+def _load_runtime_context() -> WatchRuntimeContext:
+    source_project = _coerce_str(os.environ.get("CI_DASHBOARD_POD_WATCH_SOURCE_PROJECT")) or _coerce_str(
+        os.environ.get("CI_DASHBOARD_GCP_PROJECT")
+    )
+    if source_project is None:
+        raise RuntimeError(
+            "Missing CI_DASHBOARD_POD_WATCH_SOURCE_PROJECT or CI_DASHBOARD_GCP_PROJECT"
+        )
+    return WatchRuntimeContext(
+        source_project=source_project,
+        cluster_name=_coerce_str(os.environ.get("CI_DASHBOARD_KUBERNETES_CLUSTER_NAME")),
+        location=_coerce_str(os.environ.get("CI_DASHBOARD_KUBERNETES_LOCATION")),
+    )
+
+
+def _format_watch_error(watch_event: dict[str, Any]) -> str:
+    raw_object = watch_event.get("object")
+    if isinstance(raw_object, dict):
+        message = _coerce_str(raw_object.get("message"))
+        reason = _coerce_str(raw_object.get("reason"))
+        code = _coerce_str(raw_object.get("code"))
+        return json.dumps(
+            {"reason": reason, "message": message, "code": code},
+            sort_keys=True,
+        )
+    return "unknown Kubernetes watch error"
+
+
+def _sleep_until_retry(stop_event: threading.Event) -> None:
+    retry_delay = _read_int_env(
+        "CI_DASHBOARD_POD_WATCH_RETRY_DELAY_SECONDS",
+        DEFAULT_WATCH_RETRY_DELAY_SECONDS,
+    )
+    stop_event.wait(retry_delay)
+
+
+def _read_non_negative_int_env(name: str, default: int) -> int:
+    raw = (os.environ.get(name) or "").strip()
+    if raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+def _stream_key(namespace_name: str, resource: str) -> str:
+    return f"{namespace_name}/{resource}"
+
+
+def _sort_identities(
+    identities: Iterable[tuple[str, str | None, str | None, str | None]],
+) -> list[tuple[str, str | None, str | None, str | None]]:
+    return sorted(identities, key=lambda item: tuple(value or "" for value in item))

--- a/ci-dashboard/src/ci_dashboard/jobs/pod_watcher.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/pod_watcher.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 from urllib import error as urllib_error
 from urllib import parse as urllib_parse
 from urllib import request as urllib_request
@@ -40,6 +40,7 @@ from ci_dashboard.jobs.sync_pods import (
     _infer_pod_build_system,
     _json_loads_str_mapping,
     _load_build_metadata_map,
+    _load_jenkins_pod_name_url_prefix_map,
     _load_target_namespaces,
     _null_safe_equals_sql,
     _parse_datetime,
@@ -56,6 +57,7 @@ DEFAULT_WATCH_TIMEOUT_SECONDS = 300
 DEFAULT_WATCH_RETRY_DELAY_SECONDS = 5
 DEFAULT_HEALTH_PORT = 8081
 DEFAULT_HEALTH_STALE_AFTER_SECONDS = 720
+DEFAULT_JENKINS_PREFIX_CACHE_SECONDS = 900
 POD_WATCH_TYPES = frozenset({"ADDED", "MODIFIED"})
 EVENT_WATCH_TYPES = frozenset({"ADDED", "MODIFIED"})
 
@@ -156,6 +158,26 @@ class _ProgressRecorder:
                 self._stop_event.set()
 
 
+class _JenkinsPodNameUrlPrefixCache:
+    def __init__(self, *, ttl_seconds: int) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._prefixes: dict[str, str] | None = None
+        self._expires_at = 0.0
+        self._lock = threading.Lock()
+
+    def get(self, connection: Connection) -> dict[str, str]:
+        now = time.monotonic()
+        with self._lock:
+            if self._prefixes is not None and (
+                self._ttl_seconds == 0 or now < self._expires_at
+            ):
+                return self._prefixes
+            prefixes = _load_jenkins_pod_name_url_prefix_map(connection)
+            self._prefixes = prefixes
+            self._expires_at = float("inf") if self._ttl_seconds == 0 else now + self._ttl_seconds
+            return prefixes
+
+
 class _KubernetesClient:
     def __init__(
         self,
@@ -237,6 +259,12 @@ def run_watch_pods(
     recorder = _ProgressRecorder(summary, max_events=max_events, stop_event=stop_event)
     worker_errors: queue.Queue[BaseException] = queue.Queue()
     context = _load_runtime_context()
+    jenkins_prefix_cache = _JenkinsPodNameUrlPrefixCache(
+        ttl_seconds=_read_non_negative_int_env(
+            "CI_DASHBOARD_JENKINS_POD_NAME_PREFIX_CACHE_SECONDS",
+            DEFAULT_JENKINS_PREFIX_CACHE_SECONDS,
+        )
+    )
     watch_timeout_seconds = _read_int_env(
         "CI_DASHBOARD_POD_WATCH_TIMEOUT_SECONDS",
         DEFAULT_WATCH_TIMEOUT_SECONDS,
@@ -285,6 +313,7 @@ def run_watch_pods(
                         "stream_key": pod_stream_key,
                         "health_state": health_state,
                         "recorder": recorder,
+                        "jenkins_prefix_cache": jenkins_prefix_cache,
                         "stop_event": stop_event,
                     },
                 },
@@ -308,6 +337,7 @@ def run_watch_pods(
                         "stream_key": event_stream_key,
                         "health_state": health_state,
                         "recorder": recorder,
+                        "jenkins_prefix_cache": jenkins_prefix_cache,
                         "stop_event": stop_event,
                     },
                 },
@@ -328,27 +358,26 @@ def run_watch_pods(
             except queue.Empty:
                 continue
 
-        stop_event.set()
-        for thread in threads:
-            thread.join(timeout=5)
-        if health_server is not None:
-            health_server.shutdown()
-            health_server.server_close()
-
         if not worker_errors.empty():
             raise worker_errors.get()
 
         with engine.begin() as connection:
             mark_job_succeeded(connection, JOB_NAME, {"namespaces": namespaces})
         return summary
-    except Exception as exc:
+    except BaseException as exc:
         stop_event.set()
-        if health_server is not None:
-            health_server.shutdown()
-            health_server.server_close()
         with engine.begin() as connection:
             mark_job_failed(connection, JOB_NAME, {"namespaces": namespaces}, str(exc))
         raise
+    finally:
+        stop_event.set()
+        for thread in threads:
+            thread.join(timeout=5)
+            if thread.is_alive():
+                logger.warning("pod watcher thread did not exit cleanly: %s", thread.name)
+        if health_server is not None:
+            health_server.shutdown()
+            health_server.server_close()
 
 
 def _worker_guard(
@@ -375,6 +404,7 @@ def _run_pod_worker(
     stream_key: str,
     health_state: WatchHealthState,
     recorder: _ProgressRecorder,
+    jenkins_prefix_cache: _JenkinsPodNameUrlPrefixCache,
     stop_event: threading.Event,
 ) -> None:
     while not stop_event.is_set():
@@ -395,6 +425,8 @@ def _run_pod_worker(
                 engine,
                 settings,
                 snapshots,
+                jenkins_prefix_cache=jenkins_prefix_cache,
+                on_batch_persisted=lambda: health_state.heartbeat(stream_key),
             )
             recorder.add(
                 pod_snapshots_seen=len(snapshots),
@@ -412,6 +444,13 @@ def _run_pod_worker(
                 health_state.heartbeat(stream_key)
                 event_type = _coerce_str(watch_event.get("type"))
                 if event_type == "ERROR":
+                    if _is_resource_version_expired_watch_error(watch_event):
+                        recorder.add(watch_restarts=1)
+                        logger.info(
+                            "pod watch resource version expired for namespace %s; relisting",
+                            namespace_name,
+                        )
+                        break
                     raise RuntimeError(_format_watch_error(watch_event))
                 if event_type not in POD_WATCH_TYPES:
                     continue
@@ -425,6 +464,8 @@ def _run_pod_worker(
                     engine,
                     settings,
                     [snapshot],
+                    jenkins_prefix_cache=jenkins_prefix_cache,
+                    on_batch_persisted=lambda: health_state.heartbeat(stream_key),
                 )
                 recorder.add(
                     pod_snapshots_seen=1,
@@ -453,6 +494,7 @@ def _run_event_worker(
     stream_key: str,
     health_state: WatchHealthState,
     recorder: _ProgressRecorder,
+    jenkins_prefix_cache: _JenkinsPodNameUrlPrefixCache,
     stop_event: threading.Event,
 ) -> None:
     while not stop_event.is_set():
@@ -473,6 +515,8 @@ def _run_event_worker(
                 engine,
                 settings,
                 normalized_rows,
+                jenkins_prefix_cache=jenkins_prefix_cache,
+                on_batch_persisted=lambda: health_state.heartbeat(stream_key),
             )
             recorder.add(
                 event_rows_seen=len(normalized_rows),
@@ -491,6 +535,13 @@ def _run_event_worker(
                 health_state.heartbeat(stream_key)
                 event_type = _coerce_str(watch_event.get("type"))
                 if event_type == "ERROR":
+                    if _is_resource_version_expired_watch_error(watch_event):
+                        recorder.add(watch_restarts=1)
+                        logger.info(
+                            "event watch resource version expired for namespace %s; relisting",
+                            namespace_name,
+                        )
+                        break
                     raise RuntimeError(_format_watch_error(watch_event))
                 if event_type not in EVENT_WATCH_TYPES:
                     continue
@@ -504,6 +555,8 @@ def _run_event_worker(
                     engine,
                     settings,
                     [normalized],
+                    jenkins_prefix_cache=jenkins_prefix_cache,
+                    on_batch_persisted=lambda: health_state.heartbeat(stream_key),
                 )
                 recorder.add(
                     event_rows_seen=1,
@@ -527,17 +580,32 @@ def _persist_pod_snapshots(
     engine: Engine,
     settings: Settings,
     snapshots: list[WatchedPodSnapshot],
+    *,
+    jenkins_prefix_cache: _JenkinsPodNameUrlPrefixCache | None = None,
+    on_batch_persisted: Callable[[], None] | None = None,
 ) -> int:
     if not snapshots:
         return 0
 
     rows_written = 0
     for batch in chunked(snapshots, settings.jobs.batch_size):
+        batch = list(batch)
         with engine.begin() as connection:
-            lifecycle_rows = _build_lifecycle_rows_for_snapshots(connection, list(batch))
+            jenkins_prefixes = _get_jenkins_prefixes_if_needed(
+                connection,
+                [snapshot.identity for snapshot in batch],
+                jenkins_prefix_cache,
+            )
+            lifecycle_rows = _build_lifecycle_rows_for_snapshots(
+                connection,
+                batch,
+                jenkins_pod_name_url_prefixes=jenkins_prefixes,
+            )
             if lifecycle_rows:
                 _upsert_pod_lifecycle(connection, lifecycle_rows)
                 rows_written += len(lifecycle_rows)
+        if on_batch_persisted is not None:
+            on_batch_persisted()
     return rows_written
 
 
@@ -545,6 +613,9 @@ def _persist_pod_events(
     engine: Engine,
     settings: Settings,
     rows: list[NormalizedPodEvent],
+    *,
+    jenkins_prefix_cache: _JenkinsPodNameUrlPrefixCache | None = None,
+    on_batch_persisted: Callable[[], None] | None = None,
 ) -> tuple[int, int, int]:
     if not rows:
         return 0, 0, 0
@@ -566,6 +637,11 @@ def _persist_pod_events(
         with engine.begin() as connection:
             _upsert_pod_events(connection, [row.as_db_params() for row in batch])
             event_rows_written += len(batch)
+            jenkins_prefixes = _get_jenkins_prefixes_if_needed(
+                connection,
+                batch_identities,
+                jenkins_prefix_cache,
+            )
 
             pod_metadata_by_identity = _load_existing_pod_metadata_snapshots(
                 connection,
@@ -575,10 +651,13 @@ def _persist_pod_events(
                 connection,
                 _sort_identities(batch_identities),
                 pod_metadata_by_identity=pod_metadata_by_identity,
+                jenkins_pod_name_url_prefixes=jenkins_prefixes,
             )
             if lifecycle_rows:
                 _upsert_pod_lifecycle(connection, lifecycle_rows)
                 lifecycle_rows_written += len(lifecycle_rows)
+        if on_batch_persisted is not None:
+            on_batch_persisted()
         touched_pods.update(batch_identities)
     return event_rows_written, lifecycle_rows_written, len(touched_pods)
 
@@ -586,6 +665,8 @@ def _persist_pod_events(
 def _build_lifecycle_rows_for_snapshots(
     connection: Connection,
     snapshots: list[WatchedPodSnapshot],
+    *,
+    jenkins_pod_name_url_prefixes: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     snapshot_by_identity = {snapshot.identity: snapshot.snapshot for snapshot in snapshots}
     identities = _sort_identities(snapshot_by_identity)
@@ -593,6 +674,7 @@ def _build_lifecycle_rows_for_snapshots(
         connection,
         identities,
         pod_metadata_by_identity=snapshot_by_identity,
+        jenkins_pod_name_url_prefixes=jenkins_pod_name_url_prefixes,
     )
     event_rows_by_identity = {
         _pod_identity_from_values(
@@ -613,6 +695,7 @@ def _build_lifecycle_rows_for_snapshots(
         connection,
         metadata_only_rows,
         pod_metadata_by_identity=snapshot_by_identity,
+        jenkins_pod_name_url_prefixes=jenkins_pod_name_url_prefixes,
     )
 
     rows = list(event_rows)
@@ -946,6 +1029,15 @@ def _format_watch_error(watch_event: dict[str, Any]) -> str:
     return "unknown Kubernetes watch error"
 
 
+def _is_resource_version_expired_watch_error(watch_event: dict[str, Any]) -> bool:
+    raw_object = watch_event.get("object")
+    if not isinstance(raw_object, dict):
+        return False
+    code = _coerce_str(raw_object.get("code"))
+    reason = _coerce_str(raw_object.get("reason"))
+    return code == "410" or reason in {"Expired", "Gone"}
+
+
 def _sleep_until_retry(stop_event: threading.Event) -> None:
     retry_delay = _read_int_env(
         "CI_DASHBOARD_POD_WATCH_RETRY_DELAY_SECONDS",
@@ -973,3 +1065,15 @@ def _sort_identities(
     identities: Iterable[tuple[str, str | None, str | None, str | None]],
 ) -> list[tuple[str, str | None, str | None, str | None]]:
     return sorted(identities, key=lambda item: tuple(value or "" for value in item))
+
+
+def _get_jenkins_prefixes_if_needed(
+    connection: Connection,
+    identities: Iterable[tuple[str, str | None, str | None, str | None]],
+    jenkins_prefix_cache: _JenkinsPodNameUrlPrefixCache | None,
+) -> dict[str, str] | None:
+    if jenkins_prefix_cache is None:
+        return None
+    if any(_infer_pod_build_system(namespace_name) == "JENKINS" for _, namespace_name, _, _ in identities):
+        return jenkins_prefix_cache.get(connection)
+    return None

--- a/ci-dashboard/tests/jobs/test_cli.py
+++ b/ci-dashboard/tests/jobs/test_cli.py
@@ -17,6 +17,7 @@ from ci_dashboard.common.models import (
     SyncFlakyIssuesSummary,
     SyncPodsSummary,
     SyncPrEventsSummary,
+    WatchPodsSummary,
 )
 from ci_dashboard.jobs import cli
 
@@ -212,6 +213,28 @@ def test_cli_sync_pods_dispatch(monkeypatch) -> None:
     assert cli.main() == 0
     assert called["engine"] == "engine"
     assert isinstance(called["summary"], SyncPodsSummary)
+
+
+def test_cli_watch_pods_dispatch(monkeypatch) -> None:
+    called: dict[str, object] = {}
+    monkeypatch.setattr(cli, "get_settings", lambda: _settings())
+    monkeypatch.setattr(cli, "build_engine", lambda settings: called.setdefault("engine", "engine"))
+    monkeypatch.setattr(cli, "configure_logging", lambda level: None)
+
+    def fake_run_watch_pods(engine, settings, *, max_events):
+        called["engine_arg"] = engine
+        called["settings"] = settings
+        called["max_events"] = max_events
+        return called.setdefault("summary", WatchPodsSummary(pod_snapshots_seen=1))
+
+    monkeypatch.setattr(cli, "run_watch_pods", fake_run_watch_pods)
+    monkeypatch.setattr("sys.argv", ["ci-dashboard", "watch-pods", "--max-events", "1"])
+
+    assert cli.main() == 0
+    assert called["engine"] == "engine"
+    assert called["engine_arg"] == "engine"
+    assert called["max_events"] == 1
+    assert isinstance(called["summary"], WatchPodsSummary)
 
 
 def test_cli_repair_job_names_dispatch(monkeypatch) -> None:

--- a/ci-dashboard/tests/jobs/test_pod_watcher.py
+++ b/ci-dashboard/tests/jobs/test_pod_watcher.py
@@ -13,6 +13,7 @@ from ci_dashboard.common.config import DatabaseSettings, JobSettings, Settings
 from ci_dashboard.common.models import WatchPodsSummary
 from ci_dashboard.jobs import pod_watcher as watcher
 from ci_dashboard.jobs.pod_watcher import (
+    _JenkinsPodNameUrlPrefixCache,
     WatchedPodSnapshot,
     WatchHealthState,
     WatchRuntimeContext,
@@ -21,6 +22,7 @@ from ci_dashboard.jobs.pod_watcher import (
     _build_event_source_insert_id,
     _build_lifecycle_rows_for_snapshots,
     _format_watch_error,
+    _is_resource_version_expired_watch_error,
     _load_runtime_context,
     _normalize_kubernetes_event,
     _normalize_pod_object,
@@ -56,6 +58,65 @@ def _runtime_context() -> WatchRuntimeContext:
         source_project="pingcap-testing-account",
         cluster_name="prow",
         location="us-central1-c",
+    )
+
+
+def _watched_snapshot(
+    *,
+    namespace_name: str = "jenkins-tidb",
+    pod_name: str = "agent-pod",
+    pod_uid: str = "uid-a",
+    labels: dict[str, str] | None = None,
+    annotations: dict[str, str] | None = None,
+    observed_at: datetime = datetime(2026, 5, 1, 1, 0, 2),
+    creation_timestamp: datetime = datetime(2026, 5, 1, 1, 0, 1),
+) -> WatchedPodSnapshot:
+    return WatchedPodSnapshot(
+        source_project="pingcap-testing-account",
+        cluster_name="prow",
+        location="us-central1-c",
+        namespace_name=namespace_name,
+        pod_name=pod_name,
+        pod_uid=pod_uid,
+        snapshot=PodMetadataSnapshot(
+            pod_uid=pod_uid,
+            labels=labels or {},
+            annotations=annotations or {},
+            observed_at=observed_at,
+            creation_timestamp=creation_timestamp,
+        ),
+    )
+
+
+def _pod_event(
+    *,
+    namespace_name: str = "jenkins-tidb",
+    pod_name: str = "agent-pod",
+    pod_uid: str = "uid-a",
+    reason: str = "Scheduled",
+    timestamp: datetime = datetime(2026, 5, 1, 1, 0, 5),
+    insert_id: str = "kubernetes-event:sched",
+    component: str = "default-scheduler",
+    instance: str = "scheduler",
+    message: str = "Successfully assigned",
+) -> NormalizedPodEvent:
+    return NormalizedPodEvent(
+        source_project="pingcap-testing-account",
+        cluster_name="prow",
+        location="us-central1-c",
+        namespace_name=namespace_name,
+        pod_name=pod_name,
+        pod_uid=pod_uid,
+        event_reason=reason,
+        event_type="Normal",
+        event_message=message,
+        event_timestamp=timestamp,
+        receive_timestamp=timestamp,
+        first_timestamp=timestamp,
+        last_timestamp=timestamp,
+        reporting_component=component,
+        reporting_instance=instance,
+        source_insert_id=insert_id,
     )
 
 
@@ -278,6 +339,8 @@ def test_runtime_context_and_helper_edge_cases(monkeypatch) -> None:
         '{"code": "410", "message": "too old", "reason": "Gone"}'
     )
     assert _format_watch_error({"type": "ERROR"}) == "unknown Kubernetes watch error"
+    assert _is_resource_version_expired_watch_error({"object": {"reason": "Gone", "code": 410}}) is True
+    assert _is_resource_version_expired_watch_error({"object": {"reason": "Forbidden", "code": 403}}) is False
     assert _build_event_source_insert_id({"metadata": {"uid": "uid-a"}}) == "kubernetes-event:uid-a"
     assert _build_event_source_insert_id(
         {"metadata": {"namespace": "ns", "name": "event-name", "resourceVersion": "rv"}}
@@ -376,68 +439,30 @@ def test_snapshot_lifecycle_keeps_metadata_when_events_arrive_later(sqlite_engin
             )
         )
 
-    snapshot = WatchedPodSnapshot(
-        source_project="pingcap-testing-account",
-        cluster_name="prow",
-        location="us-central1-c",
-        namespace_name="jenkins-tidb",
-        pod_name="agent-pod",
-        pod_uid="uid-a",
-        snapshot=PodMetadataSnapshot(
-            pod_uid="uid-a",
-            labels={
-                "author": "alice",
-                "org": "pingcap",
-                "repo": "tidb",
-                "jenkins/label": "pingcap_tidb_ghpr_unit_test_42-abcd",
-            },
-            annotations={
-                "buildUrl": "http://jenkins.jenkins.svc.cluster.local:80/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/42/",
-                "ci_job": "pingcap/tidb/ghpr_unit_test",
-            },
-            observed_at=datetime(2026, 5, 1, 1, 0, 2),
-            creation_timestamp=datetime(2026, 5, 1, 1, 0, 1),
-        ),
+    snapshot = _watched_snapshot(
+        labels={
+            "author": "alice",
+            "org": "pingcap",
+            "repo": "tidb",
+            "jenkins/label": "pingcap_tidb_ghpr_unit_test_42-abcd",
+        },
+        annotations={
+            "buildUrl": "http://jenkins.jenkins.svc.cluster.local:80/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/42/",
+            "ci_job": "pingcap/tidb/ghpr_unit_test",
+        },
     )
 
     assert _persist_pod_snapshots(sqlite_engine, _settings(), [snapshot]) == 1
 
     rows = [
-        NormalizedPodEvent(
-            source_project="pingcap-testing-account",
-            cluster_name="prow",
-            location="us-central1-c",
-            namespace_name="jenkins-tidb",
-            pod_name="agent-pod",
-            pod_uid="uid-a",
-            event_reason="Scheduled",
-            event_type="Normal",
-            event_message="Successfully assigned",
-            event_timestamp=datetime(2026, 5, 1, 1, 0, 5),
-            receive_timestamp=datetime(2026, 5, 1, 1, 0, 6),
-            first_timestamp=datetime(2026, 5, 1, 1, 0, 5),
-            last_timestamp=datetime(2026, 5, 1, 1, 0, 5),
-            reporting_component="default-scheduler",
-            reporting_instance="scheduler",
-            source_insert_id="kubernetes-event:sched",
-        ),
-        NormalizedPodEvent(
-            source_project="pingcap-testing-account",
-            cluster_name="prow",
-            location="us-central1-c",
-            namespace_name="jenkins-tidb",
-            pod_name="agent-pod",
-            pod_uid="uid-a",
-            event_reason="Started",
-            event_type="Normal",
-            event_message="Started container",
-            event_timestamp=datetime(2026, 5, 1, 1, 0, 25),
-            receive_timestamp=datetime(2026, 5, 1, 1, 0, 26),
-            first_timestamp=datetime(2026, 5, 1, 1, 0, 25),
-            last_timestamp=datetime(2026, 5, 1, 1, 0, 25),
-            reporting_component="kubelet",
-            reporting_instance="node-a",
-            source_insert_id="kubernetes-event:started",
+        _pod_event(),
+        _pod_event(
+            reason="Started",
+            timestamp=datetime(2026, 5, 1, 1, 0, 25),
+            insert_id="kubernetes-event:started",
+            component="kubelet",
+            instance="node-a",
+            message="Started container",
         ),
     ]
 
@@ -475,38 +500,17 @@ def test_snapshot_lifecycle_keeps_metadata_when_events_arrive_later(sqlite_engin
 
 
 def test_build_lifecycle_rows_for_snapshots_uses_existing_event_aggregates(sqlite_engine) -> None:
-    snapshot = WatchedPodSnapshot(
-        source_project="pingcap-testing-account",
-        cluster_name="prow",
-        location="us-central1-c",
+    snapshot = _watched_snapshot(
         namespace_name="prow-test-pods",
         pod_name="prow-pod",
         pod_uid="uid-prow",
-        snapshot=PodMetadataSnapshot(
-            pod_uid="uid-prow",
-            labels={"prow.k8s.io/job": "ghpr_unit_test"},
-            annotations={},
-            observed_at=datetime(2026, 5, 1, 1, 0, 2),
-            creation_timestamp=datetime(2026, 5, 1, 1, 0, 1),
-        ),
+        labels={"prow.k8s.io/job": "ghpr_unit_test"},
     )
-    event = NormalizedPodEvent(
-        source_project="pingcap-testing-account",
-        cluster_name="prow",
-        location="us-central1-c",
+    event = _pod_event(
         namespace_name="prow-test-pods",
         pod_name="prow-pod",
         pod_uid="uid-prow",
-        event_reason="Scheduled",
-        event_type="Normal",
-        event_message="Successfully assigned",
-        event_timestamp=datetime(2026, 5, 1, 1, 0, 5),
-        receive_timestamp=datetime(2026, 5, 1, 1, 0, 6),
-        first_timestamp=datetime(2026, 5, 1, 1, 0, 5),
-        last_timestamp=datetime(2026, 5, 1, 1, 0, 5),
-        reporting_component="default-scheduler",
-        reporting_instance="scheduler",
-        source_insert_id="kubernetes-event:prow-sched",
+        insert_id="kubernetes-event:prow-sched",
     )
     _persist_pod_events(sqlite_engine, _settings(), [event])
 
@@ -516,3 +520,90 @@ def test_build_lifecycle_rows_for_snapshots_uses_existing_event_aggregates(sqlit
     assert len(rows) == 1
     assert rows[0]["scheduled_at"] == datetime(2026, 5, 1, 1, 0, 5)
     assert rows[0]["pod_created_at"] == datetime(2026, 5, 1, 1, 0, 1)
+
+
+def test_persist_paths_cache_jenkins_prefixes_and_refresh_heartbeat(sqlite_engine, monkeypatch) -> None:
+    load_calls = 0
+
+    def fake_load_prefixes(connection):
+        nonlocal load_calls
+        load_calls += 1
+        return {
+            "ghpr-unit-test": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/"
+        }
+
+    monkeypatch.setattr(watcher, "_load_jenkins_pod_name_url_prefix_map", fake_load_prefixes)
+    cache = _JenkinsPodNameUrlPrefixCache(ttl_seconds=900)
+    heartbeats = 0
+
+    def heartbeat() -> None:
+        nonlocal heartbeats
+        heartbeats += 1
+
+    snapshots = [
+        WatchedPodSnapshot(
+            source_project="pingcap-testing-account",
+            cluster_name="prow",
+            location="us-central1-c",
+            namespace_name="jenkins-tidb",
+            pod_name=f"ghpr-unit-test-1234{index}-abcd",
+            pod_uid=f"uid-cache-{index}",
+            snapshot=PodMetadataSnapshot(
+                pod_uid=f"uid-cache-{index}",
+                labels={},
+                annotations={},
+                observed_at=datetime(2026, 5, 1, 1, index, 2),
+                creation_timestamp=datetime(2026, 5, 1, 1, index, 1),
+            ),
+        )
+        for index in range(2)
+    ]
+
+    assert (
+        _persist_pod_snapshots(
+            sqlite_engine,
+            _settings(batch_size=1),
+            snapshots,
+            jenkins_prefix_cache=cache,
+            on_batch_persisted=heartbeat,
+        )
+        == 2
+    )
+    assert load_calls == 1
+    assert heartbeats == 2
+
+    event_cache = _JenkinsPodNameUrlPrefixCache(ttl_seconds=900)
+    events = [
+        NormalizedPodEvent(
+            source_project="pingcap-testing-account",
+            cluster_name="prow",
+            location="us-central1-c",
+            namespace_name="jenkins-tidb",
+            pod_name=f"ghpr-unit-test-2234{index}-abcd",
+            pod_uid=f"uid-event-cache-{index}",
+            event_reason="Scheduled",
+            event_type="Normal",
+            event_message="Successfully assigned",
+            event_timestamp=datetime(2026, 5, 1, 2, index, 5),
+            receive_timestamp=datetime(2026, 5, 1, 2, index, 6),
+            first_timestamp=datetime(2026, 5, 1, 2, index, 5),
+            last_timestamp=datetime(2026, 5, 1, 2, index, 5),
+            reporting_component="default-scheduler",
+            reporting_instance="scheduler",
+            source_insert_id=f"kubernetes-event:cache-{index}",
+        )
+        for index in range(2)
+    ]
+
+    assert (
+        _persist_pod_events(
+            sqlite_engine,
+            _settings(batch_size=1),
+            events,
+            jenkins_prefix_cache=event_cache,
+            on_batch_persisted=heartbeat,
+        )
+        == (2, 2, 2)
+    )
+    assert load_calls == 2
+    assert heartbeats == 4

--- a/ci-dashboard/tests/jobs/test_pod_watcher.py
+++ b/ci-dashboard/tests/jobs/test_pod_watcher.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from datetime import datetime
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from sqlalchemy import text
+
+from ci_dashboard.common.config import DatabaseSettings, JobSettings, Settings
+from ci_dashboard.common.models import WatchPodsSummary
+from ci_dashboard.jobs import pod_watcher as watcher
+from ci_dashboard.jobs.pod_watcher import (
+    WatchedPodSnapshot,
+    WatchHealthState,
+    WatchRuntimeContext,
+    _KubernetesClient,
+    _ProgressRecorder,
+    _build_event_source_insert_id,
+    _build_lifecycle_rows_for_snapshots,
+    _format_watch_error,
+    _load_runtime_context,
+    _normalize_kubernetes_event,
+    _normalize_pod_object,
+    _persist_pod_events,
+    _persist_pod_snapshots,
+    _read_non_negative_int_env,
+    _sleep_until_retry,
+    _start_health_server,
+    _stream_key,
+    _stream_watch_json,
+)
+from ci_dashboard.jobs.sync_pods import NormalizedPodEvent, PodMetadataSnapshot
+
+
+def _settings(batch_size: int = 100) -> Settings:
+    return Settings(
+        database=DatabaseSettings(
+            url="sqlite+pysqlite:///:memory:",
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            database=None,
+            ssl_ca=None,
+        ),
+        jobs=JobSettings(batch_size=batch_size),
+        log_level="INFO",
+    )
+
+
+def _runtime_context() -> WatchRuntimeContext:
+    return WatchRuntimeContext(
+        source_project="pingcap-testing-account",
+        cluster_name="prow",
+        location="us-central1-c",
+    )
+
+
+def test_watch_health_state_requires_each_stream_heartbeat() -> None:
+    health_state = WatchHealthState(stale_after_seconds=60)
+    health_state.register("jenkins-tidb/pods")
+    health_state.register("jenkins-tidb/events")
+
+    assert health_state.snapshot()["healthy"] is False
+
+    health_state.heartbeat("jenkins-tidb/pods")
+    assert health_state.snapshot()["healthy"] is False
+
+    health_state.heartbeat("jenkins-tidb/events")
+    snapshot = health_state.snapshot()
+    assert snapshot["healthy"] is True
+    assert snapshot["streams"]["jenkins-tidb/pods"]["healthy"] is True
+    assert snapshot["streams"]["jenkins-tidb/events"]["healthy"] is True
+
+
+def test_progress_recorder_sets_stop_event_at_max_events() -> None:
+    summary = WatchPodsSummary()
+    stop_event = threading.Event()
+    recorder = _ProgressRecorder(summary, max_events=3, stop_event=stop_event)
+
+    recorder.add(pod_snapshots_seen=1, event_rows_seen=1, pods_touched=2)
+    assert stop_event.is_set() is False
+
+    recorder.add(event_rows_seen=1, event_rows_written=1, lifecycle_rows_upserted=1, watch_restarts=1)
+    assert stop_event.is_set() is True
+    assert summary.pod_snapshots_seen == 1
+    assert summary.event_rows_seen == 2
+    assert summary.event_rows_written == 1
+    assert summary.lifecycle_rows_upserted == 1
+    assert summary.pods_touched == 2
+    assert summary.watch_restarts == 1
+
+
+def test_kubernetes_client_lists_and_streams_collection(monkeypatch) -> None:
+    get_urls: list[str] = []
+    pages = iter(
+        [
+            {
+                "items": [{"metadata": {"name": "pod-a"}}, "ignore-me"],
+                "metadata": {"continue": "next", "resourceVersion": "rv-1"},
+            },
+            {
+                "items": [{"metadata": {"name": "pod-b"}}],
+                "metadata": {"resourceVersion": "rv-2"},
+            },
+        ]
+    )
+
+    def fake_get_json(url, *, headers, ca_file):
+        get_urls.append(url)
+        assert headers == {"Authorization": "Bearer token"}
+        assert ca_file == "/tmp/ca.crt"
+        return next(pages)
+
+    stream_calls: list[dict[str, object]] = []
+
+    def fake_stream_watch_json(url, *, token, ca_file, timeout_seconds):
+        stream_calls.append(
+            {
+                "url": url,
+                "token": token,
+                "ca_file": ca_file,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        yield {"type": "BOOKMARK"}
+
+    monkeypatch.setattr(watcher, "_get_json", fake_get_json)
+    monkeypatch.setattr(watcher, "_stream_watch_json", fake_stream_watch_json)
+
+    client = _KubernetesClient(
+        base_url="https://k8s.example/",
+        token="token",
+        ca_file="/tmp/ca.crt",
+        watch_timeout_seconds=60,
+    )
+    items, resource_version = client.list_collection(namespace_name="jenkins tidb", resource="pods")
+    assert [item["metadata"]["name"] for item in items] == ["pod-a", "pod-b"]
+    assert resource_version == "rv-2"
+    assert "continue=next" in get_urls[1]
+    assert "jenkins%20tidb" in get_urls[0]
+
+    assert list(client.stream_collection(namespace_name="jenkins-tidb", resource="events", resource_version="rv-2")) == [
+        {"type": "BOOKMARK"}
+    ]
+    assert stream_calls == [
+        {
+            "url": (
+                "https://k8s.example/api/v1/namespaces/jenkins-tidb/events?"
+                "watch=true&allowWatchBookmarks=true&timeoutSeconds=60&resourceVersion=rv-2"
+            ),
+            "token": "token",
+            "ca_file": "/tmp/ca.crt",
+            "timeout_seconds": 90,
+        }
+    ]
+
+
+class _FakeWatchResponse:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+
+    def __enter__(self) -> "_FakeWatchResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def readline(self) -> bytes:
+        if not self._lines:
+            return b""
+        return self._lines.pop(0)
+
+
+def test_stream_watch_json_decodes_lines_and_wraps_errors(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_urlopen(request, timeout=0, context=None):
+        observed["authorization"] = request.headers["Authorization"]
+        observed["timeout"] = timeout
+        observed["context"] = context
+        return _FakeWatchResponse([b"\n", b'{"type":"ADDED"}\n'])
+
+    monkeypatch.setattr(watcher.urllib_request, "urlopen", fake_urlopen)
+
+    assert list(_stream_watch_json("https://k8s.example/watch", token="token", ca_file=None, timeout_seconds=3)) == [
+        {"type": "ADDED"}
+    ]
+    assert observed["authorization"] == "Bearer token"
+    assert observed["timeout"] == 3
+
+    monkeypatch.setattr(
+        watcher.urllib_request,
+        "urlopen",
+        lambda request, timeout=0, context=None: (_ for _ in ()).throw(
+            urllib_error.URLError("network down")
+        ),
+    )
+    try:
+        list(_stream_watch_json("https://k8s.example/watch", token="token", ca_file=None, timeout_seconds=3))
+    except RuntimeError as exc:
+        assert "network down" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_health_server_reports_stream_health(monkeypatch) -> None:
+    health_state = WatchHealthState(stale_after_seconds=60)
+    health_state.register("jenkins-tidb/pods")
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+    monkeypatch.setenv("CI_DASHBOARD_POD_WATCH_HEALTH_PORT", str(port))
+    server = _start_health_server(health_state)
+    assert server is not None
+    try:
+        try:
+            urllib_request.urlopen(f"http://127.0.0.1:{port}/livez", timeout=2)
+        except urllib_error.HTTPError as exc:
+            assert exc.code == 503
+            payload = json.loads(exc.read().decode("utf-8"))
+            assert payload["healthy"] is False
+        else:
+            raise AssertionError("expected unhealthy response")
+
+        health_state.heartbeat("jenkins-tidb/pods")
+        with urllib_request.urlopen(f"http://127.0.0.1:{port}/readyz?verbose=1", timeout=2) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            assert response.status == 200
+            assert payload["healthy"] is True
+
+        try:
+            urllib_request.urlopen(f"http://127.0.0.1:{port}/missing", timeout=2)
+        except urllib_error.HTTPError as exc:
+            assert exc.code == 404
+        else:
+            raise AssertionError("expected not found response")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_runtime_context_and_helper_edge_cases(monkeypatch) -> None:
+    monkeypatch.delenv("CI_DASHBOARD_POD_WATCH_SOURCE_PROJECT", raising=False)
+    monkeypatch.delenv("CI_DASHBOARD_GCP_PROJECT", raising=False)
+    try:
+        _load_runtime_context()
+    except RuntimeError as exc:
+        assert "Missing CI_DASHBOARD_POD_WATCH_SOURCE_PROJECT" in str(exc)
+    else:
+        raise AssertionError("expected missing project error")
+
+    monkeypatch.setenv("CI_DASHBOARD_GCP_PROJECT", "from-gcp")
+    monkeypatch.setenv("CI_DASHBOARD_POD_WATCH_SOURCE_PROJECT", "from-watch")
+    monkeypatch.setenv("CI_DASHBOARD_KUBERNETES_CLUSTER_NAME", "prow")
+    monkeypatch.setenv("CI_DASHBOARD_KUBERNETES_LOCATION", "us-central1-c")
+    context = _load_runtime_context()
+    assert context.source_project == "from-watch"
+    assert context.cluster_name == "prow"
+    assert context.location == "us-central1-c"
+
+    monkeypatch.delenv("TEST_NON_NEGATIVE_INT", raising=False)
+    assert _read_non_negative_int_env("TEST_NON_NEGATIVE_INT", 7) == 7
+    monkeypatch.setenv("TEST_NON_NEGATIVE_INT", "bad")
+    assert _read_non_negative_int_env("TEST_NON_NEGATIVE_INT", 7) == 7
+    monkeypatch.setenv("TEST_NON_NEGATIVE_INT", "-1")
+    assert _read_non_negative_int_env("TEST_NON_NEGATIVE_INT", 7) == 7
+    monkeypatch.setenv("TEST_NON_NEGATIVE_INT", "0")
+    assert _read_non_negative_int_env("TEST_NON_NEGATIVE_INT", 7) == 0
+
+    assert _stream_key("jenkins-tidb", "pods") == "jenkins-tidb/pods"
+    assert _format_watch_error({"object": {"reason": "Gone", "message": "too old", "code": 410}}) == (
+        '{"code": "410", "message": "too old", "reason": "Gone"}'
+    )
+    assert _format_watch_error({"type": "ERROR"}) == "unknown Kubernetes watch error"
+    assert _build_event_source_insert_id({"metadata": {"uid": "uid-a"}}) == "kubernetes-event:uid-a"
+    assert _build_event_source_insert_id(
+        {"metadata": {"namespace": "ns", "name": "event-name", "resourceVersion": "rv"}}
+    ) == "kubernetes-event:ns:event-name:rv"
+    assert _build_event_source_insert_id({"metadata": {}}) is None
+
+    monkeypatch.setenv("CI_DASHBOARD_POD_WATCH_RETRY_DELAY_SECONDS", "1")
+    stop_event = threading.Event()
+    stop_event.set()
+    _sleep_until_retry(stop_event)
+
+
+def test_normalize_pod_object_preserves_creation_time_and_metadata() -> None:
+    snapshot = _normalize_pod_object(
+        {
+            "metadata": {
+                "namespace": "jenkins-tidb",
+                "name": "agent-pod",
+                "uid": "uid-a",
+                "creationTimestamp": "2026-05-01T01:02:03Z",
+                "labels": {"org": "pingcap", "repo": "tidb"},
+                "annotations": {"ci_job": "pingcap/tidb/ghpr_unit_test"},
+            }
+        },
+        context=_runtime_context(),
+    )
+
+    assert snapshot is not None
+    assert snapshot.identity == (
+        "pingcap-testing-account",
+        "jenkins-tidb",
+        "uid-a",
+        "agent-pod",
+    )
+    assert snapshot.snapshot.creation_timestamp == datetime(2026, 5, 1, 1, 2, 3)
+    assert snapshot.snapshot.labels == {"org": "pingcap", "repo": "tidb"}
+    assert snapshot.snapshot.annotations == {"ci_job": "pingcap/tidb/ghpr_unit_test"}
+
+
+def test_normalize_kubernetes_event_uses_core_event_fields() -> None:
+    normalized = _normalize_kubernetes_event(
+        {
+            "metadata": {
+                "namespace": "jenkins-tidb",
+                "name": "agent-pod.17f",
+                "uid": "event-uid",
+                "resourceVersion": "12345",
+                "creationTimestamp": "2026-05-01T01:02:08Z",
+            },
+            "involvedObject": {
+                "kind": "Pod",
+                "namespace": "jenkins-tidb",
+                "name": "agent-pod",
+                "uid": "uid-a",
+            },
+            "reason": "ImagePullBackOff",
+            "type": "Warning",
+            "message": "Back-off pulling image",
+            "lastTimestamp": "2026-05-01T01:02:10Z",
+            "firstTimestamp": "2026-05-01T01:02:09Z",
+            "source": {"component": "kubelet", "host": "node-a"},
+        },
+        context=_runtime_context(),
+    )
+
+    assert normalized is not None
+    assert normalized.source_project == "pingcap-testing-account"
+    assert normalized.namespace_name == "jenkins-tidb"
+    assert normalized.pod_name == "agent-pod"
+    assert normalized.pod_uid == "uid-a"
+    assert normalized.event_reason == "ImagePullBackOff"
+    assert normalized.event_timestamp == datetime(2026, 5, 1, 1, 2, 10)
+    assert normalized.source_insert_id == "kubernetes-event:event-uid:12345"
+    assert normalized.reporting_component == "kubelet"
+    assert normalized.reporting_instance == "node-a"
+
+
+def test_snapshot_lifecycle_keeps_metadata_when_events_arrive_later(sqlite_engine) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_builds (
+                  source_prow_row_id, source_prow_job_id, namespace, job_name, job_type, state,
+                  optional, report, org, repo, repo_full_name, url, normalized_build_url,
+                  pod_name, start_time, cloud_phase, build_system
+                ) VALUES (
+                  10, 'prow-job-jenkins-42', 'apps',
+                  'ghpr_unit_test', 'presubmit', 'success',
+                  0, 1, 'pingcap', 'tidb', 'pingcap/tidb',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/42/',
+                  'https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/42/',
+                  'opaque-prow-pod', '2026-05-01T01:00:00Z', 'GCP', 'JENKINS'
+                )
+                """
+            )
+        )
+
+    snapshot = WatchedPodSnapshot(
+        source_project="pingcap-testing-account",
+        cluster_name="prow",
+        location="us-central1-c",
+        namespace_name="jenkins-tidb",
+        pod_name="agent-pod",
+        pod_uid="uid-a",
+        snapshot=PodMetadataSnapshot(
+            pod_uid="uid-a",
+            labels={
+                "author": "alice",
+                "org": "pingcap",
+                "repo": "tidb",
+                "jenkins/label": "pingcap_tidb_ghpr_unit_test_42-abcd",
+            },
+            annotations={
+                "buildUrl": "http://jenkins.jenkins.svc.cluster.local:80/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/42/",
+                "ci_job": "pingcap/tidb/ghpr_unit_test",
+            },
+            observed_at=datetime(2026, 5, 1, 1, 0, 2),
+            creation_timestamp=datetime(2026, 5, 1, 1, 0, 1),
+        ),
+    )
+
+    assert _persist_pod_snapshots(sqlite_engine, _settings(), [snapshot]) == 1
+
+    rows = [
+        NormalizedPodEvent(
+            source_project="pingcap-testing-account",
+            cluster_name="prow",
+            location="us-central1-c",
+            namespace_name="jenkins-tidb",
+            pod_name="agent-pod",
+            pod_uid="uid-a",
+            event_reason="Scheduled",
+            event_type="Normal",
+            event_message="Successfully assigned",
+            event_timestamp=datetime(2026, 5, 1, 1, 0, 5),
+            receive_timestamp=datetime(2026, 5, 1, 1, 0, 6),
+            first_timestamp=datetime(2026, 5, 1, 1, 0, 5),
+            last_timestamp=datetime(2026, 5, 1, 1, 0, 5),
+            reporting_component="default-scheduler",
+            reporting_instance="scheduler",
+            source_insert_id="kubernetes-event:sched",
+        ),
+        NormalizedPodEvent(
+            source_project="pingcap-testing-account",
+            cluster_name="prow",
+            location="us-central1-c",
+            namespace_name="jenkins-tidb",
+            pod_name="agent-pod",
+            pod_uid="uid-a",
+            event_reason="Started",
+            event_type="Normal",
+            event_message="Started container",
+            event_timestamp=datetime(2026, 5, 1, 1, 0, 25),
+            receive_timestamp=datetime(2026, 5, 1, 1, 0, 26),
+            first_timestamp=datetime(2026, 5, 1, 1, 0, 25),
+            last_timestamp=datetime(2026, 5, 1, 1, 0, 25),
+            reporting_component="kubelet",
+            reporting_instance="node-a",
+            source_insert_id="kubernetes-event:started",
+        ),
+    ]
+
+    assert _persist_pod_events(sqlite_engine, _settings(), rows) == (2, 1, 1)
+
+    with sqlite_engine.begin() as connection:
+        lifecycle = connection.execute(
+            text(
+                """
+                SELECT
+                  pod_created_at,
+                  pod_author,
+                  ci_job,
+                  source_prow_job_id,
+                  normalized_build_url,
+                  scheduled_at,
+                  first_started_at,
+                  schedule_to_started_seconds
+                FROM ci_l1_pod_lifecycle
+                WHERE pod_uid = 'uid-a'
+                """
+            )
+        ).mappings().one()
+
+    assert str(lifecycle["pod_created_at"]) == "2026-05-01 01:00:01"
+    assert lifecycle["pod_author"] == "alice"
+    assert lifecycle["ci_job"] == "pingcap/tidb/ghpr_unit_test"
+    assert lifecycle["source_prow_job_id"] == "prow-job-jenkins-42"
+    assert lifecycle["normalized_build_url"] == (
+        "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/42/"
+    )
+    assert str(lifecycle["scheduled_at"]) == "2026-05-01 01:00:05"
+    assert str(lifecycle["first_started_at"]) == "2026-05-01 01:00:25"
+    assert lifecycle["schedule_to_started_seconds"] == 20
+
+
+def test_build_lifecycle_rows_for_snapshots_uses_existing_event_aggregates(sqlite_engine) -> None:
+    snapshot = WatchedPodSnapshot(
+        source_project="pingcap-testing-account",
+        cluster_name="prow",
+        location="us-central1-c",
+        namespace_name="prow-test-pods",
+        pod_name="prow-pod",
+        pod_uid="uid-prow",
+        snapshot=PodMetadataSnapshot(
+            pod_uid="uid-prow",
+            labels={"prow.k8s.io/job": "ghpr_unit_test"},
+            annotations={},
+            observed_at=datetime(2026, 5, 1, 1, 0, 2),
+            creation_timestamp=datetime(2026, 5, 1, 1, 0, 1),
+        ),
+    )
+    event = NormalizedPodEvent(
+        source_project="pingcap-testing-account",
+        cluster_name="prow",
+        location="us-central1-c",
+        namespace_name="prow-test-pods",
+        pod_name="prow-pod",
+        pod_uid="uid-prow",
+        event_reason="Scheduled",
+        event_type="Normal",
+        event_message="Successfully assigned",
+        event_timestamp=datetime(2026, 5, 1, 1, 0, 5),
+        receive_timestamp=datetime(2026, 5, 1, 1, 0, 6),
+        first_timestamp=datetime(2026, 5, 1, 1, 0, 5),
+        last_timestamp=datetime(2026, 5, 1, 1, 0, 5),
+        reporting_component="default-scheduler",
+        reporting_instance="scheduler",
+        source_insert_id="kubernetes-event:prow-sched",
+    )
+    _persist_pod_events(sqlite_engine, _settings(), [event])
+
+    with sqlite_engine.begin() as connection:
+        rows = _build_lifecycle_rows_for_snapshots(connection, [snapshot])
+
+    assert len(rows) == 1
+    assert rows[0]["scheduled_at"] == datetime(2026, 5, 1, 1, 0, 5)
+    assert rows[0]["pod_created_at"] == datetime(2026, 5, 1, 1, 0, 1)


### PR DESCRIPTION
## Summary
- add a long-running `watch-pods` job that watches live Kubernetes Pods and Events into existing pod lifecycle/event tables
- persist Pod metadata, labels, annotations, and `metadata.creationTimestamp` as `pod_created_at`
- add Deployment/RBAC renderers, health endpoints, liveness/readiness probes, and rollout docs

## Smoke
- applied RBAC for `apps/ci-dashboard` to read `pods/events` in `prow-test-pods`, `jenkins-tidb`, and `jenkins-tiflow`
- ran temporary smoke image: `us-docker.pkg.dev/pingcap-testing-account/internal/test/ci-dashboard-jobs:pod-watcher-smoke-20260501-020919`
- one-shot smoke job completed successfully: `ci-dashboard-pod-watcher-smoke-20260501-0215`
- DB verification after smoke: 141 recent lifecycle rows, 141/141 with `pod_created_at`; 670 recent Kubernetes event rows; `ci-watch-pods` state succeeded
- canary Deployment currently running in `apps`: `ci-dashboard-pod-watcher`, 1/1 ready, 0 restarts

## Tests
- `/Users/dillon/.pyenv/shims/python3.12 -m ruff check .`
- `PYTHONPATH=src /Users/dillon/.pyenv/shims/python3.12 -m coverage run --source=src/ci_dashboard -m pytest -q`
- `/Users/dillon/.pyenv/shims/python3.12 -m coverage report --fail-under=90 --show-missing` (91%)