### PR TITLE
feat(ci-dashboard): add cost dashboard insights

### DIFF
--- a/ci-dashboard/README.md
+++ b/ci-dashboard/README.md
@@ -70,6 +70,7 @@ Notes:
 - FastAPI serves the built frontend from `web/dist` after `make web-build`
 - set `CI_DASHBOARD_STATIC_DIR` when the built frontend lives outside the default repo or container layout
 - `CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS` enables the experimental Runtime Insights tab when set to `true`; accepted boolean values include `true`/`false`, `1`/`0`, `yes`/`no`, and `on`/`off`, it defaults to hidden, and invalid values fail startup
+- `CI_DASHBOARD_ENABLE_COST_DASHBOARD` enables the Cost tab when set to `true`; it uses the same accepted boolean values as the Runtime Insights flag, defaults to hidden, and invalid values fail startup
 - during UI iteration, run `make api` and `make web-dev` in separate terminals
 - `backfill-range` is stateless and does not update `ci_job_state`, so the same time window can be re-imported safely
 - `CI_DASHBOARD_REFRESH_BUILD_LIMIT` controls how many impacted builds one `refresh-build-derived` run will process before checkpointing and continuing in the next CronJob run; the default is `5000`, valid values are positive integers, and smaller values trade shorter/faster runs for more CronJob passes before backlog catch-up finishes

--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date
+from datetime import date, timedelta
 from typing import Any, Mapping
 
 from sqlalchemy import text
@@ -92,19 +92,27 @@ def get_cost_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     total_resource_cost = _money(coverage_row["total_resource_cost"]) if coverage_row else 0.0
     matched_resource_cost = _money(coverage_row["matched_resource_cost"]) if coverage_row else 0.0
 
+    buckets = _bucket_starts(filters, data_rows)
+    net_cost_by_bucket = {bucket: 0.0 for bucket in buckets}
+    list_cost_by_bucket = {bucket: 0.0 for bucket in buckets}
+    for row in data_rows:
+        bucket_start = str(row["bucket_start"])
+        net_cost_by_bucket[bucket_start] = _money(row["net_cost"])
+        list_cost_by_bucket[bucket_start] = _money(row["list_cost"])
+
     return {
         "series": [
             {
                 "key": "list_cost",
                 "label": "List cost",
                 "type": "bar",
-                "points": [[str(row["bucket_start"]), _money(row["list_cost"])] for row in data_rows],
+                "points": [[bucket, list_cost_by_bucket[bucket]] for bucket in buckets],
             },
             {
                 "key": "net_cost",
                 "label": "Net cost",
                 "type": "line",
-                "points": [[str(row["bucket_start"]), _money(row["net_cost"])] for row in data_rows],
+                "points": [[bucket, net_cost_by_bucket[bucket]] for bucket in buckets],
             },
         ],
         "meta": {
@@ -175,19 +183,22 @@ def get_repo_group_cost_stack(engine: Engine, filters: CommonFilters) -> dict[st
         ).mappings()
         data_rows = [dict(row) for row in rows]
 
-    buckets = sorted({str(row["bucket_start"]) for row in data_rows})
+    buckets = _bucket_starts(filters, data_rows)
     values_by_key = {
-        _repo_key(repo_name): {bucket: 0.0 for bucket in buckets}
-        for repo_name in top_repos
+        _repo_key(repo_name, index): {bucket: 0.0 for bucket in buckets}
+        for index, repo_name in enumerate(top_repos)
     }
     labels_by_key = {
-        _repo_key(repo_name): repo_name
-        for repo_name in top_repos
+        _repo_key(repo_name, index): repo_name
+        for index, repo_name in enumerate(top_repos)
+    }
+    repo_key_by_name = {
+        repo_name: _repo_key(repo_name, index)
+        for index, repo_name in enumerate(top_repos)
     }
     for row in data_rows:
-        key = _repo_key(str(row["repo_name"]))
-        values_by_key.setdefault(key, {bucket: 0.0 for bucket in buckets})
-        labels_by_key.setdefault(key, str(row["repo_name"]))
+        repo_name = str(row["repo_name"])
+        key = repo_key_by_name[repo_name]
         values_by_key[key][str(row["bucket_start"])] = _money(row["list_cost"])
 
     return {
@@ -444,12 +455,40 @@ def _like_prefix_expr(connection: Connection, value_expr: str, prefix_expr: str)
     return f"{value_expr} LIKE CONCAT({prefix_expr}, '%')"
 
 
-def _repo_key(repo_name: str) -> str:
-    return f"repo__{_slug(repo_name)}"
+def _repo_key(repo_name: str, index: int) -> str:
+    if repo_name == "(no repo)":
+        return "repo__no_repo"
+    return f"repo__{index}"
 
 
-def _slug(value: str) -> str:
-    return "".join(char.lower() if char.isalnum() else "_" for char in value).strip("_") or "unknown"
+def _bucket_starts(filters: CommonFilters, rows: list[dict[str, Any]]) -> list[str]:
+    if filters.start_date and filters.end_date:
+        if filters.granularity == "month":
+            return _month_bucket_starts(filters.start_date, filters.end_date)
+        return _week_bucket_starts(filters.start_date, filters.end_date)
+    return sorted({str(row["bucket_start"]) for row in rows})
+
+
+def _week_bucket_starts(start_date: date, end_date: date) -> list[str]:
+    cursor = start_date - timedelta(days=start_date.weekday())
+    buckets: list[str] = []
+    while cursor <= end_date:
+        buckets.append(cursor.isoformat())
+        cursor += timedelta(days=7)
+    return buckets
+
+
+def _month_bucket_starts(start_date: date, end_date: date) -> list[str]:
+    cursor = start_date.replace(day=1)
+    end_bucket = end_date.replace(day=1)
+    buckets: list[str] = []
+    while cursor <= end_bucket:
+        buckets.append(cursor.isoformat())
+        if cursor.month == 12:
+            cursor = cursor.replace(year=cursor.year + 1, month=1)
+        else:
+            cursor = cursor.replace(month=cursor.month + 1)
+    return buckets
 
 
 def _resource_labels(row: Mapping[str, Any]) -> str:

--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+
+from ci_dashboard.api.queries.base import CommonFilters, bucket_expr, rate_pct, to_number
+
+COST_STACK_LIMIT = 8
+UNMATCHED_RESOURCE_LIMIT = 20
+ENGINEERING_GROUP_NAME = "Engineering Group"
+UNALLOCATED_GKE_NAMESPACE_BUCKETS = (
+    "kube:unallocated",
+    "kube:system-overhead",
+    "goog-k8s-unsupported-sku",
+    "goog-k8s-unknown",
+)
+
+
+def get_cost_page(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    cost_filters = _cost_filters(filters)
+    if engine.dialect.name == "sqlite":
+        sections = {
+            "cost_trend": get_cost_trend(engine, cost_filters),
+            "repo_group_stack": get_repo_group_cost_stack(engine, cost_filters),
+            "engineering_group_share": get_engineering_group_share(engine, cost_filters),
+        }
+    else:
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            futures = {
+                "cost_trend": executor.submit(get_cost_trend, engine, cost_filters),
+                "repo_group_stack": executor.submit(
+                    get_repo_group_cost_stack,
+                    engine,
+                    cost_filters,
+                ),
+                "engineering_group_share": executor.submit(
+                    get_engineering_group_share,
+                    engine,
+                    cost_filters,
+                ),
+            }
+            sections = {name: future.result() for name, future in futures.items()}
+
+    return {
+        "scope": cost_filters.meta(),
+        **sections,
+    }
+
+
+def get_cost_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    with engine.begin() as connection:
+        where_clause, params = _build_cost_where(filters, table_alias="c")
+        bucket = bucket_expr(connection, "c.usage_date", filters.granularity)
+        rows = connection.execute(
+            text(
+                f"""
+                SELECT
+                  {bucket} AS bucket_start,
+                  SUM(c.net_cost) AS net_cost,
+                  SUM(c.effective_cost) AS effective_cost,
+                  SUM(c.list_cost) AS list_cost
+                FROM cost_attribution_daily c
+                WHERE {where_clause}
+                GROUP BY bucket_start
+                ORDER BY bucket_start
+                """
+            ),
+            params,
+        ).mappings()
+        data_rows = [dict(row) for row in rows]
+        coverage_row = connection.execute(
+            text(
+                f"""
+                SELECT
+                  SUM(c.list_cost) AS total_resource_cost,
+                  SUM(CASE WHEN c.employee_id IS NOT NULL THEN c.list_cost ELSE 0 END) AS matched_resource_cost
+                FROM cost_attribution_daily c
+                WHERE {where_clause}
+                  AND c.list_cost IS NOT NULL
+                """
+            ),
+            params,
+        ).mappings().first()
+
+    summary_net_cost = sum(_money(row["net_cost"]) for row in data_rows)
+    summary_effective_cost = sum(_money(row["effective_cost"]) for row in data_rows)
+    summary_list_cost = sum(_money(row["list_cost"]) for row in data_rows)
+    total_resource_cost = _money(coverage_row["total_resource_cost"]) if coverage_row else 0.0
+    matched_resource_cost = _money(coverage_row["matched_resource_cost"]) if coverage_row else 0.0
+
+    return {
+        "series": [
+            {
+                "key": "list_cost",
+                "label": "List cost",
+                "type": "bar",
+                "points": [[str(row["bucket_start"]), _money(row["list_cost"])] for row in data_rows],
+            },
+            {
+                "key": "net_cost",
+                "label": "Net cost",
+                "type": "line",
+                "points": [[str(row["bucket_start"]), _money(row["net_cost"])] for row in data_rows],
+            },
+        ],
+        "meta": {
+            **filters.meta(),
+            "summary": {
+                "net_cost": round(summary_net_cost, 2),
+                "effective_cost": round(summary_effective_cost, 2),
+                "list_cost": round(summary_list_cost, 2),
+                "matched_resource_pct": rate_pct(matched_resource_cost, total_resource_cost),
+                "matched_resource_cost": matched_resource_cost,
+                "total_resource_cost": total_resource_cost,
+            },
+        },
+    }
+
+
+def get_repo_group_cost_stack(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    with engine.begin() as connection:
+        where_clause, params = _build_cost_where(filters, table_alias="c")
+        bucket = bucket_expr(connection, "c.usage_date", filters.granularity)
+        top_rows = connection.execute(
+            text(
+                f"""
+                SELECT
+                  COALESCE(NULLIF(c.repo, ''), '(no repo)') AS repo_name,
+                  SUM(c.list_cost) AS list_cost
+                FROM cost_attribution_daily c
+                WHERE {where_clause}
+                GROUP BY repo_name
+                ORDER BY list_cost DESC, repo_name
+                LIMIT :limit
+                """
+            ),
+            {**params, "limit": COST_STACK_LIMIT},
+        ).mappings()
+        top_repos = [str(row["repo_name"]) for row in top_rows]
+        if not top_repos:
+            return {
+                "series": [],
+                "items": [],
+                "meta": {**filters.meta(), "limit": COST_STACK_LIMIT},
+            }
+
+        dimension_conditions = []
+        dimension_params: dict[str, Any] = {}
+        for index, repo_name in enumerate(top_repos):
+            repo_key = f"repo_{index}"
+            dimension_conditions.append(
+                f"COALESCE(NULLIF(c.repo, ''), '(no repo)') = :{repo_key}"
+            )
+            dimension_params[repo_key] = repo_name
+
+        rows = connection.execute(
+            text(
+                f"""
+                SELECT
+                  {bucket} AS bucket_start,
+                  COALESCE(NULLIF(c.repo, ''), '(no repo)') AS repo_name,
+                  SUM(c.list_cost) AS list_cost
+                FROM cost_attribution_daily c
+                WHERE {where_clause}
+                  AND ({" OR ".join(dimension_conditions)})
+                GROUP BY bucket_start, repo_name
+                ORDER BY bucket_start, repo_name
+                """
+            ),
+            {**params, **dimension_params},
+        ).mappings()
+        data_rows = [dict(row) for row in rows]
+
+    buckets = sorted({str(row["bucket_start"]) for row in data_rows})
+    values_by_key = {
+        _repo_key(repo_name): {bucket: 0.0 for bucket in buckets}
+        for repo_name in top_repos
+    }
+    labels_by_key = {
+        _repo_key(repo_name): repo_name
+        for repo_name in top_repos
+    }
+    for row in data_rows:
+        key = _repo_key(str(row["repo_name"]))
+        values_by_key.setdefault(key, {bucket: 0.0 for bucket in buckets})
+        labels_by_key.setdefault(key, str(row["repo_name"]))
+        values_by_key[key][str(row["bucket_start"])] = _money(row["list_cost"])
+
+    return {
+        "series": [
+            {
+                "key": key,
+                "label": labels_by_key[key],
+                "type": "bar",
+                "points": [[bucket, values_by_key[key].get(bucket, 0.0)] for bucket in buckets],
+            }
+            for key in values_by_key
+        ],
+        "items": [
+            {
+                "name": labels_by_key[key],
+                "value": round(sum(values_by_key[key].values()), 2),
+            }
+            for key in values_by_key
+        ],
+        "meta": {**filters.meta(), "limit": COST_STACK_LIMIT},
+    }
+
+
+def get_engineering_group_share(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    with engine.begin() as connection:
+        root = connection.execute(
+            text(
+                """
+                SELECT id, path
+                FROM roster_groups
+                WHERE name = :group_name
+                  AND is_active = 1
+                ORDER BY id
+                LIMIT 1
+                """
+            ),
+            {"group_name": ENGINEERING_GROUP_NAME},
+        ).mappings().first()
+        if root is None:
+            return {
+                "level1": {"items": [], "meta": {**filters.meta(), "group_name": ENGINEERING_GROUP_NAME}},
+                "level2": {"items": [], "meta": {**filters.meta(), "group_name": ENGINEERING_GROUP_NAME}},
+            }
+
+        level1 = _engineering_share_by_level(connection, filters, root, level=1)
+        level2 = _engineering_share_by_level(connection, filters, root, level=2)
+
+    return {
+        "level1": level1,
+        "level2": level2,
+    }
+
+
+def get_unmatched_resources(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    with engine.begin() as connection:
+        attr_where_clause, attr_params = _build_cost_where(filters, table_alias="c")
+        raw_where_clause, raw_params = _build_cost_where(filters, table_alias="r")
+        namespace_clause, namespace_params = _build_unallocated_namespace_where("r.namespace")
+        rows = connection.execute(
+            text(
+                f"""
+                WITH unmatched_resources AS (
+                  SELECT
+                    c.resource_name AS resource_name,
+                    MAX(c.attribution_key) AS attribution_key,
+                    MAX(c.attribution_source) AS attribution_source,
+                    MAX(c.attribution_status) AS attribution_status
+                  FROM cost_attribution_daily c
+                  WHERE {attr_where_clause}
+                    AND c.employee_id IS NULL
+                    AND c.resource_name IS NOT NULL
+                    AND c.resource_name <> ''
+                  GROUP BY c.resource_name
+                ),
+                unallocated_resources AS (
+                  SELECT
+                    r.resource_name AS resource_name,
+                    MAX(r.service_name) AS service_name,
+                    MAX(r.sku_name) AS sku_name,
+                    MAX(r.org) AS org_name,
+                    MAX(r.repo) AS repo_name,
+                    MAX(r.author) AS author_name,
+                    MIN(r.usage_date) AS first_seen_date,
+                    MAX(r.usage_date) AS last_seen_date,
+                    GROUP_CONCAT(DISTINCT COALESCE(r.namespace, '<null>')) AS allocation_buckets,
+                    SUM(COALESCE(r.usage_seconds, 0)) AS usage_seconds,
+                    SUM(r.list_cost) AS list_cost
+                  FROM cost_raw_details r
+                  WHERE {raw_where_clause}
+                    AND r.resource_name IS NOT NULL
+                    AND r.resource_name <> ''
+                    AND ({namespace_clause})
+                  GROUP BY r.resource_name
+                )
+                SELECT
+                  u.resource_name AS resource_name,
+                  u.service_name AS service_name,
+                  u.sku_name AS sku_name,
+                  u.org_name AS org_name,
+                  u.repo_name AS repo_name,
+                  u.author_name AS author_name,
+                  u.first_seen_date AS first_seen_date,
+                  u.last_seen_date AS last_seen_date,
+                  m.attribution_key AS attribution_key,
+                  m.attribution_source AS attribution_source,
+                  m.attribution_status AS attribution_status,
+                  u.allocation_buckets AS allocation_buckets,
+                  u.usage_seconds AS usage_seconds,
+                  u.list_cost AS list_cost
+                FROM unallocated_resources u
+                JOIN unmatched_resources m
+                  ON m.resource_name = u.resource_name
+                ORDER BY list_cost DESC, u.resource_name
+                LIMIT :limit
+                """
+            ),
+            {
+                **attr_params,
+                **raw_params,
+                **namespace_params,
+                "limit": UNMATCHED_RESOURCE_LIMIT,
+            },
+        ).mappings()
+        items = [
+            {
+                "resource_name": str(row["resource_name"]),
+                "service_name": str(row["service_name"] or ""),
+                "sku_name": str(row["sku_name"] or ""),
+                "repo_name": str(row["repo_name"] or ""),
+                "labels": _resource_labels(row),
+                "allocation_buckets": str(row["allocation_buckets"] or ""),
+                "first_seen_date": _date_text(row["first_seen_date"]),
+                "last_seen_date": _date_text(row["last_seen_date"]),
+                "observed_days": _observed_days(
+                    row["first_seen_date"],
+                    row["last_seen_date"],
+                    window_start=filters.start_date,
+                    window_end=filters.end_date,
+                ),
+                "attribution_source": str(row["attribution_source"] or ""),
+                "attribution_status": str(row["attribution_status"] or ""),
+                "usage_seconds": round(float(to_number(row["usage_seconds"]) or 0), 2),
+                "list_cost": _money(row["list_cost"]),
+            }
+            for row in rows
+        ]
+
+    return {
+        "items": items,
+        "meta": {**filters.meta(), "limit": UNMATCHED_RESOURCE_LIMIT},
+    }
+
+
+def _engineering_share_by_level(
+    connection: Connection,
+    filters: CommonFilters,
+    root: Any,
+    *,
+    level: int,
+) -> dict[str, Any]:
+    where_clause, params = _build_cost_where(filters, table_alias="c")
+    like_expr = _like_prefix_expr(connection, "c_group.path", "target_group.path")
+    if level == 1:
+        hierarchy_joins = f"""
+            JOIN roster_groups target_group
+              ON target_group.is_active = 1
+             AND target_group.parent_id = :root_id
+             AND {like_expr}
+        """
+    else:
+        hierarchy_joins = f"""
+            JOIN roster_groups target_parent
+              ON target_parent.is_active = 1
+             AND target_parent.parent_id = :root_id
+            JOIN roster_groups target_group
+              ON target_group.is_active = 1
+             AND target_group.parent_id = target_parent.id
+             AND {like_expr}
+        """
+    rows = connection.execute(
+        text(
+            f"""
+            SELECT
+              target_group.name AS group_name,
+              SUM(c.list_cost) AS list_cost
+            FROM cost_attribution_daily c
+            JOIN roster_groups c_group ON c_group.id = c.group_id
+            {hierarchy_joins}
+            WHERE {where_clause}
+              AND c_group.path IS NOT NULL
+              AND c_group.path LIKE :root_path_like
+            GROUP BY target_group.id, target_group.name
+            ORDER BY list_cost DESC, target_group.name
+            """
+        ),
+        {
+            **params,
+            "root_id": root["id"],
+            "root_path_like": f"{root['path']}%",
+        },
+    ).mappings()
+    items = [
+        {
+            "name": str(row["group_name"]),
+            "value": _money(row["list_cost"]),
+        }
+        for row in rows
+    ]
+    total = sum(item["value"] for item in items)
+    for item in items:
+        item["share_pct"] = rate_pct(item["value"], total)
+        item["interactive"] = False
+
+    return {
+        "items": items,
+        "meta": {
+            **filters.meta(),
+            "group_name": ENGINEERING_GROUP_NAME,
+            "level": level,
+            "total_list_cost": round(total, 2),
+        },
+    }
+
+
+def _cost_filters(filters: CommonFilters) -> CommonFilters:
+    granularity = filters.granularity if filters.granularity in {"week", "month"} else "week"
+    return CommonFilters(
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        granularity=granularity,
+    )
+
+
+def _build_cost_where(
+    filters: CommonFilters,
+    *,
+    table_alias: str = "",
+) -> tuple[str, dict[str, Any]]:
+    prefix = f"{table_alias}." if table_alias else ""
+    conditions = ["1=1"]
+    params: dict[str, Any] = {}
+    if filters.start_date:
+        conditions.append(f"{prefix}usage_date >= :usage_date_from")
+        params["usage_date_from"] = filters.start_date
+    if filters.end_date:
+        conditions.append(f"{prefix}usage_date <= :usage_date_to")
+        params["usage_date_to"] = filters.end_date
+    return " AND ".join(conditions), params
+
+
+def _like_prefix_expr(connection: Connection, value_expr: str, prefix_expr: str) -> str:
+    if connection.dialect.name == "sqlite":
+        return f"{value_expr} LIKE {prefix_expr} || '%'"
+    return f"{value_expr} LIKE CONCAT({prefix_expr}, '%')"
+
+
+def _repo_key(repo_name: str) -> str:
+    return f"repo__{_slug(repo_name)}"
+
+
+def _slug(value: str) -> str:
+    return "".join(char.lower() if char.isalnum() else "_" for char in value).strip("_") or "unknown"
+
+
+def _resource_labels(row: Mapping[str, Any]) -> str:
+    pairs = []
+    for key, label in (
+        ("org_name", "org"),
+        ("repo_name", "repo"),
+        ("author_name", "author"),
+        ("attribution_key", "key"),
+    ):
+        value = str(row[key] or "").strip()
+        if value:
+            pairs.append(f"{label}={value}")
+    return ", ".join(pairs)
+
+
+def _build_unallocated_namespace_where(column: str) -> tuple[str, dict[str, Any]]:
+    conditions = [f"{column} IS NULL"]
+    params: dict[str, Any] = {}
+    for index, bucket in enumerate(UNALLOCATED_GKE_NAMESPACE_BUCKETS):
+        key = f"namespace_bucket_{index}"
+        conditions.append(f"{column} = :{key}")
+        params[key] = bucket
+    return " OR ".join(conditions), params
+
+
+def _money(value: Any) -> float:
+    numeric = to_number(value)
+    return round(float(numeric or 0), 2)
+
+
+def _date_text(value: Any) -> str | None:
+    parsed = _parse_date(value)
+    return parsed.isoformat() if parsed else None
+
+
+def _observed_days(
+    first_value: Any,
+    last_value: Any,
+    *,
+    window_start: date | None = None,
+    window_end: date | None = None,
+) -> int | None:
+    first_seen = _parse_date(first_value)
+    last_seen = _parse_date(last_value)
+    if first_seen is None or last_seen is None:
+        return None
+    # If the resource touches either edge of the selected window, we only know a lower
+    # bound for how long it existed. Show no duration rather than implying exact uptime.
+    if (window_start and first_seen <= window_start) or (window_end and last_seen >= window_end):
+        return None
+    return max((last_seen - first_seen).days + 1, 1)
+
+
+def _parse_date(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None

--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -233,55 +233,43 @@ def get_runtime_insights_page(engine: Engine, filters: CommonFilters) -> dict[st
 
 
 def get_cost_insight_page(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
-    return get_cost_page(engine, filters)
+    return get_cost_page(engine, _normalize_cost_filters(filters))
 
 
 def get_cost_unmatched_resources_page(
     engine: Engine,
     filters: CommonFilters,
 ) -> dict[str, Any]:
-    cost_filters = CommonFilters(
-        start_date=filters.start_date,
-        end_date=filters.end_date,
-        granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
-    )
-    return get_unmatched_resources(engine, cost_filters)
+    return get_unmatched_resources(engine, _normalize_cost_filters(filters))
 
 
 def get_cost_trend_page(
     engine: Engine,
     filters: CommonFilters,
 ) -> dict[str, Any]:
-    cost_filters = CommonFilters(
-        start_date=filters.start_date,
-        end_date=filters.end_date,
-        granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
-    )
-    return get_cost_trend(engine, cost_filters)
+    return get_cost_trend(engine, _normalize_cost_filters(filters))
 
 
 def get_cost_repo_group_stack_page(
     engine: Engine,
     filters: CommonFilters,
 ) -> dict[str, Any]:
-    cost_filters = CommonFilters(
-        start_date=filters.start_date,
-        end_date=filters.end_date,
-        granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
-    )
-    return get_repo_group_cost_stack(engine, cost_filters)
+    return get_repo_group_cost_stack(engine, _normalize_cost_filters(filters))
 
 
 def get_cost_engineering_group_share_page(
     engine: Engine,
     filters: CommonFilters,
 ) -> dict[str, Any]:
-    cost_filters = CommonFilters(
+    return get_engineering_group_share(engine, _normalize_cost_filters(filters))
+
+
+def _normalize_cost_filters(filters: CommonFilters) -> CommonFilters:
+    return CommonFilters(
         start_date=filters.start_date,
         end_date=filters.end_date,
         granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
     )
-    return get_engineering_group_share(engine, cost_filters)
 
 
 def _get_previous_date_range(filters: CommonFilters) -> tuple[date | None, date | None]:

--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -18,6 +18,13 @@ from ci_dashboard.api.queries.builds import (
     get_lowest_success_rate_jobs,
     get_outcome_trend,
 )
+from ci_dashboard.api.queries.cost import (
+    get_cost_page,
+    get_cost_trend,
+    get_engineering_group_share,
+    get_repo_group_cost_stack,
+    get_unmatched_resources,
+)
 from ci_dashboard.api.queries.failures import (
     get_failure_category_share,
     get_failure_category_trend,
@@ -223,6 +230,58 @@ def get_runtime_insights_page(engine: Engine, filters: CommonFilters) -> dict[st
         "scope": filters.meta(),
         **sections,
     }
+
+
+def get_cost_insight_page(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    return get_cost_page(engine, filters)
+
+
+def get_cost_unmatched_resources_page(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    cost_filters = CommonFilters(
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
+    )
+    return get_unmatched_resources(engine, cost_filters)
+
+
+def get_cost_trend_page(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    cost_filters = CommonFilters(
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
+    )
+    return get_cost_trend(engine, cost_filters)
+
+
+def get_cost_repo_group_stack_page(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    cost_filters = CommonFilters(
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
+    )
+    return get_repo_group_cost_stack(engine, cost_filters)
+
+
+def get_cost_engineering_group_share_page(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    cost_filters = CommonFilters(
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
+    )
+    return get_engineering_group_share(engine, cost_filters)
 
 
 def _get_previous_date_range(filters: CommonFilters) -> tuple[date | None, date | None]:

--- a/ci-dashboard/src/ci_dashboard/api/routes/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/pages.py
@@ -8,6 +8,11 @@ from ci_dashboard.api.queries.base import CommonFilters
 from ci_dashboard.api.queries.base import MAX_RANKING_LIMIT
 from ci_dashboard.api.queries.pages import (
     get_build_trend_page,
+    get_cost_engineering_group_share_page,
+    get_cost_insight_page,
+    get_cost_repo_group_stack_page,
+    get_cost_trend_page,
+    get_cost_unmatched_resources_page,
     get_flaky_page,
     get_overview_page,
     get_runtime_insights_page,
@@ -25,6 +30,7 @@ def navigation_page(settings: Settings = Depends(get_settings)) -> dict[str, obj
     return {
         "features": {
             "runtime_insights_enabled": settings.features.runtime_insights_enabled,
+            "cost_dashboard_enabled": settings.features.cost_dashboard_enabled,
         }
     }
 
@@ -59,6 +65,46 @@ def runtime_insights_page(
     engine: Engine = Depends(get_engine),
 ) -> dict[str, object]:
     return get_runtime_insights_page(engine, filters)
+
+
+@router.get("/cost")
+def cost_page(
+    filters: CommonFilters = Depends(get_common_filters),
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return get_cost_insight_page(engine, filters)
+
+
+@router.get("/cost-trend")
+def cost_trend_page(
+    filters: CommonFilters = Depends(get_common_filters),
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return get_cost_trend_page(engine, filters)
+
+
+@router.get("/cost-repo-group-stack")
+def cost_repo_group_stack_page(
+    filters: CommonFilters = Depends(get_common_filters),
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return get_cost_repo_group_stack_page(engine, filters)
+
+
+@router.get("/cost-engineering-group-share")
+def cost_engineering_group_share_page(
+    filters: CommonFilters = Depends(get_common_filters),
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return get_cost_engineering_group_share_page(engine, filters)
+
+
+@router.get("/cost-unmatched-resources")
+def cost_unmatched_resources_page(
+    filters: CommonFilters = Depends(get_common_filters),
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return get_cost_unmatched_resources_page(engine, filters)
 
 
 @router.get("/runtime-error-top-jobs")

--- a/ci-dashboard/src/ci_dashboard/common/config.py
+++ b/ci-dashboard/src/ci_dashboard/common/config.py
@@ -108,6 +108,7 @@ class LLMSettings:
 @dataclass(frozen=True)
 class FeatureSettings:
     runtime_insights_enabled: bool = False
+    cost_dashboard_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -205,6 +206,11 @@ def load_settings(environ: Mapping[str, str] | None = None) -> Settings:
             runtime_insights_enabled=_read_bool(
                 env,
                 "CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS",
+                False,
+            ),
+            cost_dashboard_enabled=_read_bool(
+                env,
+                "CI_DASHBOARD_ENABLE_COST_DASHBOARD",
                 False,
             ),
         ),

--- a/ci-dashboard/src/ci_dashboard/common/db.py
+++ b/ci-dashboard/src/ci_dashboard/common/db.py
@@ -27,8 +27,8 @@ def _build_engine_kwargs(database: DatabaseSettings) -> dict[str, object]:
         return engine_kwargs
     return {
         **engine_kwargs,
-        "pool_size": 20,
-        "max_overflow": 20,
+        "pool_size": 40,
+        "max_overflow": 40,
         "pool_timeout": 60,
     }
 

--- a/ci-dashboard/src/ci_dashboard/common/db.py
+++ b/ci-dashboard/src/ci_dashboard/common/db.py
@@ -17,6 +17,22 @@ def _build_connect_args(database: DatabaseSettings) -> dict[str, object]:
     }
 
 
+def _build_engine_kwargs(database: DatabaseSettings) -> dict[str, object]:
+    engine_kwargs = {
+        "pool_pre_ping": True,
+        "future": True,
+        "connect_args": _build_connect_args(database),
+    }
+    if database.url and database.url.startswith("sqlite"):
+        return engine_kwargs
+    return {
+        **engine_kwargs,
+        "pool_size": 20,
+        "max_overflow": 20,
+        "pool_timeout": 60,
+    }
+
+
 def install_sqlite_functions(engine: Engine) -> None:
     if engine.dialect.name != "sqlite":
         return
@@ -40,8 +56,7 @@ def build_engine(settings: Settings | None = None) -> Engine:
     if resolved.database.url:
         engine = create_engine(
             resolved.database.url,
-            pool_pre_ping=True,
-            future=True,
+            **_build_engine_kwargs(resolved.database),
         )
         install_sqlite_functions(engine)
         return engine
@@ -56,9 +71,7 @@ def build_engine(settings: Settings | None = None) -> Engine:
     )
     engine = create_engine(
         url,
-        pool_pre_ping=True,
-        future=True,
-        connect_args=_build_connect_args(resolved.database),
+        **_build_engine_kwargs(resolved.database),
     )
     install_sqlite_functions(engine)
     return engine

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -2085,7 +2085,13 @@ def test_cost_page_route(sqlite_engine, api_client: TestClient) -> None:
     assert body["cost_trend"]["meta"]["summary"]["matched_resource_cost"] == 75.0
     assert body["cost_trend"]["meta"]["summary"]["total_resource_cost"] == 75.0
     trend_series = {series["key"]: series["points"] for series in body["cost_trend"]["series"]}
-    assert trend_series["net_cost"] == [["2026-04-06", 30.0], ["2026-04-13", 30.0]]
+    assert trend_series["net_cost"] == [
+        ["2026-03-30", 0.0],
+        ["2026-04-06", 30.0],
+        ["2026-04-13", 30.0],
+        ["2026-04-20", 0.0],
+        ["2026-04-27", 0.0],
+    ]
 
     stack = body["repo_group_stack"]
     assert [item["name"] for item in stack["items"]] == [
@@ -2093,8 +2099,20 @@ def test_cost_page_route(sqlite_engine, api_client: TestClient) -> None:
         "tiflash",
     ]
     stack_series = {series["label"]: series["points"] for series in stack["series"]}
-    assert stack_series["tidb"] == [["2026-04-06", 40.0], ["2026-04-13", 0.0]]
-    assert stack_series["tiflash"] == [["2026-04-06", 0.0], ["2026-04-13", 35.0]]
+    assert stack_series["tidb"] == [
+        ["2026-03-30", 0.0],
+        ["2026-04-06", 40.0],
+        ["2026-04-13", 0.0],
+        ["2026-04-20", 0.0],
+        ["2026-04-27", 0.0],
+    ]
+    assert stack_series["tiflash"] == [
+        ["2026-03-30", 0.0],
+        ["2026-04-06", 0.0],
+        ["2026-04-13", 35.0],
+        ["2026-04-20", 0.0],
+        ["2026-04-27", 0.0],
+    ]
 
     engineering_share = body["engineering_group_share"]
     level1 = {item["name"]: item for item in engineering_share["level1"]["items"]}
@@ -2321,12 +2339,34 @@ def test_cost_page_supporting_routes(sqlite_engine, api_client: TestClient) -> N
     assert trend_body["meta"]["granularity"] == "week"
     assert trend_body["meta"]["summary"]["list_cost"] == 10.0
     assert trend_body["meta"]["summary"]["net_cost"] == 8.0
+    trend_series = {series["key"]: series["points"] for series in trend_body["series"]}
+    assert trend_series["list_cost"] == [
+        ["2026-04-27", 10.0],
+        ["2026-05-04", 0.0],
+        ["2026-05-11", 0.0],
+        ["2026-05-18", 0.0],
+        ["2026-05-25", 0.0],
+    ]
 
     stack_response = api_client.get("/api/v1/pages/cost-repo-group-stack", params=params)
     assert stack_response.status_code == 200
     stack_body = stack_response.json()
     assert stack_body["meta"]["granularity"] == "week"
     assert stack_body["items"] == [{"name": "(no repo)", "value": 10.0}]
+    assert stack_body["series"] == [
+        {
+            "key": "repo__no_repo",
+            "label": "(no repo)",
+            "type": "bar",
+            "points": [
+                ["2026-04-27", 10.0],
+                ["2026-05-04", 0.0],
+                ["2026-05-11", 0.0],
+                ["2026-05-18", 0.0],
+                ["2026-05-25", 0.0],
+            ],
+        }
+    ]
 
     share_response = api_client.get("/api/v1/pages/cost-engineering-group-share", params=params)
     assert share_response.status_code == 200
@@ -2393,6 +2433,17 @@ def test_cost_query_page_helpers_cover_parallel_paths(monkeypatch: pytest.Monkey
         "alpha": 1,
         "beta": 2,
     }
+    assert page_queries._normalize_cost_filters(
+        CommonFilters(
+            start_date=date(2026, 5, 1),
+            end_date=date(2026, 5, 31),
+            granularity="day",
+        )
+    ) == CommonFilters(
+        start_date=date(2026, 5, 1),
+        end_date=date(2026, 5, 31),
+        granularity="week",
+    )
 
 
 def test_get_cost_page_parallelizes_for_non_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2494,6 +2545,98 @@ def test_cost_query_helpers_cover_edge_cases(sqlite_engine) -> None:
         == 2
     )
     assert cost_queries._parse_date("not-a-date") is None
+    assert cost_queries._bucket_starts(
+        CommonFilters(
+            start_date=date(2026, 5, 1),
+            end_date=date(2026, 5, 31),
+            granularity="week",
+        ),
+        [],
+    ) == [
+        "2026-04-27",
+        "2026-05-04",
+        "2026-05-11",
+        "2026-05-18",
+        "2026-05-25",
+    ]
+    assert cost_queries._bucket_starts(
+        CommonFilters(
+            start_date=date(2026, 5, 1),
+            end_date=date(2026, 7, 2),
+            granularity="month",
+        ),
+        [],
+    ) == [
+        "2026-05-01",
+        "2026-06-01",
+        "2026-07-01",
+    ]
+    assert cost_queries._repo_key("(no repo)", 0) == "repo__no_repo"
+    assert cost_queries._repo_key("repo-1", 0) != cost_queries._repo_key("repo.1", 1)
+
+
+def test_cost_repo_group_stack_keeps_distinct_repo_keys_on_slug_collisions(sqlite_engine, api_client: TestClient) -> None:
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=100,
+        lark_group_id="eng",
+        name="Engineering Group",
+        path="/100/",
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=110,
+        lark_group_id="database",
+        name="Database",
+        parent_id=100,
+        path="/100/110/",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-05",
+        repo="repo-1",
+        group_id=110,
+        net_cost=5,
+        effective_cost=5,
+        list_cost=10,
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-05",
+        repo="repo.1",
+        group_id=110,
+        net_cost=7,
+        effective_cost=7,
+        list_cost=20,
+    )
+
+    response = api_client.get(
+        "/api/v1/pages/cost-repo-group-stack",
+        params={
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-31",
+            "granularity": "week",
+        },
+    )
+
+    assert response.status_code == 200
+    series = response.json()["series"]
+    assert [item["label"] for item in series] == ["repo.1", "repo-1"]
+    assert [item["key"] for item in series] == ["repo__0", "repo__1"]
+    assert series[0]["points"] == [
+        ["2026-04-27", 0.0],
+        ["2026-05-04", 20.0],
+        ["2026-05-11", 0.0],
+        ["2026-05-18", 0.0],
+        ["2026-05-25", 0.0],
+    ]
+    assert series[1]["points"] == [
+        ["2026-04-27", 0.0],
+        ["2026-05-04", 10.0],
+        ["2026-05-11", 0.0],
+        ["2026-05-18", 0.0],
+        ["2026-05-25", 0.0],
+    ]
 
 
 def test_migration_fixed_window_comparison_rows(

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -10,6 +11,9 @@ from sqlalchemy import text
 
 from ci_dashboard.api.dependencies import get_engine
 from ci_dashboard.api.main import app, create_app
+from ci_dashboard.api.queries import cost as cost_queries
+from ci_dashboard.api.queries import pages as page_queries
+from ci_dashboard.api.queries.base import CommonFilters
 from ci_dashboard.common.config import FeatureSettings, get_settings, load_settings
 from ci_dashboard.jobs.build_url_matcher import normalize_build_url
 
@@ -356,6 +360,140 @@ def _insert_job_state(
                 "job_name": job_name,
                 "last_status": last_status,
                 "last_succeeded_at": last_succeeded_at,
+            },
+        )
+
+
+def _insert_roster_group(
+    sqlite_engine,
+    *,
+    group_id: int,
+    lark_group_id: str,
+    name: str,
+    path: str,
+    parent_id: int | None = None,
+) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO roster_groups (
+                  id, lark_group_id, parent_id, name, path, is_active
+                ) VALUES (
+                  :id, :lark_group_id, :parent_id, :name, :path, 1
+                )
+                """
+            ),
+            {
+                "id": group_id,
+                "lark_group_id": lark_group_id,
+                "parent_id": parent_id,
+                "name": name,
+                "path": path,
+            },
+        )
+
+
+def _insert_cost_attribution(
+    sqlite_engine,
+    *,
+    usage_date: str,
+    repo: str,
+    group_id: int,
+    net_cost: float,
+    effective_cost: float | None = None,
+    list_cost: float | None = None,
+    dimension_hash: str | None = None,
+    resource_name: str | None = None,
+    author: str | None = "alice",
+    owner: str | None = "alice",
+    attribution_key: str | None = "employee:1",
+    attribution_source: str = "author_github",
+    attribution_status: str = "matched",
+    employee_id: int | None = 1,
+    usage_seconds: float = 3600,
+) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cost_attribution_daily (
+                  usage_date, vendor, account_id, service_name, sku_name, org, repo,
+                  resource_name, author, owner, attribution_key, attribution_source,
+                  attribution_status, employee_id, group_id, manager_id, usage_seconds,
+                  list_cost, effective_cost, credit_amount, net_cost, source_rows, dimension_hash
+                ) VALUES (
+                  :usage_date, 'gcp', 'pingcap-testing-account', 'Compute Engine', 'runner',
+                  'pingcap', :repo, :resource_name, :author, :owner, :attribution_key, :attribution_source,
+                  :attribution_status, :employee_id, :group_id, NULL, :usage_seconds, :list_cost, :effective_cost,
+                  0, :net_cost, 1, :dimension_hash
+                )
+                """
+            ),
+            {
+                "usage_date": usage_date,
+                "repo": repo,
+                "group_id": group_id,
+                "resource_name": resource_name,
+                "author": author,
+                "owner": owner,
+                "attribution_key": attribution_key,
+                "attribution_source": attribution_source,
+                "attribution_status": attribution_status,
+                "employee_id": employee_id,
+                "usage_seconds": usage_seconds,
+                "list_cost": list_cost if list_cost is not None else net_cost,
+                "effective_cost": effective_cost if effective_cost is not None else net_cost,
+                "net_cost": net_cost,
+                "dimension_hash": dimension_hash or f"{usage_date}-{repo}-{group_id}-{net_cost}",
+            },
+        )
+
+
+def _insert_cost_raw_detail(
+    sqlite_engine,
+    *,
+    usage_date: str,
+    repo: str,
+    resource_name: str,
+    namespace: str | None,
+    list_cost: float,
+    effective_cost: float | None = None,
+    net_cost: float | None = None,
+    author: str | None = "alice",
+    usage_seconds: float = 3600,
+    service_name: str = "Compute Engine",
+    sku_name: str = "runner",
+    source_row_hash: str | None = None,
+) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cost_raw_details (
+                  vendor, account_id, billing_account_id, usage_date, service_name, sku_name,
+                  region, namespace, author, org, repo, resource_name, usage_seconds,
+                  list_cost, effective_cost, credit_amount, net_cost, source_export_time, source_row_hash
+                ) VALUES (
+                  'gcp', 'pingcap-testing-account', 'billing-account-1', :usage_date, :service_name, :sku_name,
+                  'us-central1', :namespace, :author, 'pingcap', :repo, :resource_name, :usage_seconds,
+                  :list_cost, :effective_cost, 0, :net_cost, '2026-05-19 00:00:00', :source_row_hash
+                )
+                """
+            ),
+            {
+                "usage_date": usage_date,
+                "service_name": service_name,
+                "sku_name": sku_name,
+                "namespace": namespace,
+                "author": author,
+                "repo": repo,
+                "resource_name": resource_name,
+                "usage_seconds": usage_seconds,
+                "list_cost": list_cost,
+                "effective_cost": effective_cost if effective_cost is not None else list_cost,
+                "net_cost": net_cost if net_cost is not None else list_cost,
+                "source_row_hash": source_row_hash or f"{usage_date}-{resource_name}-{namespace}-{list_cost}",
             },
         )
 
@@ -731,10 +869,17 @@ def test_frontend_uses_configured_static_dir(tmp_path: Path, monkeypatch) -> Non
     assert response.text == "configured-ok"
 
 
-def _get_navigation_response(runtime_insights_enabled: bool):
+def _get_navigation_response(
+    runtime_insights_enabled: bool,
+    *,
+    cost_dashboard_enabled: bool = False,
+):
     settings = replace(
         load_settings({"CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///:memory:"}),
-        features=FeatureSettings(runtime_insights_enabled=runtime_insights_enabled),
+        features=FeatureSettings(
+            runtime_insights_enabled=runtime_insights_enabled,
+            cost_dashboard_enabled=cost_dashboard_enabled,
+        ),
     )
     test_app = create_app()
     test_app.dependency_overrides[get_settings] = lambda: settings
@@ -751,6 +896,7 @@ def test_navigation_page_hides_runtime_insights_by_default() -> None:
 
     assert response.status_code == 200
     assert response.json()["features"]["runtime_insights_enabled"] is False
+    assert response.json()["features"]["cost_dashboard_enabled"] is False
 
 
 def test_navigation_page_can_enable_runtime_insights() -> None:
@@ -758,6 +904,15 @@ def test_navigation_page_can_enable_runtime_insights() -> None:
 
     assert response.status_code == 200
     assert response.json()["features"]["runtime_insights_enabled"] is True
+    assert response.json()["features"]["cost_dashboard_enabled"] is False
+
+
+def test_navigation_page_can_enable_cost_dashboard() -> None:
+    response = _get_navigation_response(False, cost_dashboard_enabled=True)
+
+    assert response.status_code == 200
+    assert response.json()["features"]["runtime_insights_enabled"] is False
+    assert response.json()["features"]["cost_dashboard_enabled"] is True
 
 
 def test_status_and_filter_endpoints(api_client: TestClient, sqlite_engine) -> None:
@@ -1850,6 +2005,495 @@ def test_page_routes(api_client: TestClient) -> None:
     assert flaky_with_open_issues_body["failure_category_share"] == flaky_body["failure_category_share"]
     assert flaky_with_open_issues_body["failure_category_trend"] == flaky_body["failure_category_trend"]
     assert flaky_with_open_issues_body["period_comparison"] == flaky_body["period_comparison"]
+
+
+def test_cost_page_route(sqlite_engine, api_client: TestClient) -> None:
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=100,
+        lark_group_id="eng",
+        name="Engineering Group",
+        path="/100/",
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=110,
+        lark_group_id="database",
+        name="Database",
+        parent_id=100,
+        path="/100/110/",
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=111,
+        lark_group_id="tidb",
+        name="TiDB",
+        parent_id=110,
+        path="/100/110/111/",
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=120,
+        lark_group_id="infra",
+        name="Infra",
+        parent_id=100,
+        path="/100/120/",
+    )
+
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-04-06",
+        repo="tidb",
+        group_id=111,
+        net_cost=10,
+        effective_cost=12,
+        list_cost=15,
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-04-07",
+        repo="tidb",
+        group_id=110,
+        net_cost=20,
+        effective_cost=22,
+        list_cost=25,
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-04-13",
+        repo="tiflash",
+        group_id=120,
+        net_cost=30,
+        effective_cost=32,
+        list_cost=35,
+    )
+
+    response = api_client.get(
+        "/api/v1/pages/cost",
+        params={
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-30",
+            "granularity": "week",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scope"]["granularity"] == "week"
+    assert body["cost_trend"]["meta"]["summary"]["net_cost"] == 60.0
+    assert body["cost_trend"]["meta"]["summary"]["matched_resource_pct"] == 100.0
+    assert body["cost_trend"]["meta"]["summary"]["matched_resource_cost"] == 75.0
+    assert body["cost_trend"]["meta"]["summary"]["total_resource_cost"] == 75.0
+    trend_series = {series["key"]: series["points"] for series in body["cost_trend"]["series"]}
+    assert trend_series["net_cost"] == [["2026-04-06", 30.0], ["2026-04-13", 30.0]]
+
+    stack = body["repo_group_stack"]
+    assert [item["name"] for item in stack["items"]] == [
+        "tidb",
+        "tiflash",
+    ]
+    stack_series = {series["label"]: series["points"] for series in stack["series"]}
+    assert stack_series["tidb"] == [["2026-04-06", 40.0], ["2026-04-13", 0.0]]
+    assert stack_series["tiflash"] == [["2026-04-06", 0.0], ["2026-04-13", 35.0]]
+
+    engineering_share = body["engineering_group_share"]
+    level1 = {item["name"]: item for item in engineering_share["level1"]["items"]}
+    assert level1["Database"]["value"] == 40.0
+    assert level1["Infra"]["value"] == 35.0
+    assert level1["Database"]["share_pct"] == 53.33
+    level2 = {item["name"]: item for item in engineering_share["level2"]["items"]}
+    assert level2["TiDB"]["value"] == 15.0
+
+
+def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) -> None:
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=100,
+        lark_group_id="eng",
+        name="Engineering Group",
+        path="/100/",
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=110,
+        lark_group_id="database",
+        name="Database",
+        parent_id=100,
+        path="/100/110/",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-10",
+        repo="tidb",
+        group_id=110,
+        net_cost=0,
+        effective_cost=90,
+        list_cost=120,
+        resource_name="projects/pingcap-prod/zones/us-central1-a/instances/tidb-ci-runner-1",
+        author=None,
+        owner=None,
+        attribution_key=None,
+        attribution_source="missing_author",
+        attribution_status="unmatched",
+        employee_id=None,
+        usage_seconds=172800,
+    )
+    _insert_cost_raw_detail(
+        sqlite_engine,
+        usage_date="2026-05-10",
+        repo="tidb",
+        resource_name="projects/pingcap-prod/zones/us-central1-a/instances/tidb-ci-runner-1",
+        namespace="kube:unallocated",
+        author=None,
+        list_cost=120,
+        effective_cost=90,
+        net_cost=0,
+        usage_seconds=172800,
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-01",
+        repo="platform",
+        group_id=110,
+        net_cost=0,
+        effective_cost=20,
+        list_cost=30,
+        resource_name="//logging.googleapis.com/projects/890604261603/locations/global/buckets/_Default",
+        author=None,
+        owner=None,
+        attribution_key=None,
+        attribution_source="missing_author",
+        attribution_status="unattributed",
+        employee_id=None,
+        usage_seconds=86400,
+        dimension_hash="cost-log-bucket-start",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-31",
+        repo="platform",
+        group_id=110,
+        net_cost=0,
+        effective_cost=20,
+        list_cost=30,
+        resource_name="//logging.googleapis.com/projects/890604261603/locations/global/buckets/_Default",
+        author=None,
+        owner=None,
+        attribution_key=None,
+        attribution_source="missing_author",
+        attribution_status="unattributed",
+        employee_id=None,
+        usage_seconds=86400,
+        dimension_hash="cost-log-bucket-end",
+    )
+    _insert_cost_raw_detail(
+        sqlite_engine,
+        usage_date="2026-05-01",
+        repo="platform",
+        resource_name="//logging.googleapis.com/projects/890604261603/locations/global/buckets/_Default",
+        namespace=None,
+        author=None,
+        list_cost=30,
+        effective_cost=20,
+        net_cost=0,
+        usage_seconds=86400,
+        service_name="Cloud Logging",
+        sku_name="Vended Logs Storage",
+        source_row_hash="raw-log-bucket-start",
+    )
+    _insert_cost_raw_detail(
+        sqlite_engine,
+        usage_date="2026-05-31",
+        repo="platform",
+        resource_name="//logging.googleapis.com/projects/890604261603/locations/global/buckets/_Default",
+        namespace=None,
+        author=None,
+        list_cost=30,
+        effective_cost=20,
+        net_cost=0,
+        usage_seconds=86400,
+        service_name="Cloud Logging",
+        sku_name="Vended Logs Storage",
+        source_row_hash="raw-log-bucket-end",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-11",
+        repo="ticdc",
+        group_id=110,
+        net_cost=0,
+        effective_cost=70,
+        list_cost=95,
+        resource_name="projects/pingcap-prod/zones/us-central1-b/instances/ticdc-batch-2",
+        author="bob",
+        owner=None,
+        attribution_key="repo:ticdc",
+        attribution_source="missing_owner",
+        attribution_status="partial",
+        employee_id=None,
+        usage_seconds=21600,
+    )
+    _insert_cost_raw_detail(
+        sqlite_engine,
+        usage_date="2026-05-11",
+        repo="ticdc",
+        resource_name="projects/pingcap-prod/zones/us-central1-b/instances/ticdc-batch-2",
+        namespace="jenkins-tidb",
+        author="bob",
+        list_cost=95,
+        effective_cost=70,
+        net_cost=0,
+        usage_seconds=21600,
+    )
+
+    response = api_client.get(
+        "/api/v1/pages/cost-unmatched-resources",
+        params={
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-31",
+            "granularity": "week",
+        },
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["resource_name"] for item in items] == [
+        "projects/pingcap-prod/zones/us-central1-a/instances/tidb-ci-runner-1",
+        "//logging.googleapis.com/projects/890604261603/locations/global/buckets/_Default",
+    ]
+    assert items[0]["list_cost"] == 120.0
+    assert items[0]["first_seen_date"] == "2026-05-10"
+    assert items[0]["last_seen_date"] == "2026-05-10"
+    assert items[0]["observed_days"] == 1
+    assert items[0]["labels"] == "org=pingcap, repo=tidb"
+    assert items[0]["allocation_buckets"] == "kube:unallocated"
+    assert items[0]["attribution_source"] == "missing_author"
+    assert items[1]["list_cost"] == 60.0
+    assert items[1]["first_seen_date"] == "2026-05-01"
+    assert items[1]["last_seen_date"] == "2026-05-31"
+    assert items[1]["observed_days"] is None
+
+
+def test_cost_page_supporting_routes(sqlite_engine, api_client: TestClient) -> None:
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=100,
+        lark_group_id="eng",
+        name="Engineering Group",
+        path="/100/",
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=110,
+        lark_group_id="database",
+        name="Database",
+        parent_id=100,
+        path="/100/110/",
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=111,
+        lark_group_id="tidb",
+        name="TiDB",
+        parent_id=110,
+        path="/100/110/111/",
+    )
+
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-02",
+        repo="",
+        group_id=111,
+        net_cost=8,
+        effective_cost=9,
+        list_cost=10,
+    )
+
+    params = {
+        "start_date": "2026-05-01",
+        "end_date": "2026-05-31",
+        "granularity": "day",
+    }
+
+    trend_response = api_client.get("/api/v1/pages/cost-trend", params=params)
+    assert trend_response.status_code == 200
+    trend_body = trend_response.json()
+    assert trend_body["meta"]["granularity"] == "week"
+    assert trend_body["meta"]["summary"]["list_cost"] == 10.0
+    assert trend_body["meta"]["summary"]["net_cost"] == 8.0
+
+    stack_response = api_client.get("/api/v1/pages/cost-repo-group-stack", params=params)
+    assert stack_response.status_code == 200
+    stack_body = stack_response.json()
+    assert stack_body["meta"]["granularity"] == "week"
+    assert stack_body["items"] == [{"name": "(no repo)", "value": 10.0}]
+
+    share_response = api_client.get("/api/v1/pages/cost-engineering-group-share", params=params)
+    assert share_response.status_code == 200
+    share_body = share_response.json()
+    assert share_body["level1"]["meta"]["granularity"] == "week"
+    assert share_body["level1"]["items"] == [
+        {
+            "name": "Database",
+            "value": 10.0,
+            "share_pct": 100.0,
+            "interactive": False,
+        }
+    ]
+    assert share_body["level2"]["items"] == [
+        {
+            "name": "TiDB",
+            "value": 10.0,
+            "share_pct": 100.0,
+            "interactive": False,
+        }
+    ]
+
+
+def test_cost_query_page_helpers_cover_parallel_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert page_queries._get_previous_date_range(CommonFilters()) == (None, None)
+    assert page_queries._get_previous_date_range(
+        CommonFilters(
+            start_date=date(2026, 5, 1),
+            end_date=date(2026, 5, 7),
+        )
+    ) == (date(2026, 4, 24), date(2026, 4, 30))
+
+    class _ImmediateFuture:
+        def __init__(self, value):
+            self._value = value
+
+        def result(self):
+            return self._value
+
+    class _InlineExecutor:
+        def __init__(self, *, max_workers: int):
+            self.max_workers = max_workers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def submit(self, task):
+            return _ImmediateFuture(task())
+
+    monkeypatch.setattr(page_queries, "ThreadPoolExecutor", _InlineExecutor)
+
+    engine = SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
+    resolved = page_queries._resolve_page_sections(
+        engine,
+        {
+            "alpha": lambda: 1,
+            "beta": lambda: 2,
+        },
+    )
+    assert resolved == {
+        "alpha": 1,
+        "beta": 2,
+    }
+
+
+def test_get_cost_page_parallelizes_for_non_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_granularities: list[str | None] = []
+
+    def _capture(name: str):
+        def _inner(_engine, filters: CommonFilters):
+            captured_granularities.append(filters.granularity)
+            return {"name": name, "granularity": filters.granularity}
+
+        return _inner
+
+    class _ImmediateFuture:
+        def __init__(self, value):
+            self._value = value
+
+        def result(self):
+            return self._value
+
+    class _InlineExecutor:
+        def __init__(self, *, max_workers: int):
+            self.max_workers = max_workers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def submit(self, task, *args):
+            return _ImmediateFuture(task(*args))
+
+    monkeypatch.setattr(cost_queries, "ThreadPoolExecutor", _InlineExecutor)
+    monkeypatch.setattr(cost_queries, "get_cost_trend", _capture("trend"))
+    monkeypatch.setattr(cost_queries, "get_repo_group_cost_stack", _capture("stack"))
+    monkeypatch.setattr(cost_queries, "get_engineering_group_share", _capture("share"))
+
+    result = cost_queries.get_cost_page(
+        SimpleNamespace(dialect=SimpleNamespace(name="mysql")),
+        CommonFilters(
+            start_date=date(2026, 5, 1),
+            end_date=date(2026, 5, 31),
+            granularity="day",
+        ),
+    )
+
+    assert result["scope"]["start_date"] == "2026-05-01"
+    assert result["scope"]["end_date"] == "2026-05-31"
+    assert result["scope"]["granularity"] == "week"
+    assert result["scope"]["job_names"] == []
+    assert result["cost_trend"] == {"name": "trend", "granularity": "week"}
+    assert result["repo_group_stack"] == {"name": "stack", "granularity": "week"}
+    assert result["engineering_group_share"] == {"name": "share", "granularity": "week"}
+    assert captured_granularities == ["week", "week", "week"]
+
+
+def test_cost_query_helpers_cover_edge_cases(sqlite_engine) -> None:
+    empty_share = cost_queries.get_engineering_group_share(
+        sqlite_engine,
+        CommonFilters(
+            start_date=date(2026, 5, 1),
+            end_date=date(2026, 5, 31),
+            granularity="month",
+        ),
+    )
+    assert empty_share["level1"]["items"] == []
+    assert empty_share["level2"]["items"] == []
+    assert empty_share["level1"]["meta"]["group_name"] == "Engineering Group"
+    assert empty_share["level2"]["meta"]["group_name"] == "Engineering Group"
+    assert empty_share["level1"]["meta"]["job_names"] == []
+    assert empty_share["level2"]["meta"]["job_names"] == []
+    assert empty_share["level1"]["meta"]["granularity"] == "month"
+    assert empty_share["level2"]["meta"]["granularity"] == "month"
+    assert (
+        cost_queries._like_prefix_expr(
+            SimpleNamespace(dialect=SimpleNamespace(name="mysql")),
+            "child.path",
+            "parent.path",
+        )
+        == "child.path LIKE CONCAT(parent.path, '%')"
+    )
+    assert cost_queries._observed_days("bad-date", "2026-05-03") is None
+    assert (
+        cost_queries._observed_days(
+            "2026-05-01",
+            "2026-05-03",
+            window_start=date(2026, 5, 1),
+            window_end=date(2026, 5, 31),
+        )
+        is None
+    )
+    assert (
+        cost_queries._observed_days(
+            "2026-05-02",
+            "2026-05-03",
+            window_start=date(2026, 5, 1),
+            window_end=date(2026, 5, 31),
+        )
+        == 2
+    )
+    assert cost_queries._parse_date("not-a-date") is None
 
 
 def test_migration_fixed_window_comparison_rows(

--- a/ci-dashboard/tests/conftest.py
+++ b/ci-dashboard/tests/conftest.py
@@ -276,6 +276,75 @@ def _create_test_schema(engine: Engine) -> None:
           UNIQUE(source_project, namespace_name, pod_uid, pod_name)
         )
         """,
+        """
+        CREATE TABLE roster_groups (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          lark_group_id TEXT NOT NULL UNIQUE,
+          parent_id INTEGER NULL,
+          name TEXT NOT NULL,
+          manager_id INTEGER NULL,
+          path TEXT NULL,
+          is_active INTEGER NOT NULL DEFAULT 1,
+          last_seen_at TEXT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE cost_attribution_daily (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          usage_date TEXT NOT NULL,
+          vendor TEXT NOT NULL,
+          account_id TEXT NOT NULL,
+          service_name TEXT NULL,
+          sku_name TEXT NULL,
+          org TEXT NULL,
+          repo TEXT NULL,
+          resource_name TEXT NULL,
+          author TEXT NULL,
+          owner TEXT NULL,
+          attribution_key TEXT NULL,
+          attribution_source TEXT NOT NULL,
+          attribution_status TEXT NOT NULL,
+          employee_id INTEGER NULL,
+          group_id INTEGER NULL,
+          manager_id INTEGER NULL,
+          usage_seconds REAL NULL,
+          list_cost REAL NULL,
+          effective_cost REAL NULL,
+          credit_amount REAL NULL,
+          net_cost REAL NULL,
+          source_rows INTEGER NOT NULL DEFAULT 0,
+          dimension_hash TEXT NOT NULL,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE cost_raw_details (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          vendor TEXT NOT NULL,
+          account_id TEXT NOT NULL,
+          billing_account_id TEXT NULL,
+          usage_date TEXT NOT NULL,
+          service_name TEXT NULL,
+          sku_name TEXT NULL,
+          region TEXT NULL,
+          namespace TEXT NULL,
+          author TEXT NULL,
+          org TEXT NULL,
+          repo TEXT NULL,
+          resource_name TEXT NULL,
+          usage_seconds REAL NULL,
+          list_cost REAL NULL,
+          effective_cost REAL NULL,
+          credit_amount REAL NULL,
+          net_cost REAL NULL,
+          source_export_time TEXT NULL,
+          source_row_hash TEXT NOT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
     ]
     with engine.begin() as connection:
         for statement in statements:

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -280,8 +280,8 @@ def test_build_engine_builds_mysql_url_and_ssl_connect_args(monkeypatch: pytest.
     assert captured["kwargs"] == {
         "pool_pre_ping": True,
         "future": True,
-        "pool_size": 20,
-        "max_overflow": 20,
+        "pool_size": 40,
+        "max_overflow": 40,
         "pool_timeout": 60,
         "connect_args": {"ssl": {"ca": "/etc/certs/ca.pem"}},
     }

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -36,6 +36,7 @@ def test_load_settings_supports_db_url() -> None:
             "CI_DASHBOARD_LLM_BASE_URL": "https://api-vip.codex-for.me/v1",
             "CI_DASHBOARD_LLM_REASONING_EFFORT": "high",
             "CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS": "true",
+            "CI_DASHBOARD_ENABLE_COST_DASHBOARD": "true",
             "CI_DASHBOARD_LOG_LEVEL": "debug",
         }
     )
@@ -64,12 +65,14 @@ def test_load_settings_supports_db_url() -> None:
     assert settings.llm.base_url == "https://api-vip.codex-for.me/v1"
     assert settings.llm.reasoning_effort == "high"
     assert settings.features.runtime_insights_enabled is True
+    assert settings.features.cost_dashboard_enabled is True
     assert settings.log_level == "DEBUG"
 
 
 def test_load_settings_hides_runtime_insights_by_default() -> None:
     settings = load_settings({"CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db"})
     assert settings.features.runtime_insights_enabled is False
+    assert settings.features.cost_dashboard_enabled is False
 
 
 @pytest.mark.parametrize(
@@ -194,6 +197,19 @@ def test_load_settings_rejects_invalid_runtime_insights_flag() -> None:
         )
 
 
+def test_load_settings_rejects_invalid_cost_dashboard_flag() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"CI_DASHBOARD_ENABLE_COST_DASHBOARD must be a boolean .* got 'maybe'",
+    ):
+        load_settings(
+            {
+                "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
+                "CI_DASHBOARD_ENABLE_COST_DASHBOARD": "maybe",
+            }
+        )
+
+
 def test_build_engine_supports_sqlite_url() -> None:
     settings = load_settings({"CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///:memory:"})
     engine = build_engine(settings)
@@ -264,6 +280,9 @@ def test_build_engine_builds_mysql_url_and_ssl_connect_args(monkeypatch: pytest.
     assert captured["kwargs"] == {
         "pool_pre_ping": True,
         "future": True,
+        "pool_size": 20,
+        "max_overflow": 20,
+        "pool_timeout": 60,
         "connect_args": {"ssl": {"ca": "/etc/certs/ca.pem"}},
     }
     assert install_calls == [engine]

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -128,7 +128,10 @@ export default function App() {
 
     setFiltersByPath((current) => {
       const routeFilters = current[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
-      if (routeFilters.granularity === "week") {
+      const hasValidGranularity = location.pathname === COST_PATH
+        ? routeFilters.granularity === "week" || routeFilters.granularity === "month"
+        : routeFilters.granularity === "week";
+      if (hasValidGranularity) {
         return current;
       }
 

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -7,6 +7,7 @@ import BuildTrendPage from "./pages/BuildTrendPage";
 import MigrateStatusPage from "./pages/MigrateStatusPage";
 import FlakyPage from "./pages/FlakyPage";
 import RuntimeInsightsPage from "./pages/RuntimeInsightsPage";
+import CostPage from "./pages/CostPage";
 import { buildScopeLabel, getDefaultDateRange, useApiData } from "./lib/api";
 
 const REPO_OPTIONS = [{ value: "pingcap/tidb", label: "pingcap/tidb" }];
@@ -18,9 +19,22 @@ const BRANCH_OPTIONS = [
 const CI_STATUS_PATH = "/ci-status";
 const MIGRATE_STATUS_PATH = "/migrate-status";
 const RUNTIME_INSIGHTS_PATH = "/runtime-insights";
-const WEEK_GRANULARITY_PATHS = new Set([CI_STATUS_PATH, MIGRATE_STATUS_PATH, RUNTIME_INSIGHTS_PATH]);
+const COST_PATH = "/cost";
+const WEEK_GRANULARITY_PATHS = new Set([
+  CI_STATUS_PATH,
+  MIGRATE_STATUS_PATH,
+  RUNTIME_INSIGHTS_PATH,
+  COST_PATH,
+]);
 
 function buildDefaultFilters(defaultRange, pathname) {
+  const costRange =
+    pathname === COST_PATH
+      ? {
+          start_date: defaultRange.end_date.slice(0, 8) + "01",
+          end_date: defaultRange.end_date,
+        }
+      : defaultRange;
   const baseFilters = {
     repo: "",
     branch: "",
@@ -28,8 +42,8 @@ function buildDefaultFilters(defaultRange, pathname) {
     cloud_phase: "",
     issue_status: "",
     granularity: WEEK_GRANULARITY_PATHS.has(pathname) ? "week" : "day",
-    start_date: defaultRange.start_date,
-    end_date: defaultRange.end_date,
+    start_date: costRange.start_date,
+    end_date: costRange.end_date,
   };
 
   if (pathname === "/flaky") {
@@ -45,12 +59,17 @@ function buildDefaultFilters(defaultRange, pathname) {
 }
 
 export default function App() {
-  const defaultRange = getDefaultDateRange();
+  const [defaultRange] = useState(() => getDefaultDateRange());
   const location = useLocation();
-  const [filters, setFilters] = useState(() => buildDefaultFilters(defaultRange, location.pathname));
+  const [filtersByPath, setFiltersByPath] = useState(() => ({
+    [location.pathname]: buildDefaultFilters(defaultRange, location.pathname),
+  }));
+  const filters = filtersByPath[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
   const navigation = useApiData("/api/v1/pages/navigation");
   const runtimeInsightsEnabled = navigation.data?.features?.runtime_insights_enabled === true;
+  const costDashboardEnabled = navigation.data?.features?.cost_dashboard_enabled === true;
   const runtimeInsightsReady = !navigation.loading;
+  const costDashboardReady = !navigation.loading;
   const runtimeInsightsRoute = runtimeInsightsEnabled ? (
     <RuntimeInsightsPage filters={filters} />
   ) : runtimeInsightsReady ? (
@@ -58,42 +77,70 @@ export default function App() {
   ) : (
     <div className="empty-state">Loading feature settings...</div>
   );
+  const costDashboardRoute = costDashboardEnabled ? (
+    <CostPage filters={filters} />
+  ) : costDashboardReady ? (
+    <Navigate to={CI_STATUS_PATH} replace />
+  ) : (
+    <div className="empty-state">Loading feature settings...</div>
+  );
+
+  useEffect(() => {
+    setFiltersByPath((current) => {
+      if (current[location.pathname]) {
+        return current;
+      }
+
+      return {
+        ...current,
+        [location.pathname]: buildDefaultFilters(defaultRange, location.pathname),
+      };
+    });
+  }, [defaultRange, location.pathname]);
 
   useEffect(() => {
     if (location.pathname !== "/flaky") {
       return;
     }
 
-    setFilters((current) => {
-      if (current.repo || current.branch || current.issue_status) {
+    setFiltersByPath((current) => {
+      const routeFilters = current[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
+      if (routeFilters.repo || routeFilters.branch || routeFilters.issue_status) {
         return current;
       }
 
       return {
         ...current,
-        repo: "pingcap/tidb",
-        branch: "master",
-        issue_status: "closed",
+        [location.pathname]: {
+          ...routeFilters,
+          repo: "pingcap/tidb",
+          branch: "master",
+          issue_status: "closed",
+        },
       };
     });
-  }, [location.pathname]);
+  }, [defaultRange, location.pathname]);
 
   useEffect(() => {
     if (!WEEK_GRANULARITY_PATHS.has(location.pathname)) {
       return;
     }
 
-    setFilters((current) => {
-      if (current.granularity === "week") {
+    setFiltersByPath((current) => {
+      const routeFilters = current[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
+      if (routeFilters.granularity === "week") {
         return current;
       }
 
       return {
         ...current,
-        granularity: "week",
+        [location.pathname]: {
+          ...routeFilters,
+          granularity: "week",
+        },
       };
     });
-  }, [location.pathname]);
+  }, [defaultRange, location.pathname]);
 
   const jobs = useApiData(
     "/api/v1/filters/jobs",
@@ -113,25 +160,35 @@ export default function App() {
   });
 
   function handleFilterChange(key, value) {
-    setFilters((current) => {
+    setFiltersByPath((current) => {
+      const routeFilters = current[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
       if (key === "repo") {
         return {
           ...current,
-          repo: value,
-          branch: "",
-          job_name: "",
+          [location.pathname]: {
+            ...routeFilters,
+            repo: value,
+            branch: "",
+            job_name: "",
+          },
         };
       }
       if (key === "branch") {
         return {
           ...current,
-          branch: value,
-          job_name: "",
+          [location.pathname]: {
+            ...routeFilters,
+            branch: value,
+            job_name: "",
+          },
         };
       }
       return {
         ...current,
-        [key]: value,
+        [location.pathname]: {
+          ...routeFilters,
+          [key]: value,
+        },
       };
     });
   }
@@ -149,7 +206,7 @@ export default function App() {
       filters={filters}
       onFilterChange={handleFilterChange}
       filterOptions={filterOptions}
-      features={{ runtimeInsightsEnabled }}
+      features={{ runtimeInsightsEnabled, costDashboardEnabled }}
     >
       <Routes>
         <Route path="/" element={<OverviewPage filters={filters} />} />
@@ -157,6 +214,7 @@ export default function App() {
         <Route path="/flaky" element={<FlakyPage filters={filters} />} />
         <Route path={MIGRATE_STATUS_PATH} element={<MigrateStatusPage filters={filters} />} />
         <Route path={RUNTIME_INSIGHTS_PATH} element={runtimeInsightsRoute} />
+        <Route path={COST_PATH} element={costDashboardRoute} />
       </Routes>
     </DashboardLayout>
   );

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -1,7 +1,8 @@
-import { useId } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import {
   formatCompact,
+  formatCurrency,
   formatDateRangeLabel,
   formatNumber,
   formatPercent,
@@ -47,6 +48,11 @@ const SERIES_COLORS = {
   issue_closed_count: "#2a9d8f",
   issue_reopened_count: "#e9c46a",
   issue_open_count: "#315772",
+  net_cost: "#0f766e",
+  effective_cost: "#2a9d8f",
+  list_cost: "#d88b3d",
+  gcp_budget: "#d1495b",
+  repo__no_repo: "#c8d0d6",
   total_failure_like_count: "#264653",
   issue_filtered_flaky_rate_pct: "#0f7c82",
   scheduling_wait_avg_s: "#bc6c25",
@@ -164,6 +170,7 @@ export function TrendChart({
   compactY = false,
   stackBars = false,
   yTickMode = "default",
+  yTickSegments = null,
   rightYTickMode = "default",
   axisLabelSize = 11,
   bottomLabelSize = 11,
@@ -175,6 +182,18 @@ export function TrendChart({
   onBucketSelect = null,
   preserveLabelOrder = false,
 }) {
+  const [hoveredBucketIndex, setHoveredBucketIndex] = useState(null);
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const hoverTimerRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (hoverTimerRef.current) {
+        window.clearTimeout(hoverTimerRef.current);
+      }
+    };
+  }, []);
+
   if (!series?.length) {
     return <EmptyState message="No chart data for the current filters." />;
   }
@@ -229,7 +248,7 @@ export function TrendChart({
       .filter((value) => value != null),
   );
   const sharedTickSegments =
-    yTickMode === "integer" || rightYTickMode === "integer" ? 5 : 4;
+    yTickSegments ?? (yTickMode === "integer" || rightYTickMode === "integer" ? 5 : 4);
   const rawLeftMaxValue = yMax ?? (leftAxisIsPercent ? 100 : Math.max(...leftValues, 1));
   const leftAxisTicks = buildAxisTicks({
     min: 0,
@@ -262,13 +281,24 @@ export function TrendChart({
     (bucketAnnotations || []).map((annotation) => [annotation.label, annotation.text]),
   );
   const padding = {
-    top: annotationMap.size ? 34 : compactY ? 6 : 20,
+    top: annotationMap.size ? 54 : compactY ? 6 : 20,
     right: hasRightAxis ? 58 : 20,
     bottom: compactY ? 22 : 42,
     left: leftPadding,
   };
   const plotWidth = width - padding.left - padding.right;
   const plotHeight = height - padding.top - padding.bottom;
+  const barSeries = series.filter((item) => item.type === "bar");
+  const lineSeries = series.filter((item) => item.type === "line");
+  const hasBars = barSeries.length > 0;
+  const xInset =
+    hasBars && labels.length > 1
+      ? Math.min(Math.max(barMaxWidth / 2 + 8, 20), plotWidth * 0.1)
+      : 0;
+  const xRangeWidth = Math.max(plotWidth - xInset * 2, 1);
+  const xStep = labels.length > 1 ? xRangeWidth / (labels.length - 1) : plotWidth;
+  const xForIndex = (index) =>
+    labels.length > 1 ? padding.left + xInset + index * xStep : padding.left + plotWidth / 2;
   const displayLabels = labels.map((label) => formatBottomAxisLabel(label));
   const longestDisplayLabelLength = Math.max(...displayLabels.map((label) => label.length), 1);
   const estimatedBottomLabelWidth = longestDisplayLabelLength * (bottomLabelSize * 0.62) + 14;
@@ -277,7 +307,6 @@ export function TrendChart({
     labels.length > maxBottomLabels
       ? Math.ceil((labels.length - 1) / Math.max(maxBottomLabels - 1, 1))
       : 1;
-  const xStep = labels.length > 1 ? plotWidth / (labels.length - 1) : plotWidth;
   const minBottomLabelIndexGap = Math.max(
     1,
     Math.ceil(estimatedBottomLabelWidth / Math.max(xStep, 1)),
@@ -289,16 +318,47 @@ export function TrendChart({
   );
   const interactiveBuckets = typeof onBucketSelect === "function";
   const selectedBucketIndex = selectedBucketLabel ? labels.indexOf(selectedBucketLabel) : -1;
-  const barSeries = series.filter((item) => item.type === "bar");
-  const lineSeries = series.filter((item) => item.type === "line");
   const getBucketArea = (index) => {
     if (labels.length === 1) {
       return { x: padding.left, width: plotWidth };
     }
-    const center = padding.left + index * xStep;
+    const center = xForIndex(index);
     const left = index === 0 ? padding.left : center - xStep / 2;
     const right = index === labels.length - 1 ? padding.left + plotWidth : center + xStep / 2;
     return { x: left, width: Math.max(right - left, 12) };
+  };
+  const hoveredBucket =
+    hoveredBucketIndex == null || hoveredBucketIndex < 0
+      ? null
+      : buildBucketTooltip({
+          label: labels[hoveredBucketIndex],
+          index: hoveredBucketIndex,
+          series,
+          pointMaps,
+          xForIndex,
+          yFormatter,
+          rightYFormatter,
+          width,
+          height,
+          padding,
+        });
+  const handleBucketHoverStart = (index) => {
+    if (hoverTimerRef.current) {
+      window.clearTimeout(hoverTimerRef.current);
+    }
+    setHoveredBucketIndex(index);
+    setTooltipVisible(false);
+    hoverTimerRef.current = window.setTimeout(() => {
+      setTooltipVisible(true);
+    }, 1000);
+  };
+  const handleBucketHoverEnd = () => {
+    if (hoverTimerRef.current) {
+      window.clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    setTooltipVisible(false);
+    setHoveredBucketIndex(null);
   };
 
   return (
@@ -365,9 +425,10 @@ export function TrendChart({
             const barWidth = stackBars
               ? Math.max(groupWidth - 4, 10)
               : Math.max(groupWidth / Math.max(barSeries.length, 1) - 6, 10);
-            const groupStart = padding.left + index * xStep - groupWidth / 2;
+            const centerX = xForIndex(index);
+            const groupStart = centerX - groupWidth / 2;
             const x = stackBars
-              ? padding.left + index * xStep - barWidth / 2
+              ? centerX - barWidth / 2
               : groupStart + seriesIndex * (barWidth + 6);
             const axisRange =
               item.axis === "right"
@@ -419,7 +480,7 @@ export function TrendChart({
               return;
             }
 
-            const x = padding.left + index * xStep;
+            const x = xForIndex(index);
             const y = padding.top + plotHeight - ((value - axisMin) / axisRange) * plotHeight;
             currentSegment.push({ label, x, y });
           });
@@ -437,32 +498,35 @@ export function TrendChart({
                   fill="none"
                   stroke={seriesColor(item.key)}
                   strokeWidth="3"
+                  strokeDasharray={item.dash ? "7 6" : undefined}
                   strokeLinejoin="round"
                   strokeLinecap="round"
                 />
               ))}
-              {segments.flatMap((segment) =>
-                segment.map((point) => (
-                  <circle
-                    key={`${item.key}-${point.label}`}
-                    cx={point.x}
-                    cy={point.y}
-                    r={selectedBucketLabel === point.label ? "5.5" : "4.5"}
-                    fill={seriesColor(item.key)}
-                    stroke="#fcf7ef"
-                    strokeWidth={selectedBucketLabel === point.label ? "3" : "2"}
-                    style={interactiveBuckets ? { cursor: "pointer" } : undefined}
-                    onClick={
-                      interactiveBuckets
-                        ? () =>
-                            onBucketSelect(
-                              selectedBucketLabel === point.label ? null : point.label,
-                            )
-                        : undefined
-                    }
-                  />
-                )),
-              )}
+              {item.showPoints === false
+                ? null
+                : segments.flatMap((segment) =>
+                    segment.map((point) => (
+                      <circle
+                        key={`${item.key}-${point.label}`}
+                        cx={point.x}
+                        cy={point.y}
+                        r={selectedBucketLabel === point.label ? "5.5" : "4.5"}
+                        fill={seriesColor(item.key)}
+                        stroke="#fcf7ef"
+                        strokeWidth={selectedBucketLabel === point.label ? "3" : "2"}
+                        style={interactiveBuckets ? { cursor: "pointer" } : undefined}
+                        onClick={
+                          interactiveBuckets
+                            ? () =>
+                                onBucketSelect(
+                                  selectedBucketLabel === point.label ? null : point.label,
+                                )
+                            : undefined
+                        }
+                      />
+                    )),
+                  )}
             </g>
           );
         })}
@@ -483,7 +547,8 @@ export function TrendChart({
             padding,
             plotHeight,
           });
-          const x = padding.left + index * xStep;
+          const x = xForIndex(index);
+          const annotationLines = String(annotation).split("\n");
           return (
             <text
               key={`${label}-annotation`}
@@ -492,7 +557,15 @@ export function TrendChart({
               className="chart-axis-label chart-axis-label--annotation"
               style={{ fontSize: `${annotationLabelSize}px` }}
             >
-              {annotation}
+              {annotationLines.map((line, lineIndex) => (
+                <tspan
+                  key={`${label}-annotation-line-${lineIndex}`}
+                  x={x}
+                  dy={lineIndex === 0 ? 0 : annotationLabelSize + 2}
+                >
+                  {line}
+                </tspan>
+              ))}
             </text>
           );
         })}
@@ -503,7 +576,7 @@ export function TrendChart({
           }
           const isFirstLabel = index === 0;
           const isLastLabel = index === labels.length - 1;
-          const x = padding.left + index * xStep;
+          const x = xForIndex(index);
           const textAnchor = isLastLabel ? "end" : isFirstLabel ? "start" : "middle";
           return (
             <text
@@ -519,23 +592,50 @@ export function TrendChart({
           );
         })}
 
-        {interactiveBuckets
-          ? labels.map((label, index) => {
-              const area = getBucketArea(index);
-              return (
-                <rect
-                  key={`${label}-hit-area`}
-                  x={area.x}
-                  y={padding.top}
-                  width={area.width}
-                  height={plotHeight}
-                  fill="transparent"
-                  style={{ cursor: "pointer" }}
-                  onClick={() => onBucketSelect(selectedBucketLabel === label ? null : label)}
-                />
-              );
-            })
-          : null}
+        {tooltipVisible && hoveredBucket ? (
+          <g className="chart-tooltip" transform={`translate(${hoveredBucket.x}, ${hoveredBucket.y})`}>
+            <rect
+              width={hoveredBucket.width}
+              height={hoveredBucket.height}
+              rx="8"
+              className="chart-tooltip__box"
+            />
+            <text x="12" y="18" className="chart-tooltip__title">
+              {formatBottomAxisLabel(hoveredBucket.label)}
+            </text>
+            {hoveredBucket.rows.map((row, index) => (
+              <g key={`${hoveredBucket.label}-${row.key}`} transform={`translate(0, ${34 + index * 18})`}>
+                <circle cx="14" cy="-4" r="4" fill={seriesColor(row.key)} />
+                <text x="25" y="0" className="chart-tooltip__text">
+                  {row.label}: {row.value}
+                </text>
+              </g>
+            ))}
+          </g>
+        ) : null}
+
+        {labels.map((label, index) => {
+          const area = getBucketArea(index);
+          return (
+            <rect
+              key={`${label}-hit-area`}
+              x={area.x}
+              y={padding.top}
+              width={area.width}
+              height={plotHeight}
+              fill="transparent"
+              className="chart-hit-area"
+              style={{ cursor: interactiveBuckets ? "pointer" : "default" }}
+              onMouseEnter={() => handleBucketHoverStart(index)}
+              onMouseLeave={handleBucketHoverEnd}
+              onClick={
+                interactiveBuckets
+                  ? () => onBucketSelect(selectedBucketLabel === label ? null : label)
+                  : undefined
+              }
+            />
+          );
+        })}
       </svg>
 
       <div className="chart-legend">
@@ -1165,6 +1265,52 @@ export function BucketFlakyRateTable({
   );
 }
 
+export function UnmatchedResourceTable({ items }) {
+  if (!items?.length) {
+    return <EmptyState message="No unmatched unallocated named resources for the current filters." />;
+  }
+
+  return (
+    <div className="table-scroll table-scroll--compact-y">
+      <table className="data-table data-table--compact">
+        <thead>
+          <tr>
+            <th>Resource name</th>
+            <th>List cost</th>
+            <th>Duration</th>
+            <th>Service</th>
+            <th>SKU</th>
+            <th>Labels</th>
+            <th>Allocation</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.resource_name}>
+              <th scope="row">
+                <div className="resource-table__name">{item.resource_name}</div>
+                {item.repo_name ? (
+                  <div className="resource-table__meta">repo: {item.repo_name}</div>
+                ) : null}
+              </th>
+              <td>{formatCurrency(item.list_cost)}</td>
+              <td>{formatResourceDuration(item.observed_days)}</td>
+              <td>{item.service_name || "--"}</td>
+              <td>{item.sku_name || "--"}</td>
+              <td className="resource-table__labels">{item.labels || "--"}</td>
+              <td>
+                <div className="resource-table__meta">{item.allocation_buckets || "--"}</div>
+                <div className="resource-table__meta">{item.attribution_status || "--"}</div>
+                <div className="resource-table__meta">{item.attribution_source || "--"}</div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export function EmptyState({ message, compact = false }) {
   return <div className={compact ? "empty-state empty-state--compact" : "empty-state"}>{message}</div>;
 }
@@ -1208,8 +1354,60 @@ function ErrorState({ error }) {
   return <div className="empty-state empty-state--error">Could not load panel: {error}</div>;
 }
 
+function buildBucketTooltip({
+  label,
+  index,
+  series,
+  pointMaps,
+  xForIndex,
+  yFormatter,
+  rightYFormatter,
+  width,
+  height,
+  padding,
+}) {
+  const rows = series
+    .map((item) => {
+      const rawValue = pointMaps.get(item.key)?.get(label);
+      if (rawValue == null) {
+        return null;
+      }
+      const formatter = item.axis === "right" ? rightYFormatter : yFormatter;
+      return {
+        key: item.key,
+        label: item.label || formatSeriesLabel(item.key),
+        value: formatter(rawValue),
+      };
+    })
+    .filter(Boolean);
+  const longestRowLength = Math.max(
+    String(formatBottomAxisLabel(label)).length,
+    ...rows.map((row) => `${row.label}: ${row.value}`.length),
+  );
+  const tooltipWidth = Math.min(Math.max(170, longestRowLength * 7 + 42), 300);
+  const tooltipHeight = Math.max(48, 34 + rows.length * 18 + 10);
+  const preferredX = xForIndex(index) + 14;
+  const x =
+    preferredX + tooltipWidth > width - 8
+      ? Math.max(8, xForIndex(index) - tooltipWidth - 14)
+      : preferredX;
+  const y = Math.max(8, Math.min(padding.top + 8, height - tooltipHeight - 8));
+
+  return {
+    label,
+    rows,
+    x,
+    y,
+    width: tooltipWidth,
+    height: tooltipHeight,
+  };
+}
+
 function seriesColor(key) {
-  return SERIES_COLORS[key] || "#315772";
+  if (SERIES_COLORS[key]) {
+    return SERIES_COLORS[key];
+  }
+  return DONUT_COLORS[Math.abs(hashString(String(key || ""))) % DONUT_COLORS.length];
 }
 
 function donutColor(name, index) {
@@ -1237,6 +1435,14 @@ function formatBottomAxisLabel(label) {
   }
   const [, _year, month, day] = match;
   return `${month}-${day}`;
+}
+
+function hashString(value) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+  return hash;
 }
 
 function buildVisibleBottomLabelIndices(labelCount, step, minGap) {
@@ -1432,6 +1638,14 @@ function formatShortDate(value) {
   return date.toISOString().slice(0, 10);
 }
 
+function formatResourceDuration(value) {
+  const days = Number(value || 0);
+  if (days <= 0) {
+    return "--";
+  }
+  return `${days.toFixed(0)}d`;
+}
+
 function getAnnotationY({
   label,
   series,
@@ -1511,7 +1725,7 @@ function buildAxisTicks({
 
   if (tickMode === "thousands-rounded") {
     const rawStep = Math.max(safeMax, 1) / safeSegments;
-    const step = Math.max(1000, Math.round(rawStep / 1000) * 1000);
+    const step = niceStep(rawStep);
     const roundedMax = step * safeSegments;
     return {
       min: 0,
@@ -1551,4 +1765,26 @@ function buildAxisTicks({
       (_, index) => safeMin + (span * index) / safeSegments,
     ),
   };
+}
+
+function niceStep(value) {
+  const safeValue = Math.max(Number(value) || 0, 1);
+  const exponent = Math.floor(Math.log10(safeValue));
+  const magnitude = 10 ** exponent;
+  const normalized = safeValue / magnitude;
+  const niceNormalized =
+    normalized <= 1
+      ? 1
+      : normalized <= 1.5
+        ? 1.5
+      : normalized <= 2
+        ? 2
+        : normalized <= 3
+          ? 3
+          : normalized <= 4
+            ? 4
+            : normalized <= 5
+              ? 5
+              : 10;
+  return Math.max(1000, niceNormalized * magnitude);
 }

--- a/ci-dashboard/web/src/components/layout.jsx
+++ b/ci-dashboard/web/src/components/layout.jsx
@@ -11,6 +11,7 @@ export function DashboardLayout({
 }) {
   const currentVersion = packageInfo.version;
   const showRuntimeInsights = features.runtimeInsightsEnabled === true;
+  const showCostDashboard = features.costDashboardEnabled === true;
 
   return (
     <div className="app-shell">
@@ -25,6 +26,9 @@ export function DashboardLayout({
           <NavItem to="/ci-status" label="CI Status" caption="Volume and duration" />
           <NavItem to="/flaky" label="Flaky" caption="Noisy failures and blind-retry-loop patterns" />
           <NavItem to="/migrate-status" label="GCP Migration" caption="GCP rollout and runtime drift" />
+          {showCostDashboard && (
+            <NavItem to="/cost" label="Cost" caption="Spend by repo and engineering ownership" />
+          )}
           {showRuntimeInsights && (
             <NavItem
               to="/runtime-insights"
@@ -110,7 +114,7 @@ function FilterBar({ filters, onFilterChange, filterOptions }) {
     <section className={isCompact ? "filter-bar filter-bar--compact" : "filter-bar"}>
       <div className="filter-bar__header">
         <div className="filter-bar__header-copy">
-          <span className="filter-bar__eyebrow">Global filters</span>
+          <span className="filter-bar__eyebrow">Page filters</span>
           <h2>{filterOptions.scopeLabel}</h2>
         </div>
       </div>
@@ -125,7 +129,7 @@ function FilterBar({ filters, onFilterChange, filterOptions }) {
       </div>
 
       <p className="filter-bar__note">
-        Ingestion stays all-repo and all-branch. These filters only narrow the dashboard view.
+        Each tab keeps its own filter state. Ingestion stays all-repo and all-branch.
       </p>
 
       <div className="filter-grid">

--- a/ci-dashboard/web/src/lib/api.js
+++ b/ci-dashboard/web/src/lib/api.js
@@ -173,6 +173,24 @@ export function formatCompact(value) {
   }).format(value || 0);
 }
 
+export function formatCurrency(value) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: Math.abs(Number(value || 0)) >= 100000 ? "compact" : "standard",
+    maximumFractionDigits: Math.abs(Number(value || 0)) >= 1000 ? 0 : 2,
+  }).format(value || 0);
+}
+
+export function formatCompactCurrency(value) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 0,
+  }).format(value || 0);
+}
+
 export function formatRoundedThousands(value) {
   const numeric = Number(value || 0);
   if (numeric === 0) {

--- a/ci-dashboard/web/src/pages/CostPage.jsx
+++ b/ci-dashboard/web/src/pages/CostPage.jsx
@@ -23,25 +23,9 @@ export default function CostPage({ filters }) {
     granularity: filters.granularity === "month" ? "month" : "week",
   };
   const trend = useApiData("/api/v1/pages/cost-trend", costFilters);
-  const trendSettled = Boolean(trend.data) || Boolean(trend.error);
-  const repoGroupStack = useApiData(
-    "/api/v1/pages/cost-repo-group-stack",
-    costFilters,
-    trendSettled,
-  );
-  const repoStackSettled = trendSettled && (Boolean(repoGroupStack.data) || Boolean(repoGroupStack.error));
-  const engineeringGroupShare = useApiData(
-    "/api/v1/pages/cost-engineering-group-share",
-    costFilters,
-    repoStackSettled,
-  );
-  const engineeringGroupSettled = repoStackSettled
-    && (Boolean(engineeringGroupShare.data) || Boolean(engineeringGroupShare.error));
-  const unmatchedResources = useApiData(
-    "/api/v1/pages/cost-unmatched-resources",
-    costFilters,
-    engineeringGroupSettled,
-  );
+  const repoGroupStack = useApiData("/api/v1/pages/cost-repo-group-stack", costFilters);
+  const engineeringGroupShare = useApiData("/api/v1/pages/cost-engineering-group-share", costFilters);
+  const unmatchedResources = useApiData("/api/v1/pages/cost-unmatched-resources", costFilters);
   const summary = trend.data?.meta?.summary || {};
   const stackTotal = (repoGroupStack.data?.items || []).reduce(
     (sum, item) => sum + Number(item.value || 0),

--- a/ci-dashboard/web/src/pages/CostPage.jsx
+++ b/ci-dashboard/web/src/pages/CostPage.jsx
@@ -1,0 +1,185 @@
+import {
+  formatCompactCurrency,
+  formatCurrency,
+  formatPercent,
+  useApiData,
+} from "../lib/api";
+import {
+  DonutShareChart,
+  PageIntro,
+  Panel,
+  StatCard,
+  TrendChart,
+  UnmatchedResourceTable,
+} from "../components/charts";
+
+const ANNUAL_GCP_BUDGET = 17300 * 12;
+const ANNUAL_TICDC_BUDGET = 4500 * 12;
+
+export default function CostPage({ filters }) {
+  const costFilters = {
+    start_date: filters.start_date,
+    end_date: filters.end_date,
+    granularity: filters.granularity === "month" ? "month" : "week",
+  };
+  const trend = useApiData("/api/v1/pages/cost-trend", costFilters);
+  const trendSettled = Boolean(trend.data) || Boolean(trend.error);
+  const repoGroupStack = useApiData(
+    "/api/v1/pages/cost-repo-group-stack",
+    costFilters,
+    trendSettled,
+  );
+  const repoStackSettled = trendSettled && (Boolean(repoGroupStack.data) || Boolean(repoGroupStack.error));
+  const engineeringGroupShare = useApiData(
+    "/api/v1/pages/cost-engineering-group-share",
+    costFilters,
+    repoStackSettled,
+  );
+  const engineeringGroupSettled = repoStackSettled
+    && (Boolean(engineeringGroupShare.data) || Boolean(engineeringGroupShare.error));
+  const unmatchedResources = useApiData(
+    "/api/v1/pages/cost-unmatched-resources",
+    costFilters,
+    engineeringGroupSettled,
+  );
+  const summary = trend.data?.meta?.summary || {};
+  const stackTotal = (repoGroupStack.data?.items || []).reduce(
+    (sum, item) => sum + Number(item.value || 0),
+    0,
+  );
+  const level1Total = engineeringGroupShare.data?.level1?.meta?.total_list_cost || 0;
+  const level2Total = engineeringGroupShare.data?.level2?.meta?.total_list_cost || 0;
+  const costTrendSeries = withBudgetSeries(
+    trend.data?.series,
+    costFilters.granularity,
+  );
+
+  return (
+    <div className="page-stack">
+      <PageIntro
+        eyebrow="Cost Insight"
+        title="Cloud spend by time, repo, and engineering ownership"
+        description="A first read on GCP cost attribution after raw billing rows are joined with roster ownership."
+        kicker={`${costFilters.granularity} buckets`}
+      />
+
+      <section className="stats-grid">
+        <StatCard
+          label="Net cost"
+          value={formatCurrency(summary.net_cost)}
+          detail="After credits in the selected window"
+        />
+        <StatCard
+          label="List cost"
+          value={formatCurrency(summary.list_cost)}
+          detail="At public SKU pricing before negotiated discounts"
+          tone="teal"
+        />
+        <StatCard
+          label="Resource labeled rate"
+          value={formatPercent(summary.matched_resource_pct)}
+          detail={`${formatCurrency(summary.matched_resource_cost)} / ${formatCurrency(summary.total_resource_cost)} list cost matched to employee`}
+          tone="amber"
+        />
+        <StatCard
+          label="Annual budget"
+          value={formatCurrency(ANNUAL_GCP_BUDGET)}
+          detail={`Includes ticdc ${formatCurrency(ANNUAL_TICDC_BUDGET)} / year`}
+          tone="rose"
+        />
+      </section>
+
+      <div className="page-grid page-grid--two-column">
+        <Panel
+          title="Cost trend"
+          subtitle="Weekly or monthly list cost with net cost as the final billing comparison line."
+          loading={trend.loading}
+          error={trend.error}
+        >
+          <TrendChart
+            series={costTrendSeries}
+            yFormatter={formatCompactCurrency}
+            height={320}
+            yTickMode="thousands-rounded"
+            yTickSegments={5}
+          />
+        </Panel>
+
+        <Panel
+          title="Repo cost stack"
+          subtitle="Top repos stacked by list cost bucket."
+          loading={repoGroupStack.loading}
+          error={repoGroupStack.error}
+        >
+          <TrendChart
+            series={repoGroupStack.data?.series}
+            yFormatter={formatCompactCurrency}
+            height={300}
+            compactY
+            stackBars
+            yTickMode="thousands-rounded"
+            yTickSegments={5}
+            barGroupWidthFactor={0.56}
+            barMaxWidth={58}
+          />
+        </Panel>
+      </div>
+
+      <Panel
+        title="Engineering Group allocation"
+        subtitle="List cost share under Engineering Group, split once by direct child groups and once by second-level groups."
+        loading={engineeringGroupShare.loading}
+        error={engineeringGroupShare.error}
+      >
+        <div className="donut-grid">
+          <DonutShareChart
+            title="Level 1 groups"
+            subtitle="Direct children under Engineering Group."
+            items={engineeringGroupShare.data?.level1?.items}
+            totalLabel="list cost"
+            emptyMessage="No Engineering Group level-1 cost share data yet."
+          />
+          <DonutShareChart
+            title="Level 2 groups"
+            subtitle="Second-level teams under Engineering Group."
+            items={engineeringGroupShare.data?.level2?.items}
+            totalLabel="list cost"
+            emptyMessage="No Engineering Group level-2 cost share data yet."
+          />
+        </div>
+      </Panel>
+
+      <Panel
+        title="Top unmatched resources"
+        subtitle="Top 20 named resources without an employee match and without GKE workload allocation, ordered by unallocated list cost."
+        loading={unmatchedResources.loading}
+        error={unmatchedResources.error}
+      >
+        <UnmatchedResourceTable items={unmatchedResources.data?.items} />
+      </Panel>
+    </div>
+  );
+}
+
+function withBudgetSeries(series, granularity) {
+  if (!series?.length) {
+    return series;
+  }
+  const labels = Array.from(
+    new Set(series.flatMap((item) => item.points.map((point) => point[0]))),
+  ).sort();
+  const budgetPerBucket =
+    granularity === "month" ? ANNUAL_GCP_BUDGET / 12 : ANNUAL_GCP_BUDGET / 52;
+
+  return [
+    ...series,
+    {
+      key: "gcp_budget",
+      label: granularity === "month" ? "Monthly budget" : "Weekly budget",
+      type: "line",
+      dash: true,
+      showPoints: false,
+      points: labels.map((label) => [label, budgetPerBucket]),
+    },
+  ];
+}

--- a/ci-dashboard/web/src/styles.css
+++ b/ci-dashboard/web/src/styles.css
@@ -725,8 +725,25 @@ select {
 .chart-axis-label--annotation {
   text-anchor: middle;
   font-size: 10px;
+  font-weight: 650;
+  fill: #526b76;
+}
+
+.chart-tooltip__box {
+  fill: rgba(18, 35, 47, 0.82);
+  stroke: rgba(255, 255, 255, 0.18);
+  stroke-width: 1;
+}
+
+.chart-tooltip__title {
+  fill: #f8fbfc;
+  font-size: 12px;
   font-weight: 700;
-  fill: var(--navy);
+}
+
+.chart-tooltip__text {
+  fill: rgba(248, 251, 252, 0.92);
+  font-size: 11px;
 }
 
 .chart-legend {
@@ -1498,6 +1515,26 @@ select {
 .data-row--selected th,
 .data-row--selected td {
   background: rgba(42, 157, 143, 0.12) !important;
+}
+
+.resource-table__name {
+  max-width: 28rem;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.resource-table__meta {
+  margin-top: 0.2rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+.data-table td.resource-table__labels {
+  min-width: 20rem;
+  white-space: normal;
+  word-break: break-word;
+  line-height: 1.45;
 }
 
 .metric-cell {


### PR DESCRIPTION
## Summary
- add a dedicated cost dashboard page with cost trend, repo cost stack, engineering group allocation, and top unmatched resources views
- add backend cost queries and API routes, plus a feature flag so the Cost tab can be shown or hidden like CI details insight
- tighten cost dashboard coverage with route/helper tests and keep local sqlite tests working after the larger DB pool settings change

## Testing
- `./.venv/bin/ruff check src tests`
- `./.venv/bin/python -m coverage run -m pytest`
- `./.venv/bin/python -m coverage report -m` (`TOTAL 91%`, exact `90.76%`)
- `npm run build`
