### PR TITLE
feat(roster): validate historical identities and sync en_name

### DIFF
--- a/roster/README.md
+++ b/roster/README.md
@@ -19,6 +19,12 @@ Validate Lark data without writing DB:
 python -m roster.jobs.cli validate-lark
 ```
 
+Compare synced roster rows with historical employee identity tables:
+
+```bash
+python -m roster.jobs.cli validate-history --details-limit 20
+```
+
 Database configuration accepts either a SQLAlchemy URL:
 
 ```bash

--- a/roster/docs/schema-design.md
+++ b/roster/docs/schema-design.md
@@ -25,6 +25,7 @@ CREATE TABLE roster_employees (
   id BIGINT NOT NULL AUTO_INCREMENT,
   lark_id VARCHAR(128) NOT NULL,
   name VARCHAR(255) NOT NULL,
+  en_name VARCHAR(255) NULL,
   employee_no VARCHAR(64) NULL,
   email VARCHAR(255) NULL,
   github_id VARCHAR(255) NULL,
@@ -51,6 +52,7 @@ Field notes:
 
 - `id`: internal numeric primary key for joins.
 - `lark_id`: Lark `union_id`, used for sync upsert.
+- `en_name`: English display name from Lark `en_name`, used as a readable identity hint.
 - `employee_no`: employee number from Lark, used for HR and cost data reconciliation.
 - `email`: company email. Empty values from Lark must be normalized to `NULL`.
 - `github_id`: GitHub account value from Lark. This is expected to be the GitHub login/name if Lark stores that as the custom field.

--- a/roster/sql/001_create_roster_tables.sql
+++ b/roster/sql/001_create_roster_tables.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS roster_employees (
   id BIGINT NOT NULL AUTO_INCREMENT,
   lark_id VARCHAR(128) NOT NULL,
   name VARCHAR(255) NOT NULL,
+  en_name VARCHAR(255) NULL,
   employee_no VARCHAR(64) NULL,
   email VARCHAR(255) NULL,
   github_id VARCHAR(255) NULL,

--- a/roster/sql/003_alter_roster_employees_add_en_name.sql
+++ b/roster/sql/003_alter_roster_employees_add_en_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE roster_employees
+  ADD COLUMN en_name VARCHAR(255) NULL AFTER name;

--- a/roster/src/roster/jobs/cli.py
+++ b/roster/src/roster/jobs/cli.py
@@ -9,6 +9,7 @@ from roster.common.config import get_settings
 from roster.common.db import build_engine
 from roster.common.logging import configure_logging
 from roster.jobs.sync_roster import run_sync_roster
+from roster.jobs.validate_history import validate_historical_employees
 from roster.jobs.validate_lark import validate_lark_roster
 from roster.sources.lark import LarkApiClient, LarkRosterSource
 
@@ -18,12 +19,22 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("sync-roster", help="Sync Lark roster data into roster tables")
     subparsers.add_parser("validate-lark", help="Fetch Lark roster data and print field quality summary")
+    validate_history = subparsers.add_parser(
+        "validate-history",
+        help="Compare roster employees against historical employee identity tables",
+    )
+    validate_history.add_argument(
+        "--details-limit",
+        type=int,
+        default=20,
+        help="Maximum GitHub mismatch rows to include in the JSON output",
+    )
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    settings = get_settings(require_database=args.command == "sync-roster")
+    settings = get_settings(require_database=args.command in {"sync-roster", "validate-history"})
     configure_logging(settings.log_level)
 
     if args.command == "sync-roster":
@@ -45,6 +56,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         summary = validate_lark_roster(_build_lark_source(settings))
         print(json.dumps(summary.to_dict(), indent=2, sort_keys=True))
         return 0
+
+    if args.command == "validate-history":
+        engine = build_engine(settings)
+        try:
+            report = validate_historical_employees(engine, details_limit=args.details_limit)
+            print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+            return 0
+        finally:
+            engine.dispose()
 
     raise AssertionError(f"Unhandled command: {args.command}")  # pragma: no cover
 

--- a/roster/src/roster/jobs/sync_roster.py
+++ b/roster/src/roster/jobs/sync_roster.py
@@ -43,6 +43,7 @@ employees_table = Table(
     Column("id", BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True),
     Column("lark_id", String(128), nullable=False, unique=True),
     Column("name", String(255), nullable=False),
+    Column("en_name", String(255)),
     Column("employee_no", String(64)),
     Column("email", String(255), unique=True),
     Column("github_id", String(255), unique=True),
@@ -86,6 +87,7 @@ class SyncRosterSummary:
 class FetchedEmployee:
     lark_id: str
     name: str
+    en_name: str | None = None
     employee_no: str | None = None
     email: str | None = None
     github_id: str | None = None
@@ -231,6 +233,7 @@ def _employee_pass1_rows(
             {
                 "lark_id": employee.lark_id,
                 "name": employee.name,
+                "en_name": _nullable_text(employee.en_name),
                 "employee_no": _nullable_text(employee.employee_no),
                 "email": None if email in duplicate_emails else email,
                 "github_id": None if github_id in duplicate_github_ids else github_id,

--- a/roster/src/roster/jobs/validate_history.py
+++ b/roster/src/roster/jobs/validate_history.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+
+@dataclass(frozen=True)
+class HistoricalEmployeeSource:
+    name: str
+    table_sql: str
+    email_sql: str
+    github_sql: str
+    name_sql: str
+    display_name_sql: str = "NULL"
+    github_name_sql: str = "NULL"
+    github_email_sql: str = "NULL"
+
+
+DEFAULT_HISTORICAL_EMPLOYEE_SOURCES = (
+    HistoricalEmployeeSource(
+        name="employee_details",
+        table_sql="employee_details",
+        email_sql="email",
+        github_sql="githubid",
+        name_sql="name",
+    ),
+    HistoricalEmployeeSource(
+        name="pingcap-ids",
+        table_sql="`pingcap-ids`",
+        email_sql="email",
+        github_sql="githubid",
+        name_sql="name",
+        display_name_sql="displayname",
+        github_name_sql="githubname",
+        github_email_sql="githubemail",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class HistoricalEmployeeValidationSummary:
+    source: str
+    legacy_rows: int
+    legacy_rows_with_email: int
+    legacy_distinct_emails: int
+    legacy_duplicate_emails: int
+    roster_rows_with_email: int
+    matched_rows: int
+    matched_emails: int
+    legacy_rows_missing_from_roster: int
+    roster_emails_missing_from_legacy: int
+    github_matches: int
+    github_mismatches: int
+    roster_missing_github_with_legacy_github: int
+    legacy_missing_github_with_roster_github: int
+    both_missing_github: int
+
+
+@dataclass(frozen=True)
+class HistoricalEmployeeGithubMismatch:
+    source: str
+    email: str
+    roster_name: str | None
+    legacy_name: str | None
+    legacy_display_name: str | None
+    roster_github_id: str
+    legacy_github_id: str
+    legacy_github_name: str | None
+    legacy_github_email: str | None
+
+
+@dataclass(frozen=True)
+class HistoricalEmployeeValidationReport:
+    summaries: tuple[HistoricalEmployeeValidationSummary, ...]
+    github_mismatches: tuple[HistoricalEmployeeGithubMismatch, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "summaries": [asdict(summary) for summary in self.summaries],
+            "github_mismatches": [asdict(mismatch) for mismatch in self.github_mismatches],
+        }
+
+
+def validate_historical_employees(
+    engine: Engine,
+    *,
+    sources: tuple[HistoricalEmployeeSource, ...] = DEFAULT_HISTORICAL_EMPLOYEE_SOURCES,
+    details_limit: int = 20,
+) -> HistoricalEmployeeValidationReport:
+    summaries: list[HistoricalEmployeeValidationSummary] = []
+    github_mismatches: list[HistoricalEmployeeGithubMismatch] = []
+    with engine.connect() as connection:
+        for source in sources:
+            summary_row = connection.execute(text(_summary_sql(source))).one()._mapping
+            summaries.append(
+                HistoricalEmployeeValidationSummary(
+                    source=source.name,
+                    **{key: _int_value(summary_row[key]) for key in summary_row if key != "source"},
+                )
+            )
+            if details_limit > 0:
+                rows = connection.execute(
+                    text(_github_mismatch_sql(source)),
+                    {"details_limit": details_limit},
+                ).all()
+                github_mismatches.extend(
+                    HistoricalEmployeeGithubMismatch(
+                        source=source.name,
+                        email=_optional_str(row.email) or "",
+                        roster_name=_optional_str(row.roster_name),
+                        legacy_name=_optional_str(row.legacy_name),
+                        legacy_display_name=_optional_str(row.legacy_display_name),
+                        roster_github_id=_optional_str(row.roster_github_id) or "",
+                        legacy_github_id=_optional_str(row.legacy_github_id) or "",
+                        legacy_github_name=_optional_str(row.legacy_github_name),
+                        legacy_github_email=_optional_str(row.legacy_github_email),
+                    )
+                    for row in rows
+                )
+    return HistoricalEmployeeValidationReport(
+        summaries=tuple(summaries),
+        github_mismatches=tuple(github_mismatches),
+    )
+
+
+def _summary_sql(source: HistoricalEmployeeSource) -> str:
+    return f"""
+WITH
+legacy AS (
+  SELECT
+    NULLIF(LOWER(TRIM({source.email_sql})), '') AS email_key,
+    NULLIF(TRIM({source.github_sql}), '') AS github_id
+  FROM {source.table_sql}
+),
+roster AS (
+  SELECT
+    NULLIF(LOWER(TRIM(email)), '') AS email_key,
+    NULLIF(TRIM(github_id), '') AS github_id
+  FROM roster_employees
+),
+matched AS (
+  SELECT
+    l.email_key,
+    l.github_id AS legacy_github_id,
+    r.github_id AS roster_github_id
+  FROM legacy l
+  JOIN roster r ON r.email_key = l.email_key
+  WHERE l.email_key IS NOT NULL
+),
+legacy_duplicate_emails AS (
+  SELECT email_key
+  FROM legacy
+  WHERE email_key IS NOT NULL
+  GROUP BY email_key
+  HAVING COUNT(*) > 1
+)
+SELECT
+  COUNT(*) AS legacy_rows,
+  SUM(CASE WHEN l.email_key IS NOT NULL THEN 1 ELSE 0 END) AS legacy_rows_with_email,
+  COUNT(DISTINCT l.email_key) AS legacy_distinct_emails,
+  (SELECT COUNT(*) FROM legacy_duplicate_emails) AS legacy_duplicate_emails,
+  (SELECT COUNT(*) FROM roster WHERE email_key IS NOT NULL) AS roster_rows_with_email,
+  (SELECT COUNT(*) FROM matched) AS matched_rows,
+  (SELECT COUNT(DISTINCT email_key) FROM matched) AS matched_emails,
+  SUM(
+    CASE
+      WHEN l.email_key IS NOT NULL AND r.email_key IS NULL THEN 1
+      ELSE 0
+    END
+  ) AS legacy_rows_missing_from_roster,
+  (
+    SELECT COUNT(DISTINCT r2.email_key)
+    FROM roster r2
+    LEFT JOIN legacy l2 ON l2.email_key = r2.email_key
+    WHERE r2.email_key IS NOT NULL AND l2.email_key IS NULL
+  ) AS roster_emails_missing_from_legacy,
+  (
+    SELECT SUM(
+      CASE
+        WHEN legacy_github_id IS NOT NULL
+          AND roster_github_id IS NOT NULL
+          AND LOWER(legacy_github_id) = LOWER(roster_github_id)
+        THEN 1
+        ELSE 0
+      END
+    )
+    FROM matched
+  ) AS github_matches,
+  (
+    SELECT SUM(
+      CASE
+        WHEN legacy_github_id IS NOT NULL
+          AND roster_github_id IS NOT NULL
+          AND LOWER(legacy_github_id) <> LOWER(roster_github_id)
+        THEN 1
+        ELSE 0
+      END
+    )
+    FROM matched
+  ) AS github_mismatches,
+  (
+    SELECT SUM(
+      CASE
+        WHEN legacy_github_id IS NOT NULL AND roster_github_id IS NULL THEN 1
+        ELSE 0
+      END
+    )
+    FROM matched
+  ) AS roster_missing_github_with_legacy_github,
+  (
+    SELECT SUM(
+      CASE
+        WHEN legacy_github_id IS NULL AND roster_github_id IS NOT NULL THEN 1
+        ELSE 0
+      END
+    )
+    FROM matched
+  ) AS legacy_missing_github_with_roster_github,
+  (
+    SELECT SUM(
+      CASE
+        WHEN legacy_github_id IS NULL AND roster_github_id IS NULL THEN 1
+        ELSE 0
+      END
+    )
+    FROM matched
+  ) AS both_missing_github
+FROM legacy l
+LEFT JOIN roster r ON r.email_key = l.email_key
+"""
+
+
+def _github_mismatch_sql(source: HistoricalEmployeeSource) -> str:
+    return f"""
+WITH
+legacy AS (
+  SELECT
+    NULLIF(LOWER(TRIM({source.email_sql})), '') AS email_key,
+    NULLIF(TRIM({source.email_sql}), '') AS email,
+    NULLIF(TRIM({source.github_sql}), '') AS github_id,
+    NULLIF(TRIM({source.name_sql}), '') AS name,
+    NULLIF(TRIM({source.display_name_sql}), '') AS display_name,
+    NULLIF(TRIM({source.github_name_sql}), '') AS github_name,
+    NULLIF(TRIM({source.github_email_sql}), '') AS github_email
+  FROM {source.table_sql}
+),
+roster AS (
+  SELECT
+    NULLIF(LOWER(TRIM(email)), '') AS email_key,
+    NULLIF(TRIM(name), '') AS name,
+    NULLIF(TRIM(github_id), '') AS github_id
+  FROM roster_employees
+)
+SELECT
+  l.email,
+  r.name AS roster_name,
+  l.name AS legacy_name,
+  l.display_name AS legacy_display_name,
+  r.github_id AS roster_github_id,
+  l.github_id AS legacy_github_id,
+  l.github_name AS legacy_github_name,
+  l.github_email AS legacy_github_email
+FROM legacy l
+JOIN roster r ON r.email_key = l.email_key
+WHERE l.github_id IS NOT NULL
+  AND r.github_id IS NOT NULL
+  AND LOWER(l.github_id) <> LOWER(r.github_id)
+ORDER BY l.email
+LIMIT :details_limit
+"""
+
+
+def _int_value(value: object) -> int:
+    if value is None:
+        return 0
+    return int(value)
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/roster/src/roster/sources/lark.py
+++ b/roster/src/roster/sources/lark.py
@@ -212,6 +212,7 @@ class LarkRosterSource(RosterSource):
         return FetchedEmployee(
             lark_id=lark_id,
             name=_required_text(item, "name"),
+            en_name=_optional_text(item.get("en_name")),
             employee_no=_optional_text(item.get("employee_no")),
             email=_optional_text(item.get("enterprise_email") or item.get("email")),
             github_id=self._github_id_from_custom_attrs(item),

--- a/roster/tests/test_cli.py
+++ b/roster/tests/test_cli.py
@@ -17,6 +17,13 @@ def test_parser_exposes_validate_lark_command() -> None:
     assert args.command == "validate-lark"
 
 
+def test_parser_exposes_validate_history_command() -> None:
+    args = cli.build_parser().parse_args(["validate-history", "--details-limit", "5"])
+
+    assert args.command == "validate-history"
+    assert args.details_limit == 5
+
+
 def test_main_runs_sync_roster(monkeypatch) -> None:
     calls: dict[str, object] = {}
     settings = SimpleNamespace(log_level="INFO", lark=SimpleNamespace(is_configured=False))
@@ -159,6 +166,33 @@ def test_main_validate_lark_prints_json(monkeypatch, capsys) -> None:
 
     assert calls == {"source": source}
     assert capsys.readouterr().out == '{\n  "employees": 3,\n  "groups": 2\n}\n'
+
+
+def test_main_validate_history_prints_json_and_disposes_engine(monkeypatch, capsys) -> None:
+    calls: dict[str, object] = {}
+    settings = SimpleNamespace(log_level="INFO", lark=SimpleNamespace(is_configured=False))
+    engine = SimpleNamespace(dispose=lambda: calls.setdefault("disposed", True))
+    report = SimpleNamespace(to_dict=lambda: {"summaries": [{"source": "pingcap-ids"}]})
+
+    monkeypatch.setattr(cli, "get_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda log_level: calls.setdefault("log", log_level))
+    monkeypatch.setattr(cli, "build_engine", lambda resolved: calls.setdefault("engine", engine))
+
+    def fake_validate_historical_employees(built_engine, *, details_limit):
+        calls["validate"] = (built_engine, details_limit)
+        return report
+
+    monkeypatch.setattr(cli, "validate_historical_employees", fake_validate_historical_employees)
+
+    assert cli.main(["validate-history", "--details-limit", "3"]) == 0
+
+    assert calls == {
+        "log": "INFO",
+        "engine": engine,
+        "validate": (engine, 3),
+        "disposed": True,
+    }
+    assert capsys.readouterr().out == '{\n  "summaries": [\n    {\n      "source": "pingcap-ids"\n    }\n  ]\n}\n'
 
 
 def test_main_rejects_unknown_args() -> None:

--- a/roster/tests/test_lark_source.py
+++ b/roster/tests/test_lark_source.py
@@ -82,6 +82,7 @@ def test_lark_roster_source_fetches_token_departments_and_users() -> None:
                         {
                             "union_id": "manager",
                             "name": "Manager",
+                            "en_name": "Engineering Manager",
                             "enterprise_email": "manager@example.com",
                             "employee_no": "E002",
                             "join_time": 1706745600,
@@ -128,6 +129,7 @@ def test_lark_roster_source_fetches_token_departments_and_users() -> None:
     assert roster.employees[0].group_lark_id == "od-root"
     assert roster.employees[0].join_time.isoformat() == "2024-01-01T00:00:00"
     assert roster.employees[1].email == "manager@example.com"
+    assert roster.employees[1].en_name == "Engineering Manager"
     assert roster.employees[1].github_id == "manager-gh"
     assert roster.employees[1].join_time.isoformat() == "2024-02-01T00:00:00"
     assert roster.employees[1].manager_lark_id == "ceo"
@@ -293,6 +295,7 @@ def test_lark_roster_source_maps_fallback_fields() -> None:
                         {
                             "union_id": "alice",
                             "name": "Alice",
+                            "en_name": "Alice Example",
                             "email": "alice@example.com",
                             "join_time": 0,
                             "orders": [
@@ -324,6 +327,7 @@ def test_lark_roster_source_maps_fallback_fields() -> None:
     roster = source.fetch_roster()
 
     assert roster.employees[0].email == "alice@example.com"
+    assert roster.employees[0].en_name == "Alice Example"
     assert roster.employees[0].github_id == "alice-gh"
     assert roster.employees[0].join_time is None
     assert roster.employees[0].group_lark_id == "od-a"

--- a/roster/tests/test_sql_schema.py
+++ b/roster/tests/test_sql_schema.py
@@ -7,6 +7,9 @@ SQL_PATH = Path(__file__).resolve().parents[1] / "sql" / "001_create_roster_tabl
 JOIN_TIME_SQL_PATH = (
     Path(__file__).resolve().parents[1] / "sql" / "002_alter_roster_employees_add_join_time.sql"
 )
+EN_NAME_SQL_PATH = (
+    Path(__file__).resolve().parents[1] / "sql" / "003_alter_roster_employees_add_en_name.sql"
+)
 
 
 def test_schema_migration_creates_expected_tables() -> None:
@@ -22,6 +25,7 @@ def test_employee_schema_has_join_keys_and_paths() -> None:
 
     assert "id BIGINT NOT NULL AUTO_INCREMENT" in sql
     assert "lark_id VARCHAR(128) NOT NULL" in sql
+    assert "en_name VARCHAR(255) NULL" in sql
     assert "employee_no VARCHAR(64) NULL" in sql
     assert "join_time DATETIME NULL" in sql
     assert "UNIQUE KEY uk_roster_employees_lark_id (lark_id)" in sql
@@ -50,3 +54,10 @@ def test_join_time_alter_sql_adds_employee_column() -> None:
 
     assert "ALTER TABLE roster_employees" in sql
     assert "ADD COLUMN join_time DATETIME NULL AFTER github_id" in sql
+
+
+def test_en_name_alter_sql_adds_employee_column() -> None:
+    sql = EN_NAME_SQL_PATH.read_text()
+
+    assert "ALTER TABLE roster_employees" in sql
+    assert "ADD COLUMN en_name VARCHAR(255) NULL AFTER name" in sql

--- a/roster/tests/test_sync_roster.py
+++ b/roster/tests/test_sync_roster.py
@@ -55,6 +55,7 @@ def test_run_sync_roster_writes_groups_employees_and_paths() -> None:
                 FetchedEmployee(
                     lark_id="manager",
                     name="Manager",
+                    en_name="Engineering Manager",
                     employee_no="E002",
                     email="manager@example.com",
                     github_id="manager-gh",
@@ -95,6 +96,7 @@ def test_run_sync_roster_writes_groups_employees_and_paths() -> None:
     assert groups["db"]["path"] == f"/{groups['root']['id']}/{groups['eng']['id']}/{groups['db']['id']}/"
 
     assert employees["manager"]["manager_id"] == employees["ceo"]["id"]
+    assert employees["manager"]["en_name"] == "Engineering Manager"
     assert employees["manager"]["manager_path"] == f"/{employees['ceo']['id']}/"
     assert employees["manager"]["group_id"] == groups["eng"]["id"]
     assert employees["manager"]["group_path"] == groups["eng"]["path"]
@@ -116,6 +118,7 @@ def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -
                 FetchedEmployee(
                     lark_id="alice",
                     name="Alice",
+                    en_name="Alice Example",
                     email="alice@example.com",
                     github_id="alice",
                     join_time=_dt("2024-01-02T00:00:00"),
@@ -131,6 +134,7 @@ def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -
                 FetchedEmployee(
                     lark_id="alice",
                     name="Alice Zhang",
+                    en_name="Alice Z.",
                     email="alice.zhang@example.com",
                     github_id="alicezhang",
                     join_time=_dt("2024-03-04T00:00:00"),
@@ -153,6 +157,7 @@ def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -
 
     assert employee["id"] == original_employee_id
     assert employee["name"] == "Alice Zhang"
+    assert employee["en_name"] == "Alice Z."
     assert employee["email"] == "alice.zhang@example.com"
     assert employee["github_id"] == "alicezhang"
     assert employee["join_time"] == _dt("2024-03-04T00:00:00")
@@ -288,6 +293,7 @@ def test_run_sync_roster_normalizes_empty_join_keys_to_null() -> None:
         rows = conn.execute(select(employees_table).order_by(employees_table.c.lark_id)).all()
 
     assert [row._mapping["employee_no"] for row in rows] == [None, None]
+    assert [row._mapping["en_name"] for row in rows] == [None, None]
     assert [row._mapping["email"] for row in rows] == [None, None]
     assert [row._mapping["github_id"] for row in rows] == [None, None]
 
@@ -393,6 +399,7 @@ def _stable_employee(row) -> dict[str, object]:
         "id": row["id"],
         "lark_id": row["lark_id"],
         "name": row["name"],
+        "en_name": row["en_name"],
         "employee_no": row["employee_no"],
         "email": row["email"],
         "github_id": row["github_id"],

--- a/roster/tests/test_validate_history.py
+++ b/roster/tests/test_validate_history.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine, text
+
+from roster.jobs.sync_roster import FetchedEmployee, FetchedRoster, StaticRosterSource, metadata, run_sync_roster
+from roster.jobs.validate_history import validate_historical_employees
+
+
+def test_validate_historical_employees_compares_email_matched_github_ids() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    _create_historical_tables(engine)
+    run_sync_roster(
+        engine,
+        source=StaticRosterSource(
+            FetchedRoster(
+                employees=[
+                    FetchedEmployee(
+                        lark_id="alice",
+                        name="Alice Zhang",
+                        email="alice@example.com",
+                        github_id="alice-gh",
+                    ),
+                    FetchedEmployee(
+                        lark_id="bob",
+                        name="Bob Li",
+                        email="bob@example.com",
+                        github_id="bob-roster",
+                    ),
+                    FetchedEmployee(
+                        lark_id="carol",
+                        name="Carol Wu",
+                        email="carol@example.com",
+                    ),
+                    FetchedEmployee(
+                        lark_id="dave",
+                        name="Dave Xu",
+                        email="dave@example.com",
+                        github_id="dave-gh",
+                    ),
+                ]
+            )
+        ),
+    )
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO employee_details (name, email, dept, `sub-dept`, active, githubid)
+                VALUES
+                  ('Alice Legacy', 'alice@example.com', 'eng', 'db', 1, 'alice-gh'),
+                  ('Bob Legacy', 'bob@example.com', 'eng', 'db', 1, 'bob-legacy'),
+                  ('Carol Legacy', 'carol@example.com', 'eng', 'db', 1, 'carol-gh'),
+                  ('Eve Legacy', 'eve@example.com', 'eng', 'db', 1, 'eve-gh')
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO `pingcap-ids`
+                  (email, name, displayname, githubid, githubname, githubemail)
+                VALUES
+                  ('alice@example.com', 'Alice', 'Alice Zhang', 'alice-gh', 'AliceGH', ''),
+                  ('bob@example.com', 'Bob', 'Bob Li', 'bob-legacy', 'BobGH', 'bob@github.test'),
+                  ('dave@example.com', 'Dave', 'Dave Xu', '', 'DaveGH', '')
+                """
+            )
+        )
+
+    report = validate_historical_employees(engine, details_limit=10)
+    summaries = {summary.source: summary for summary in report.summaries}
+
+    assert summaries["employee_details"].legacy_rows == 4
+    assert summaries["employee_details"].matched_emails == 3
+    assert summaries["employee_details"].legacy_rows_missing_from_roster == 1
+    assert summaries["employee_details"].github_matches == 1
+    assert summaries["employee_details"].github_mismatches == 1
+    assert summaries["employee_details"].roster_missing_github_with_legacy_github == 1
+
+    assert summaries["pingcap-ids"].legacy_rows == 3
+    assert summaries["pingcap-ids"].matched_emails == 3
+    assert summaries["pingcap-ids"].github_matches == 1
+    assert summaries["pingcap-ids"].github_mismatches == 1
+    assert summaries["pingcap-ids"].legacy_missing_github_with_roster_github == 1
+
+    mismatch = next(item for item in report.github_mismatches if item.source == "pingcap-ids")
+    assert mismatch.email == "bob@example.com"
+    assert mismatch.roster_github_id == "bob-roster"
+    assert mismatch.legacy_github_id == "bob-legacy"
+    assert mismatch.legacy_display_name == "Bob Li"
+    assert mismatch.legacy_github_email == "bob@github.test"
+
+
+def test_validate_historical_employees_can_omit_details() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    _create_historical_tables(engine)
+
+    report = validate_historical_employees(engine, details_limit=0)
+
+    assert len(report.summaries) == 2
+    assert report.github_mismatches == ()
+
+
+def _create_historical_tables(engine) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE employee_details (
+                  name TEXT,
+                  email TEXT NOT NULL,
+                  dept TEXT,
+                  `sub-dept` TEXT,
+                  active INTEGER,
+                  githubid TEXT
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE `pingcap-ids` (
+                  email TEXT,
+                  name TEXT,
+                  displayname TEXT,
+                  githubid TEXT,
+                  githubname TEXT,
+                  githubemail TEXT
+                )
+                """
+            )
+        )


### PR DESCRIPTION
## Summary
- add a read-only `validate-history` roster command comparing `roster_employees` with `employee_details` and `pingcap-ids` by normalized email/GitHub ID
- sync Lark `en_name` into `roster_employees.en_name` and document the schema
- add migration `003_alter_roster_employees_add_en_name.sql` for environments that have not already added the column

## Notes
- Production table column has already been added manually per discussion; the migration remains for reproducibility.
- `Contact Email` and `[D]Email` custom attrs are intentionally not stored.

## Tests
- `pytest roster/tests`
- `cd roster && ruff check .`