### PR TITLE
fix(publisher): support calendar semver nextgen image tags without suffix

### DIFF
--- a/publisher/internal/service/impl/tidbcloud/ops.go
+++ b/publisher/internal/service/impl/tidbcloud/ops.go
@@ -61,8 +61,6 @@ func (s *tidbcloudsrvc) UpdateComponentVersionInCloudconfig(ctx context.Context,
 	}
 	slices.Sort(components)
 
-	s.Logger.Info().Interface("components", components).Msg("debug")
-
 	componentVersion := strings.SplitN(imageTag, "-", 2)[0]
 
 	for _, component := range components {

--- a/publisher/internal/service/impl/tidbcloud/ops.go
+++ b/publisher/internal/service/impl/tidbcloud/ops.go
@@ -14,7 +14,10 @@ import (
 
 const nextgenCalendarTagThreshold = "v26.0.0"
 
-var legacyNextgenImageTagRegexp = regexp.MustCompile(`^v\d+\.\d+\.\d+-nextgen\.\d{6}\.\d+$`)
+var (
+	legacyNextgenImageTagRegexp         = regexp.MustCompile(`^v\d+\.\d+\.\d+-nextgen\.\d{6}\.\d+$`)
+	calendarSemverNextgenImageTagRegexp = regexp.MustCompile(`^v2[6-9]\.\d+\.\d+(-nextgen)?$`)
+)
 
 // UpdateComponentVersionInCloudconfig implements
 // update-component-version-in-cloudconfig.
@@ -57,6 +60,8 @@ func (s *tidbcloudsrvc) UpdateComponentVersionInCloudconfig(ctx context.Context,
 		}
 	}
 	slices.Sort(components)
+
+	s.Logger.Info().Interface("components", components).Msg("debug")
 
 	componentVersion := strings.SplitN(imageTag, "-", 2)[0]
 
@@ -183,12 +188,12 @@ func isSupportedNextgenImageTag(tag string) bool {
 	if legacyNextgenImageTagRegexp.MatchString(tag) {
 		return true
 	}
-	if !strings.HasSuffix(tag, "-nextgen") {
-		return false
+	if calendarSemverNextgenImageTagRegexp.MatchString(tag) {
+		baseTag := strings.TrimSuffix(tag, "-nextgen")
+		return semver.IsValid(baseTag) &&
+			!strings.Contains(strings.TrimPrefix(baseTag, "v"), "-") &&
+			semver.Compare(baseTag, nextgenCalendarTagThreshold) >= 0
 	}
 
-	baseTag := strings.TrimSuffix(tag, "-nextgen")
-	return semver.IsValid(baseTag) &&
-		!strings.Contains(strings.TrimPrefix(baseTag, "v"), "-") &&
-		semver.Compare(baseTag, nextgenCalendarTagThreshold) >= 0
+	return false
 }

--- a/publisher/internal/service/impl/tidbcloud/ops_test.go
+++ b/publisher/internal/service/impl/tidbcloud/ops_test.go
@@ -12,8 +12,8 @@ func TestIsSupportedNextgenImageTag(t *testing.T) {
 		{tag: "v26.3.0-nextgen", want: true},
 		{tag: "v26.0.0-nextgen", want: true},
 		{tag: "v26.3.1-nextgen", want: true},
+		{tag: "v26.3.1", want: true},
 		{tag: "v26.3.1-2-gabcdef0-nextgen", want: false},
-		{tag: "v26.3.1", want: false},
 		{tag: "master-next-gen", want: false},
 	}
 


### PR DESCRIPTION
A `v26.3.1` tag now passes `isSupportedNextgenImageTag` as a valid calendar semver tag, matching the updated regex and logic.

As we will build and push the image for tiproxy nextgen without suffix `-nextgen` since it build with classic profile.