### PR TITLE
fix(roster): preserve existing github id on empty sync

### DIFF
--- a/roster/src/roster/jobs/sync_roster.py
+++ b/roster/src/roster/jobs/sync_roster.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Table,
     and_,
     bindparam,
+    func,
     select,
     update,
 )
@@ -273,6 +274,7 @@ def _upsert_rows(
             for column in table.columns
             if column.name not in {"id", "created_at", *key_columns}
         }
+        _preserve_existing_github_id_when_source_is_empty(table, update_values, excluded)
         connection.execute(statement.on_conflict_do_update(index_elements=key_columns, set_=update_values))
         return
 
@@ -284,10 +286,22 @@ def _upsert_rows(
             for column in table.columns
             if column.name not in {"id", "created_at", *key_columns}
         }
+        _preserve_existing_github_id_when_source_is_empty(table, update_values, inserted)
         connection.execute(statement.on_duplicate_key_update(**update_values))
         return
 
     raise RuntimeError(f"Unsupported database dialect for roster sync: {dialect}")
+
+
+def _preserve_existing_github_id_when_source_is_empty(
+    table: Table,
+    update_values: dict[str, object],
+    incoming: Any,
+) -> None:
+    if table.name != employees_table.name or "github_id" not in update_values:
+        return
+
+    update_values["github_id"] = func.coalesce(incoming.github_id, table.c.github_id)
 
 
 def _employee_id_map(connection: Connection) -> dict[str, int]:

--- a/roster/tests/test_sync_roster.py
+++ b/roster/tests/test_sync_roster.py
@@ -160,6 +160,75 @@ def test_run_sync_roster_updates_existing_rows_without_changing_internal_ids() -
     assert group["name"] == "Engineering Platform"
 
 
+def test_run_sync_roster_preserves_existing_github_id_when_lark_value_is_empty() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+
+    first = StaticRosterSource(
+        FetchedRoster(
+            employees=[
+                FetchedEmployee(
+                    lark_id="changrui",
+                    name="Changrui",
+                    employee_no="P01398",
+                    email="changrui@example.com",
+                    github_id="changrui-ryan",
+                )
+            ],
+        )
+    )
+    second = StaticRosterSource(
+        FetchedRoster(
+            employees=[
+                FetchedEmployee(
+                    lark_id="changrui",
+                    name="Changrui",
+                    employee_no="P01398",
+                    email="changrui@example.com",
+                    github_id=None,
+                )
+            ],
+        )
+    )
+
+    run_sync_roster(engine, source=first, now=_dt("2026-05-14T08:00:00"))
+    run_sync_roster(engine, source=second, now=_dt("2026-05-14T09:00:00"))
+
+    with engine.connect() as conn:
+        employee = conn.execute(select(employees_table)).one()._mapping
+
+    assert employee["github_id"] == "changrui-ryan"
+    assert employee["last_seen_at"] == _dt("2026-05-14T09:00:00")
+
+
+def test_run_sync_roster_updates_existing_github_id_when_lark_value_is_present() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+
+    first = StaticRosterSource(
+        FetchedRoster(
+            employees=[
+                FetchedEmployee(lark_id="alice", name="Alice", github_id="alice-old")
+            ],
+        )
+    )
+    second = StaticRosterSource(
+        FetchedRoster(
+            employees=[
+                FetchedEmployee(lark_id="alice", name="Alice", github_id="alice-new")
+            ],
+        )
+    )
+
+    run_sync_roster(engine, source=first, now=_dt("2026-05-14T08:00:00"))
+    run_sync_roster(engine, source=second, now=_dt("2026-05-14T09:00:00"))
+
+    with engine.connect() as conn:
+        github_id = conn.execute(select(employees_table.c.github_id)).scalar_one()
+
+    assert github_id == "alice-new"
+
+
 def test_run_sync_roster_is_idempotent_for_same_roster() -> None:
     engine = create_engine("sqlite:///:memory:", future=True)
     metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- keep an existing roster employee github_id when the incoming Lark value is empty
- still allow non-empty Lark github_id values to update existing records
- add regression coverage for manually backfilled github_id values like P01398 / changrui-ryan

## Tests
- pytest roster/tests/test_sync_roster.py