### PR TITLE
fix(ci-dashboard): optimize slow pod lifecycle and build lookup queries

### DIFF
--- a/ci-dashboard/sql/019_add_build_system_state_index.sql
+++ b/ci-dashboard/sql/019_add_build_system_state_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_ci_l1_builds_build_system_state_start_id
+  ON ci_l1_builds (build_system, state, start_time DESC, id DESC);

--- a/ci-dashboard/sql/020_add_state_review_index.sql
+++ b/ci-dashboard/sql/020_add_state_review_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_ci_l1_builds_state_review_time_id
+  ON ci_l1_builds (state, revise_error_l1_category, revise_error_l2_subcategory, start_time DESC, id DESC);

--- a/ci-dashboard/sql/021_add_prow_jobs_prow_job_id_index.sql
+++ b/ci-dashboard/sql/021_add_prow_jobs_prow_job_id_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_prow_jobs_prow_job_id
+  ON prow_jobs (prowJobId);

--- a/ci-dashboard/src/ci_dashboard/jobs/analyze_errors.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/analyze_errors.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 
 FAILURE_LIKE_STATES = ("failure", "error", "timeout", "timed_out", "aborted")
 
-FETCH_CANDIDATE_BUILDS = text(
+FETCH_CANDIDATE_BUILDS_SCAN = text(
     """
     SELECT b.id, b.source_prow_job_id, b.job_name, b.job_type, b.repo_full_name,
            b.pr_number, b.head_sha, b.url, b.log_gcs_uri,
@@ -64,10 +64,61 @@ FETCH_CANDIDATE_BUILDS = text(
       AND b.state IN :failure_states
       AND b.revise_error_l1_category IS NULL
       AND b.revise_error_l2_subcategory IS NULL
-      AND (:build_id IS NULL OR b.id = :build_id)
       AND (:force = 1 OR b.error_l1_category IS NULL OR b.error_l2_subcategory IS NULL)
     ORDER BY b.start_time DESC, b.id DESC
     LIMIT :limit_value
+    """
+).bindparams(bindparam("failure_states", expanding=True))
+
+FETCH_CANDIDATE_BUILD_BY_ID = text(
+    """
+    SELECT b.id, b.source_prow_job_id, b.job_name, b.job_type, b.repo_full_name,
+           b.pr_number, b.head_sha, b.url, b.log_gcs_uri,
+           b.error_l1_category, b.error_l2_subcategory,
+           b.revise_error_l1_category, b.revise_error_l2_subcategory,
+           pj.state AS prow_state, pj.status AS prow_status,
+           CASE
+             WHEN EXISTS (
+               SELECT 1
+               FROM ci_l1_builds newer
+               WHERE newer.repo_full_name = b.repo_full_name
+                 AND newer.pr_number = b.pr_number
+                 AND newer.job_name = b.job_name
+                 AND newer.start_time > b.start_time
+                 AND newer.id <> b.id
+             ) THEN 1 ELSE 0
+           END AS has_newer_pr_job_version,
+           CASE
+             WHEN EXISTS (
+               SELECT 1
+               FROM ci_l1_builds newer
+               WHERE newer.repo_full_name = b.repo_full_name
+                 AND newer.pr_number = b.pr_number
+                 AND newer.job_name = b.job_name
+                 AND newer.start_time > b.start_time
+                 AND newer.id <> b.id
+                 AND COALESCE(newer.head_sha, '') <> COALESCE(b.head_sha, '')
+             ) THEN 1 ELSE 0
+           END AS has_newer_pr_job_version_with_different_sha
+    FROM ci_l1_builds b
+    LEFT JOIN prow_jobs pj ON pj.prowJobId = b.source_prow_job_id
+    WHERE b.id = :build_id
+      AND b.state IN :failure_states
+      AND b.revise_error_l1_category IS NULL
+      AND b.revise_error_l2_subcategory IS NULL
+      AND (b.log_gcs_uri IS NOT NULL OR (
+        pj.state = 'aborted'
+        AND EXISTS (
+          SELECT 1
+          FROM ci_l1_builds newer
+          WHERE newer.repo_full_name = b.repo_full_name
+            AND newer.pr_number = b.pr_number
+            AND newer.job_name = b.job_name
+            AND newer.start_time > b.start_time
+            AND newer.id <> b.id
+        )
+      ))
+      AND (:force = 1 OR b.error_l1_category IS NULL OR b.error_l2_subcategory IS NULL)
     """
 ).bindparams(bindparam("failure_states", expanding=True))
 
@@ -110,17 +161,28 @@ def run_analyze_errors(
     pending_updates: list[dict[str, Any]] = []
 
     with engine.begin() as connection:
-        candidates = list(
-            connection.execute(
-                FETCH_CANDIDATE_BUILDS,
-                {
-                    "failure_states": FAILURE_LIKE_STATES,
-                    "build_id": build_id,
-                    "force": 1 if force else 0,
-                    "limit_value": resolved_limit,
-                },
-            ).mappings()
-        )
+        if build_id is not None:
+            candidates = list(
+                connection.execute(
+                    FETCH_CANDIDATE_BUILD_BY_ID,
+                    {
+                        "failure_states": FAILURE_LIKE_STATES,
+                        "build_id": build_id,
+                        "force": 1 if force else 0,
+                    },
+                ).mappings()
+            )
+        else:
+            candidates = list(
+                connection.execute(
+                    FETCH_CANDIDATE_BUILDS_SCAN,
+                    {
+                        "failure_states": FAILURE_LIKE_STATES,
+                        "force": 1 if force else 0,
+                        "limit_value": resolved_limit,
+                    },
+                ).mappings()
+            )
 
     if not candidates:
         return summary

--- a/ci-dashboard/src/ci_dashboard/jobs/archive_error_logs.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/archive_error_logs.py
@@ -17,14 +17,25 @@ LOG = logging.getLogger(__name__)
 
 FAILURE_LIKE_STATES = ("failure", "error", "timeout", "timed_out", "aborted")
 
-FETCH_CANDIDATE_BUILDS = text(
+FETCH_CANDIDATE_BUILD_BY_ID = text(
+    """
+    SELECT id, url, normalized_build_url, log_gcs_uri, state, build_system,
+           start_time, completion_time
+    FROM ci_l1_builds
+    WHERE id = :build_id
+      AND build_system = 'JENKINS'
+      AND state IN :failure_states
+      AND (:force = 1 OR log_gcs_uri IS NULL)
+    """
+).bindparams(bindparam("failure_states", expanding=True))
+
+FETCH_CANDIDATE_BUILDS_SCAN = text(
     """
     SELECT id, url, normalized_build_url, log_gcs_uri, state, build_system,
            start_time, completion_time
     FROM ci_l1_builds
     WHERE build_system = 'JENKINS'
       AND state IN :failure_states
-      AND (:build_id IS NULL OR id = :build_id)
       AND (:force = 1 OR log_gcs_uri IS NULL)
     ORDER BY start_time DESC, id DESC
     LIMIT :limit_value
@@ -65,17 +76,28 @@ def run_archive_error_logs(
     resolved_limit = limit or settings.archive.build_limit
 
     with engine.begin() as connection:
-        candidates = list(
-            connection.execute(
-                FETCH_CANDIDATE_BUILDS.bindparams(),
-                {
-                    "failure_states": FAILURE_LIKE_STATES,
-                    "build_id": build_id,
-                    "force": 1 if force else 0,
-                    "limit_value": resolved_limit,
-                },
-            ).mappings()
-        )
+        if build_id is not None:
+            candidates = list(
+                connection.execute(
+                    FETCH_CANDIDATE_BUILD_BY_ID,
+                    {
+                        "build_id": build_id,
+                        "failure_states": FAILURE_LIKE_STATES,
+                        "force": 1 if force else 0,
+                    },
+                ).mappings()
+            )
+        else:
+            candidates = list(
+                connection.execute(
+                    FETCH_CANDIDATE_BUILDS_SCAN,
+                    {
+                        "failure_states": FAILURE_LIKE_STATES,
+                        "force": 1 if force else 0,
+                        "limit_value": resolved_limit,
+                    },
+                ).mappings()
+            )
 
     if not candidates:
         return summary

--- a/ci-dashboard/src/ci_dashboard/jobs/sync_pods.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/sync_pods.py
@@ -67,6 +67,7 @@ POD_NAME_BUILD_NUMBER_MIN_DIGITS = 2
 POD_LINK_RECONCILE_WINDOW_HOURS = 72
 POD_LINK_RECONCILE_BATCH_SIZE = 1000
 JENKINS_POD_NAME_PREFIX_LOOKBACK_DAYS = 30
+BUILD_URL_LOOKBACK_DAYS = 30
 
 
 @dataclass(frozen=True)
@@ -706,6 +707,51 @@ def _build_ci_job_from_build_metadata(build_meta: dict[str, Any]) -> str | None:
     return canonicalized if canonicalized and "/" in canonicalized else None
 
 
+_MAX_LIFECYCLE_UNION_PODS = 50
+
+_LIFECYCLE_AGGREGATE_SUFFIX = """\
+  MIN(CASE WHEN events.event_reason = 'Scheduled' THEN events.event_timestamp END) AS scheduled_at,
+  MIN(CASE WHEN events.event_reason = 'Pulling' THEN events.event_timestamp END) AS first_pulling_at,
+  MIN(CASE WHEN events.event_reason = 'Pulled' THEN events.event_timestamp END) AS first_pulled_at,
+  MIN(CASE WHEN events.event_reason = 'Created' THEN events.event_timestamp END) AS first_created_at,
+  MIN(CASE WHEN events.event_reason = 'Started' THEN events.event_timestamp END) AS first_started_at,
+  MAX(CASE WHEN events.event_reason = 'FailedScheduling' THEN events.event_timestamp END) AS last_failed_scheduling_at,
+  SUM(CASE WHEN events.event_reason = 'FailedScheduling' THEN 1 ELSE 0 END) AS failed_scheduling_count,
+  MAX(events.event_timestamp) AS last_event_at
+FROM {events_table}
+WHERE {where_clause}
+GROUP BY
+  events.source_project,
+  events.cluster_name,
+  events.location,
+  events.namespace_name,
+  events.pod_name,
+  events.pod_uid"""
+
+
+def _build_lifecycle_aggregate_where(
+    index: int,
+    source_project: str,
+    namespace_name: str | None,
+    pod_uid: str | None,
+    pod_name: str | None,
+) -> tuple[str, dict[str, Any]]:
+    conditions: list[str] = [f"events.source_project = :sp_{index}"]
+    params: dict[str, Any] = {f"sp_{index}": source_project}
+    for col, val in [
+        ("namespace_name", namespace_name),
+        ("pod_uid", pod_uid),
+        ("pod_name", pod_name),
+    ]:
+        if val is None:
+            conditions.append(f"events.{col} IS NULL")
+        else:
+            param = f"{col}_{index}"
+            conditions.append(f"events.{col} = :{param}")
+            params[param] = val
+    return "\n      AND ".join(conditions), params
+
+
 def _load_lifecycle_aggregates(
     connection: Connection,
     pods: list[tuple[str, str | None, str | None, str | None]],
@@ -715,45 +761,32 @@ def _load_lifecycle_aggregates(
     if len(pods) == 1:
         return _load_single_lifecycle_aggregate(connection, pods[0])
 
-    requested_pods_sql, params = _build_requested_pods_relation(pods)
+    all_rows: list[dict[str, Any]] = []
     events_table = _pod_events_table_expr(connection.dialect.name)
-    statement = text(
-        f"""
-        WITH requested_pods AS (
-          {requested_pods_sql}
-        )
-        SELECT
-          events.source_project,
-          events.cluster_name,
-          events.location,
-          events.namespace_name,
-          events.pod_name,
-          events.pod_uid,
-          MIN(CASE WHEN events.event_reason = 'Scheduled' THEN events.event_timestamp END) AS scheduled_at,
-          MIN(CASE WHEN events.event_reason = 'Pulling' THEN events.event_timestamp END) AS first_pulling_at,
-          MIN(CASE WHEN events.event_reason = 'Pulled' THEN events.event_timestamp END) AS first_pulled_at,
-          MIN(CASE WHEN events.event_reason = 'Created' THEN events.event_timestamp END) AS first_created_at,
-          MIN(CASE WHEN events.event_reason = 'Started' THEN events.event_timestamp END) AS first_started_at,
-          MAX(CASE WHEN events.event_reason = 'FailedScheduling' THEN events.event_timestamp END) AS last_failed_scheduling_at,
-          SUM(CASE WHEN events.event_reason = 'FailedScheduling' THEN 1 ELSE 0 END) AS failed_scheduling_count,
-          MAX(events.event_timestamp) AS last_event_at
-        FROM {events_table}
-        JOIN requested_pods AS requested
-          ON events.source_project = requested.source_project
-         AND {_null_safe_equals_sql('events.namespace_name', 'requested.namespace_name', connection.dialect.name)}
-         AND {_null_safe_equals_sql('events.pod_uid', 'requested.pod_uid', connection.dialect.name)}
-         AND {_null_safe_equals_sql('events.pod_name', 'requested.pod_name', connection.dialect.name)}
-        GROUP BY
-          events.source_project,
-          events.cluster_name,
-          events.location,
-          events.namespace_name,
-          events.pod_name,
-          events.pod_uid
-        """
-    )
-    rows = connection.execute(statement, params).mappings()
-    return [dict(row) for row in rows]
+    for offset in range(0, len(pods), _MAX_LIFECYCLE_UNION_PODS):
+        sub_batch = pods[offset : offset + _MAX_LIFECYCLE_UNION_PODS]
+        branches: list[str] = []
+        params: dict[str, Any] = {}
+        for index, (source_project, namespace_name, pod_uid, pod_name) in enumerate(sub_batch):
+            where_clause, branch_params = _build_lifecycle_aggregate_where(
+                index, source_project, namespace_name, pod_uid, pod_name
+            )
+            params.update(branch_params)
+            branches.append(
+                f"""\
+SELECT
+  events.source_project,
+  events.cluster_name,
+  events.location,
+  events.namespace_name,
+  events.pod_name,
+  events.pod_uid,
+{_LIFECYCLE_AGGREGATE_SUFFIX.format(events_table=events_table, where_clause=where_clause)}"""
+            )
+        sql = "\nUNION ALL\n".join(branches)
+        rows = connection.execute(text(sql), params).mappings()
+        all_rows.extend(dict(row) for row in rows)
+    return all_rows
 
 
 def _load_single_lifecycle_aggregate(
@@ -901,6 +934,21 @@ def _load_build_metadata_map(
             if candidate_urls:
                 candidate_urls_by_identity[identity] = candidate_urls
 
+        jenkins_scheduled_ats = [
+            payload.get("scheduled_at")
+            for payload in jenkins_rows_by_identity.values()
+            if isinstance(payload.get("scheduled_at"), datetime)
+        ]
+        if jenkins_scheduled_ats:
+            earliest_scheduled = min(jenkins_scheduled_ats)
+            lookback_days = _read_int_env(
+                "CI_DASHBOARD_BUILD_URL_LOOKBACK_DAYS",
+                BUILD_URL_LOOKBACK_DAYS,
+            )
+            start_time_cutoff = earliest_scheduled - timedelta(days=lookback_days)
+        else:
+            start_time_cutoff = None
+
         build_candidates_by_url = _load_build_candidates_by_normalized_url(
             connection,
             normalized_build_urls=sorted(
@@ -910,6 +958,7 @@ def _load_build_metadata_map(
                     for candidate_url in candidate_urls
                 }
             ),
+            start_time_cutoff=start_time_cutoff,
         )
         for identity, payload in jenkins_rows_by_identity.items():
             resolved = _resolve_jenkins_build_metadata(
@@ -984,11 +1033,19 @@ def _load_build_candidates_by_normalized_url(
     connection: Connection,
     *,
     normalized_build_urls: list[str],
+    start_time_cutoff: datetime | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     if not normalized_build_urls:
         return {}
 
-    params: dict[str, Any] = {}
+    if start_time_cutoff is None:
+        lookback_days = _read_int_env(
+            "CI_DASHBOARD_BUILD_URL_LOOKBACK_DAYS",
+            BUILD_URL_LOOKBACK_DAYS,
+        )
+        start_time_cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=lookback_days)
+
+    params: dict[str, Any] = {"start_time_cutoff": start_time_cutoff}
     placeholders: list[str] = []
     for index, normalized_build_url in enumerate(normalized_build_urls):
         param_name = f"normalized_build_url_{index}"
@@ -1010,6 +1067,7 @@ def _load_build_candidates_by_normalized_url(
             FROM ci_l1_builds
             WHERE normalized_build_url IS NOT NULL
               AND normalized_build_url IN ({", ".join(placeholders)})
+              AND start_time >= :start_time_cutoff
             ORDER BY start_time DESC
             """
         ),


### PR DESCRIPTION
## Summary

- P0: Rewrite `_load_lifecycle_aggregates` batch path from CTE + JOIN + `<=>` to UNION ALL of single-pod aggregations with `=`/`IS NULL` predicates — targets 93% of slow queries (cumulative ~2767s)
- P1: Add `idx_ci_l1_builds_build_system_state_start_id` index + split archive query into build_id point-lookup and scan templates
- P2: Add `idx_ci_l1_builds_state_review_time_id` index + split analyze_errors query into build_id point-lookup and scan templates
- P3: Bound `_load_build_candidates_by_normalized_url` time window to pod `scheduled_at` to avoid pulling full build history
- P4: Add `idx_prow_jobs_prow_job_id` index for analyze_errors LEFT JOIN

## Test plan

- [x] All existing tests pass (52 tests across test_sync_pods, test_archive_error_logs, test_analyze_errors, test_pod_watcher)
- [x] Combined coverage for modified files: 90%
- [ ] Verify slow query log after deployment shows reduced pod lifecycle query latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)