### PR TITLE
feat(roster): add roster sync job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,8 @@ jobs:
           filters: |
             ci-dashboard:
               - 'ci-dashboard/**'
+            roster:
+              - 'roster/**'
             cloudevents-server:
               - 'cloudevents-server/**'
             tibuild:
@@ -101,6 +103,14 @@ jobs:
       - name: Build image - ci-dashboard
         if: steps.changes.outputs.ci-dashboard == 'true'
         working-directory: ci-dashboard
+        run: |
+          skaffold build \
+            --push=false \
+            --platform ${{ matrix.platform }} \
+            --default-repo ghcr.io/pingcap-qe/ee-apps
+      - name: Build image - roster
+        if: steps.changes.outputs.roster == 'true'
+        working-directory: roster
         run: |
           skaffold build \
             --push=false \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,8 @@ jobs:
           filters: |
             ci-dashboard:
               - 'ci-dashboard/**'
+            roster:
+              - 'roster/**'
             cloudevents-server:
               - 'cloudevents-server/**'
             tibuild:
@@ -99,6 +101,11 @@ jobs:
       - name: Publish image - ci-dashboard
         if: steps.changes.outputs.ci-dashboard == 'true'
         working-directory: ci-dashboard
+        run: |
+          skaffold build --default-repo ghcr.io/pingcap-qe/ee-apps
+      - name: Publish image - roster
+        if: steps.changes.outputs.roster == 'true'
+        working-directory: roster
         run: |
           skaffold build --default-repo ghcr.io/pingcap-qe/ee-apps
       - name: Publish image - tibuild

--- a/roster/Dockerfile.jobs
+++ b/roster/Dockerfile.jobs
@@ -1,0 +1,26 @@
+FROM python:3.12-slim
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.source="https://github.com/PingCAP-QE/ee-apps"
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_DEFAULT_TIMEOUT=120 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip setuptools wheel
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+COPY sql ./sql
+
+RUN pip install --retries 5 .
+
+ENTRYPOINT ["python", "-m", "roster.jobs.cli"]

--- a/roster/README.md
+++ b/roster/README.md
@@ -1,0 +1,74 @@
+# Roster
+
+Roster syncs company employee and group data into the database for cost attribution,
+CI ownership lookup, and issue routing.
+
+The initial design is documented in [docs/schema-design.md](docs/schema-design.md).
+
+## Local Job Entry
+
+The sync command is:
+
+```bash
+python -m roster.jobs.cli sync-roster
+```
+
+Validate Lark data without writing DB:
+
+```bash
+python -m roster.jobs.cli validate-lark
+```
+
+Database configuration accepts either a SQLAlchemy URL:
+
+```bash
+ROSTER_DB_URL='mysql+pymysql://user:pass@host:4000/db?charset=utf8mb4'
+```
+
+or TiDB fields. For compatibility with the existing CI Dashboard DB secret,
+both `ROSTER_TIDB_*` and plain `TIDB_*` names are accepted:
+
+```bash
+ROSTER_TIDB_HOST=...
+ROSTER_TIDB_PORT=4000
+ROSTER_TIDB_USER=...
+ROSTER_TIDB_PASSWORD=...
+ROSTER_TIDB_DB=...
+```
+
+Lark sync is enabled when both of these are present:
+
+```bash
+ROSTER_LARK_APP_ID=...
+ROSTER_LARK_APP_SECRET=...
+```
+
+Optional Lark settings:
+
+```bash
+ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID=...
+ROSTER_LARK_ROOT_DEPARTMENT_ID=0
+```
+
+## Kubernetes CronJob
+
+Build the jobs image from this directory:
+
+```bash
+docker build -f Dockerfile.jobs -t ghcr.io/pingcap-qe/ee-apps/roster-jobs:<tag> .
+```
+
+Render a CronJob manifest:
+
+```bash
+./scripts/render_roster_sync_cronjob.sh \
+  --image ghcr.io/pingcap-qe/ee-apps/roster-jobs:<tag> \
+  --db-secret ci-dashboard-eq-prd-insight-db \
+  --lark-secret roster-lark \
+  --suspend true \
+  > /tmp/roster-sync.yaml
+```
+
+The DB secret should contain `ROSTER_DB_URL`, `CI_DASHBOARD_DB_URL`,
+`ROSTER_TIDB_*`, or `TIDB_*` fields. The Lark secret should contain `ROSTER_LARK_APP_ID` and
+`ROSTER_LARK_APP_SECRET`, plus optional `ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID`.

--- a/roster/docs/schema-design.md
+++ b/roster/docs/schema-design.md
@@ -28,6 +28,7 @@ CREATE TABLE roster_employees (
   employee_no VARCHAR(64) NULL,
   email VARCHAR(255) NULL,
   github_id VARCHAR(255) NULL,
+  join_time DATETIME NULL,
   manager_id BIGINT NULL,
   manager_path VARCHAR(1024) NULL,
   group_id BIGINT NULL,
@@ -53,6 +54,7 @@ Field notes:
 - `employee_no`: employee number from Lark, used for HR and cost data reconciliation.
 - `email`: company email. Empty values from Lark must be normalized to `NULL`.
 - `github_id`: GitHub account value from Lark. This is expected to be the GitHub login/name if Lark stores that as the custom field.
+- `join_time`: employee join time from Lark `join_time`, stored as UTC `DATETIME`.
 - `manager_id`: direct manager, references `roster_employees.id`.
 - `manager_path`: ancestor manager chain, stored as `/ceo_id/cto_id/direct_manager_id/`. It does not include the employee's own `id`.
 - `group_id`: employee's primary/direct group, usually the leaf group from Lark.

--- a/roster/docs/schema-design.md
+++ b/roster/docs/schema-design.md
@@ -1,0 +1,185 @@
+# Roster Schema Design
+
+## Goal
+
+Sync company employee information from Lark into DB tables that can be joined by
+email or GitHub account for cost attribution, CI ownership, and issue tracking.
+
+The schema keeps the first version small:
+
+- no snapshots
+- no identity table
+- no closure table
+- no multi-group relation table for now
+
+Hierarchy queries use materialized path columns.
+
+## Tables
+
+### `roster_employees`
+
+Stores one row per employee.
+
+```sql
+CREATE TABLE roster_employees (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  lark_id VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  employee_no VARCHAR(64) NULL,
+  email VARCHAR(255) NULL,
+  github_id VARCHAR(255) NULL,
+  manager_id BIGINT NULL,
+  manager_path VARCHAR(1024) NULL,
+  group_id BIGINT NULL,
+  group_path VARCHAR(1024) NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  last_seen_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_roster_employees_lark_id (lark_id),
+  UNIQUE KEY uk_roster_employees_email (email),
+  UNIQUE KEY uk_roster_employees_github_id (github_id),
+  KEY idx_roster_employees_employee_no (employee_no),
+  KEY idx_roster_employees_manager (manager_id),
+  KEY idx_roster_employees_group (group_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+Field notes:
+
+- `id`: internal numeric primary key for joins.
+- `lark_id`: Lark `union_id`, used for sync upsert.
+- `employee_no`: employee number from Lark, used for HR and cost data reconciliation.
+- `email`: company email. Empty values from Lark must be normalized to `NULL`.
+- `github_id`: GitHub account value from Lark. This is expected to be the GitHub login/name if Lark stores that as the custom field.
+- `manager_id`: direct manager, references `roster_employees.id`.
+- `manager_path`: ancestor manager chain, stored as `/ceo_id/cto_id/direct_manager_id/`. It does not include the employee's own `id`.
+- `group_id`: employee's primary/direct group, usually the leaf group from Lark.
+- `group_path`: full group path for the primary group, copied from `roster_groups.path`.
+- `is_active`: active employee flag.
+- `last_seen_at`: last successful sync time when this employee was returned by Lark.
+
+### `roster_groups`
+
+Stores one row per Lark group/department.
+
+```sql
+CREATE TABLE roster_groups (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  lark_group_id VARCHAR(128) NOT NULL,
+  parent_id BIGINT NULL,
+  name VARCHAR(255) NOT NULL,
+  manager_id BIGINT NULL,
+  path VARCHAR(1024) NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  last_seen_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_roster_groups_lark_group_id (lark_group_id),
+  KEY idx_roster_groups_parent (parent_id),
+  KEY idx_roster_groups_manager (manager_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+Field notes:
+
+- `id`: internal numeric primary key.
+- `lark_group_id`: Lark group/department ID used for sync upsert.
+- `parent_id`: parent group, references `roster_groups.id`.
+- `manager_id`: group manager, references `roster_employees.id`.
+- `path`: materialized group path including itself, for example `/root_id/dept_id/team_id/`.
+- `is_active`: active group flag.
+- `last_seen_at`: last successful sync time when this group was returned by Lark.
+
+## Hierarchy Queries
+
+Find all direct and indirect reports of a manager:
+
+```sql
+SELECT *
+FROM roster_employees
+WHERE manager_path LIKE CONCAT('%/', :manager_id, '/%')
+  AND is_active = 1;
+```
+
+Find a manager and all direct or indirect reports:
+
+```sql
+SELECT *
+FROM roster_employees
+WHERE (id = :manager_id OR manager_path LIKE CONCAT('%/', :manager_id, '/%'))
+  AND is_active = 1;
+```
+
+Find employees under a group, including nested child groups:
+
+```sql
+SELECT *
+FROM roster_employees
+WHERE group_path LIKE CONCAT('%/', :group_id, '/%')
+  AND is_active = 1;
+```
+
+Find child groups under a group:
+
+```sql
+SELECT *
+FROM roster_groups
+WHERE path LIKE CONCAT('%/', :group_id, '/%')
+  AND is_active = 1;
+```
+
+## Sync Rules
+
+The sync job should run as a full refresh:
+
+Implementation should run Pass 1 and Pass 2 in a single DB transaction:
+
+```python
+with engine.begin() as conn:
+    ...
+```
+
+Pass 1:
+
+1. Fetch all Lark groups and employees.
+2. Upsert groups by `lark_group_id`, with reference columns set to `NULL` for now.
+3. Upsert employees by `lark_id`, with reference columns set to `NULL` for now.
+4. Update `last_seen_at` for every group and employee returned by Lark.
+
+Pass 2:
+
+1. Build in-memory maps from Lark IDs to internal numeric IDs.
+2. Resolve group `parent_id`.
+3. Resolve group `manager_id`.
+4. Resolve employee `manager_id`.
+5. Resolve employee `group_id`.
+6. Build `roster_groups.path` from group parent chains.
+7. Build `roster_employees.manager_path` from employee manager chains.
+8. Copy the employee primary group's `path` into `roster_employees.group_path`.
+
+Inactive handling:
+
+- A failed sync must not update `is_active`.
+- Employees and groups should only be marked inactive after they have not been seen for
+  a grace period, for example `last_seen_at < NOW() - INTERVAL 2 DAY`.
+- Empty `email` and `github_id` values from Lark must be stored as `NULL`, not empty strings,
+  so nullable unique keys do not conflict.
+- Duplicate `email` or `github_id` values in one Lark fetch must be stored as `NULL` for all
+  employees with that duplicated value. These columns are join keys; keeping ambiguous values is
+  worse than leaving the join key empty.
+- TODO: During implementation, verify whether Lark `employee_no` is globally unique and whether
+  empty values are returned as empty strings. If it is stable and unique, change
+  `idx_roster_employees_employee_no` to a unique key.
+- Because `group_path` is denormalized onto employees, every full sync must refresh it after
+  group paths are rebuilt.
+
+## Current Tradeoffs
+
+The first version stores only one primary group per employee. This is enough for the
+initial cost and ownership joins when we choose the leaf/default group from Lark.
+
+If cost attribution later needs multiple direct groups per employee, add a relation
+table then. Do not add it before that need is real.

--- a/roster/pyproject.toml
+++ b/roster/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "roster"
+version = "0.1.0"
+description = "Company roster sync jobs and schema"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "PyMySQL>=1.1.0",
+  "SQLAlchemy>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "coverage>=7.0.0",
+  "pytest>=8.0.0",
+  "ruff>=0.4.0",
+]
+
+[project.scripts]
+roster = "roster.jobs.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+line-length = 100
+src = ["src", "tests"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+source = ["src/roster"]
+
+[tool.coverage.report]
+fail_under = 90

--- a/roster/scripts/render_roster_sync_cronjob.sh
+++ b/roster/scripts/render_roster_sync_cronjob.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+namespace="apps"
+image="ghcr.io/pingcap-qe/ee-apps/roster-jobs:latest"
+cronjob_name="roster-sync"
+schedule="0 3 * * *"
+time_zone="Asia/Shanghai"
+db_secret="ci-dashboard-eq-prd-insight-db"
+lark_secret="roster-lark"
+log_level="INFO"
+image_pull_policy="IfNotPresent"
+service_account=""
+ca_secret=""
+ca_key="ca.crt"
+cpu_request="250m"
+memory_request="512Mi"
+cpu_limit="1"
+memory_limit="1Gi"
+successful_jobs_history="3"
+failed_jobs_history="3"
+backoff_limit="1"
+active_deadline_seconds="3600"
+starting_deadline_seconds="1800"
+concurrency_policy="Forbid"
+suspend="false"
+
+usage() {
+  cat <<'EOF'
+Render a Kubernetes CronJob manifest for roster sync.
+
+Usage:
+  render_roster_sync_cronjob.sh [options]
+
+Optional:
+  --namespace NAME             Kubernetes namespace. Default: apps
+  --image IMAGE                Jobs image. Default: ghcr.io/pingcap-qe/ee-apps/roster-jobs:latest
+  --cronjob-name NAME          CronJob name. Default: roster-sync
+  --schedule CRON              Cron expression. Default: "0 3 * * *"
+  --time-zone TZ               CronJob timeZone. Default: Asia/Shanghai
+  --db-secret NAME             Secret containing ROSTER_DB_URL, ROSTER_TIDB_*, CI_DASHBOARD_DB_URL, or TIDB_* keys. Default: ci-dashboard-eq-prd-insight-db
+  --lark-secret NAME           Secret containing ROSTER_LARK_* keys. Default: roster-lark
+  --log-level LEVEL            ROSTER_LOG_LEVEL override. Default: INFO
+  --image-pull-policy P        Image pull policy. Default: IfNotPresent
+  --service-account NAME       Optional service account name.
+  --ca-secret NAME             Optional secret containing CA file for TiDB SSL.
+  --ca-key NAME                Key inside CA secret. Default: ca.crt
+  --cpu-request VALUE          CPU request. Default: 250m
+  --memory-request VALUE       Memory request. Default: 512Mi
+  --cpu-limit VALUE            CPU limit. Default: 1
+  --memory-limit VALUE         Memory limit. Default: 1Gi
+  --successful-history N       successfulJobsHistoryLimit. Default: 3
+  --failed-history N           failedJobsHistoryLimit. Default: 3
+  --backoff-limit N            Job backoffLimit. Default: 1
+  --active-deadline N          activeDeadlineSeconds. Default: 3600
+  --starting-deadline N        startingDeadlineSeconds. Default: 1800
+  --concurrency-policy VALUE   CronJob concurrencyPolicy. Default: Forbid
+  --suspend true|false         Suspend CronJob. Default: false
+  --help                       Show this help text.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      namespace="${2:-}"
+      shift 2
+      ;;
+    --image)
+      image="${2:-}"
+      shift 2
+      ;;
+    --cronjob-name)
+      cronjob_name="${2:-}"
+      shift 2
+      ;;
+    --schedule)
+      schedule="${2:-}"
+      shift 2
+      ;;
+    --time-zone)
+      time_zone="${2:-}"
+      shift 2
+      ;;
+    --db-secret)
+      db_secret="${2:-}"
+      shift 2
+      ;;
+    --lark-secret)
+      lark_secret="${2:-}"
+      shift 2
+      ;;
+    --log-level)
+      log_level="${2:-}"
+      shift 2
+      ;;
+    --image-pull-policy)
+      image_pull_policy="${2:-}"
+      shift 2
+      ;;
+    --service-account)
+      service_account="${2:-}"
+      shift 2
+      ;;
+    --ca-secret)
+      ca_secret="${2:-}"
+      shift 2
+      ;;
+    --ca-key)
+      ca_key="${2:-}"
+      shift 2
+      ;;
+    --cpu-request)
+      cpu_request="${2:-}"
+      shift 2
+      ;;
+    --memory-request)
+      memory_request="${2:-}"
+      shift 2
+      ;;
+    --cpu-limit)
+      cpu_limit="${2:-}"
+      shift 2
+      ;;
+    --memory-limit)
+      memory_limit="${2:-}"
+      shift 2
+      ;;
+    --successful-history)
+      successful_jobs_history="${2:-}"
+      shift 2
+      ;;
+    --failed-history)
+      failed_jobs_history="${2:-}"
+      shift 2
+      ;;
+    --backoff-limit)
+      backoff_limit="${2:-}"
+      shift 2
+      ;;
+    --active-deadline)
+      active_deadline_seconds="${2:-}"
+      shift 2
+      ;;
+    --starting-deadline)
+      starting_deadline_seconds="${2:-}"
+      shift 2
+      ;;
+    --concurrency-policy)
+      concurrency_policy="${2:-}"
+      shift 2
+      ;;
+    --suspend)
+      suspend="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+service_account_block=""
+if [[ -n "${service_account}" ]]; then
+  service_account_block=$(cat <<EOF
+          serviceAccountName: ${service_account}
+EOF
+)
+fi
+
+time_zone_block=""
+if [[ -n "${time_zone}" ]]; then
+  time_zone_block=$(cat <<EOF
+  timeZone: ${time_zone}
+EOF
+)
+fi
+
+ca_env_block=""
+ca_mount_block=""
+ca_volume_block=""
+if [[ -n "${ca_secret}" ]]; then
+  ca_env_block=$(cat <<EOF
+                - name: ROSTER_TIDB_SSL_CA
+                  value: /var/run/roster/ssl/${ca_key}
+EOF
+)
+  ca_mount_block=$(cat <<EOF
+              volumeMounts:
+                - name: tidb-ca
+                  mountPath: /var/run/roster/ssl
+                  readOnly: true
+EOF
+)
+  ca_volume_block=$(cat <<EOF
+          volumes:
+            - name: tidb-ca
+              secret:
+                secretName: ${ca_secret}
+                items:
+                  - key: ${ca_key}
+                    path: ${ca_key}
+EOF
+)
+fi
+
+cat <<EOF
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ${cronjob_name}
+  namespace: ${namespace}
+  labels:
+    app.kubernetes.io/name: roster-sync
+    app.kubernetes.io/part-of: roster
+spec:
+  schedule: "${schedule}"
+${time_zone_block}
+  suspend: ${suspend}
+  concurrencyPolicy: ${concurrency_policy}
+  startingDeadlineSeconds: ${starting_deadline_seconds}
+  successfulJobsHistoryLimit: ${successful_jobs_history}
+  failedJobsHistoryLimit: ${failed_jobs_history}
+  jobTemplate:
+    spec:
+      backoffLimit: ${backoff_limit}
+      activeDeadlineSeconds: ${active_deadline_seconds}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: roster-sync
+            app.kubernetes.io/part-of: roster
+        spec:
+          restartPolicy: Never
+${service_account_block}
+          containers:
+            - name: sync-roster
+              image: ${image}
+              imagePullPolicy: ${image_pull_policy}
+              args:
+                - sync-roster
+              envFrom:
+                - secretRef:
+                    name: ${db_secret}
+                - secretRef:
+                    name: ${lark_secret}
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: ROSTER_LOG_LEVEL
+                  value: "${log_level}"
+${ca_env_block}
+              resources:
+                requests:
+                  cpu: "${cpu_request}"
+                  memory: "${memory_request}"
+                limits:
+                  cpu: "${cpu_limit}"
+                  memory: "${memory_limit}"
+${ca_mount_block}
+${ca_volume_block}
+EOF

--- a/roster/skaffold.yaml
+++ b/roster/skaffold.yaml
@@ -1,0 +1,15 @@
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: roster
+
+build:
+  platforms: ["linux/amd64", "linux/arm64"]
+  artifacts:
+    - image: roster-jobs
+      docker:
+        dockerfile: Dockerfile.jobs
+  local:
+    useDockerCLI: true
+    useBuildkit: true
+    concurrency: 0

--- a/roster/sql/001_create_roster_tables.sql
+++ b/roster/sql/001_create_roster_tables.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS roster_employees (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  lark_id VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  employee_no VARCHAR(64) NULL,
+  email VARCHAR(255) NULL,
+  github_id VARCHAR(255) NULL,
+  manager_id BIGINT NULL,
+  manager_path VARCHAR(1024) NULL,
+  group_id BIGINT NULL,
+  group_path VARCHAR(1024) NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  last_seen_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_roster_employees_lark_id (lark_id),
+  UNIQUE KEY uk_roster_employees_email (email),
+  UNIQUE KEY uk_roster_employees_github_id (github_id),
+  KEY idx_roster_employees_employee_no (employee_no),
+  KEY idx_roster_employees_manager (manager_id),
+  KEY idx_roster_employees_group (group_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS roster_groups (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  lark_group_id VARCHAR(128) NOT NULL,
+  parent_id BIGINT NULL,
+  name VARCHAR(255) NOT NULL,
+  manager_id BIGINT NULL,
+  path VARCHAR(1024) NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  last_seen_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_roster_groups_lark_group_id (lark_group_id),
+  KEY idx_roster_groups_parent (parent_id),
+  KEY idx_roster_groups_manager (manager_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/roster/sql/001_create_roster_tables.sql
+++ b/roster/sql/001_create_roster_tables.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS roster_employees (
   employee_no VARCHAR(64) NULL,
   email VARCHAR(255) NULL,
   github_id VARCHAR(255) NULL,
+  join_time DATETIME NULL,
   manager_id BIGINT NULL,
   manager_path VARCHAR(1024) NULL,
   group_id BIGINT NULL,

--- a/roster/sql/002_alter_roster_employees_add_join_time.sql
+++ b/roster/sql/002_alter_roster_employees_add_join_time.sql
@@ -1,0 +1,2 @@
+ALTER TABLE roster_employees
+  ADD COLUMN join_time DATETIME NULL AFTER github_id;

--- a/roster/src/roster/__init__.py
+++ b/roster/src/roster/__init__.py
@@ -1,0 +1,3 @@
+"""Company roster sync package."""
+
+__version__ = "0.1.0"

--- a/roster/src/roster/common/__init__.py
+++ b/roster/src/roster/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared roster configuration and database helpers."""

--- a/roster/src/roster/common/config.py
+++ b/roster/src/roster/common/config.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Mapping
+
+
+def _read_required(environ: Mapping[str, str], key: str) -> str:
+    value = environ.get(key)
+    if value is None or value.strip() == "":
+        raise ValueError(f"Missing required environment variable: {key}")
+    return value
+
+
+def _read_int(environ: Mapping[str, str], key: str, default: int) -> int:
+    raw = environ.get(key, str(default))
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{key} must be an integer, got {raw!r}") from exc
+    if value <= 0:
+        raise ValueError(f"{key} must be positive, got {raw!r}")
+    return value
+
+
+@dataclass(frozen=True)
+class DatabaseSettings:
+    url: str | None
+    host: str | None
+    port: int | None
+    user: str | None
+    password: str | None
+    database: str | None
+    ssl_ca: str | None
+
+
+@dataclass(frozen=True)
+class LarkSettings:
+    app_id: str | None = None
+    app_secret: str | None = None
+    github_custom_attr_id: str | None = None
+    root_department_id: str = "0"
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.app_id and self.app_secret)
+
+
+@dataclass(frozen=True)
+class Settings:
+    database: DatabaseSettings
+    lark: LarkSettings = LarkSettings()
+    log_level: str = "INFO"
+
+
+def load_settings(
+    environ: Mapping[str, str] | None = None,
+    *,
+    require_database: bool = True,
+) -> Settings:
+    env = os.environ if environ is None else environ
+    database_url = env.get("ROSTER_DB_URL") or env.get("CI_DASHBOARD_DB_URL") or None
+    if database_url:
+        database = DatabaseSettings(
+            url=database_url,
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            database=None,
+            ssl_ca=env.get("ROSTER_TIDB_SSL_CA") or env.get("TIDB_SSL_CA") or None,
+        )
+    elif not require_database:
+        database = DatabaseSettings(
+            url=None,
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            database=None,
+            ssl_ca=env.get("ROSTER_TIDB_SSL_CA") or env.get("TIDB_SSL_CA") or None,
+        )
+    else:
+        database = DatabaseSettings(
+            url=None,
+            host=_read_required_any(env, "ROSTER_TIDB_HOST", "TIDB_HOST"),
+            port=_read_int_any(env, ("ROSTER_TIDB_PORT", "TIDB_PORT"), 4000),
+            user=_read_required_any(env, "ROSTER_TIDB_USER", "TIDB_USER"),
+            password=_read_required_any(env, "ROSTER_TIDB_PASSWORD", "TIDB_PASSWORD"),
+            database=_read_required_any(env, "ROSTER_TIDB_DB", "TIDB_DB"),
+            ssl_ca=env.get("ROSTER_TIDB_SSL_CA") or env.get("TIDB_SSL_CA") or None,
+        )
+    return Settings(
+        database=database,
+        lark=LarkSettings(
+            app_id=env.get("ROSTER_LARK_APP_ID") or None,
+            app_secret=env.get("ROSTER_LARK_APP_SECRET") or None,
+            github_custom_attr_id=env.get("ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID") or None,
+            root_department_id=env.get("ROSTER_LARK_ROOT_DEPARTMENT_ID") or "0",
+        ),
+        log_level=(env.get("ROSTER_LOG_LEVEL") or "INFO").upper(),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_settings(require_database: bool = True) -> Settings:
+    return load_settings(require_database=require_database)
+
+
+def _read_required_any(environ: Mapping[str, str], *keys: str) -> str:
+    for key in keys:
+        value = environ.get(key)
+        if value is not None and value.strip() != "":
+            return value
+    raise ValueError(f"Missing required environment variable: {' or '.join(keys)}")
+
+
+def _read_int_any(environ: Mapping[str, str], keys: tuple[str, ...], default: int) -> int:
+    for key in keys:
+        if key in environ:
+            return _read_int(environ, key, default)
+    return default

--- a/roster/src/roster/common/db.py
+++ b/roster/src/roster/common/db.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine, URL
+
+from roster.common.config import DatabaseSettings, Settings, get_settings
+
+
+def _build_connect_args(database: DatabaseSettings) -> dict[str, object]:
+    if not database.ssl_ca:
+        return {}
+    return {"ssl": {"ca": database.ssl_ca}}
+
+
+def build_engine(settings: Settings | None = None) -> Engine:
+    resolved = settings or get_settings()
+    if resolved.database.url:
+        return create_engine(
+            resolved.database.url,
+            pool_pre_ping=True,
+            future=True,
+        )
+
+    url = URL.create(
+        drivername="mysql+pymysql",
+        username=resolved.database.user,
+        password=resolved.database.password,
+        host=resolved.database.host,
+        port=resolved.database.port,
+        database=resolved.database.database,
+        query={"charset": "utf8mb4"},
+    )
+    return create_engine(
+        url,
+        pool_pre_ping=True,
+        future=True,
+        connect_args=_build_connect_args(resolved.database),
+    )

--- a/roster/src/roster/common/logging.py
+++ b/roster/src/roster/common/logging.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import logging
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )

--- a/roster/src/roster/jobs/__init__.py
+++ b/roster/src/roster/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Roster job entrypoints."""

--- a/roster/src/roster/jobs/cli.py
+++ b/roster/src/roster/jobs/cli.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections.abc import Sequence
+
+from roster.common.config import get_settings
+from roster.common.db import build_engine
+from roster.common.logging import configure_logging
+from roster.jobs.sync_roster import run_sync_roster
+from roster.jobs.validate_lark import validate_lark_roster
+from roster.sources.lark import LarkApiClient, LarkRosterSource
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Roster job runner")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("sync-roster", help="Sync Lark roster data into roster tables")
+    subparsers.add_parser("validate-lark", help="Fetch Lark roster data and print field quality summary")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    settings = get_settings(require_database=args.command == "sync-roster")
+    configure_logging(settings.log_level)
+
+    if args.command == "sync-roster":
+        engine = build_engine(settings)
+        try:
+            source = _build_lark_source(settings) if settings.lark.is_configured else None
+            summary = run_sync_roster(engine, source=source)
+            logging.getLogger(__name__).info(
+                "sync-roster finished",
+                extra={"summary": summary.__dict__},
+            )
+            return 0
+        finally:
+            engine.dispose()
+
+    if args.command == "validate-lark":
+        if not settings.lark.is_configured:
+            raise SystemExit("validate-lark requires ROSTER_LARK_APP_ID and ROSTER_LARK_APP_SECRET")
+        summary = validate_lark_roster(_build_lark_source(settings))
+        print(json.dumps(summary.to_dict(), indent=2, sort_keys=True))
+        return 0
+
+    raise AssertionError(f"Unhandled command: {args.command}")  # pragma: no cover
+
+
+def _build_lark_source(settings) -> LarkRosterSource:
+    return LarkRosterSource(
+        LarkApiClient(settings.lark.app_id, settings.lark.app_secret),
+        github_custom_attr_id=settings.lark.github_custom_attr_id,
+        root_department_id=settings.lark.root_department_id,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/roster/src/roster/jobs/sync_roster.py
+++ b/roster/src/roster/jobs/sync_roster.py
@@ -46,6 +46,7 @@ employees_table = Table(
     Column("employee_no", String(64)),
     Column("email", String(255), unique=True),
     Column("github_id", String(255), unique=True),
+    Column("join_time", DateTime),
     Column("manager_id", BigInteger),
     Column("manager_path", String(1024)),
     Column("group_id", BigInteger),
@@ -88,6 +89,7 @@ class FetchedEmployee:
     employee_no: str | None = None
     email: str | None = None
     github_id: str | None = None
+    join_time: datetime | None = None
     manager_lark_id: str | None = None
     group_lark_id: str | None = None
 
@@ -232,6 +234,7 @@ def _employee_pass1_rows(
                 "employee_no": _nullable_text(employee.employee_no),
                 "email": None if email in duplicate_emails else email,
                 "github_id": None if github_id in duplicate_github_ids else github_id,
+                "join_time": employee.join_time,
                 "manager_id": None,
                 "manager_path": None,
                 "group_id": None,

--- a/roster/src/roster/jobs/sync_roster.py
+++ b/roster/src/roster/jobs/sync_roster.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     String,
     Table,
     and_,
+    bindparam,
     select,
     update,
 )
@@ -28,6 +29,7 @@ LOG = logging.getLogger(__name__)
 
 RosterSyncStatus = Literal["not_implemented", "success", "failed", "partial"]
 DEFAULT_INACTIVE_GRACE = timedelta(days=2)
+BULK_UPDATE_CHUNK_SIZE = 500
 
 metadata = MetaData()
 
@@ -304,6 +306,7 @@ def _update_group_references(
 ) -> dict[int, str]:
     group_by_lark_group_id = {group.lark_group_id: group for group in groups}
     path_by_lark_group_id: dict[str, str] = {}
+    update_rows: list[dict[str, object]] = []
 
     def build_path(lark_group_id: str, visiting: set[str] | None = None) -> str:
         if lark_group_id in path_by_lark_group_id:
@@ -335,12 +338,21 @@ def _update_group_references(
             else None
         )
         path = build_path(group.lark_group_id)
-        connection.execute(
-            update(groups_table)
-            .where(groups_table.c.id == group_id)
-            .values(parent_id=parent_id, manager_id=manager_id, path=path)
+        update_rows.append(
+            {
+                "id": group_id,
+                "parent_id": parent_id,
+                "manager_id": manager_id,
+                "path": path,
+            }
         )
 
+    _bulk_update_by_id(
+        connection,
+        groups_table,
+        update_rows,
+        value_columns=("parent_id", "manager_id", "path"),
+    )
     return {group_id_by_lark_group_id[lark_id]: path for lark_id, path in path_by_lark_group_id.items()}
 
 
@@ -354,6 +366,7 @@ def _update_employee_references(
 ) -> None:
     employee_by_lark_id = {employee.lark_id: employee for employee in employees}
     manager_path_by_lark_id: dict[str, str] = {}
+    update_rows: list[dict[str, object]] = []
 
     def build_manager_path(lark_id: str, visiting: set[str] | None = None) -> str:
         if lark_id in manager_path_by_lark_id:
@@ -387,16 +400,57 @@ def _update_employee_references(
         )
         manager_path = build_manager_path(employee.lark_id) or None
         group_path = group_path_by_id.get(group_id) if group_id else None
-        connection.execute(
-            update(employees_table)
-            .where(employees_table.c.id == employee_id)
-            .values(
-                manager_id=manager_id,
-                manager_path=manager_path,
-                group_id=group_id,
-                group_path=group_path,
-            )
+        update_rows.append(
+            {
+                "id": employee_id,
+                "manager_id": manager_id,
+                "manager_path": manager_path,
+                "group_id": group_id,
+                "group_path": group_path,
+            }
         )
+
+    _bulk_update_by_id(
+        connection,
+        employees_table,
+        update_rows,
+        value_columns=("manager_id", "manager_path", "group_id", "group_path"),
+    )
+
+
+def _bulk_update_by_id(
+    connection: Connection,
+    table: Table,
+    rows: Sequence[dict[str, object]],
+    *,
+    value_columns: Sequence[str],
+) -> None:
+    if not rows:
+        return
+
+    statement = (
+        update(table)
+        .where(table.c.id == bindparam("_target_id"))
+        .values({column: bindparam(f"_{column}") for column in value_columns})
+    )
+    for chunk in _chunks(rows, BULK_UPDATE_CHUNK_SIZE):
+        connection.execute(
+            statement,
+            [
+                {
+                    "_target_id": row["id"],
+                    **{f"_{column}": row[column] for column in value_columns},
+                }
+                for row in chunk
+            ],
+        )
+
+
+def _chunks(
+    rows: Sequence[dict[str, object]],
+    size: int,
+) -> list[Sequence[dict[str, object]]]:
+    return [rows[index : index + size] for index in range(0, len(rows), size)]
 
 
 def _mark_stale_rows_inactive(

--- a/roster/src/roster/jobs/sync_roster.py
+++ b/roster/src/roster/jobs/sync_roster.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal, Protocol
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    and_,
+    select,
+    update,
+)
+from sqlalchemy.dialects.mysql import insert as mysql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import Connection
+
+LOG = logging.getLogger(__name__)
+
+RosterSyncStatus = Literal["not_implemented", "success", "failed", "partial"]
+DEFAULT_INACTIVE_GRACE = timedelta(days=2)
+
+metadata = MetaData()
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+employees_table = Table(
+    "roster_employees",
+    metadata,
+    Column("id", BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True),
+    Column("lark_id", String(128), nullable=False, unique=True),
+    Column("name", String(255), nullable=False),
+    Column("employee_no", String(64)),
+    Column("email", String(255), unique=True),
+    Column("github_id", String(255), unique=True),
+    Column("manager_id", BigInteger),
+    Column("manager_path", String(1024)),
+    Column("group_id", BigInteger),
+    Column("group_path", String(1024)),
+    Column("is_active", Boolean, nullable=False, default=True),
+    Column("last_seen_at", DateTime),
+    Column("created_at", DateTime, nullable=False, default=_utcnow_naive),
+    Column("updated_at", DateTime, nullable=False, default=_utcnow_naive),
+)
+
+groups_table = Table(
+    "roster_groups",
+    metadata,
+    Column("id", BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True),
+    Column("lark_group_id", String(128), nullable=False, unique=True),
+    Column("parent_id", BigInteger),
+    Column("name", String(255), nullable=False),
+    Column("manager_id", BigInteger),
+    Column("path", String(1024)),
+    Column("is_active", Boolean, nullable=False, default=True),
+    Column("last_seen_at", DateTime),
+    Column("created_at", DateTime, nullable=False, default=_utcnow_naive),
+    Column("updated_at", DateTime, nullable=False, default=_utcnow_naive),
+)
+
+
+@dataclass(frozen=True)
+class SyncRosterSummary:
+    """Summary for a roster sync run."""
+
+    groups_seen: int
+    employees_seen: int
+    status: RosterSyncStatus
+
+
+@dataclass(frozen=True)
+class FetchedEmployee:
+    lark_id: str
+    name: str
+    employee_no: str | None = None
+    email: str | None = None
+    github_id: str | None = None
+    manager_lark_id: str | None = None
+    group_lark_id: str | None = None
+
+
+@dataclass(frozen=True)
+class FetchedGroup:
+    lark_group_id: str
+    name: str
+    parent_lark_group_id: str | None = None
+    manager_lark_id: str | None = None
+
+
+@dataclass(frozen=True)
+class FetchedRoster:
+    groups: Sequence[FetchedGroup] = field(default_factory=tuple)
+    employees: Sequence[FetchedEmployee] = field(default_factory=tuple)
+
+
+class RosterSource(Protocol):
+    def fetch_roster(self) -> FetchedRoster: ...
+
+
+@dataclass(frozen=True)
+class StaticRosterSource:
+    roster: FetchedRoster
+
+    def fetch_roster(self) -> FetchedRoster:
+        return self.roster
+
+
+def run_sync_roster(
+    engine: Any,
+    *,
+    source: RosterSource | None = None,
+    now: datetime | None = None,
+    inactive_grace: timedelta = DEFAULT_INACTIVE_GRACE,
+) -> SyncRosterSummary:
+    if source is None:
+        summary = SyncRosterSummary(groups_seen=0, employees_seen=0, status="not_implemented")
+        LOG.warning("sync-roster is not implemented yet", extra={"summary": summary.__dict__})
+        return summary
+
+    sync_time = now or _utcnow_naive()
+    roster = source.fetch_roster()
+    with engine.begin() as connection:
+        _sync_roster_rows(
+            connection,
+            roster=roster,
+            sync_time=sync_time,
+            inactive_grace=inactive_grace,
+        )
+
+    return SyncRosterSummary(
+        groups_seen=len(roster.groups),
+        employees_seen=len(roster.employees),
+        status="success",
+    )
+
+
+def _sync_roster_rows(
+    connection: Connection,
+    *,
+    roster: FetchedRoster,
+    sync_time: datetime,
+    inactive_grace: timedelta,
+) -> None:
+    group_rows = [_group_pass1_row(group, sync_time) for group in roster.groups]
+    employee_rows = _employee_pass1_rows(roster.employees, sync_time)
+
+    _upsert_rows(connection, groups_table, group_rows, key_columns=("lark_group_id",))
+    _upsert_rows(connection, employees_table, employee_rows, key_columns=("lark_id",))
+
+    employee_id_by_lark_id = _employee_id_map(connection)
+    group_id_by_lark_group_id = _group_id_map(connection)
+
+    group_path_by_id = _update_group_references(
+        connection,
+        groups=roster.groups,
+        employee_id_by_lark_id=employee_id_by_lark_id,
+        group_id_by_lark_group_id=group_id_by_lark_group_id,
+    )
+    _update_employee_references(
+        connection,
+        employees=roster.employees,
+        employee_id_by_lark_id=employee_id_by_lark_id,
+        group_id_by_lark_group_id=group_id_by_lark_group_id,
+        group_path_by_id=group_path_by_id,
+    )
+    _mark_stale_rows_inactive(
+        connection,
+        sync_time=sync_time,
+        inactive_grace=inactive_grace,
+    )
+
+
+def _group_pass1_row(group: FetchedGroup, sync_time: datetime) -> dict[str, object]:
+    return {
+        "lark_group_id": group.lark_group_id,
+        "name": group.name,
+        "parent_id": None,
+        "manager_id": None,
+        "path": None,
+        "is_active": True,
+        "last_seen_at": sync_time,
+        "updated_at": sync_time,
+    }
+
+
+def _employee_pass1_rows(
+    employees: Sequence[FetchedEmployee],
+    sync_time: datetime,
+) -> list[dict[str, object]]:
+    email_counts = Counter(
+        normalized
+        for employee in employees
+        if (normalized := _nullable_text(employee.email)) is not None
+    )
+    github_id_counts = Counter(
+        normalized
+        for employee in employees
+        if (normalized := _nullable_text(employee.github_id)) is not None
+    )
+    duplicate_emails = {value for value, count in email_counts.items() if count > 1}
+    duplicate_github_ids = {value for value, count in github_id_counts.items() if count > 1}
+    if duplicate_emails or duplicate_github_ids:
+        LOG.warning(
+            "dropping duplicate roster join keys",
+            extra={
+                "duplicate_email_count": len(duplicate_emails),
+                "duplicate_github_id_count": len(duplicate_github_ids),
+            },
+        )
+
+    rows = []
+    for employee in employees:
+        email = _nullable_text(employee.email)
+        github_id = _nullable_text(employee.github_id)
+        rows.append(
+            {
+                "lark_id": employee.lark_id,
+                "name": employee.name,
+                "employee_no": _nullable_text(employee.employee_no),
+                "email": None if email in duplicate_emails else email,
+                "github_id": None if github_id in duplicate_github_ids else github_id,
+                "manager_id": None,
+                "manager_path": None,
+                "group_id": None,
+                "group_path": None,
+                "is_active": True,
+                "last_seen_at": sync_time,
+                "updated_at": sync_time,
+            }
+        )
+    return rows
+
+
+def _nullable_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _upsert_rows(
+    connection: Connection,
+    table: Table,
+    rows: Sequence[dict[str, object]],
+    *,
+    key_columns: Sequence[str],
+) -> None:
+    if not rows:
+        return
+
+    dialect = connection.dialect.name
+    if dialect == "sqlite":
+        statement = sqlite_insert(table).values(list(rows))
+        excluded = statement.excluded
+        update_values = {
+            column.name: getattr(excluded, column.name)
+            for column in table.columns
+            if column.name not in {"id", "created_at", *key_columns}
+        }
+        connection.execute(statement.on_conflict_do_update(index_elements=key_columns, set_=update_values))
+        return
+
+    if dialect == "mysql":
+        statement = mysql_insert(table).values(list(rows))
+        inserted = statement.inserted
+        update_values = {
+            column.name: getattr(inserted, column.name)
+            for column in table.columns
+            if column.name not in {"id", "created_at", *key_columns}
+        }
+        connection.execute(statement.on_duplicate_key_update(**update_values))
+        return
+
+    raise RuntimeError(f"Unsupported database dialect for roster sync: {dialect}")
+
+
+def _employee_id_map(connection: Connection) -> dict[str, int]:
+    rows = connection.execute(select(employees_table.c.lark_id, employees_table.c.id)).all()
+    return {str(row.lark_id): int(row.id) for row in rows}
+
+
+def _group_id_map(connection: Connection) -> dict[str, int]:
+    rows = connection.execute(select(groups_table.c.lark_group_id, groups_table.c.id)).all()
+    return {str(row.lark_group_id): int(row.id) for row in rows}
+
+
+def _update_group_references(
+    connection: Connection,
+    *,
+    groups: Sequence[FetchedGroup],
+    employee_id_by_lark_id: dict[str, int],
+    group_id_by_lark_group_id: dict[str, int],
+) -> dict[int, str]:
+    group_by_lark_group_id = {group.lark_group_id: group for group in groups}
+    path_by_lark_group_id: dict[str, str] = {}
+
+    def build_path(lark_group_id: str, visiting: set[str] | None = None) -> str:
+        if lark_group_id in path_by_lark_group_id:
+            return path_by_lark_group_id[lark_group_id]
+        visiting = visiting or set()
+        if lark_group_id in visiting:
+            raise ValueError(f"Cycle detected in roster group tree at {lark_group_id!r}")
+        visiting.add(lark_group_id)
+        group = group_by_lark_group_id[lark_group_id]
+        group_id = group_id_by_lark_group_id[lark_group_id]
+        if group.parent_lark_group_id and group.parent_lark_group_id in group_id_by_lark_group_id:
+            path = f"{build_path(group.parent_lark_group_id, visiting)}{group_id}/"
+        else:
+            path = f"/{group_id}/"
+        path_by_lark_group_id[lark_group_id] = path
+        visiting.remove(lark_group_id)
+        return path
+
+    for group in groups:
+        group_id = group_id_by_lark_group_id[group.lark_group_id]
+        parent_id = (
+            group_id_by_lark_group_id.get(group.parent_lark_group_id)
+            if group.parent_lark_group_id
+            else None
+        )
+        manager_id = (
+            employee_id_by_lark_id.get(group.manager_lark_id)
+            if group.manager_lark_id
+            else None
+        )
+        path = build_path(group.lark_group_id)
+        connection.execute(
+            update(groups_table)
+            .where(groups_table.c.id == group_id)
+            .values(parent_id=parent_id, manager_id=manager_id, path=path)
+        )
+
+    return {group_id_by_lark_group_id[lark_id]: path for lark_id, path in path_by_lark_group_id.items()}
+
+
+def _update_employee_references(
+    connection: Connection,
+    *,
+    employees: Sequence[FetchedEmployee],
+    employee_id_by_lark_id: dict[str, int],
+    group_id_by_lark_group_id: dict[str, int],
+    group_path_by_id: dict[int, str],
+) -> None:
+    employee_by_lark_id = {employee.lark_id: employee for employee in employees}
+    manager_path_by_lark_id: dict[str, str] = {}
+
+    def build_manager_path(lark_id: str, visiting: set[str] | None = None) -> str:
+        if lark_id in manager_path_by_lark_id:
+            return manager_path_by_lark_id[lark_id]
+        visiting = visiting or set()
+        if lark_id in visiting:
+            raise ValueError(f"Cycle detected in roster manager tree at {lark_id!r}")
+        visiting.add(lark_id)
+        employee = employee_by_lark_id[lark_id]
+        if employee.manager_lark_id and employee.manager_lark_id in employee_id_by_lark_id:
+            manager_path = build_manager_path(employee.manager_lark_id, visiting)
+            manager_id = employee_id_by_lark_id[employee.manager_lark_id]
+            path = f"{manager_path}{manager_id}/" if manager_path else f"/{manager_id}/"
+        else:
+            path = None
+        manager_path_by_lark_id[lark_id] = path or ""
+        visiting.remove(lark_id)
+        return manager_path_by_lark_id[lark_id]
+
+    for employee in employees:
+        employee_id = employee_id_by_lark_id[employee.lark_id]
+        manager_id = (
+            employee_id_by_lark_id.get(employee.manager_lark_id)
+            if employee.manager_lark_id
+            else None
+        )
+        group_id = (
+            group_id_by_lark_group_id.get(employee.group_lark_id)
+            if employee.group_lark_id
+            else None
+        )
+        manager_path = build_manager_path(employee.lark_id) or None
+        group_path = group_path_by_id.get(group_id) if group_id else None
+        connection.execute(
+            update(employees_table)
+            .where(employees_table.c.id == employee_id)
+            .values(
+                manager_id=manager_id,
+                manager_path=manager_path,
+                group_id=group_id,
+                group_path=group_path,
+            )
+        )
+
+
+def _mark_stale_rows_inactive(
+    connection: Connection,
+    *,
+    sync_time: datetime,
+    inactive_grace: timedelta,
+) -> None:
+    cutoff = sync_time - inactive_grace
+    stale_filter = and_(
+        employees_table.c.is_active.is_(True),
+        employees_table.c.last_seen_at.is_not(None),
+        employees_table.c.last_seen_at < cutoff,
+    )
+    connection.execute(update(employees_table).where(stale_filter).values(is_active=False))
+    connection.execute(
+        update(groups_table)
+        .where(
+            and_(
+                groups_table.c.is_active.is_(True),
+                groups_table.c.last_seen_at.is_not(None),
+                groups_table.c.last_seen_at < cutoff,
+            )
+        )
+        .values(is_active=False)
+    )

--- a/roster/src/roster/jobs/validate_lark.py
+++ b/roster/src/roster/jobs/validate_lark.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import asdict, dataclass
+
+from roster.jobs.sync_roster import FetchedRoster, RosterSource
+
+
+@dataclass(frozen=True)
+class RosterValidationSummary:
+    groups: int
+    employees: int
+    root_groups: int
+    groups_without_manager: int
+    groups_with_missing_parent: int
+    employees_without_email: int
+    employees_without_employee_no: int
+    employees_without_github_id: int
+    employees_without_group: int
+    employees_with_missing_group: int
+    duplicate_employee_no: int
+    duplicate_email: int
+    duplicate_github_id: int
+
+    def to_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+def validate_lark_roster(source: RosterSource) -> RosterValidationSummary:
+    roster = source.fetch_roster()
+    return summarize_roster(roster)
+
+
+def summarize_roster(roster: FetchedRoster) -> RosterValidationSummary:
+    group_ids = {group.lark_group_id for group in roster.groups}
+    employee_nos = [_normalized(employee.employee_no) for employee in roster.employees]
+    emails = [_normalized(employee.email) for employee in roster.employees]
+    github_ids = [_normalized(employee.github_id) for employee in roster.employees]
+
+    return RosterValidationSummary(
+        groups=len(roster.groups),
+        employees=len(roster.employees),
+        root_groups=sum(1 for group in roster.groups if not group.parent_lark_group_id),
+        groups_without_manager=sum(1 for group in roster.groups if not group.manager_lark_id),
+        groups_with_missing_parent=sum(
+            1
+            for group in roster.groups
+            if group.parent_lark_group_id and group.parent_lark_group_id not in group_ids
+        ),
+        employees_without_email=sum(1 for email in emails if not email),
+        employees_without_employee_no=sum(1 for employee_no in employee_nos if not employee_no),
+        employees_without_github_id=sum(1 for github_id in github_ids if not github_id),
+        employees_without_group=sum(1 for employee in roster.employees if not employee.group_lark_id),
+        employees_with_missing_group=sum(
+            1
+            for employee in roster.employees
+            if employee.group_lark_id and employee.group_lark_id not in group_ids
+        ),
+        duplicate_employee_no=_duplicate_count(employee_nos),
+        duplicate_email=_duplicate_count(emails),
+        duplicate_github_id=_duplicate_count(github_ids),
+    )
+
+
+def _normalized(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _duplicate_count(values: list[str | None]) -> int:
+    counts = Counter(value for value in values if value)
+    return sum(1 for count in counts.values() if count > 1)

--- a/roster/src/roster/sources/__init__.py
+++ b/roster/src/roster/sources/__init__.py
@@ -1,0 +1,1 @@
+"""Roster data sources."""

--- a/roster/src/roster/sources/lark.py
+++ b/roster/src/roster/sources/lark.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib import error, parse, request
+
+from roster.jobs.sync_roster import FetchedEmployee, FetchedGroup, FetchedRoster, RosterSource
+
+LARK_OPENAPI_BASE_URL = "https://open.feishu.cn/open-apis"
+
+
+class LarkTransport(Protocol):
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, object] | None = None,
+        json_body: dict[str, object] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class UrllibLarkTransport:
+    base_url: str = LARK_OPENAPI_BASE_URL
+    timeout_seconds: int = 30
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, object] | None = None,
+        json_body: dict[str, object] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        query = ""
+        if params:
+            query = "?" + parse.urlencode(
+                {key: value for key, value in params.items() if value is not None}
+            )
+        url = f"{self.base_url}{path}{query}"
+        body = None
+        request_headers = {"Content-Type": "application/json"}
+        if headers:
+            request_headers.update(headers)
+        if json_body is not None:
+            body = json.dumps(json_body).encode("utf-8")
+        req = request.Request(url, data=body, method=method, headers=request_headers)
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:  # noqa: S310
+                payload = response.read().decode("utf-8")
+        except error.HTTPError as exc:
+            payload = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(_format_lark_http_error(exc.code, payload)) from exc
+        parsed = json.loads(payload)
+        if not isinstance(parsed, dict):
+            raise RuntimeError("Lark API response is not a JSON object")
+        return parsed
+
+
+@dataclass
+class LarkApiClient:
+    app_id: str
+    app_secret: str
+    transport: LarkTransport | None = None
+
+    def __post_init__(self) -> None:
+        if self.transport is None:
+            self.transport = UrllibLarkTransport()
+
+    def tenant_access_token(self) -> str:
+        response = self._request(
+            "POST",
+            "/auth/v3/tenant_access_token/internal",
+            json_body={"app_id": self.app_id, "app_secret": self.app_secret},
+            auth=False,
+        )
+        token = response.get("tenant_access_token")
+        if not isinstance(token, str) or not token:
+            raise RuntimeError("Lark tenant_access_token response did not include a token")
+        return token
+
+    def get(
+        self,
+        path: str,
+        *,
+        params: dict[str, object] | None = None,
+        token: str,
+    ) -> dict[str, Any]:
+        return self._request(
+            "GET",
+            path,
+            params=params,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, object] | None = None,
+        json_body: dict[str, object] | None = None,
+        headers: dict[str, str] | None = None,
+        auth: bool = True,
+    ) -> dict[str, Any]:
+        if auth and headers is None:
+            raise ValueError("authenticated Lark requests require headers")
+        assert self.transport is not None
+        response = self.transport.request_json(
+            method,
+            path,
+            params=params,
+            json_body=json_body,
+            headers=headers,
+        )
+        code = response.get("code")
+        if code != 0:
+            message = response.get("msg") or response.get("message") or "unknown Lark API error"
+            raise RuntimeError(f"Lark API {method} {path} failed: {message} (code={code})")
+        return response
+
+
+@dataclass(frozen=True)
+class LarkRosterSource(RosterSource):
+    client: LarkApiClient
+    root_department_id: str = "0"
+    github_custom_attr_id: str | None = None
+    page_size: int = 50
+
+    def fetch_roster(self) -> FetchedRoster:
+        token = self.client.tenant_access_token()
+        groups = self._fetch_groups(token)
+        employees = self._fetch_employees(token, groups)
+        return FetchedRoster(groups=groups, employees=employees)
+
+    def _fetch_groups(self, token: str) -> list[FetchedGroup]:
+        items = self._paginate(
+            token,
+            f"/contact/v3/departments/{self.root_department_id}/children",
+            params={
+                "user_id_type": "union_id",
+                "department_id_type": "open_department_id",
+                "fetch_child": True,
+                "page_size": self.page_size,
+            },
+        )
+        return [self._map_group(item) for item in items]
+
+    def _fetch_employees(self, token: str, groups: list[FetchedGroup]) -> list[FetchedEmployee]:
+        employees_by_lark_id: dict[str, FetchedEmployee] = {}
+        for group in groups:
+            items = self._paginate(
+                token,
+                "/contact/v3/users/find_by_department",
+                params={
+                    "user_id_type": "union_id",
+                    "department_id_type": "open_department_id",
+                    "department_id": group.lark_group_id,
+                    "page_size": self.page_size,
+                },
+            )
+            for item in items:
+                employee = self._map_employee(item, fallback_group_id=group.lark_group_id)
+                employees_by_lark_id.setdefault(employee.lark_id, employee)
+        return list(employees_by_lark_id.values())
+
+    def _paginate(
+        self,
+        token: str,
+        path: str,
+        *,
+        params: dict[str, object],
+    ) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        page_token: str | None = None
+        while True:
+            request_params = dict(params)
+            if page_token:
+                request_params["page_token"] = page_token
+            response = self.client.get(path, params=request_params, token=token)
+            data = response.get("data")
+            if not isinstance(data, dict):
+                raise RuntimeError(f"Lark API {path} response did not include data")
+            page_items = data.get("items") or []
+            if not isinstance(page_items, list):
+                raise RuntimeError(f"Lark API {path} data.items is not a list")
+            items.extend(item for item in page_items if isinstance(item, dict))
+            if not data.get("has_more"):
+                return items
+            next_token = data.get("page_token")
+            if not isinstance(next_token, str) or not next_token:
+                raise RuntimeError(f"Lark API {path} has_more=true but page_token is missing")
+            page_token = next_token
+
+    def _map_group(self, item: dict[str, Any]) -> FetchedGroup:
+        group_id = _required_text(item, "open_department_id")
+        parent_id = _optional_text(item.get("parent_department_id"))
+        return FetchedGroup(
+            lark_group_id=group_id,
+            name=_required_text(item, "name"),
+            parent_lark_group_id=None if parent_id in {None, "0"} else parent_id,
+            manager_lark_id=_optional_text(item.get("leader_user_id")),
+        )
+
+    def _map_employee(self, item: dict[str, Any], *, fallback_group_id: str) -> FetchedEmployee:
+        lark_id = _required_text(item, "union_id")
+        return FetchedEmployee(
+            lark_id=lark_id,
+            name=_required_text(item, "name"),
+            employee_no=_optional_text(item.get("employee_no")),
+            email=_optional_text(item.get("enterprise_email") or item.get("email")),
+            github_id=self._github_id_from_custom_attrs(item),
+            manager_lark_id=_optional_text(item.get("leader_user_id")),
+            group_lark_id=_primary_group_id(item, fallback_group_id=fallback_group_id),
+        )
+
+    def _github_id_from_custom_attrs(self, item: dict[str, Any]) -> str | None:
+        if not self.github_custom_attr_id:
+            return None
+        custom_attrs = item.get("custom_attrs")
+        if not isinstance(custom_attrs, list):
+            return None
+        for attr in custom_attrs:
+            if not isinstance(attr, dict) or attr.get("id") != self.github_custom_attr_id:
+                continue
+            value = attr.get("value")
+            if not isinstance(value, dict):
+                return None
+            return _optional_text(
+                value.get("text")
+                or value.get("url")
+                or value.get("option_value")
+                or value.get("name")
+            )
+        return None
+
+
+def _primary_group_id(item: dict[str, Any], *, fallback_group_id: str) -> str:
+    orders = item.get("orders")
+    if isinstance(orders, list):
+        order_items = [order for order in orders if isinstance(order, dict)]
+        for order in order_items:
+            if order.get("is_primary_dept"):
+                primary = _optional_text(order.get("department_id"))
+                if primary:
+                    return primary
+        sorted_orders = sorted(
+            order_items,
+            key=lambda order: int(order.get("department_order") or 0),
+            reverse=True,
+        )
+        if sorted_orders:
+            primary = _optional_text(sorted_orders[0].get("department_id"))
+            if primary:
+                return primary
+    department_ids = item.get("department_ids")
+    if isinstance(department_ids, list):
+        for department_id in department_ids:
+            normalized = _optional_text(department_id)
+            if normalized:
+                return normalized
+    return fallback_group_id
+
+
+def _required_text(item: dict[str, Any], key: str) -> str:
+    value = _optional_text(item.get(key))
+    if value is None:
+        raise RuntimeError(f"Lark response item missing required field {key!r}")
+    return value
+
+
+def _optional_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _format_lark_http_error(status_code: int, payload: str) -> str:
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        return f"Lark API HTTP {status_code}: {payload[:500]}"
+    if not isinstance(parsed, dict):
+        return f"Lark API HTTP {status_code}: {payload[:500]}"
+    message = parsed.get("msg") or parsed.get("message") or "unknown Lark API error"
+    code = parsed.get("code")
+    return f"Lark API HTTP {status_code}: {message} (code={code})"

--- a/roster/src/roster/sources/lark.py
+++ b/roster/src/roster/sources/lark.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any, Protocol
 from urllib import error, parse, request
 
@@ -214,6 +215,7 @@ class LarkRosterSource(RosterSource):
             employee_no=_optional_text(item.get("employee_no")),
             email=_optional_text(item.get("enterprise_email") or item.get("email")),
             github_id=self._github_id_from_custom_attrs(item),
+            join_time=_join_time_from_epoch(item.get("join_time")),
             manager_lark_id=_optional_text(item.get("leader_user_id")),
             group_lark_id=_primary_group_id(item, fallback_group_id=fallback_group_id),
         )
@@ -278,6 +280,12 @@ def _optional_text(value: object) -> str | None:
         return None
     value = value.strip()
     return value or None
+
+
+def _join_time_from_epoch(value: object) -> datetime | None:
+    if not isinstance(value, int) or value <= 0:
+        return None
+    return datetime.fromtimestamp(value, UTC).replace(tzinfo=None)
 
 
 def _format_lark_http_error(status_code: int, payload: str) -> str:

--- a/roster/tests/test_cli.py
+++ b/roster/tests/test_cli.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from roster.jobs import cli
+
+
+def test_parser_exposes_sync_roster_command() -> None:
+    args = cli.build_parser().parse_args(["sync-roster"])
+
+    assert args.command == "sync-roster"
+
+
+def test_parser_exposes_validate_lark_command() -> None:
+    args = cli.build_parser().parse_args(["validate-lark"])
+
+    assert args.command == "validate-lark"
+
+
+def test_main_runs_sync_roster(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+    settings = SimpleNamespace(log_level="INFO", lark=SimpleNamespace(is_configured=False))
+    engine = SimpleNamespace(dispose=lambda: calls.setdefault("disposed", True))
+    summary = SimpleNamespace(groups_seen=2, employees_seen=3)
+
+    monkeypatch.setattr(cli, "get_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda log_level: calls.setdefault("log", log_level))
+    monkeypatch.setattr(cli, "build_engine", lambda resolved: calls.setdefault("engine", engine))
+
+    def fake_run_sync_roster(built_engine, *, source=None):
+        calls["sync"] = (built_engine, source)
+        return summary
+
+    monkeypatch.setattr(cli, "run_sync_roster", fake_run_sync_roster)
+
+    assert cli.main(["sync-roster"]) == 0
+    assert calls == {
+        "log": "INFO",
+        "engine": engine,
+        "sync": (engine, None),
+        "disposed": True,
+    }
+
+
+def test_main_disposes_engine_when_sync_fails(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+    settings = SimpleNamespace(log_level="INFO", lark=SimpleNamespace(is_configured=False))
+    engine = SimpleNamespace(dispose=lambda: calls.setdefault("disposed", True))
+
+    monkeypatch.setattr(cli, "get_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda log_level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda resolved: engine)
+
+    def fail_sync(_built_engine, *, source=None):
+        calls["source"] = source
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli, "run_sync_roster", fail_sync)
+
+    try:
+        cli.main(["sync-roster"])
+    except RuntimeError as exc:
+        assert str(exc) == "boom"
+    else:  # pragma: no cover
+        raise AssertionError("sync failure should propagate")
+
+    assert calls == {"source": None, "disposed": True}
+
+
+def test_main_builds_lark_source_when_configured(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+    lark_settings = SimpleNamespace(
+        is_configured=True,
+        app_id="cli_xxx",
+        app_secret="secret",
+        github_custom_attr_id="github_attr",
+        root_department_id="od-root",
+    )
+    settings = SimpleNamespace(log_level="INFO", lark=lark_settings)
+    engine = SimpleNamespace(dispose=lambda: calls.setdefault("disposed", True))
+    source = object()
+    client = object()
+    summary = SimpleNamespace(groups_seen=2, employees_seen=3)
+
+    monkeypatch.setattr(cli, "get_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda log_level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda resolved: engine)
+    def fake_lark_api_client(app_id, app_secret):
+        calls["client"] = (app_id, app_secret)
+        return client
+
+    def fake_lark_roster_source(built_client, github_custom_attr_id, root_department_id):
+        calls["source_args"] = (built_client, github_custom_attr_id, root_department_id)
+        return source
+
+    monkeypatch.setattr(cli, "LarkApiClient", fake_lark_api_client)
+    monkeypatch.setattr(cli, "LarkRosterSource", fake_lark_roster_source)
+
+    def fake_run_sync_roster(built_engine, *, source=None):
+        calls["sync"] = (built_engine, source)
+        return summary
+
+    monkeypatch.setattr(cli, "run_sync_roster", fake_run_sync_roster)
+
+    assert cli.main(["sync-roster"]) == 0
+    assert calls == {
+        "client": ("cli_xxx", "secret"),
+        "source_args": (client, "github_attr", "od-root"),
+        "sync": (engine, source),
+        "disposed": True,
+    }
+
+
+def test_main_validate_lark_requires_lark_config(monkeypatch) -> None:
+    settings = SimpleNamespace(log_level="INFO", lark=SimpleNamespace(is_configured=False))
+    calls: dict[str, object] = {}
+
+    def fake_get_settings(*, require_database=True):
+        calls["require_database"] = require_database
+        return settings
+
+    monkeypatch.setattr(cli, "get_settings", fake_get_settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda log_level: None)
+
+    try:
+        cli.main(["validate-lark"])
+    except SystemExit as exc:
+        assert exc.code == "validate-lark requires ROSTER_LARK_APP_ID and ROSTER_LARK_APP_SECRET"
+    else:  # pragma: no cover
+        raise AssertionError("validate-lark should require Lark config")
+    assert calls == {"require_database": False}
+
+
+def test_main_validate_lark_prints_json(monkeypatch, capsys) -> None:
+    calls: dict[str, object] = {}
+    lark_settings = SimpleNamespace(
+        is_configured=True,
+        app_id="cli_xxx",
+        app_secret="secret",
+        github_custom_attr_id="github_attr",
+        root_department_id="od-root",
+    )
+    settings = SimpleNamespace(log_level="INFO", lark=lark_settings)
+    client = object()
+    source = object()
+    summary = SimpleNamespace(to_dict=lambda: {"groups": 2, "employees": 3})
+
+    monkeypatch.setattr(cli, "get_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda log_level: None)
+    monkeypatch.setattr(cli, "LarkApiClient", lambda app_id, app_secret: client)
+    monkeypatch.setattr(cli, "LarkRosterSource", lambda *args, **kwargs: source)
+    def fake_validate_lark_roster(built_source):
+        calls["source"] = built_source
+        return summary
+
+    monkeypatch.setattr(cli, "validate_lark_roster", fake_validate_lark_roster)
+
+    assert cli.main(["validate-lark"]) == 0
+
+    assert calls == {"source": source}
+    assert capsys.readouterr().out == '{\n  "employees": 3,\n  "groups": 2\n}\n'
+
+
+def test_main_rejects_unknown_args() -> None:
+    parser = cli.build_parser()
+
+    try:
+        parser.parse_args(["sync-roster", "--unknown"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:  # pragma: no cover
+        raise AssertionError("parse_args should reject unknown arguments")

--- a/roster/tests/test_config_and_db.py
+++ b/roster/tests/test_config_and_db.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+
+from roster.common.config import load_settings
+from roster.common.db import build_engine
+
+
+def test_load_settings_uses_roster_db_url() -> None:
+    settings = load_settings({"ROSTER_DB_URL": "sqlite:///:memory:"})
+
+    assert settings.database.url == "sqlite:///:memory:"
+    assert settings.database.host is None
+    assert settings.lark.app_id is None
+    assert settings.lark.app_secret is None
+
+
+def test_load_settings_builds_tidb_fields() -> None:
+    settings = load_settings(
+        {
+            "ROSTER_TIDB_HOST": "tidb.example.com",
+            "ROSTER_TIDB_PORT": "4000",
+            "ROSTER_TIDB_USER": "roster",
+            "ROSTER_TIDB_PASSWORD": "secret",
+            "ROSTER_TIDB_DB": "insight",
+            "ROSTER_TIDB_SSL_CA": "/var/run/ca.crt",
+            "ROSTER_LOG_LEVEL": "debug",
+            "ROSTER_LARK_APP_ID": "cli_xxx",
+            "ROSTER_LARK_APP_SECRET": "secret",
+            "ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID": "github_attr",
+            "ROSTER_LARK_ROOT_DEPARTMENT_ID": "od-root",
+        }
+    )
+
+    assert settings.database.host == "tidb.example.com"
+    assert settings.database.port == 4000
+    assert settings.database.user == "roster"
+    assert settings.database.password == "secret"
+    assert settings.database.database == "insight"
+    assert settings.database.ssl_ca == "/var/run/ca.crt"
+    assert settings.lark.app_id == "cli_xxx"
+    assert settings.lark.app_secret == "secret"
+    assert settings.lark.github_custom_attr_id == "github_attr"
+    assert settings.lark.root_department_id == "od-root"
+    assert settings.log_level == "DEBUG"
+
+
+def test_load_settings_accepts_ci_dashboard_tidb_secret_keys() -> None:
+    settings = load_settings(
+        {
+            "TIDB_HOST": "tidb.example.com",
+            "TIDB_PORT": "4000",
+            "TIDB_USER": "roster",
+            "TIDB_PASSWORD": "secret",
+            "TIDB_DB": "insight",
+            "TIDB_SSL_CA": "/var/run/ca.crt",
+        }
+    )
+
+    assert settings.database.host == "tidb.example.com"
+    assert settings.database.port == 4000
+    assert settings.database.user == "roster"
+    assert settings.database.password == "secret"
+    assert settings.database.database == "insight"
+    assert settings.database.ssl_ca == "/var/run/ca.crt"
+
+
+def test_load_settings_accepts_ci_dashboard_db_url_key() -> None:
+    settings = load_settings({"CI_DASHBOARD_DB_URL": "sqlite:///:memory:"})
+
+    assert settings.database.url == "sqlite:///:memory:"
+
+
+def test_load_settings_can_skip_database_for_lark_only_commands() -> None:
+    settings = load_settings(
+        {
+            "ROSTER_LARK_APP_ID": "cli_xxx",
+            "ROSTER_LARK_APP_SECRET": "secret",
+        },
+        require_database=False,
+    )
+
+    assert settings.database.url is None
+    assert settings.database.host is None
+    assert settings.lark.is_configured is True
+
+
+def test_lark_settings_are_disabled_when_partially_configured() -> None:
+    settings = load_settings(
+        {
+            "ROSTER_DB_URL": "sqlite:///:memory:",
+            "ROSTER_LARK_APP_ID": "cli_xxx",
+        }
+    )
+
+    assert settings.lark.is_configured is False
+
+
+def test_load_settings_requires_tidb_fields_without_url() -> None:
+    with pytest.raises(ValueError, match="ROSTER_TIDB_HOST"):
+        load_settings({})
+
+
+def test_build_engine_uses_sqlite_url() -> None:
+    settings = load_settings({"ROSTER_DB_URL": "sqlite:///:memory:"})
+    engine = build_engine(settings)
+
+    assert engine.dialect.name == "sqlite"
+
+
+def test_build_engine_builds_mysql_url() -> None:
+    settings = load_settings(
+        {
+            "ROSTER_TIDB_HOST": "tidb.example.com",
+            "ROSTER_TIDB_PORT": "4000",
+            "ROSTER_TIDB_USER": "roster",
+            "ROSTER_TIDB_PASSWORD": "secret",
+            "ROSTER_TIDB_DB": "insight",
+        }
+    )
+    engine = build_engine(settings)
+
+    assert engine.dialect.name == "mysql"
+    assert str(engine.url) == "mysql+pymysql://roster:***@tidb.example.com:4000/insight?charset=utf8mb4"

--- a/roster/tests/test_deploy_artifacts.py
+++ b/roster/tests/test_deploy_artifacts.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_jobs_dockerfile_uses_roster_cli_entrypoint() -> None:
+    dockerfile = (PROJECT_ROOT / "Dockerfile.jobs").read_text()
+
+    assert "FROM python:3.12-slim" in dockerfile
+    assert "COPY pyproject.toml README.md ./" in dockerfile
+    assert 'ENTRYPOINT ["python", "-m", "roster.jobs.cli"]' in dockerfile
+
+
+def test_skaffold_builds_roster_jobs_image() -> None:
+    skaffold = (PROJECT_ROOT / "skaffold.yaml").read_text()
+
+    assert "apiVersion: skaffold/v4beta6" in skaffold
+    assert "name: roster" in skaffold
+    assert "image: roster-jobs" in skaffold
+    assert "dockerfile: Dockerfile.jobs" in skaffold
+
+
+def test_render_roster_sync_cronjob_outputs_expected_manifest() -> None:
+    script = PROJECT_ROOT / "scripts" / "render_roster_sync_cronjob.sh"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(script),
+            "--namespace",
+            "apps",
+            "--image",
+            "example/roster:dev",
+            "--db-secret",
+            "ci-dashboard-eq-prd-insight-db",
+            "--lark-secret",
+            "roster-lark",
+            "--ca-secret",
+            "roster-ca",
+            "--service-account",
+            "roster",
+            "--suspend",
+            "true",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    manifest = result.stdout
+    assert "kind: CronJob" in manifest
+    assert "name: roster-sync" in manifest
+    assert "namespace: apps" in manifest
+    assert "image: example/roster:dev" in manifest
+    assert "serviceAccountName: roster" in manifest
+    assert "suspend: true" in manifest
+    assert "concurrencyPolicy: Forbid" in manifest
+    assert "app.kubernetes.io/name: roster-sync" in manifest
+    assert "app.kubernetes.io/part-of: roster" in manifest
+    assert "name: ci-dashboard-eq-prd-insight-db" in manifest
+    assert "name: roster-lark" in manifest
+    assert "ROSTER_LOG_LEVEL" in manifest
+    assert "ROSTER_TIDB_SSL_CA" in manifest
+    assert "value: /var/run/roster/ssl/ca.crt" in manifest
+    assert "secretName: roster-ca" in manifest
+    assert "- sync-roster" in manifest

--- a/roster/tests/test_lark_source.py
+++ b/roster/tests/test_lark_source.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import urllib.error
+
+import pytest
+
+from roster.sources import lark
+from roster.sources.lark import LarkApiClient, LarkRosterSource, UrllibLarkTransport
+
+
+class FakeTransport:
+    def __init__(self, responses: list[dict]):
+        self.responses = responses
+        self.calls: list[dict] = []
+
+    def request_json(self, method, path, *, params=None, json_body=None, headers=None):
+        self.calls.append(
+            {
+                "method": method,
+                "path": path,
+                "params": params or {},
+                "json_body": json_body or {},
+                "headers": headers or {},
+            }
+        )
+        return self.responses.pop(0)
+
+
+def test_lark_roster_source_fetches_token_departments_and_users() -> None:
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [
+                        {
+                            "open_department_id": "od-root",
+                            "parent_department_id": "0",
+                            "name": "Root",
+                            "leader_user_id": "ceo",
+                        },
+                        {
+                            "open_department_id": "od-eng",
+                            "parent_department_id": "od-root",
+                            "name": "Engineering",
+                            "leader_user_id": "manager",
+                        },
+                    ],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [
+                        {
+                            "union_id": "ceo",
+                            "name": "CEO",
+                            "email": "ceo@example.com",
+                            "employee_no": "E001",
+                            "leader_user_id": "",
+                            "department_ids": ["od-root"],
+                            "orders": [
+                                {
+                                    "department_id": "od-root",
+                                    "department_order": 10,
+                                    "is_primary_dept": True,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [
+                        {
+                            "union_id": "manager",
+                            "name": "Manager",
+                            "enterprise_email": "manager@example.com",
+                            "employee_no": "E002",
+                            "leader_user_id": "ceo",
+                            "department_ids": ["od-eng", "od-root"],
+                            "orders": [
+                                {
+                                    "department_id": "od-root",
+                                    "department_order": 1,
+                                    "is_primary_dept": False,
+                                },
+                                {
+                                    "department_id": "od-eng",
+                                    "department_order": 20,
+                                    "is_primary_dept": True,
+                                },
+                            ],
+                            "custom_attrs": [
+                                {
+                                    "id": "github_attr",
+                                    "type": "TEXT",
+                                    "value": {"text": "manager-gh"},
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        ]
+    )
+    source = LarkRosterSource(
+        LarkApiClient("app_id", "app_secret", transport=transport),
+        github_custom_attr_id="github_attr",
+    )
+
+    roster = source.fetch_roster()
+
+    assert [group.lark_group_id for group in roster.groups] == ["od-root", "od-eng"]
+    assert roster.groups[0].parent_lark_group_id is None
+    assert roster.groups[0].manager_lark_id == "ceo"
+    assert roster.groups[1].parent_lark_group_id == "od-root"
+    assert roster.groups[1].manager_lark_id == "manager"
+    assert [employee.lark_id for employee in roster.employees] == ["ceo", "manager"]
+    assert roster.employees[0].group_lark_id == "od-root"
+    assert roster.employees[1].email == "manager@example.com"
+    assert roster.employees[1].github_id == "manager-gh"
+    assert roster.employees[1].manager_lark_id == "ceo"
+    assert roster.employees[1].group_lark_id == "od-eng"
+    assert transport.calls[0] == {
+        "method": "POST",
+        "path": "/auth/v3/tenant_access_token/internal",
+        "params": {},
+        "json_body": {"app_id": "app_id", "app_secret": "app_secret"},
+        "headers": {},
+    }
+    assert transport.calls[1]["path"] == "/contact/v3/departments/0/children"
+    assert transport.calls[1]["params"]["fetch_child"] is True
+    assert transport.calls[1]["params"]["department_id_type"] == "open_department_id"
+    assert transport.calls[1]["params"]["user_id_type"] == "union_id"
+    assert transport.calls[2]["path"] == "/contact/v3/users/find_by_department"
+    assert transport.calls[2]["params"]["department_id"] == "od-root"
+    assert transport.calls[3]["params"]["department_id"] == "od-eng"
+    assert all(call["headers"].get("Authorization") == "Bearer token" for call in transport.calls[1:])
+
+
+def test_lark_roster_source_handles_pagination_and_deduplicates_users() -> None:
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {
+                "code": 0,
+                "data": {
+                    "has_more": True,
+                    "page_token": "next-dept",
+                    "items": [{"open_department_id": "od-a", "name": "A"}],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [{"open_department_id": "od-b", "name": "B"}],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": True,
+                    "page_token": "next-user",
+                    "items": [{"union_id": "alice", "name": "Alice", "department_ids": ["od-a"]}],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [{"union_id": "alice", "name": "Alice v2", "department_ids": ["od-a"]}],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [{"union_id": "bob", "name": "Bob", "department_ids": ["od-b"]}],
+                },
+            },
+        ]
+    )
+    source = LarkRosterSource(LarkApiClient("app_id", "app_secret", transport=transport))
+
+    roster = source.fetch_roster()
+
+    assert [group.lark_group_id for group in roster.groups] == ["od-a", "od-b"]
+    assert [employee.lark_id for employee in roster.employees] == ["alice", "bob"]
+    assert roster.employees[0].name == "Alice"
+    assert transport.calls[2]["params"]["page_token"] == "next-dept"
+    assert transport.calls[4]["params"]["page_token"] == "next-user"
+
+
+def test_lark_api_client_raises_on_lark_error() -> None:
+    transport = FakeTransport([{"code": 999, "msg": "bad token"}])
+    client = LarkApiClient("app_id", "app_secret", transport=transport)
+
+    try:
+        client.tenant_access_token()
+    except RuntimeError as exc:
+        assert "bad token" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected lark error")
+
+
+def test_lark_api_client_raises_when_token_missing() -> None:
+    transport = FakeTransport([{"code": 0}])
+    client = LarkApiClient("app_id", "app_secret", transport=transport)
+
+    with pytest.raises(RuntimeError, match="did not include a token"):
+        client.tenant_access_token()
+
+
+def test_lark_api_client_rejects_authenticated_request_without_headers() -> None:
+    client = LarkApiClient("app_id", "app_secret", transport=FakeTransport([]))
+
+    with pytest.raises(ValueError, match="require headers"):
+        client._request("GET", "/contact/v3/x")  # noqa: SLF001
+
+
+def test_lark_roster_source_rejects_bad_pagination_shapes() -> None:
+    missing_data = LarkRosterSource(
+        LarkApiClient(
+            "app_id",
+            "app_secret",
+            transport=FakeTransport(
+                [
+                    {"code": 0, "tenant_access_token": "token"},
+                    {"code": 0},
+                ]
+            ),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="did not include data"):
+        missing_data.fetch_roster()
+
+    bad_items = LarkRosterSource(
+        LarkApiClient(
+            "app_id",
+            "app_secret",
+            transport=FakeTransport(
+                [
+                    {"code": 0, "tenant_access_token": "token"},
+                    {"code": 0, "data": {"items": "not-list"}},
+                ]
+            ),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="data.items is not a list"):
+        bad_items.fetch_roster()
+
+    missing_page_token = LarkRosterSource(
+        LarkApiClient(
+            "app_id",
+            "app_secret",
+            transport=FakeTransport(
+                [
+                    {"code": 0, "tenant_access_token": "token"},
+                    {"code": 0, "data": {"has_more": True, "items": []}},
+                ]
+            ),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="page_token is missing"):
+        missing_page_token.fetch_roster()
+
+
+def test_lark_roster_source_maps_fallback_fields() -> None:
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {"code": 0, "data": {"has_more": False, "items": [{"open_department_id": "od-a", "name": "A"}]}},
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [
+                        {
+                            "union_id": "alice",
+                            "name": "Alice",
+                            "email": "alice@example.com",
+                            "orders": [
+                                {"department_id": "od-a", "department_order": 20},
+                                {"department_id": "od-b", "department_order": 5},
+                            ],
+                            "custom_attrs": [
+                                {"id": "github_attr", "value": {"url": "alice-gh"}}
+                            ],
+                        },
+                        {
+                            "union_id": "bob",
+                            "name": "Bob",
+                            "department_ids": ["od-a"],
+                            "custom_attrs": [
+                                {"id": "github_attr", "value": "bad-value"}
+                            ],
+                        },
+                    ],
+                },
+            },
+        ]
+    )
+    source = LarkRosterSource(
+        LarkApiClient("app_id", "app_secret", transport=transport),
+        github_custom_attr_id="github_attr",
+    )
+
+    roster = source.fetch_roster()
+
+    assert roster.employees[0].email == "alice@example.com"
+    assert roster.employees[0].github_id == "alice-gh"
+    assert roster.employees[0].group_lark_id == "od-a"
+    assert roster.employees[1].github_id is None
+    assert roster.employees[1].group_lark_id == "od-a"
+
+
+def test_lark_roster_source_requires_ids_and_names() -> None:
+    source = LarkRosterSource(
+        LarkApiClient(
+            "app_id",
+            "app_secret",
+            transport=FakeTransport(
+                [
+                    {"code": 0, "tenant_access_token": "token"},
+                    {"code": 0, "data": {"has_more": False, "items": [{"name": "No ID"}]}},
+                ]
+            ),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="open_department_id"):
+        source.fetch_roster()
+
+
+def test_urllib_lark_transport_encodes_request(monkeypatch) -> None:
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb):
+            return None
+
+        def read(self):
+            return b'{"code": 0, "data": {"ok": true}}'
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = req.data
+        captured["headers"] = dict(req.header_items())
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(lark.request, "urlopen", fake_urlopen)
+
+    response = UrllibLarkTransport(base_url="https://example.test", timeout_seconds=7).request_json(
+        "POST",
+        "/x",
+        params={"a": "1", "skip": None},
+        json_body={"hello": "world"},
+        headers={"Authorization": "Bearer token"},
+    )
+
+    assert response == {"code": 0, "data": {"ok": True}}
+    assert captured["url"] == "https://example.test/x?a=1"
+    assert captured["method"] == "POST"
+    assert captured["body"] == b'{"hello": "world"}'
+    assert captured["headers"]["Authorization"] == "Bearer token"
+    assert captured["timeout"] == 7
+
+
+def test_urllib_lark_transport_surfaces_http_error_body(monkeypatch) -> None:
+    class FakeErrorResponse:
+        def read(self):
+            return b'{"code":40004,"msg":"no dept authority error"}'
+
+        def close(self):
+            return None
+
+    def fake_urlopen(_req, timeout):
+        assert timeout == 30
+        raise urllib.error.HTTPError(
+            url="https://example.test/x",
+            code=403,
+            msg="Forbidden",
+            hdrs={},
+            fp=FakeErrorResponse(),
+        )
+
+    monkeypatch.setattr(lark.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="no dept authority error.*40004"):
+        UrllibLarkTransport(base_url="https://example.test").request_json("GET", "/x")

--- a/roster/tests/test_lark_source.py
+++ b/roster/tests/test_lark_source.py
@@ -60,6 +60,7 @@ def test_lark_roster_source_fetches_token_departments_and_users() -> None:
                             "name": "CEO",
                             "email": "ceo@example.com",
                             "employee_no": "E001",
+                            "join_time": 1704067200,
                             "leader_user_id": "",
                             "department_ids": ["od-root"],
                             "orders": [
@@ -83,6 +84,7 @@ def test_lark_roster_source_fetches_token_departments_and_users() -> None:
                             "name": "Manager",
                             "enterprise_email": "manager@example.com",
                             "employee_no": "E002",
+                            "join_time": 1706745600,
                             "leader_user_id": "ceo",
                             "department_ids": ["od-eng", "od-root"],
                             "orders": [
@@ -124,8 +126,10 @@ def test_lark_roster_source_fetches_token_departments_and_users() -> None:
     assert roster.groups[1].manager_lark_id == "manager"
     assert [employee.lark_id for employee in roster.employees] == ["ceo", "manager"]
     assert roster.employees[0].group_lark_id == "od-root"
+    assert roster.employees[0].join_time.isoformat() == "2024-01-01T00:00:00"
     assert roster.employees[1].email == "manager@example.com"
     assert roster.employees[1].github_id == "manager-gh"
+    assert roster.employees[1].join_time.isoformat() == "2024-02-01T00:00:00"
     assert roster.employees[1].manager_lark_id == "ceo"
     assert roster.employees[1].group_lark_id == "od-eng"
     assert transport.calls[0] == {
@@ -290,6 +294,7 @@ def test_lark_roster_source_maps_fallback_fields() -> None:
                             "union_id": "alice",
                             "name": "Alice",
                             "email": "alice@example.com",
+                            "join_time": 0,
                             "orders": [
                                 {"department_id": "od-a", "department_order": 20},
                                 {"department_id": "od-b", "department_order": 5},
@@ -320,6 +325,7 @@ def test_lark_roster_source_maps_fallback_fields() -> None:
 
     assert roster.employees[0].email == "alice@example.com"
     assert roster.employees[0].github_id == "alice-gh"
+    assert roster.employees[0].join_time is None
     assert roster.employees[0].group_lark_id == "od-a"
     assert roster.employees[1].github_id is None
     assert roster.employees[1].group_lark_id == "od-a"

--- a/roster/tests/test_sql_schema.py
+++ b/roster/tests/test_sql_schema.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SQL_PATH = Path(__file__).resolve().parents[1] / "sql" / "001_create_roster_tables.sql"
+
+
+def test_schema_migration_creates_expected_tables() -> None:
+    sql = SQL_PATH.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS roster_employees" in sql
+    assert "CREATE TABLE IF NOT EXISTS roster_groups" in sql
+    assert sql.count("ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci") == 2
+
+
+def test_employee_schema_has_join_keys_and_paths() -> None:
+    sql = SQL_PATH.read_text()
+
+    assert "id BIGINT NOT NULL AUTO_INCREMENT" in sql
+    assert "lark_id VARCHAR(128) NOT NULL" in sql
+    assert "employee_no VARCHAR(64) NULL" in sql
+    assert "UNIQUE KEY uk_roster_employees_lark_id (lark_id)" in sql
+    assert "UNIQUE KEY uk_roster_employees_email (email)" in sql
+    assert "UNIQUE KEY uk_roster_employees_github_id (github_id)" in sql
+    assert "KEY idx_roster_employees_employee_no (employee_no)" in sql
+    assert "manager_path VARCHAR(1024) NULL" in sql
+    assert "group_path VARCHAR(1024) NULL" in sql
+    assert "last_seen_at DATETIME NULL" in sql
+
+
+def test_group_schema_has_parent_manager_and_path() -> None:
+    sql = SQL_PATH.read_text()
+
+    assert "lark_group_id VARCHAR(128) NOT NULL" in sql
+    assert "parent_id BIGINT NULL" in sql
+    assert "manager_id BIGINT NULL" in sql
+    assert "path VARCHAR(1024) NULL" in sql
+    assert "UNIQUE KEY uk_roster_groups_lark_group_id (lark_group_id)" in sql
+    assert "KEY idx_roster_groups_parent (parent_id)" in sql
+    assert "KEY idx_roster_groups_manager (manager_id)" in sql

--- a/roster/tests/test_sql_schema.py
+++ b/roster/tests/test_sql_schema.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 
 SQL_PATH = Path(__file__).resolve().parents[1] / "sql" / "001_create_roster_tables.sql"
+JOIN_TIME_SQL_PATH = (
+    Path(__file__).resolve().parents[1] / "sql" / "002_alter_roster_employees_add_join_time.sql"
+)
 
 
 def test_schema_migration_creates_expected_tables() -> None:
@@ -20,6 +23,7 @@ def test_employee_schema_has_join_keys_and_paths() -> None:
     assert "id BIGINT NOT NULL AUTO_INCREMENT" in sql
     assert "lark_id VARCHAR(128) NOT NULL" in sql
     assert "employee_no VARCHAR(64) NULL" in sql
+    assert "join_time DATETIME NULL" in sql
     assert "UNIQUE KEY uk_roster_employees_lark_id (lark_id)" in sql
     assert "UNIQUE KEY uk_roster_employees_email (email)" in sql
     assert "UNIQUE KEY uk_roster_employees_github_id (github_id)" in sql
@@ -39,3 +43,10 @@ def test_group_schema_has_parent_manager_and_path() -> None:
     assert "UNIQUE KEY uk_roster_groups_lark_group_id (lark_group_id)" in sql
     assert "KEY idx_roster_groups_parent (parent_id)" in sql
     assert "KEY idx_roster_groups_manager (manager_id)" in sql
+
+
+def test_join_time_alter_sql_adds_employee_column() -> None:
+    sql = JOIN_TIME_SQL_PATH.read_text()
+
+    assert "ALTER TABLE roster_employees" in sql
+    assert "ADD COLUMN join_time DATETIME NULL AFTER github_id" in sql

--- a/roster/tests/test_sync_roster.py
+++ b/roster/tests/test_sync_roster.py
@@ -67,6 +67,7 @@ def test_run_sync_roster_writes_groups_employees_and_paths() -> None:
                     employee_no="E003",
                     email="dev@example.com",
                     github_id="dev-gh",
+                    join_time=_dt("2024-01-02T00:00:00"),
                     manager_lark_id="manager",
                     group_lark_id="db",
                 ),
@@ -101,6 +102,7 @@ def test_run_sync_roster_writes_groups_employees_and_paths() -> None:
     assert employees["dev"]["manager_path"] == f"/{employees['ceo']['id']}/{employees['manager']['id']}/"
     assert employees["dev"]["group_id"] == groups["db"]["id"]
     assert employees["dev"]["group_path"] == groups["db"]["path"]
+    assert employees["dev"]["join_time"] == _dt("2024-01-02T00:00:00")
 
 
 def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -> None:
@@ -116,6 +118,7 @@ def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -
                     name="Alice",
                     email="alice@example.com",
                     github_id="alice",
+                    join_time=_dt("2024-01-02T00:00:00"),
                     group_lark_id="eng",
                 )
             ],
@@ -130,6 +133,7 @@ def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -
                     name="Alice Zhang",
                     email="alice.zhang@example.com",
                     github_id="alicezhang",
+                    join_time=_dt("2024-03-04T00:00:00"),
                     group_lark_id="eng",
                 )
             ],
@@ -151,6 +155,7 @@ def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -
     assert employee["name"] == "Alice Zhang"
     assert employee["email"] == "alice.zhang@example.com"
     assert employee["github_id"] == "alicezhang"
+    assert employee["join_time"] == _dt("2024-03-04T00:00:00")
     assert group["id"] == original_group_id
     assert group["name"] == "Engineering Platform"
 
@@ -391,6 +396,7 @@ def _stable_employee(row) -> dict[str, object]:
         "employee_no": row["employee_no"],
         "email": row["email"],
         "github_id": row["github_id"],
+        "join_time": row["join_time"],
         "manager_id": row["manager_id"],
         "manager_path": row["manager_path"],
         "group_id": row["group_id"],

--- a/roster/tests/test_sync_roster.py
+++ b/roster/tests/test_sync_roster.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import get_args
+
+import pytest
+from sqlalchemy import create_engine, select
+
+from roster.jobs.sync_roster import (
+    FetchedEmployee,
+    FetchedGroup,
+    FetchedRoster,
+    RosterSyncStatus,
+    StaticRosterSource,
+    SyncRosterSummary,
+    employees_table,
+    groups_table,
+    metadata,
+    run_sync_roster,
+)
+
+
+def test_roster_sync_status_values_are_explicit() -> None:
+    assert get_args(RosterSyncStatus) == (
+        "not_implemented",
+        "success",
+        "failed",
+        "partial",
+    )
+
+
+def test_run_sync_roster_returns_placeholder_summary() -> None:
+    summary = run_sync_roster(engine=object())
+
+    assert summary == SyncRosterSummary(groups_seen=0, employees_seen=0, status="not_implemented")
+
+
+def test_run_sync_roster_writes_groups_employees_and_paths() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    source = StaticRosterSource(
+        FetchedRoster(
+            groups=[
+                FetchedGroup(lark_group_id="root", name="Root"),
+                FetchedGroup(lark_group_id="eng", name="Engineering", parent_lark_group_id="root"),
+                FetchedGroup(
+                    lark_group_id="db",
+                    name="Database",
+                    parent_lark_group_id="eng",
+                    manager_lark_id="manager",
+                ),
+            ],
+            employees=[
+                FetchedEmployee(lark_id="ceo", name="CEO", email="ceo@example.com"),
+                FetchedEmployee(
+                    lark_id="manager",
+                    name="Manager",
+                    employee_no="E002",
+                    email="manager@example.com",
+                    github_id="manager-gh",
+                    manager_lark_id="ceo",
+                    group_lark_id="eng",
+                ),
+                FetchedEmployee(
+                    lark_id="dev",
+                    name="Dev",
+                    employee_no="E003",
+                    email="dev@example.com",
+                    github_id="dev-gh",
+                    manager_lark_id="manager",
+                    group_lark_id="db",
+                ),
+            ],
+        )
+    )
+
+    summary = run_sync_roster(engine, source=source, now=_dt("2026-05-14T08:00:00"))
+
+    assert summary == SyncRosterSummary(groups_seen=3, employees_seen=3, status="success")
+    with engine.connect() as conn:
+        groups = {
+            row.lark_group_id: row._mapping
+            for row in conn.execute(select(groups_table)).all()
+        }
+        employees = {
+            row.lark_id: row._mapping
+            for row in conn.execute(select(employees_table)).all()
+        }
+
+    assert groups["root"]["path"] == f"/{groups['root']['id']}/"
+    assert groups["eng"]["parent_id"] == groups["root"]["id"]
+    assert groups["eng"]["path"] == f"/{groups['root']['id']}/{groups['eng']['id']}/"
+    assert groups["db"]["manager_id"] == employees["manager"]["id"]
+    assert groups["db"]["path"] == f"/{groups['root']['id']}/{groups['eng']['id']}/{groups['db']['id']}/"
+
+    assert employees["manager"]["manager_id"] == employees["ceo"]["id"]
+    assert employees["manager"]["manager_path"] == f"/{employees['ceo']['id']}/"
+    assert employees["manager"]["group_id"] == groups["eng"]["id"]
+    assert employees["manager"]["group_path"] == groups["eng"]["path"]
+    assert employees["dev"]["manager_id"] == employees["manager"]["id"]
+    assert employees["dev"]["manager_path"] == f"/{employees['ceo']['id']}/{employees['manager']['id']}/"
+    assert employees["dev"]["group_id"] == groups["db"]["id"]
+    assert employees["dev"]["group_path"] == groups["db"]["path"]
+
+
+def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+
+    first = StaticRosterSource(
+        FetchedRoster(
+            groups=[FetchedGroup(lark_group_id="eng", name="Engineering")],
+            employees=[
+                FetchedEmployee(
+                    lark_id="alice",
+                    name="Alice",
+                    email="alice@example.com",
+                    github_id="alice",
+                    group_lark_id="eng",
+                )
+            ],
+        )
+    )
+    second = StaticRosterSource(
+        FetchedRoster(
+            groups=[FetchedGroup(lark_group_id="eng", name="Engineering Platform")],
+            employees=[
+                FetchedEmployee(
+                    lark_id="alice",
+                    name="Alice Zhang",
+                    email="alice.zhang@example.com",
+                    github_id="alicezhang",
+                    group_lark_id="eng",
+                )
+            ],
+        )
+    )
+
+    run_sync_roster(engine, source=first, now=_dt("2026-05-14T08:00:00"))
+    with engine.connect() as conn:
+        original_employee_id = conn.execute(select(employees_table.c.id)).scalar_one()
+        original_group_id = conn.execute(select(groups_table.c.id)).scalar_one()
+
+    run_sync_roster(engine, source=second, now=_dt("2026-05-14T09:00:00"))
+
+    with engine.connect() as conn:
+        employee = conn.execute(select(employees_table)).one()._mapping
+        group = conn.execute(select(groups_table)).one()._mapping
+
+    assert employee["id"] == original_employee_id
+    assert employee["name"] == "Alice Zhang"
+    assert employee["email"] == "alice.zhang@example.com"
+    assert employee["github_id"] == "alicezhang"
+    assert group["id"] == original_group_id
+    assert group["name"] == "Engineering Platform"
+
+
+def test_run_sync_roster_is_idempotent_for_same_roster() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    source = StaticRosterSource(
+        FetchedRoster(
+            groups=[
+                FetchedGroup(lark_group_id="root", name="Root"),
+                FetchedGroup(lark_group_id="eng", name="Engineering", parent_lark_group_id="root"),
+            ],
+            employees=[
+                FetchedEmployee(lark_id="ceo", name="CEO", email="ceo@example.com"),
+                FetchedEmployee(
+                    lark_id="alice",
+                    name="Alice",
+                    employee_no="E001",
+                    email="alice@example.com",
+                    github_id="alice-gh",
+                    manager_lark_id="ceo",
+                    group_lark_id="eng",
+                ),
+            ],
+        )
+    )
+
+    run_sync_roster(engine, source=source, now=_dt("2026-05-14T08:00:00"))
+    with engine.connect() as conn:
+        first_groups = [
+            row._mapping
+            for row in conn.execute(
+                select(groups_table).order_by(groups_table.c.lark_group_id)
+            ).all()
+        ]
+        first_employees = [
+            row._mapping
+            for row in conn.execute(
+                select(employees_table).order_by(employees_table.c.lark_id)
+            ).all()
+        ]
+
+    run_sync_roster(engine, source=source, now=_dt("2026-05-14T09:00:00"))
+    with engine.connect() as conn:
+        second_groups = [
+            row._mapping
+            for row in conn.execute(
+                select(groups_table).order_by(groups_table.c.lark_group_id)
+            ).all()
+        ]
+        second_employees = [
+            row._mapping
+            for row in conn.execute(
+                select(employees_table).order_by(employees_table.c.lark_id)
+            ).all()
+        ]
+
+    assert len(second_groups) == len(first_groups) == 2
+    assert len(second_employees) == len(first_employees) == 2
+    assert [_stable_group(row) for row in second_groups] == [
+        _stable_group(row) for row in first_groups
+    ]
+    assert [_stable_employee(row) for row in second_employees] == [
+        _stable_employee(row) for row in first_employees
+    ]
+
+
+def test_run_sync_roster_marks_missing_rows_inactive_after_grace_period() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    original_time = _dt("2026-05-10T08:00:00")
+    source = StaticRosterSource(
+        FetchedRoster(
+            groups=[FetchedGroup(lark_group_id="eng", name="Engineering")],
+            employees=[FetchedEmployee(lark_id="alice", name="Alice", group_lark_id="eng")],
+        )
+    )
+
+    run_sync_roster(engine, source=source, now=original_time)
+    run_sync_roster(
+        engine,
+        source=StaticRosterSource(FetchedRoster(groups=[], employees=[])),
+        now=original_time + timedelta(days=1),
+        inactive_grace=timedelta(days=2),
+    )
+    with engine.connect() as conn:
+        employee_is_active = conn.execute(select(employees_table.c.is_active)).scalar_one()
+        group_is_active = conn.execute(select(groups_table.c.is_active)).scalar_one()
+
+    assert employee_is_active is True
+    assert group_is_active is True
+
+    run_sync_roster(
+        engine,
+        source=StaticRosterSource(FetchedRoster(groups=[], employees=[])),
+        now=original_time + timedelta(days=3),
+        inactive_grace=timedelta(days=2),
+    )
+    with engine.connect() as conn:
+        employee_is_active = conn.execute(select(employees_table.c.is_active)).scalar_one()
+        group_is_active = conn.execute(select(groups_table.c.is_active)).scalar_one()
+
+    assert employee_is_active is False
+    assert group_is_active is False
+
+
+def test_run_sync_roster_normalizes_empty_join_keys_to_null() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    source = StaticRosterSource(
+        FetchedRoster(
+            groups=[],
+            employees=[
+                FetchedEmployee(lark_id="alice", name="Alice", employee_no="", email="", github_id=""),
+                FetchedEmployee(
+                    lark_id="bob",
+                    name="Bob",
+                    employee_no="   ",
+                    email="  ",
+                    github_id="  ",
+                ),
+            ],
+        )
+    )
+
+    run_sync_roster(engine, source=source, now=_dt("2026-05-14T08:00:00"))
+
+    with engine.connect() as conn:
+        rows = conn.execute(select(employees_table).order_by(employees_table.c.lark_id)).all()
+
+    assert [row._mapping["employee_no"] for row in rows] == [None, None]
+    assert [row._mapping["email"] for row in rows] == [None, None]
+    assert [row._mapping["github_id"] for row in rows] == [None, None]
+
+
+def test_run_sync_roster_nulls_duplicate_unique_join_keys() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    source = StaticRosterSource(
+        FetchedRoster(
+            groups=[],
+            employees=[
+                FetchedEmployee(
+                    lark_id="alice",
+                    name="Alice",
+                    email="shared@example.com",
+                    github_id="same-gh",
+                ),
+                FetchedEmployee(
+                    lark_id="bob",
+                    name="Bob",
+                    email="shared@example.com",
+                    github_id="same-gh",
+                ),
+                FetchedEmployee(
+                    lark_id="carol",
+                    name="Carol",
+                    email="carol@example.com",
+                    github_id="carol-gh",
+                ),
+            ],
+        )
+    )
+
+    run_sync_roster(engine, source=source, now=_dt("2026-05-14T08:00:00"))
+
+    with engine.connect() as conn:
+        employees = {
+            row.lark_id: row._mapping
+            for row in conn.execute(select(employees_table).order_by(employees_table.c.lark_id))
+        }
+
+    assert set(employees) == {"alice", "bob", "carol"}
+    assert employees["alice"]["email"] is None
+    assert employees["bob"]["email"] is None
+    assert employees["alice"]["github_id"] is None
+    assert employees["bob"]["github_id"] is None
+    assert employees["carol"]["email"] == "carol@example.com"
+    assert employees["carol"]["github_id"] == "carol-gh"
+
+
+def test_run_sync_roster_detects_group_cycle() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    source = StaticRosterSource(
+        FetchedRoster(
+            groups=[
+                FetchedGroup(lark_group_id="a", name="A", parent_lark_group_id="b"),
+                FetchedGroup(lark_group_id="b", name="B", parent_lark_group_id="a"),
+            ],
+            employees=[],
+        )
+    )
+
+    with pytest.raises(ValueError, match="Cycle detected in roster group tree"):
+        run_sync_roster(engine, source=source, now=_dt("2026-05-14T08:00:00"))
+
+
+def test_run_sync_roster_detects_manager_cycle() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    source = StaticRosterSource(
+        FetchedRoster(
+            groups=[],
+            employees=[
+                FetchedEmployee(lark_id="alice", name="Alice", manager_lark_id="bob"),
+                FetchedEmployee(lark_id="bob", name="Bob", manager_lark_id="alice"),
+            ],
+        )
+    )
+
+    with pytest.raises(ValueError, match="Cycle detected in roster manager tree"):
+        run_sync_roster(engine, source=source, now=_dt("2026-05-14T08:00:00"))
+
+
+def _dt(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _stable_group(row) -> dict[str, object]:
+    return {
+        "id": row["id"],
+        "lark_group_id": row["lark_group_id"],
+        "parent_id": row["parent_id"],
+        "name": row["name"],
+        "manager_id": row["manager_id"],
+        "path": row["path"],
+        "is_active": row["is_active"],
+    }
+
+
+def _stable_employee(row) -> dict[str, object]:
+    return {
+        "id": row["id"],
+        "lark_id": row["lark_id"],
+        "name": row["name"],
+        "employee_no": row["employee_no"],
+        "email": row["email"],
+        "github_id": row["github_id"],
+        "manager_id": row["manager_id"],
+        "manager_path": row["manager_path"],
+        "group_id": row["group_id"],
+        "group_path": row["group_path"],
+        "is_active": row["is_active"],
+    }

--- a/roster/tests/test_validate_lark.py
+++ b/roster/tests/test_validate_lark.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from roster.jobs.sync_roster import FetchedEmployee, FetchedGroup, FetchedRoster, StaticRosterSource
+from roster.jobs.validate_lark import RosterValidationSummary, validate_lark_roster
+
+
+def test_validate_lark_roster_summarizes_field_quality() -> None:
+    source = StaticRosterSource(
+        FetchedRoster(
+            groups=[
+                FetchedGroup(lark_group_id="root", name="Root"),
+                FetchedGroup(lark_group_id="eng", name="Engineering", parent_lark_group_id="root"),
+                FetchedGroup(lark_group_id="sales", name="Sales", parent_lark_group_id="missing"),
+                FetchedGroup(lark_group_id="ops", name="Ops"),
+            ],
+            employees=[
+                FetchedEmployee(
+                    lark_id="alice",
+                    name="Alice",
+                    employee_no="E001",
+                    email="alice@example.com",
+                    github_id="alice-gh",
+                    group_lark_id="eng",
+                ),
+                FetchedEmployee(
+                    lark_id="bob",
+                    name="Bob",
+                    employee_no="E001",
+                    email="bob@example.com",
+                    group_lark_id="missing",
+                ),
+                FetchedEmployee(
+                    lark_id="carol",
+                    name="Carol",
+                    github_id="alice-gh",
+                ),
+            ],
+        )
+    )
+
+    summary = validate_lark_roster(source)
+
+    assert summary == RosterValidationSummary(
+        groups=4,
+        employees=3,
+        root_groups=2,
+        groups_without_manager=4,
+        groups_with_missing_parent=1,
+        employees_without_email=1,
+        employees_without_employee_no=1,
+        employees_without_github_id=1,
+        employees_without_group=1,
+        employees_with_missing_group=1,
+        duplicate_employee_no=1,
+        duplicate_email=0,
+        duplicate_github_id=1,
+    )
+    assert summary.to_dict()["employees"] == 3


### PR DESCRIPTION
## Summary
- add the `roster` Python job project for syncing Lark employees and groups into `roster_employees` / `roster_groups`
- implement Lark fetching, two-pass id/path resolution, duplicate join-key nulling, validation, Dockerfile, CronJob renderer, and schema docs
- wire roster image builds into CI/release skaffold workflows

## Validation
- `python -m coverage run -m pytest -q && python -m coverage report -m` -> 44 passed, 95% coverage
- `python -m ruff check .` -> passed
- online validation: `validate-lark` fetched 145 groups and 480 employees
- online idempotency check: ran two consecutive syncs; counts, active rows, id sums, duplicate join-key counts, and reference integrity remained unchanged

## Notes
- local `skaffold diagnose` was not run because skaffold is not installed on this machine; CI will exercise the added `roster/skaffold.yaml`
