### PR TITLE
feat(cost-insight): publish jobs image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,8 @@ jobs:
           filters: |
             ci-dashboard:
               - 'ci-dashboard/**'
+            cost-insight:
+              - 'cost-insight/**'
             roster:
               - 'roster/**'
             cloudevents-server:
@@ -103,6 +105,14 @@ jobs:
       - name: Build image - ci-dashboard
         if: steps.changes.outputs.ci-dashboard == 'true'
         working-directory: ci-dashboard
+        run: |
+          skaffold build \
+            --push=false \
+            --platform ${{ matrix.platform }} \
+            --default-repo ghcr.io/pingcap-qe/ee-apps
+      - name: Build image - cost-insight
+        if: steps.changes.outputs.cost-insight == 'true'
+        working-directory: cost-insight
         run: |
           skaffold build \
             --push=false \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,8 @@ jobs:
           filters: |
             ci-dashboard:
               - 'ci-dashboard/**'
+            cost-insight:
+              - 'cost-insight/**'
             roster:
               - 'roster/**'
             cloudevents-server:
@@ -101,6 +103,11 @@ jobs:
       - name: Publish image - ci-dashboard
         if: steps.changes.outputs.ci-dashboard == 'true'
         working-directory: ci-dashboard
+        run: |
+          skaffold build --default-repo ghcr.io/pingcap-qe/ee-apps
+      - name: Publish image - cost-insight
+        if: steps.changes.outputs.cost-insight == 'true'
+        working-directory: cost-insight
         run: |
           skaffold build --default-repo ghcr.io/pingcap-qe/ee-apps
       - name: Publish image - roster

--- a/cost-insight/Dockerfile.jobs
+++ b/cost-insight/Dockerfile.jobs
@@ -1,0 +1,30 @@
+FROM python:3.12-slim
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.source="https://github.com/PingCAP-QE/ee-apps"
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_DEFAULT_TIMEOUT=120 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip setuptools wheel
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+RUN python -m pip install --retries 5 .
+
+COPY sql ./sql
+
+RUN useradd --create-home --shell /usr/sbin/nologin app
+USER app
+
+ENTRYPOINT ["cost-insight"]

--- a/cost-insight/skaffold.yaml
+++ b/cost-insight/skaffold.yaml
@@ -1,0 +1,15 @@
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: cost-insight
+
+build:
+  platforms: ["linux/amd64", "linux/arm64"]
+  artifacts:
+    - image: cost-insight-jobs
+      docker:
+        dockerfile: Dockerfile.jobs
+  local:
+    useDockerCLI: true
+    useBuildkit: true
+    concurrency: 0


### PR DESCRIPTION
## Summary
- add a cost-insight jobs Dockerfile and skaffold config for the cost-insight CLI
- wire cost-insight into the Skaffold test workflow
- wire cost-insight into the release workflow so main pushes publish ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs

## Test
- cost-insight: pytest
- cost-insight: ruff check .

## Notes
- Verified the merged #452 release run skipped every existing publish step because cost-insight was not in the paths-filter/build list.
- Local docker build was not run because the Docker daemon is not running on this machine.