### PR TITLE
fix(ci-dashboard): repair pod watcher SQL and bump 0.3.1

### DIFF
--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-dashboard"
-version = "0.2.1"
+version = "0.3.1"
 description = "CI dashboard jobs and API scaffold"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
+++ b/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: ci-dashboard
-Version: 0.2.1
+Version: 0.3.1
 Summary: CI dashboard jobs and API scaffold
 Requires-Python: >=3.11
 Description-Content-Type: text/markdown

--- a/ci-dashboard/src/ci_dashboard/__init__.py
+++ b/ci-dashboard/src/ci_dashboard/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.1"
+__version__ = "0.3.1"

--- a/ci-dashboard/src/ci_dashboard/api/main.py
+++ b/ci-dashboard/src/ci_dashboard/api/main.py
@@ -71,7 +71,7 @@ def _attach_frontend(app: FastAPI) -> None:
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="CI Dashboard", version="0.2.1")
+    app = FastAPI(title="CI Dashboard", version="0.3.1")
 
     app.include_router(status_router)
     app.include_router(filters_router)

--- a/ci-dashboard/src/ci_dashboard/jobs/sync_pods.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/sync_pods.py
@@ -716,9 +716,7 @@ def _load_lifecycle_aggregates(
         return _load_single_lifecycle_aggregate(connection, pods[0])
 
     requested_pods_sql, params = _build_requested_pods_relation(pods)
-    events_table = "ci_l1_pod_events AS events"
-    if connection.dialect.name != "sqlite":
-        events_table = "ci_l1_pod_events USE INDEX(idx_ci_l1_pod_events_identity_time) AS events"
+    events_table = _pod_events_table_expr(connection.dialect.name)
     statement = text(
         f"""
         WITH requested_pods AS (
@@ -763,9 +761,7 @@ def _load_single_lifecycle_aggregate(
     pod: tuple[str, str | None, str | None, str | None],
 ) -> list[dict[str, Any]]:
     source_project, namespace_name, pod_uid, pod_name = pod
-    events_table = "ci_l1_pod_events AS events"
-    if connection.dialect.name != "sqlite":
-        events_table = "ci_l1_pod_events USE INDEX(idx_ci_l1_pod_events_identity_time) AS events"
+    events_table = _pod_events_table_expr(connection.dialect.name)
     statement = text(
         f"""
         SELECT
@@ -807,6 +803,13 @@ def _load_single_lifecycle_aggregate(
         },
     ).mappings()
     return [dict(row) for row in rows]
+
+
+def _pod_events_table_expr(dialect_name: str) -> str:
+    table = "ci_l1_pod_events AS events"
+    if dialect_name != "sqlite":
+        table = "ci_l1_pod_events events USE INDEX(idx_ci_l1_pod_events_identity_time)"
+    return table
 
 
 def _build_requested_pods_relation(

--- a/ci-dashboard/tests/jobs/test_sync_pods.py
+++ b/ci-dashboard/tests/jobs/test_sync_pods.py
@@ -40,6 +40,7 @@ from ci_dashboard.jobs.sync_pods import (
     _normalize_jenkins_runtime_url,
     _null_safe_equals_sql,
     _parse_jenkins_pod_name_build_ref,
+    _pod_events_table_expr,
     _post_json,
     _read_int_env,
     _request_json,
@@ -227,6 +228,8 @@ def test_sync_pod_helper_functions_cover_common_edge_cases(sqlite_engine, monkey
     assert _max_receive_timestamp([]) is None
     assert _null_safe_equals_sql("a", "b", "sqlite") == "a IS b"
     assert _null_safe_equals_sql("a", "b", "mysql") == "a <=> b"
+    assert _pod_events_table_expr("sqlite") == "ci_l1_pod_events AS events"
+    assert _pod_events_table_expr("mysql") == "ci_l1_pod_events events USE INDEX(idx_ci_l1_pod_events_identity_time)"
     assert {"Failed", "BackOff", "ErrImagePull", "ImagePullBackOff"}.issubset(POD_EVENT_REASONS)
     relation_sql, params = _build_requested_pods_relation([("p1", "ns", "uid", "pod")])
     assert "UNION ALL" not in relation_sql

--- a/ci-dashboard/web/package-lock.json
+++ b/ci-dashboard/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-dashboard-web",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- repair the TiDB pod watcher lifecycle query by using the correct table alias and `USE INDEX` order
- cover the pod events table expression with a regression test
- bump the ci-dashboard app and web release version from `0.2.1` to `0.3.1`

## Testing
- `PYTHONPATH=src uv run pytest tests/jobs/test_sync_pods.py`
- `PYTHONPATH=src uv run pytest tests/api/test_routes.py -k navigation_page_`
- `npm run build`