### PR TITLE
feat(ci-dashboard): expand flaky and migration dashboards

### DIFF
--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-dashboard"
-version = "0.3.2"
+version = "0.3.3"
 description = "CI dashboard jobs and API scaffold"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ci-dashboard/src/ci_dashboard/__init__.py
+++ b/ci-dashboard/src/ci_dashboard/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/ci-dashboard/src/ci_dashboard/api/main.py
+++ b/ci-dashboard/src/ci_dashboard/api/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from ci_dashboard import __version__
 from ci_dashboard.api.routes.builds import router as builds_router
 from ci_dashboard.api.routes.failures import router as failures_router
 from ci_dashboard.api.routes.filters import router as filters_router
@@ -71,7 +72,7 @@ def _attach_frontend(app: FastAPI) -> None:
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="CI Dashboard", version="0.3.1")
+    app = FastAPI(title="CI Dashboard", version=__version__)
 
     app.include_router(status_router)
     app.include_router(filters_router)

--- a/ci-dashboard/src/ci_dashboard/api/queries/base.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/base.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Connection
 
 FAILURE_LIKE_STATES = ("failure", "error", "timeout", "timed_out", "aborted")
 SUCCESS_STATES = ("success", "pass")
-SUPPORTED_GRANULARITIES = {"day", "week"}
+SUPPORTED_GRANULARITIES = {"day", "week", "month"}
 MAX_RANKING_LIMIT = 50
 
 
@@ -178,6 +178,11 @@ def branch_match_expr(table_alias: str = "", *, bind_name: str = "branch") -> st
 def bucket_expr(connection: Connection, column_name: str, granularity: str) -> str:
     if granularity == "day":
         return f"DATE({column_name})"
+
+    if granularity == "month":
+        if connection.dialect.name == "sqlite":
+            return f"DATE(strftime('%Y-%m-01', {column_name}))"
+        return f"DATE_SUB(DATE({column_name}), INTERVAL DAYOFMONTH({column_name}) - 1 DAY)"
 
     if connection.dialect.name == "sqlite":
         return (

--- a/ci-dashboard/src/ci_dashboard/api/queries/builds.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/builds.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, time, timedelta
+from datetime import date, datetime, time, timedelta
 from typing import Any
 
 from sqlalchemy import text
@@ -25,6 +25,14 @@ MIGRATION_MIN_SUCCESS_RUNS = 5
 MIGRATION_IMPROVED_LIMIT = 10
 MIGRATION_REGRESSED_LIMIT = 10
 BUILD_TREND_JOB_RANKING_LIMIT = 10
+MIGRATION_FIXED_BASELINE_START = date(2025, 12, 15)
+MIGRATION_FIXED_BASELINE_END = date(2026, 1, 14)
+MIGRATION_FIXED_RECENT_START = date(2026, 4, 15)
+MIGRATION_FIXED_COMPARISON_SCOPES = (
+    ("all_repos", "All repos", None),
+    ("tidb", "TiDB", "pingcap/tidb"),
+    ("ticdc", "TiCDC", "pingcap/ticdc"),
+)
 
 
 def get_outcome_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
@@ -714,6 +722,61 @@ def get_migration_runtime_comparison(engine: Engine, filters: CommonFilters) -> 
     }
 
 
+def get_migration_fixed_window_comparison(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    with engine.begin() as connection:
+        success_where = success_expr("b")
+        recent_end_date = filters.end_date or _find_latest_gcp_success_date(
+            connection,
+            "1=1",
+            {},
+            success_where,
+        )
+
+        rows = [
+            {
+                "scope_key": scope_key,
+                "scope_label": scope_label,
+                "repo_full_name": repo_full_name,
+                "baseline": _fetch_migration_window_summary(
+                    connection,
+                    repo_full_name=repo_full_name,
+                    start_date=MIGRATION_FIXED_BASELINE_START,
+                    end_date=MIGRATION_FIXED_BASELINE_END,
+                    cloud_phase=None,
+                ),
+                "recent_gcp": _fetch_migration_window_summary(
+                    connection,
+                    repo_full_name=repo_full_name,
+                    start_date=MIGRATION_FIXED_RECENT_START,
+                    end_date=recent_end_date,
+                    cloud_phase="GCP",
+                ),
+            }
+            for scope_key, scope_label, repo_full_name in MIGRATION_FIXED_COMPARISON_SCOPES
+        ]
+
+    return {
+        "rows": rows,
+        "meta": {
+            **filters.meta(),
+            "baseline_start_date": MIGRATION_FIXED_BASELINE_START.isoformat(),
+            "baseline_end_date": MIGRATION_FIXED_BASELINE_END.isoformat(),
+            "recent_start_date": MIGRATION_FIXED_RECENT_START.isoformat(),
+            "recent_end_date": recent_end_date.isoformat() if recent_end_date else None,
+            "scopes": [
+                {"scope_key": scope_key, "scope_label": scope_label, "repo_full_name": repo_full_name}
+                for scope_key, scope_label, repo_full_name in MIGRATION_FIXED_COMPARISON_SCOPES
+            ],
+            "ignores_repo_filter": True,
+            "ignores_branch_filter": True,
+            "ignores_job_filter": True,
+            "ignores_start_date": True,
+            "ignores_bucket": True,
+            "ignores_cloud_phase": True,
+        },
+    }
+
+
 def _find_latest_gcp_success_date(
     connection,
     where_clause: str,
@@ -777,3 +840,56 @@ def _coerce_isoformat_utc(value: Any) -> str | None:
     if isinstance(value, str):
         return isoformat_utc(datetime.fromisoformat(value))
     return isoformat_utc(value)
+
+
+def _fetch_migration_window_summary(
+    connection,
+    *,
+    repo_full_name: str | None,
+    start_date: date,
+    end_date: date | None,
+    cloud_phase: str | None,
+) -> dict[str, Any]:
+    if end_date is None or end_date < start_date:
+        return {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat() if end_date else None,
+            "total_build_count": 0,
+            "success_count": 0,
+            "success_rate_pct": 0.0,
+            "success_avg_total_s": 0,
+        }
+
+    filters = CommonFilters(
+        repo=repo_full_name,
+        start_date=start_date,
+        end_date=end_date,
+        cloud_phase=cloud_phase,
+    )
+    where_clause, params = build_common_where(filters, table_alias="b")
+    builds_table = builds_table_expr(connection, filters, alias="b")
+    success_where = success_expr("b")
+    row = connection.execute(
+        text(
+            f"""
+            SELECT
+              COUNT(*) AS total_build_count,
+              SUM(CASE WHEN {success_where} THEN 1 ELSE 0 END) AS success_count,
+              AVG(CASE WHEN {success_where} THEN b.total_seconds END) AS success_avg_total_s
+            FROM {builds_table}
+            WHERE {where_clause}
+            """
+        ),
+        params,
+    ).mappings().one()
+
+    total_build_count = int(row["total_build_count"] or 0)
+    success_count = int(row["success_count"] or 0)
+    return {
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "total_build_count": total_build_count,
+        "success_count": success_count,
+        "success_rate_pct": rate_pct(success_count, total_build_count),
+        "success_avg_total_s": round(float(row["success_avg_total_s"] or 0)),
+    }

--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -74,6 +74,64 @@ def get_flaky_composition(engine: Engine, filters: CommonFilters) -> dict[str, A
     }
 
 
+def get_flaky_bucketed_rate_view(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    effective_granularity = _flaky_rate_bucket_granularity(filters.granularity)
+    effective_filters = CommonFilters(
+        repo=filters.repo,
+        branch=filters.branch,
+        job_name=filters.job_name,
+        cloud_phase=filters.cloud_phase,
+        issue_status=None,
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        granularity=effective_granularity,
+    )
+    rows = _query_bucketed_flaky_metrics(
+        engine,
+        effective_filters,
+        exclude_partial_weeks=False,
+    )
+
+    points: list[list[Any]] = []
+    table_rows: list[dict[str, Any]] = []
+    previous_rate: float | None = None
+
+    for row in rows:
+        bucket_start = str(row["bucket_start"])
+        total_failure_like = int(row["total_failure_like_count"] or 0)
+        flaky_build_count = int(row["flaky_build_count"] or 0)
+        flaky_rate_pct = rate_pct(flaky_build_count, total_failure_like)
+        time_to_time_pct = _period_over_period_delta(flaky_rate_pct, previous_rate)
+
+        points.append([bucket_start, flaky_rate_pct])
+        table_rows.append(
+            {
+                "time": bucket_start,
+                "flaky_rate_pct": flaky_rate_pct,
+                "time_to_time_pct": time_to_time_pct,
+            }
+        )
+        previous_rate = flaky_rate_pct
+
+    return {
+        "series": [
+            {
+                "key": "flaky_rate_pct",
+                "label": "Flaky rate",
+                "type": "line",
+                "points": points,
+            }
+        ],
+        "rows": table_rows,
+        "meta": {
+            **filters.meta(),
+            "requested_granularity": filters.granularity,
+            "effective_granularity": effective_granularity,
+            "ignores_issue_status": True,
+        },
+    }
+
+
 def get_flaky_top_jobs(
     engine: Engine,
     filters: CommonFilters,
@@ -838,6 +896,8 @@ def get_issue_lifecycle_weekly(
 def _query_bucketed_flaky_metrics(
     engine: Engine,
     filters: CommonFilters,
+    *,
+    exclude_partial_weeks: bool = True,
 ) -> list[dict[str, Any]]:
     with engine.begin() as connection:
         where_clause, params = _build_build_where(filters, table_alias="b")
@@ -863,13 +923,25 @@ def _query_bucketed_flaky_metrics(
             params,
         ).mappings()
         data_rows = [dict(row) for row in rows]
-        if filters.granularity == "week":
+        if exclude_partial_weeks and filters.granularity == "week":
             data_rows = filter_complete_week_rows(
                 data_rows,
                 start_date=filters.start_date,
                 end_date=filters.end_date,
             )
         return data_rows
+
+
+def _flaky_rate_bucket_granularity(granularity: str) -> str:
+    if granularity == "month":
+        return "month"
+    return "week"
+
+
+def _period_over_period_delta(current: float, previous: float | None) -> float | None:
+    if previous is None:
+        return None
+    return to_number(current - previous)
 
 
 def _query_period_summary(

--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -13,6 +13,7 @@ from ci_dashboard.api.queries.builds import (
     get_cloud_repo_share,
     get_duration_trend,
     get_longest_avg_success_jobs,
+    get_migration_fixed_window_comparison,
     get_migration_runtime_comparison,
     get_lowest_success_rate_jobs,
     get_outcome_trend,
@@ -23,6 +24,7 @@ from ci_dashboard.api.queries.failures import (
 )
 from ci_dashboard.api.queries.filters import list_repos
 from ci_dashboard.api.queries.flaky import (
+    get_flaky_bucketed_rate_view,
     get_distinct_flaky_case_counts_by_branch,
     get_flaky_composition,
     get_issue_fix_progress_snapshot,
@@ -114,6 +116,10 @@ def get_build_trend_page(engine: Engine, filters: CommonFilters) -> dict[str, An
                 engine,
                 migration_filters,
             ),
+            "migration_fixed_window_comparison": lambda: get_migration_fixed_window_comparison(
+                engine,
+                filters,
+            ),
             "cloud_repo_share": lambda: get_cloud_repo_share(engine, repo_share_filters),
             "error_catalog_share": lambda: get_error_l1_share(engine, filters),
         }
@@ -150,6 +156,10 @@ def get_flaky_page(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
             "issue_case_rates": lambda: get_issue_filtered_weekly_case_rates(engine, filters),
             "trend": lambda: get_flaky_trend(engine, build_scope_filters),
             "composition": lambda: get_flaky_composition(engine, build_scope_filters_weekly),
+            "bucketed_flaky_rate": lambda: get_flaky_bucketed_rate_view(
+                engine,
+                build_scope_filters,
+            ),
             "top_jobs": lambda: get_flaky_top_jobs(engine, build_scope_filters, limit=8),
             "failure_category_share": lambda: get_failure_category_share(
                 engine,

--- a/ci-dashboard/src/ci_dashboard/api/routes/common.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/common.py
@@ -34,7 +34,7 @@ def get_common_filters(
 
 def validate_granularity(granularity: str) -> None:
     if granularity not in SUPPORTED_GRANULARITIES:
-        raise HTTPException(status_code=400, detail="granularity must be one of: day, week")
+        raise HTTPException(status_code=400, detail="granularity must be one of: day, week, month")
 
 
 def validate_date_range(start_date: date | None, end_date: date | None) -> None:

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -1422,10 +1422,10 @@ def test_distinct_case_counts_match_legacy_do_host_case_runs(sqlite_engine) -> N
 def test_flaky_validation_errors(api_client: TestClient) -> None:
     invalid_granularity = api_client.get(
         "/api/v1/flaky/trend",
-        params={"granularity": "month"},
+        params={"granularity": "quarter"},
     )
     assert invalid_granularity.status_code == 400
-    assert invalid_granularity.json()["detail"] == "granularity must be one of: day, week"
+    assert invalid_granularity.json()["detail"] == "granularity must be one of: day, week, month"
 
     invalid_range = api_client.get(
         "/api/v1/flaky/composition",
@@ -1795,6 +1795,23 @@ def test_page_routes(api_client: TestClient) -> None:
             "points": [["2026-04-06", 100.0]],
         }
     ]
+    assert flaky_body["bucketed_flaky_rate"]["series"] == [
+        {
+            "key": "flaky_rate_pct",
+            "label": "Flaky rate",
+            "type": "line",
+            "points": [["2026-04-06", 50.0]],
+        }
+    ]
+    assert flaky_body["bucketed_flaky_rate"]["rows"] == [
+        {
+            "time": "2026-04-06",
+            "flaky_rate_pct": 50.0,
+            "time_to_time_pct": None,
+        }
+    ]
+    assert flaky_body["bucketed_flaky_rate"]["meta"]["requested_granularity"] == "day"
+    assert flaky_body["bucketed_flaky_rate"]["meta"]["effective_granularity"] == "week"
     assert flaky_body["issue_case_weekly_rates"]["rows"][0]["display_name"] == "TestCaseAlpha"
     assert flaky_body["issue_case_weekly_rates"]["rows"][0]["cells"] == ["100.00% (1/1)"]
     assert flaky_body["issue_case_weekly_rates"]["rows"][1]["cells"] == ["100.00% (1/1)"]
@@ -1826,12 +1843,116 @@ def test_page_routes(api_client: TestClient) -> None:
     assert [row["case_name"] for row in flaky_with_open_issues_body["issue_case_weekly_rates"]["rows"]] == [
         "TestCaseAlpha"
     ]
+    assert flaky_with_open_issues_body["bucketed_flaky_rate"] == flaky_body["bucketed_flaky_rate"]
     assert flaky_with_open_issues_body["trend"] == flaky_body["trend"]
     assert flaky_with_open_issues_body["composition"] == flaky_body["composition"]
     assert flaky_with_open_issues_body["top_jobs"] == flaky_body["top_jobs"]
     assert flaky_with_open_issues_body["failure_category_share"] == flaky_body["failure_category_share"]
     assert flaky_with_open_issues_body["failure_category_trend"] == flaky_body["failure_category_trend"]
     assert flaky_with_open_issues_body["period_comparison"] == flaky_body["period_comparison"]
+
+
+def test_migration_fixed_window_comparison_rows(
+    sqlite_engine,
+    api_client: TestClient,
+) -> None:
+    fixtures = [
+        (2000, "baseline-tidb-success-1", "pingcap/tidb", "success", "IDC", "2025-12-20 01:00:00", 300),
+        (2001, "baseline-tidb-success-2", "pingcap/tidb", "success", "IDC", "2026-01-10 01:00:00", 420),
+        (2002, "baseline-tidb-failure", "pingcap/tidb", "failure", "IDC", "2026-01-12 01:00:00", 0),
+        (2003, "baseline-ticdc-success", "pingcap/ticdc", "success", "IDC", "2025-12-28 02:00:00", 240),
+        (2004, "baseline-ticdc-failure", "pingcap/ticdc", "failure", "IDC", "2026-01-05 02:00:00", 0),
+        (2010, "recent-tidb-success-1", "pingcap/tidb", "success", "GCP", "2026-04-20 01:00:00", 220),
+        (2011, "recent-tidb-success-2", "pingcap/tidb", "success", "GCP", "2026-05-01 01:00:00", 260),
+        (2012, "recent-tidb-failure", "pingcap/tidb", "failure", "GCP", "2026-05-03 01:00:00", 0),
+        (2013, "recent-ticdc-success", "pingcap/ticdc", "success", "GCP", "2026-04-25 02:00:00", 180),
+        (2014, "recent-ticdc-failure", "pingcap/ticdc", "failure", "GCP", "2026-05-05 02:00:00", 0),
+    ]
+    for source_prow_row_id, source_prow_job_id, repo_full_name, state, cloud_phase, start_time, total_seconds in fixtures:
+        _insert_build(
+            sqlite_engine,
+            source_prow_row_id=source_prow_row_id,
+            source_prow_job_id=source_prow_job_id,
+            repo_full_name=repo_full_name,
+            target_branch="master",
+            base_ref="master",
+            job_name=f"{repo_full_name.split('/')[-1]}-migration-job",
+            state=state,
+            cloud_phase=cloud_phase,
+            is_flaky=0,
+            is_retry_loop=0,
+            failure_category=None,
+            start_time=start_time,
+            run_seconds=max(total_seconds - 20, 0),
+            total_seconds=total_seconds,
+            pr_number=80000 + source_prow_row_id,
+        )
+
+    response = api_client.get(
+        "/api/v1/pages/ci-status",
+        params={
+            "repo": "pingcap/tidb",
+            "end_date": "2026-05-15",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    comparison = body["migration_fixed_window_comparison"]
+    assert comparison["meta"]["baseline_start_date"] == "2025-12-15"
+    assert comparison["meta"]["baseline_end_date"] == "2026-01-14"
+    assert comparison["meta"]["recent_start_date"] == "2026-04-15"
+    assert comparison["meta"]["recent_end_date"] == "2026-05-15"
+    assert comparison["meta"]["ignores_repo_filter"] is True
+
+    rows = {row["scope_key"]: row for row in comparison["rows"]}
+    assert rows["all_repos"]["baseline"] == {
+        "start_date": "2025-12-15",
+        "end_date": "2026-01-14",
+        "total_build_count": 5,
+        "success_count": 3,
+        "success_rate_pct": 60.0,
+        "success_avg_total_s": 320,
+    }
+    assert rows["all_repos"]["recent_gcp"] == {
+        "start_date": "2026-04-15",
+        "end_date": "2026-05-15",
+        "total_build_count": 5,
+        "success_count": 3,
+        "success_rate_pct": 60.0,
+        "success_avg_total_s": 220,
+    }
+    assert rows["tidb"]["baseline"] == {
+        "start_date": "2025-12-15",
+        "end_date": "2026-01-14",
+        "total_build_count": 3,
+        "success_count": 2,
+        "success_rate_pct": 66.67,
+        "success_avg_total_s": 360,
+    }
+    assert rows["tidb"]["recent_gcp"] == {
+        "start_date": "2026-04-15",
+        "end_date": "2026-05-15",
+        "total_build_count": 3,
+        "success_count": 2,
+        "success_rate_pct": 66.67,
+        "success_avg_total_s": 240,
+    }
+    assert rows["ticdc"]["baseline"] == {
+        "start_date": "2025-12-15",
+        "end_date": "2026-01-14",
+        "total_build_count": 2,
+        "success_count": 1,
+        "success_rate_pct": 50.0,
+        "success_avg_total_s": 240,
+    }
+    assert rows["ticdc"]["recent_gcp"] == {
+        "start_date": "2026-04-15",
+        "end_date": "2026-05-15",
+        "total_build_count": 2,
+        "success_count": 1,
+        "success_rate_pct": 50.0,
+        "success_avg_total_s": 180,
+    }
 
 
 def test_weekly_series_skip_partial_boundary_weeks(api_client: TestClient) -> None:
@@ -1889,6 +2010,71 @@ def test_weekly_series_skip_partial_boundary_weeks(api_client: TestClient) -> No
     assert cloud_posture_series["idc_build_count"]["points"] == [
         ["2026-03-30", 0],
         ["2026-04-06", 1],
+    ]
+
+
+def test_flaky_page_bucketed_rate_supports_month_granularity(
+    sqlite_engine,
+    api_client: TestClient,
+) -> None:
+    monthly_repo = "pingcap/flaky-monthly"
+    for build in [
+        (91001, "monthly-1", "2026-03-03T10:00:00Z", 1),
+        (91002, "monthly-2", "2026-03-18T10:00:00Z", 0),
+        (91003, "monthly-3", "2026-04-02T10:00:00Z", 1),
+        (91004, "monthly-4", "2026-04-09T10:00:00Z", 0),
+        (91005, "monthly-5", "2026-04-16T10:00:00Z", 0),
+        (91006, "monthly-6", "2026-04-24T10:00:00Z", 0),
+    ]:
+        _insert_build(
+            sqlite_engine,
+            source_prow_row_id=build[0],
+            source_prow_job_id=build[1],
+            repo_full_name=monthly_repo,
+            target_branch="master",
+            base_ref="master",
+            job_name="monthly-flaky-job",
+            state="failure",
+            cloud_phase="GCP",
+            is_flaky=build[3],
+            is_retry_loop=0,
+            failure_category="FLAKY_TEST" if build[3] else "UNCLASSIFIED",
+            start_time=build[2],
+        )
+
+    response = api_client.get(
+        "/api/v1/pages/flaky",
+        params={
+            "repo": monthly_repo,
+            "branch": "master",
+            "granularity": "month",
+            "start_date": "2026-03-01",
+            "end_date": "2026-04-30",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["bucketed_flaky_rate"]["meta"]["requested_granularity"] == "month"
+    assert body["bucketed_flaky_rate"]["meta"]["effective_granularity"] == "month"
+    assert body["bucketed_flaky_rate"]["series"] == [
+        {
+            "key": "flaky_rate_pct",
+            "label": "Flaky rate",
+            "type": "line",
+            "points": [["2026-03-01", 50.0], ["2026-04-01", 25.0]],
+        }
+    ]
+    assert body["bucketed_flaky_rate"]["rows"] == [
+        {
+            "time": "2026-03-01",
+            "flaky_rate_pct": 50.0,
+            "time_to_time_pct": None,
+        },
+        {
+            "time": "2026-04-01",
+            "flaky_rate_pct": 25.0,
+            "time_to_time_pct": -25,
+        },
     ]
 
 

--- a/ci-dashboard/tests/test_query_base.py
+++ b/ci-dashboard/tests/test_query_base.py
@@ -161,13 +161,15 @@ def test_build_common_where_supports_multiple_jobs() -> None:
     assert params["job_name_1"] == "job-b"
 
 
-def test_query_base_helpers_cover_tidb_and_week_filters() -> None:
+def test_query_base_helpers_cover_tidb_and_bucket_filters() -> None:
     sqlite_connection = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
     tidb_connection = SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
 
     assert branch_expr("b") == "COALESCE(NULLIF(b.target_branch, ''), b.base_ref)"
     assert bucket_expr(sqlite_connection, "start_time", "day") == "DATE(start_time)"
+    assert bucket_expr(sqlite_connection, "start_time", "month") == "DATE(strftime('%Y-%m-01', start_time))"
     assert "strftime('%w'" in bucket_expr(sqlite_connection, "start_time", "week")
+    assert bucket_expr(tidb_connection, "start_time", "month") == "DATE_SUB(DATE(start_time), INTERVAL DAYOFMONTH(start_time) - 1 DAY)"
     assert bucket_expr(tidb_connection, "start_time", "week") == "DATE_SUB(DATE(start_time), INTERVAL WEEKDAY(start_time) DAY)"
 
     assert builds_table_expr(sqlite_connection, CommonFilters(repo="pingcap/tidb")) == "ci_l1_builds b"

--- a/ci-dashboard/web/package-lock.json
+++ b/ci-dashboard/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-dashboard-web",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -29,6 +29,8 @@ const SERIES_COLORS = {
   success_count: "#2a9d8f",
   failure_count: "#d1495b",
   success_rate_pct: "#f4a261",
+  baseline_avg_total_s: "#7d8597",
+  recent_gcp_avg_total_s: "#2a9d8f",
   gcp_build_count: "#315772",
   idc_build_count: "#bc6c25",
   queue_avg_s: "#7f5539",
@@ -169,14 +171,19 @@ export function TrendChart({
   barGroupWidthFactor = 0.66,
   barMaxWidth = 46,
   leftPadding = 52,
+  selectedBucketLabel = null,
+  onBucketSelect = null,
+  preserveLabelOrder = false,
 }) {
   if (!series?.length) {
     return <EmptyState message="No chart data for the current filters." />;
   }
 
-  const labels = Array.from(
-    new Set(series.flatMap((item) => item.points.map((point) => point[0]))),
-  ).sort();
+  const labels = preserveLabelOrder
+    ? series.flatMap((item) => item.points.map((point) => point[0])).filter((label, index, source) => source.indexOf(label) === index)
+    : Array.from(
+        new Set(series.flatMap((item) => item.points.map((point) => point[0]))),
+      ).sort();
   if (!labels.length) {
     return <EmptyState message="No chart data for the current filters." />;
   }
@@ -279,8 +286,19 @@ export function TrendChart({
     bottomLabelStep,
     minBottomLabelIndexGap,
   );
+  const interactiveBuckets = typeof onBucketSelect === "function";
+  const selectedBucketIndex = selectedBucketLabel ? labels.indexOf(selectedBucketLabel) : -1;
   const barSeries = series.filter((item) => item.type === "bar");
   const lineSeries = series.filter((item) => item.type === "line");
+  const getBucketArea = (index) => {
+    if (labels.length === 1) {
+      return { x: padding.left, width: plotWidth };
+    }
+    const center = padding.left + index * xStep;
+    const left = index === 0 ? padding.left : center - xStep / 2;
+    const right = index === labels.length - 1 ? padding.left + plotWidth : center + xStep / 2;
+    return { x: left, width: Math.max(right - left, 12) };
+  };
 
   return (
     <div className="trend-chart">
@@ -321,6 +339,17 @@ export function TrendChart({
             </g>
           );
         })}
+
+        {selectedBucketIndex >= 0 ? (
+          <rect
+            x={getBucketArea(selectedBucketIndex).x}
+            y={padding.top}
+            width={getBucketArea(selectedBucketIndex).width}
+            height={plotHeight}
+            rx="8"
+            fill="rgba(42, 157, 143, 0.09)"
+          />
+        ) : null}
 
         {barSeries.map((item, seriesIndex) =>
           labels.map((label, index) => {
@@ -417,10 +446,19 @@ export function TrendChart({
                     key={`${item.key}-${point.label}`}
                     cx={point.x}
                     cy={point.y}
-                    r="4.5"
+                    r={selectedBucketLabel === point.label ? "5.5" : "4.5"}
                     fill={seriesColor(item.key)}
                     stroke="#fcf7ef"
-                    strokeWidth="2"
+                    strokeWidth={selectedBucketLabel === point.label ? "3" : "2"}
+                    style={interactiveBuckets ? { cursor: "pointer" } : undefined}
+                    onClick={
+                      interactiveBuckets
+                        ? () =>
+                            onBucketSelect(
+                              selectedBucketLabel === point.label ? null : point.label,
+                            )
+                        : undefined
+                    }
                   />
                 )),
               )}
@@ -479,6 +517,24 @@ export function TrendChart({
             </text>
           );
         })}
+
+        {interactiveBuckets
+          ? labels.map((label, index) => {
+              const area = getBucketArea(index);
+              return (
+                <rect
+                  key={`${label}-hit-area`}
+                  x={area.x}
+                  y={padding.top}
+                  width={area.width}
+                  height={plotHeight}
+                  fill="transparent"
+                  style={{ cursor: "pointer" }}
+                  onClick={() => onBucketSelect(selectedBucketLabel === label ? null : label)}
+                />
+              );
+            })
+          : null}
       </svg>
 
       <div className="chart-legend">
@@ -709,6 +765,43 @@ export function RuntimeComparisonBoard({
         maxRunSeconds={maxRunSeconds}
         emptyMessage="No regressed jobs met the migration comparison threshold."
       />
+    </div>
+  );
+}
+
+export function MigrationFixedWindowComparisonTable({ rows }) {
+  if (!rows?.length) {
+    return <EmptyState message="No migration comparison rows are available yet." />;
+  }
+
+  return (
+    <div className="table-scroll">
+      <table className="data-table data-table--compact migration-compare-table">
+        <thead>
+          <tr>
+            <th>Scope</th>
+            <th>Baseline avg duration</th>
+            <th>Baseline success count</th>
+            <th>Baseline success rate</th>
+            <th>Recent GCP avg duration</th>
+            <th>Recent GCP success count</th>
+            <th>Recent GCP success rate</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.scope_key}>
+              <th scope="row">{row.scope_label}</th>
+              <td>{formatSeconds(row.baseline?.success_avg_total_s)}</td>
+              <td>{formatNumber(row.baseline?.success_count)}</td>
+              <td>{formatPercent(row.baseline?.success_rate_pct)}</td>
+              <td>{formatSeconds(row.recent_gcp?.success_avg_total_s)}</td>
+              <td>{formatNumber(row.recent_gcp?.success_count)}</td>
+              <td>{formatPercent(row.recent_gcp?.success_rate_pct)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
@@ -1019,8 +1112,86 @@ export function IssueWeeklyRateTable({ weeks, rows, scrollClassName = "" }) {
   );
 }
 
+export function BucketFlakyRateTable({
+  rows,
+  effectiveGranularity,
+  selectedTime = null,
+  onSelectTime = null,
+}) {
+  if (!rows?.length) {
+    return <EmptyState message="No flaky-rate buckets matched the current build scope." compact />;
+  }
+
+  const timeLabel = effectiveGranularity === "month" ? "Time (month)" : "Time (week)";
+  const interactive = typeof onSelectTime === "function";
+
+  return (
+    <div className="table-scroll">
+      <table className="data-table data-table--compact data-table--narrow">
+        <thead>
+          <tr>
+            <th>{timeLabel}</th>
+            <th>Flaky rate</th>
+            <th>Delta vs previous</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.time}
+              className={[
+                interactive ? "data-row--interactive" : "",
+                selectedTime === row.time ? "data-row--selected" : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+              onClick={
+                interactive
+                  ? () => onSelectTime(selectedTime === row.time ? null : row.time)
+                  : undefined
+              }
+            >
+              <th scope="row">{formatBucketTimeCell(row.time, effectiveGranularity)}</th>
+              <td>{formatPercent(row.flaky_rate_pct)}</td>
+              <td className={buildBucketDeltaClassName(row.time_to_time_pct)}>
+                {formatTimeToTimeCell(row.time_to_time_pct)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export function EmptyState({ message, compact = false }) {
   return <div className={compact ? "empty-state empty-state--compact" : "empty-state"}>{message}</div>;
+}
+
+function formatBucketTimeCell(value, granularity) {
+  const text = String(value || "");
+  if (granularity !== "month") {
+    return text;
+  }
+  const match = text.match(/^(\d{4})-(\d{2})-\d{2}$/);
+  if (!match) {
+    return text;
+  }
+  return `${match[1]}-${match[2]}`;
+}
+
+function formatTimeToTimeCell(value) {
+  if (value == null) {
+    return "--";
+  }
+  return formatSignedPercent(value);
+}
+
+function buildBucketDeltaClassName(value) {
+  if (value == null) {
+    return undefined;
+  }
+  return value > 0 ? "bucket-delta bucket-delta--up" : "bucket-delta";
 }
 
 function LoadingState() {

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -179,11 +179,12 @@ export function TrendChart({
     return <EmptyState message="No chart data for the current filters." />;
   }
 
-  const labels = preserveLabelOrder
-    ? series.flatMap((item) => item.points.map((point) => point[0])).filter((label, index, source) => source.indexOf(label) === index)
-    : Array.from(
-        new Set(series.flatMap((item) => item.points.map((point) => point[0]))),
-      ).sort();
+  const labels = Array.from(
+    new Set(series.flatMap((item) => item.points.map((point) => point[0]))),
+  );
+  if (!preserveLabelOrder) {
+    labels.sort();
+  }
   if (!labels.length) {
     return <EmptyState message="No chart data for the current filters." />;
   }

--- a/ci-dashboard/web/src/components/layout.jsx
+++ b/ci-dashboard/web/src/components/layout.jsx
@@ -238,6 +238,7 @@ function FilterBar({ filters, onFilterChange, filterOptions }) {
             >
               <option value="day">Day</option>
               <option value="week">Week</option>
+              <option value="month">Month</option>
             </select>
           }
         />

--- a/ci-dashboard/web/src/pages/BuildTrendPage.jsx
+++ b/ci-dashboard/web/src/pages/BuildTrendPage.jsx
@@ -519,6 +519,17 @@ function buildBucketLabels(startDate, endDate, granularity) {
     return labels;
   }
 
+  if (granularity === "month") {
+    const labels = [];
+    const cursor = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 1, 12, 0, 0));
+    const lastMonth = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1, 12, 0, 0));
+    while (cursor <= lastMonth) {
+      labels.push(toIsoDate(cursor));
+      cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+    }
+    return labels;
+  }
+
   const labels = [];
   const cursor = new Date(start);
   while (cursor <= end) {

--- a/ci-dashboard/web/src/pages/FlakyPage.jsx
+++ b/ci-dashboard/web/src/pages/FlakyPage.jsx
@@ -1,11 +1,15 @@
+import { useEffect, useState } from "react";
+
 import {
   formatDelta,
+  formatDateRangeLabel,
   formatNumber,
   formatPercent,
   useApiData,
 } from "../lib/api";
 import {
   BLIND_RETRY_LOOP_HINT,
+  BucketFlakyRateTable,
   PageIntro,
   Panel,
   DistinctCaseCountTable,
@@ -33,6 +37,82 @@ function buildSnapshotSubtitle(meta) {
     return "Repo + branch snapshot";
   }
   return `As of ${asOfDate}, compared with ${comparisonDate}.`;
+}
+
+function buildBucketedFlakyRateSubtitle(meta) {
+  const effectiveGranularity = meta?.effective_granularity === "month" ? "month" : "week";
+  const startDate = meta?.start_date || "the selected start date";
+  const endDate = meta?.end_date || "the selected end date";
+  if (meta?.requested_granularity === "day") {
+    return `Grouped by ${effectiveGranularity} from ${startDate} to ${endDate}. Day stays rolled up to ${effectiveGranularity} here because daily buckets are too fine for this view.`;
+  }
+  return `Grouped by ${effectiveGranularity} from ${startDate} to ${endDate}, with failure-like builds as the denominator for each bucket.`;
+}
+
+function buildCenteredPercentAxisMax(rows) {
+  const values = (rows || [])
+    .map((row) => Number(row.flaky_rate_pct || 0))
+    .filter((value) => Number.isFinite(value));
+  if (!values.length) {
+    return 10;
+  }
+  const peak = Math.max(...values, 0);
+  if (peak >= 100) {
+    return 100;
+  }
+  const target = Math.max(10, Math.min(100, peak * 2));
+  return Math.ceil(target / 5) * 5;
+}
+
+function parseIsoDate(value) {
+  const [year, month, day] = String(value || "").split("-").map(Number);
+  if (!year || !month || !day) {
+    return null;
+  }
+  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+}
+
+function toIsoDate(value) {
+  return value.toISOString().slice(0, 10);
+}
+
+function resolveSelectedBucketRange(bucketTime, meta) {
+  if (!bucketTime) {
+    return null;
+  }
+
+  const bucketStart = parseIsoDate(bucketTime);
+  const selectedStart = parseIsoDate(meta?.start_date);
+  const selectedEnd = parseIsoDate(meta?.end_date);
+  if (!bucketStart || !selectedStart || !selectedEnd) {
+    return null;
+  }
+
+  const bucketEnd = new Date(bucketStart);
+  if (meta?.effective_granularity === "month") {
+    bucketEnd.setUTCMonth(bucketEnd.getUTCMonth() + 1, 0);
+  } else {
+    bucketEnd.setUTCDate(bucketEnd.getUTCDate() + 6);
+  }
+
+  const rangeStart = bucketStart > selectedStart ? bucketStart : selectedStart;
+  const rangeEnd = bucketEnd < selectedEnd ? bucketEnd : selectedEnd;
+  if (rangeStart > rangeEnd) {
+    return null;
+  }
+
+  return {
+    time: bucketTime,
+    start_date: toIsoDate(rangeStart),
+    end_date: toIsoDate(rangeEnd),
+  };
+}
+
+function buildTopJobsSubtitle(selectedBucketRange) {
+  if (!selectedBucketRange) {
+    return "Jobs ranked by noisy rate, with raw noisy and failure-like build counts kept visible for context.";
+  }
+  return `Jobs ranked by noisy rate for ${formatDateRangeLabel(selectedBucketRange.start_date, selectedBucketRange.end_date)}. Click the selected bucket again to clear the focus.`;
 }
 
 function SnapshotProgressCard({ title, subtitle, tone = "default", items, loading, error }) {
@@ -63,16 +143,7 @@ function SnapshotProgressCard({ title, subtitle, tone = "default", items, loadin
 
 export default function FlakyPage({ filters }) {
   const page = useApiData("/api/v1/pages/flaky", filters);
-  const weeklyFlakyTrend = useApiData("/api/v1/flaky/composition", {
-    repo: filters.repo,
-    branch: filters.branch,
-    job_name: filters.job_name,
-    cloud_phase: filters.cloud_phase,
-    issue_status: "",
-    start_date: filters.start_date,
-    end_date: filters.end_date,
-    granularity: "week",
-  });
+  const [selectedBucketTime, setSelectedBucketTime] = useState(null);
   const showPanelActions = !page.loading && !page.error;
   const currentPeriod = page.data?.period_comparison?.groups?.find((group) => group.name === "period_a")?.values;
   const previousPeriod = page.data?.period_comparison?.groups?.find((group) => group.name === "period_b")?.values;
@@ -96,6 +167,41 @@ export default function FlakyPage({ filters }) {
   const totalPrCount = Number(currentPeriod?.total_pr_count || 0);
   const issueFixProgress = page.data?.issue_fix_progress || {};
   const snapshotSubtitle = buildSnapshotSubtitle(issueFixProgress.meta);
+  const bucketedFlakyRate = page.data?.bucketed_flaky_rate || {};
+  const bucketedFlakyRateRows = bucketedFlakyRate.rows || [];
+  const bucketedFlakyRateMeta = bucketedFlakyRate.meta || {};
+  const bucketedFlakyRateSubtitle = buildBucketedFlakyRateSubtitle(bucketedFlakyRateMeta);
+  const bucketedFlakyRateAxisMax = buildCenteredPercentAxisMax(bucketedFlakyRateRows);
+  const selectedBucketRange = resolveSelectedBucketRange(selectedBucketTime, bucketedFlakyRateMeta);
+  const bucketTopJobs = useApiData(
+    "/api/v1/flaky/top-jobs",
+    selectedBucketRange
+      ? {
+          repo: filters.repo,
+          branch: filters.branch,
+          job_name: filters.job_name,
+          cloud_phase: filters.cloud_phase,
+          start_date: selectedBucketRange.start_date,
+          end_date: selectedBucketRange.end_date,
+          granularity: bucketedFlakyRateMeta.effective_granularity || "week",
+          limit: 8,
+        }
+      : {},
+    Boolean(selectedBucketRange),
+  );
+  const topJobsItems = selectedBucketRange ? bucketTopJobs.data?.items : page.data?.top_jobs?.items;
+  const topJobsLoading = selectedBucketRange ? bucketTopJobs.loading : page.loading;
+  const topJobsError = selectedBucketRange ? bucketTopJobs.error : page.error;
+  const topJobsSubtitle = buildTopJobsSubtitle(selectedBucketRange);
+
+  useEffect(() => {
+    if (!selectedBucketTime) {
+      return;
+    }
+    if (!bucketedFlakyRateRows.some((row) => row.time === selectedBucketTime)) {
+      setSelectedBucketTime(null);
+    }
+  }, [bucketedFlakyRateRows, selectedBucketTime]);
 
   return (
     <div className="page-stack">
@@ -291,17 +397,35 @@ export default function FlakyPage({ filters }) {
         <div className="flaky-highlight-stack">
           <Panel
             title="Flaky rate trend"
-            subtitle="Flaky, blind-retry-loop, and noisy rates together, each using failure-like builds as the denominator."
-            loading={weeklyFlakyTrend.loading}
-            error={weeklyFlakyTrend.error}
+            subtitle={bucketedFlakyRateSubtitle}
+            loading={page.loading}
+            error={page.error}
+            actions={showPanelActions ? (
+              <div className="panel-badge-row">
+                <span className="panel-badge">
+                  <strong>{formatNumber(bucketedFlakyRateRows.length)}</strong>
+                  <span>buckets</span>
+                </span>
+              </div>
+            ) : null}
           >
-            <TrendChart
-              series={weeklyFlakyTrend.data?.series}
-              rightYFormatter={formatPercent}
-              rightYMax={100}
-              compactY
-              height={208}
-            />
+            <div className="chart-table-stack">
+              <TrendChart
+                series={bucketedFlakyRate.series}
+                yFormatter={formatPercent}
+                yMax={bucketedFlakyRateAxisMax}
+                compactY
+                height={208}
+                selectedBucketLabel={selectedBucketTime}
+                onBucketSelect={setSelectedBucketTime}
+              />
+              <BucketFlakyRateTable
+                rows={bucketedFlakyRateRows}
+                effectiveGranularity={bucketedFlakyRateMeta.effective_granularity}
+                selectedTime={selectedBucketTime}
+                onSelectTime={setSelectedBucketTime}
+              />
+            </div>
           </Panel>
 
           <Panel
@@ -338,13 +462,22 @@ export default function FlakyPage({ filters }) {
 
         <Panel
           title="Top noisy jobs"
-          subtitle="Jobs ranked by noisy rate, with raw noisy and failure-like build counts kept visible for context."
-          loading={page.loading}
-          error={page.error}
+          subtitle={topJobsSubtitle}
+          loading={topJobsLoading}
+          error={topJobsError}
+          actions={selectedBucketRange ? (
+            <button
+              type="button"
+              className="ghost-button ghost-button--compact"
+              onClick={() => setSelectedBucketTime(null)}
+            >
+              Show all buckets
+            </button>
+          ) : null}
           className="panel--full-height"
         >
           <RankingList
-            items={page.data?.top_jobs?.items}
+            items={topJobsItems}
             valueFormatter={formatPercent}
           />
         </Panel>

--- a/ci-dashboard/web/src/pages/MigrateStatusPage.jsx
+++ b/ci-dashboard/web/src/pages/MigrateStatusPage.jsx
@@ -1,9 +1,11 @@
 import {
   formatPercent,
   formatRoundedThousands,
+  formatSeconds,
   useApiData,
 } from "../lib/api";
 import {
+  MigrationFixedWindowComparisonTable,
   PageIntro,
   Panel,
   RuntimeComparisonBoard,
@@ -13,6 +15,13 @@ import {
 export default function MigrateStatusPage({ filters }) {
   const page = useApiData("/api/v1/pages/ci-status", filters);
   const cloudPostureAnnotations = buildCloudPostureAnnotations(page.data?.cloud_posture_trend?.series);
+  const fixedWindowComparisonMeta = page.data?.migration_fixed_window_comparison?.meta;
+  const fixedWindowComparisonSubtitle = buildFixedWindowComparisonSubtitle(
+    fixedWindowComparisonMeta,
+  );
+  const fixedWindowDurationSeries = buildFixedWindowDurationSeries(
+    page.data?.migration_fixed_window_comparison?.rows,
+  );
 
   return (
     <div className="page-stack">
@@ -57,8 +66,59 @@ export default function MigrateStatusPage({ filters }) {
           minSuccessRuns={page.data?.migration_runtime_comparison?.meta?.min_success_runs_each_side}
         />
       </Panel>
+
+      <Panel
+        title="Pre-cloud baseline vs recent GCP"
+        subtitle={fixedWindowComparisonSubtitle}
+        loading={page.loading}
+        error={page.error}
+      >
+        <div className="chart-table-stack">
+          <TrendChart
+            series={fixedWindowDurationSeries}
+            yFormatter={formatSeconds}
+            height={220}
+            preserveLabelOrder
+          />
+          <MigrationFixedWindowComparisonTable
+            rows={page.data?.migration_fixed_window_comparison?.rows}
+          />
+        </div>
+      </Panel>
     </div>
   );
+}
+
+function buildFixedWindowComparisonSubtitle(meta) {
+  if (!meta?.baseline_start_date || !meta?.baseline_end_date || !meta?.recent_start_date) {
+    return "Fixed-window comparison for All repos, TiDB, and TiCDC.";
+  }
+
+  const recentEndDate = meta.recent_end_date || "latest GCP success date";
+  return `All repos, TiDB, and TiCDC compared side by side. Baseline uses ${meta.baseline_start_date} to ${meta.baseline_end_date} across all clouds; recent uses GCP-only builds from ${meta.recent_start_date} to ${recentEndDate}. Avg duration uses successful builds only, and this panel ignores repo, branch, job, start, bucket, and cloud filters.`;
+}
+
+function buildFixedWindowDurationSeries(rows) {
+  if (!rows?.length) {
+    return [];
+  }
+
+  return [
+    {
+      key: "baseline_avg_total_s",
+      label: "Baseline avg duration",
+      type: "bar",
+      axis: "left",
+      points: rows.map((row) => [row.scope_label, Number(row.baseline?.success_avg_total_s || 0)]),
+    },
+    {
+      key: "recent_gcp_avg_total_s",
+      label: "Recent GCP avg duration",
+      type: "bar",
+      axis: "left",
+      points: rows.map((row) => [row.scope_label, Number(row.recent_gcp?.success_avg_total_s || 0)]),
+    },
+  ];
 }
 
 function buildCloudPostureAnnotations(series) {

--- a/ci-dashboard/web/src/styles.css
+++ b/ci-dashboard/web/src/styles.css
@@ -693,6 +693,11 @@ select {
   min-width: 0;
 }
 
+.chart-table-stack {
+  display: grid;
+  gap: 0.85rem;
+}
+
 .panel--error-builds .panel__body {
   display: grid;
   align-content: start;
@@ -1430,6 +1435,10 @@ select {
   min-width: 560px;
 }
 
+.data-table--narrow {
+  min-width: 420px;
+}
+
 .data-table th,
 .data-table td {
   padding: 0.8rem 0.9rem;
@@ -1481,6 +1490,16 @@ select {
   background: rgba(15, 124, 130, 0.08);
 }
 
+.data-row--interactive th,
+.data-row--interactive td {
+  cursor: pointer;
+}
+
+.data-row--selected th,
+.data-row--selected td {
+  background: rgba(42, 157, 143, 0.12) !important;
+}
+
 .metric-cell {
   font-weight: 700;
 }
@@ -1491,6 +1510,15 @@ select {
 
 .metric-cell--cool {
   color: var(--accent) !important;
+}
+
+.bucket-delta {
+  font-variant-numeric: tabular-nums;
+}
+
+.bucket-delta--up {
+  color: var(--rose) !important;
+  font-weight: 700;
 }
 
 .issue-cell {


### PR DESCRIPTION
## Summary
- add richer flaky dashboard interactions, including bucket-aware flaky trend drilldown, month granularity support, and updated trend/table behavior
- add fixed-window migration comparison data for all repos, TiDB, and TiCDC, plus a duration chart and comparison table on the GCP Migration tab
- cover the new dashboard query behavior with API and query-base tests

## Testing
- ./.venv/bin/python -m pytest tests/test_query_base.py tests/api/test_routes.py
- ./.venv/bin/python -m pytest tests/api/test_routes.py -q
- npm run build