### PR TITLE
fix(ci-dashboard): correct CI failure misclassification

### DIFF
--- a/ci-dashboard/src/ci_dashboard/jobs/analyze_errors.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/analyze_errors.py
@@ -64,7 +64,27 @@ FETCH_CANDIDATE_BUILDS_SCAN = text(
       AND b.state IN :failure_states
       AND b.revise_error_l1_category IS NULL
       AND b.revise_error_l2_subcategory IS NULL
-      AND (:force = 1 OR b.error_l1_category IS NULL OR b.error_l2_subcategory IS NULL)
+      AND (
+        :force = 1
+        OR b.error_l1_category IS NULL
+        OR b.error_l2_subcategory IS NULL
+        OR (
+          pj.state = 'aborted'
+          AND EXISTS (
+            SELECT 1
+            FROM ci_l1_builds newer
+            WHERE newer.repo_full_name = b.repo_full_name
+              AND newer.pr_number = b.pr_number
+              AND newer.job_name = b.job_name
+              AND newer.start_time > b.start_time
+              AND newer.id <> b.id
+          )
+          AND (
+            COALESCE(b.error_l1_category, '') <> 'OTHERS'
+            OR COALESCE(b.error_l2_subcategory, '') <> 'SUPERSEDED_BY_NEWER_BUILD'
+          )
+        )
+      )
     ORDER BY b.start_time DESC, b.id DESC
     LIMIT :limit_value
     """
@@ -118,7 +138,27 @@ FETCH_CANDIDATE_BUILD_BY_ID = text(
             AND newer.id <> b.id
         )
       ))
-      AND (:force = 1 OR b.error_l1_category IS NULL OR b.error_l2_subcategory IS NULL)
+      AND (
+        :force = 1
+        OR b.error_l1_category IS NULL
+        OR b.error_l2_subcategory IS NULL
+        OR (
+          pj.state = 'aborted'
+          AND EXISTS (
+            SELECT 1
+            FROM ci_l1_builds newer
+            WHERE newer.repo_full_name = b.repo_full_name
+              AND newer.pr_number = b.pr_number
+              AND newer.job_name = b.job_name
+              AND newer.start_time > b.start_time
+              AND newer.id <> b.id
+          )
+          AND (
+            COALESCE(b.error_l1_category, '') <> 'OTHERS'
+            OR COALESCE(b.error_l2_subcategory, '') <> 'SUPERSEDED_BY_NEWER_BUILD'
+          )
+        )
+      )
     """
 ).bindparams(bindparam("failure_states", expanding=True))
 
@@ -199,6 +239,9 @@ def run_analyze_errors(
     for build in candidates:
         summary.builds_scanned += 1
         enriched_build = _enrich_build_evidence(build)
+        if not force and not _should_refresh_existing_machine_classification(enriched_build):
+            summary.builds_skipped += 1
+            continue
         try:
             classification_source, classification = _classify_single_build(
                 enriched_build,
@@ -324,6 +367,31 @@ def _parse_json_mapping(value: Any) -> Mapping[str, Any]:
         if isinstance(parsed, Mapping):
             return parsed
     return {}
+
+
+def _should_refresh_existing_machine_classification(build: Mapping[str, Any]) -> bool:
+    error_l1 = str(build.get("error_l1_category") or "").strip().upper()
+    error_l2 = str(build.get("error_l2_subcategory") or "").strip().upper()
+    if not error_l1 or not error_l2:
+        return True
+    if error_l1 == "OTHERS" and error_l2 == "SUPERSEDED_BY_NEWER_BUILD":
+        return False
+
+    prow_state = str(build.get("prow_state") or "").strip().lower()
+    if prow_state != "aborted":
+        return False
+
+    if str(build.get("has_newer_pr_job_version_with_different_sha") or "").strip().lower() in {"1", "true"}:
+        return True
+
+    status_description = str(build.get("prow_status_description") or "").strip()
+    if (
+        status_description == "Aborted as the newer version of this job is running."
+        and str(build.get("has_newer_pr_job_version") or "").strip().lower() in {"1", "true"}
+    ):
+        return True
+
+    return False
 
 
 def _normalize_review_category(value: str) -> str:

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -223,6 +223,18 @@
       ]
     },
     {
+      "name": "cdc_mysql_integration_light_test_failure",
+      "l1": "IT",
+      "l2": "TEST_FAILURE",
+      "job_name_patterns": [
+        "(^|/)pull_cdc_mysql_integration_light$",
+        "(^|_)pull_cdc_mysql_integration_light($|_)"
+      ],
+      "text_patterns": [
+        "Failed in branch Matrix - TEST_GROUP = '[^']+'"
+      ]
+    },
+    {
       "name": "merged_integration_test_failure",
       "l1": "IT",
       "l2": "TEST_FAILURE",
@@ -352,8 +364,6 @@
         "groovy\\.lang\\.(MissingPropertyException|MissingMethodException|GroovyRuntimeException):",
         "No such DSL method",
         "No such property: .* for class: groovy\\.lang\\.Binding",
-        "WorkflowScript\\.run\\(WorkflowScript:[0-9]+\\)",
-        "com\\.cloudbees\\.groovy\\.cps",
         "org\\.jenkinsci\\.plugins\\.workflow\\.cps\\.CpsCompilationErrorsException"
       ]
     },

--- a/ci-dashboard/tests/jobs/test_analyze_errors.py
+++ b/ci-dashboard/tests/jobs/test_analyze_errors.py
@@ -417,6 +417,86 @@ def test_run_analyze_errors_classifies_generic_admin_abort_with_newer_sha_after_
     assert row["error_l2_subcategory"] == "SUPERSEDED_BY_NEWER_BUILD"
 
 
+def test_run_analyze_errors_overrides_existing_groovy_with_trigger_plugin_superseded(
+    sqlite_engine,
+) -> None:
+    _insert_build(
+        sqlite_engine,
+        build_id=171,
+        source_prow_job_id="trigger-race-old-prow-job",
+        job_name="pingcap/tidb/ghpr_check2",
+        job_type="presubmit",
+        pr_number=68180,
+        head_sha="old-sha",
+        start_time="2026-05-09 02:43:50",
+        completion_time="2026-05-09 02:56:49",
+        state="failure",
+        log_gcs_uri="gcs://ci-dashboard-test/2605/171.log",
+        error_l1_category="INFRA",
+        error_l2_subcategory="JENKINS_GROOVY",
+    )
+    _insert_build(
+        sqlite_engine,
+        build_id=172,
+        source_prow_job_id="trigger-race-new-prow-job",
+        job_name="pingcap/tidb/ghpr_check2",
+        job_type="presubmit",
+        pr_number=68180,
+        head_sha="new-sha",
+        start_time="2026-05-09 02:55:18",
+        completion_time="2026-05-09 03:17:48",
+        state="success",
+        log_gcs_uri="gcs://ci-dashboard-test/2605/172.log",
+    )
+    _insert_prow_job(
+        sqlite_engine,
+        row_id=904,
+        prow_job_id="trigger-race-old-prow-job",
+        job_name="pingcap/tidb/ghpr_check2",
+        state="aborted",
+        pr_number=68180,
+        start_time="2026-05-09 02:43:50",
+        description="Aborted by trigger plugin.",
+    )
+    reader = _FakeReader(
+        {
+            (
+                "ci-dashboard-test",
+                "2605/171.log",
+            ): "groovy.lang.MissingPropertyException: No such property: WORKSPACE for class: groovy.lang.Binding\n",
+        }
+    )
+    classifier = _FakeClassifier(
+        ErrorClassification(
+            l1_category="BUILD",
+            l2_subcategory="PIPELINE_CONFIG",
+            source="llm:test",
+        )
+    )
+
+    summary = run_analyze_errors(
+        sqlite_engine,
+        _settings(),
+        reader=reader,
+        rule_engine=RuleEngine.from_file(),
+        llm_classifier=classifier,
+    )
+
+    assert summary.builds_scanned == 1
+    assert summary.builds_classified == 1
+    assert summary.builds_rule_classified == 1
+    assert reader.calls == []
+    assert classifier.calls == []
+
+    with sqlite_engine.begin() as connection:
+        row = connection.execute(
+            text("SELECT error_l1_category, error_l2_subcategory FROM ci_l1_builds WHERE id = 171")
+        ).mappings().one()
+
+    assert row["error_l1_category"] == "OTHERS"
+    assert row["error_l2_subcategory"] == "SUPERSEDED_BY_NEWER_BUILD"
+
+
 def test_run_analyze_errors_skips_success_rows_even_with_archived_log(sqlite_engine) -> None:
     _insert_build(
         sqlite_engine,

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -365,6 +365,34 @@ def test_rule_engine_classifies_cdc_storage_matrix_failure_as_integration_test_f
     assert classification.source == "rule:cdc_integration_storage_test_failure"
 
 
+def test_rule_engine_classifies_cdc_mysql_integration_light_matrix_failure_as_integration_test_failure() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)\n"
+            "Failed in branch Matrix - TEST_GROUP = 'G08'\n"
+            "Error when executing failure post condition:\n"
+            "Also: java.lang.InterruptedException\n"
+            "at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl."
+            "ThrowBlock$1.receive(ThrowBlock.java:65)\n"
+            "script returned exit code 143\n"
+        ),
+        build={
+            "job_name": "pingcap/ticdc/pull_cdc_mysql_integration_light",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/ticdc/job/"
+                "pull_cdc_mysql_integration_light/1983/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "IT"
+    assert classification.l2_subcategory == "TEST_FAILURE"
+    assert classification.source == "rule:cdc_mysql_integration_light_test_failure"
+
+
 def test_rule_engine_prefers_oomkilled_over_cdc_storage_matrix_failure() -> None:
     engine = RuleEngine.from_file()
 
@@ -646,6 +674,30 @@ def test_rule_engine_classifies_jenkins_dsl_error_as_groovy_infra() -> None:
     assert classification.l1_category == "INFRA"
     assert classification.l2_subcategory == "JENKINS_GROOVY"
     assert classification.source == "rule:infra_jenkins_groovy"
+
+
+def test_rule_engine_does_not_treat_generic_workflow_cps_stack_as_groovy_infra() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "Error when executing failure post condition:\n"
+            "Also: java.lang.InterruptedException\n"
+            "at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl."
+            "ThrowBlock$1.receive(ThrowBlock.java:65)\n"
+            "at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps."
+            "CpsThread.runNextChunk(CpsThread.java:188)\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/merged_sqllogic_test",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "merged_sqllogic_test/999/"
+            ),
+        },
+    )
+
+    assert classification is None
 
 
 def test_rule_engine_prefers_jenkins_cache_over_groovy_and_remoting_noise() -> None:


### PR DESCRIPTION
## Summary
- refresh existing machine classifications when newer-build superseded metadata arrives later
- classify `pull_cdc_mysql_integration_light` matrix failures as `IT/TEST_FAILURE`
- tighten the Jenkins Groovy rule so generic `workflow-cps` post-failure stacks do not override real test failures

## Testing
- `cd ci-dashboard && PYTHONPATH=src pytest -q tests/jobs/test_rule_engine.py tests/jobs/test_analyze_errors.py`
- replayed the live `pull_cdc_mysql_integration_light #1983` console through the rule engine and confirmed it now classifies as `IT/TEST_FAILURE`
