### PR TITLE
fix(ci-dashboard): refine error taxonomy and bump 0.3.2

### DIFF
--- a/charts/ci-dashboard/Chart.yaml
+++ b/charts/ci-dashboard/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ci-dashboard
 description: CI dashboard application for prow.tidb.net/dashboard/.
 type: application
-version: 0.1.2
-appVersion: "0.1.2"
+version: 0.3.2
+appVersion: "0.3.2"

--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-dashboard"
-version = "0.3.1"
+version = "0.3.2"
 description = "CI dashboard jobs and API scaffold"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
+++ b/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: ci-dashboard
-Version: 0.3.1
+Version: 0.3.2
 Summary: CI dashboard jobs and API scaffold
 Requires-Python: >=3.11
 Description-Content-Type: text/markdown

--- a/ci-dashboard/src/ci_dashboard/__init__.py
+++ b/ci-dashboard/src/ci_dashboard/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -170,6 +170,21 @@
       ]
     },
     {
+      "name": "br_integration_test_output_failure",
+      "l1": "IT",
+      "l2": "TEST_FAILURE",
+      "job_name_patterns": [
+        "(^|/)pull_br_integration_test(_next_gen)?$",
+        "(^|_)pull_br_integration_test(_next_gen)?($|_)"
+      ],
+      "text_patterns": [
+        "TEST FAILED: OUTPUT DOES NOT CONTAIN",
+        "check data failed [1-9][0-9]*-th time",
+        "check diff failed [1-9][0-9]*-th time",
+        "run task failed [1-9][0-9]*-th time"
+      ]
+    },
+    {
       "name": "integration_test_timeout",
       "l1": "IT",
       "l2": "TIMEOUT",
@@ -279,9 +294,6 @@
       "l1": "BUILD",
       "l2": "COMPILE",
       "text_patterns": [
-        "compilepkg: missing strict dependencies:",
-        "No dependencies were provided\\.",
-        "Check that imports in Go sources match importpath attributes in deps\\.",
         "\\.go:[0-9]+:[0-9]+: undefined:",
         "\\.go:[0-9]+:[0-9]+: .* undefined( \\(type .*\\))?",
         "\\.go:[0-9]+:[0-9]+: cannot use .* as .*",
@@ -362,6 +374,7 @@
       "l2": "JENKINS_GROOVY",
       "text_patterns": [
         "groovy\\.lang\\.(MissingPropertyException|MissingMethodException|GroovyRuntimeException):",
+        "java\\.lang\\.NullPointerException:[\\s\\S]*WorkflowScript\\.run\\(WorkflowScript:[0-9]+\\)",
         "No such DSL method",
         "No such property: .* for class: groovy\\.lang\\.Binding",
         "org\\.jenkinsci\\.plugins\\.workflow\\.cps\\.CpsCompilationErrorsException"
@@ -441,8 +454,12 @@
       "l2": "DEPENDENCY",
       "text_patterns": [
         "go: updates to go\\.mod needed; to update it:",
+        "missing go\\.sum entry for module providing package",
         "no required module provides package",
         "cannot find module",
+        "compilepkg: missing strict dependencies:",
+        "No dependencies were provided\\.",
+        "Check that imports in Go sources match importpath attributes in deps\\.",
         "No matching distribution found",
         "Could not resolve dependencies",
         "failed to download module"

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -575,6 +575,33 @@ def test_rule_engine_classifies_br_integration_timeout_before_matrix_failure() -
     assert classification.source == "rule:integration_test_timeout"
 
 
+def test_rule_engine_prefers_br_output_failure_over_later_timeout_noise() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "TEST FAILED: OUTPUT DOES NOT CONTAIN 'clustered index enabled'\n"
+            "check diff failed 3-th time, retry later\n"
+            "context deadline exceeded while waiting for local test service\n"
+            "Cancelling nested steps due to timeout\n"
+            "Timeout has been exceeded\n"
+            "Failed in branch Matrix - TEST_GROUP = 'G04'\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_br_integration_test",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_br_integration_test/1010/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "IT"
+    assert classification.l2_subcategory == "TEST_FAILURE"
+    assert classification.source == "rule:br_integration_test_output_failure"
+
+
 def test_rule_engine_prefers_kubelet_eviction_over_jenkins_disconnect_noise() -> None:
     engine = RuleEngine.from_file()
 
@@ -667,6 +694,33 @@ def test_rule_engine_classifies_jenkins_dsl_error_as_groovy_infra() -> None:
         build={
             "job_name": "pingcap/tidb/merged_sqllogic_test",
             "url": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/merged_sqllogic_test/137/",
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "INFRA"
+    assert classification.l2_subcategory == "JENKINS_GROOVY"
+    assert classification.source == "rule:infra_jenkins_groovy"
+
+
+def test_rule_engine_classifies_workflowscript_null_pointer_as_groovy_infra() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "Also: org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: cc0b3589\n"
+            "java.lang.NullPointerException: Cannot invoke method getAt() on null object\n"
+            "at org.codehaus.groovy.runtime.NullObject.invokeMethod(NullObject.java:91)\n"
+            "at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl."
+            "ArrayAccessBlock.rawGet(ArrayAccessBlock.java:20)\n"
+            "at WorkflowScript.run(WorkflowScript:11)\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/merged_integration_lightning_test",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "merged_integration_lightning_test/169/"
+            ),
         },
     )
 
@@ -926,8 +980,35 @@ def test_rule_engine_matches_bazel_strict_dependency_failure() -> None:
 
     assert classification is not None
     assert classification.l1_category == "BUILD"
-    assert classification.l2_subcategory == "COMPILE"
-    assert classification.source == "rule:build_go_compile_failure"
+    assert classification.l2_subcategory == "DEPENDENCY"
+    assert classification.source == "rule:build_dependency_failure"
+
+
+def test_rule_engine_matches_missing_go_sum_dependency_failure() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "/go/pkg/mod/github.com/mattn/go-runewidth@v0.0.23/runewidth.go:8:2: "
+            "missing go.sum entry for module providing package "
+            "github.com/clipperhouse/uax29/v2/graphemes "
+            "(imported by github.com/mattn/go-runewidth); to add:\n"
+            "\tgo get github.com/mattn/go-runewidth@v0.0.23\n"
+            "make: *** [Makefile:279: enterprise-server-build] Error 1\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_build_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_build_next_gen/2240/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "DEPENDENCY"
+    assert classification.source == "rule:build_dependency_failure"
 
 
 def test_rule_engine_prefers_go_plugin_abi_mismatch_over_jenkins_remoting_warning() -> None:

--- a/ci-dashboard/web/package-lock.json
+++ b/ci-dashboard/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-dashboard-web",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- refine Jenkins error taxonomy based on sampled console review
- classify BR output-check failures before later timeout noise
- move Bazel strict-deps and missing `go.sum` cases into `BUILD/DEPENDENCY`
- keep WorkflowScript null-pointer failures in `INFRA/JENKINS_GROOVY`
- bump ci-dashboard package/chart/web version to `0.3.2`

## Validation
- `cd ci-dashboard && PYTHONPATH=src pytest -q tests/jobs/test_rule_engine.py tests/jobs/test_analyze_errors.py`

## Notes
- sampling progress and review notes were kept under local `.local/` only and are not part of this PR
