### PR TITLE
feat(chatops-lark): add /image-tag workflow integration

### DIFF
--- a/chatops-lark/config.yaml.example
+++ b/chatops-lark/config.yaml.example
@@ -40,8 +40,8 @@ devbuild:
 image_tag:
   audit:
     webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/xxx"
-  owner: "PingCAP-QE" # Optional, defaults to PingCAP-QE
-  repo: "ci" # Optional, defaults to ci
+  owner: "tidbcloud" # Optional, defaults to tidbcloud
+  repo: "docker-image-controller" # Optional, defaults to docker-image-controller
   workflow: "query-image-tag.yml" # Optional, defaults to query-image-tag.yml
   ref: "main" # Optional, defaults to the repository default branch when omitted
   github_token: "ghp_xxx"

--- a/chatops-lark/config.yaml.example
+++ b/chatops-lark/config.yaml.example
@@ -36,8 +36,8 @@ devbuild:
     webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/xxx"
   api_url: "https://tibuild.pingcap.net/api/devbuilds"
 
-# ImageTag configuration
-image_tag:
+# RegistryImage configuration
+registry_image:
   audit:
     webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/xxx"
   owner: "tidbcloud" # Optional, defaults to tidbcloud

--- a/chatops-lark/config.yaml.example
+++ b/chatops-lark/config.yaml.example
@@ -45,6 +45,9 @@ image_tag:
   workflow: "query-image-tag.yml" # Optional, defaults to query-image-tag.yml
   ref: "main" # Optional, defaults to the repository default branch when omitted
   github_token: "ghp_xxx"
+  credential_refs: # Optional; longest matching registry prefix wins and is sent as workflow input `credential_ref`
+    "registry.pingcap.net/private": "query-image-private"
+    "ghcr.io/pingcap": "query-image-ghcr"
 
 hotfix:
   api_url: "https://tibuild.pingcap.net/api/v2/hotfix" # API endpoint for hotfix operations

--- a/chatops-lark/config.yaml.example
+++ b/chatops-lark/config.yaml.example
@@ -36,6 +36,16 @@ devbuild:
     webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/xxx"
   api_url: "https://tibuild.pingcap.net/api/devbuilds"
 
+# ImageTag configuration
+image_tag:
+  audit:
+    webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/xxx"
+  owner: "PingCAP-QE" # Optional, defaults to PingCAP-QE
+  repo: "ci" # Optional, defaults to ci
+  workflow: "query-image-tag.yml" # Optional, defaults to query-image-tag.yml
+  ref: "main" # Optional, defaults to the repository default branch when omitted
+  github_token: "ghp_xxx"
+
 hotfix:
   api_url: "https://tibuild.pingcap.net/api/v2/hotfix" # API endpoint for hotfix operations
   audit:

--- a/chatops-lark/config.yaml.example
+++ b/chatops-lark/config.yaml.example
@@ -36,7 +36,7 @@ devbuild:
     webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/xxx"
   api_url: "https://tibuild.pingcap.net/api/devbuilds"
 
-# RegistryImage configuration
+# Cloud image query configuration
 registry_image:
   audit:
     webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/xxx"
@@ -45,10 +45,6 @@ registry_image:
   workflow: "query-image-tag.yml" # Optional, defaults to query-image-tag.yml
   ref: "main" # Optional, defaults to the repository default branch when omitted
   github_token: "ghp_xxx"
-  credential_refs: # Optional; longest matching registry prefix wins and is sent as workflow input `credential_ref`
-    "registry.pingcap.net/private": "query-image-private"
-    "ghcr.io/pingcap": "query-image-ghcr"
-
 hotfix:
   api_url: "https://tibuild.pingcap.net/api/v2/hotfix" # API endpoint for hotfix operations
   audit:

--- a/chatops-lark/pkg/audit/send.go
+++ b/chatops-lark/pkg/audit/send.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
+	"text/template"
 
 	sprig "github.com/Masterminds/sprig/v3"
 	"github.com/go-resty/resty/v2"

--- a/chatops-lark/pkg/audit/send_test.go
+++ b/chatops-lark/pkg/audit/send_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -17,6 +18,22 @@ func TestNewLarkCardWithGoTemplate(t *testing.T) {
 		t.Log(str)
 		if err != nil {
 			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("preserves quotes in result markdown", func(t *testing.T) {
+		result := "version: \"9\""
+		info := &AuditInfo{
+			UserEmail: "user@example.com",
+			Command:   "/cloud-image",
+			Result:    &result,
+		}
+		str, err := newLarkCardWithGoTemplate(info)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if strings.Contains(str, "&#34;") {
+			t.Fatalf("expected rendered audit card to preserve quotes, got: %s", str)
 		}
 	})
 }

--- a/chatops-lark/pkg/config/config.go
+++ b/chatops-lark/pkg/config/config.go
@@ -51,9 +51,6 @@ type Config struct {
 
 	RegistryImage *RegistryImageConfig `yaml:"registry_image" json:"registry_image"`
 
-	// ImageTag is a deprecated compatibility alias for the old pre-merge config block name.
-	ImageTag *RegistryImageConfig `yaml:"image_tag,omitempty" json:"image_tag,omitempty"`
-
 	Hotfix *struct {
 		BaseCmdConfig `yaml:",inline" json:",inline"`
 
@@ -119,12 +116,4 @@ func (c *Config) Validate() error {
 		return errors.New("app_secret is required")
 	}
 	return nil
-}
-
-func (c Config) EffectiveRegistryImage() *RegistryImageConfig {
-	if c.RegistryImage != nil {
-		return c.RegistryImage
-	}
-
-	return c.ImageTag
 }

--- a/chatops-lark/pkg/config/config.go
+++ b/chatops-lark/pkg/config/config.go
@@ -75,12 +75,11 @@ type BaseCmdConfig struct {
 type RegistryImageConfig struct {
 	BaseCmdConfig `yaml:",inline" json:",inline"`
 
-	Owner          string            `yaml:"owner" json:"owner"`
-	Repo           string            `yaml:"repo" json:"repo"`
-	Workflow       string            `yaml:"workflow" json:"workflow"`
-	Ref            string            `yaml:"ref" json:"ref"`
-	GitHubToken    string            `yaml:"github_token" json:"github_token"`
-	CredentialRefs map[string]string `yaml:"credential_refs" json:"credential_refs"`
+	Owner       string `yaml:"owner" json:"owner"`
+	Repo        string `yaml:"repo" json:"repo"`
+	Workflow    string `yaml:"workflow" json:"workflow"`
+	Ref         string `yaml:"ref" json:"ref"`
+	GitHubToken string `yaml:"github_token" json:"github_token"`
 }
 
 type AuditConfig struct {

--- a/chatops-lark/pkg/config/config.go
+++ b/chatops-lark/pkg/config/config.go
@@ -49,16 +49,10 @@ type Config struct {
 		ApiURL string `yaml:"api_url" json:"api_url"`
 	} `yaml:"devbuild" json:"devbuild"`
 
-	ImageTag *struct {
-		BaseCmdConfig `yaml:",inline" json:",inline"`
+	RegistryImage *RegistryImageConfig `yaml:"registry_image" json:"registry_image"`
 
-		Owner          string            `yaml:"owner" json:"owner"`
-		Repo           string            `yaml:"repo" json:"repo"`
-		Workflow       string            `yaml:"workflow" json:"workflow"`
-		Ref            string            `yaml:"ref" json:"ref"`
-		GitHubToken    string            `yaml:"github_token" json:"github_token"`
-		CredentialRefs map[string]string `yaml:"credential_refs" json:"credential_refs"`
-	} `yaml:"image_tag" json:"image_tag"`
+	// ImageTag is a deprecated compatibility alias for the old pre-merge config block name.
+	ImageTag *RegistryImageConfig `yaml:"image_tag,omitempty" json:"image_tag,omitempty"`
 
 	Hotfix *struct {
 		BaseCmdConfig `yaml:",inline" json:",inline"`
@@ -79,6 +73,17 @@ type Config struct {
 
 type BaseCmdConfig struct {
 	Audit *AuditConfig `yaml:"audit,omitempty" json:"audit,omitempty"`
+}
+
+type RegistryImageConfig struct {
+	BaseCmdConfig `yaml:",inline" json:",inline"`
+
+	Owner          string            `yaml:"owner" json:"owner"`
+	Repo           string            `yaml:"repo" json:"repo"`
+	Workflow       string            `yaml:"workflow" json:"workflow"`
+	Ref            string            `yaml:"ref" json:"ref"`
+	GitHubToken    string            `yaml:"github_token" json:"github_token"`
+	CredentialRefs map[string]string `yaml:"credential_refs" json:"credential_refs"`
 }
 
 type AuditConfig struct {
@@ -114,4 +119,12 @@ func (c *Config) Validate() error {
 		return errors.New("app_secret is required")
 	}
 	return nil
+}
+
+func (c Config) EffectiveRegistryImage() *RegistryImageConfig {
+	if c.RegistryImage != nil {
+		return c.RegistryImage
+	}
+
+	return c.ImageTag
 }

--- a/chatops-lark/pkg/config/config.go
+++ b/chatops-lark/pkg/config/config.go
@@ -52,11 +52,12 @@ type Config struct {
 	ImageTag *struct {
 		BaseCmdConfig `yaml:",inline" json:",inline"`
 
-		Owner       string `yaml:"owner" json:"owner"`
-		Repo        string `yaml:"repo" json:"repo"`
-		Workflow    string `yaml:"workflow" json:"workflow"`
-		Ref         string `yaml:"ref" json:"ref"`
-		GitHubToken string `yaml:"github_token" json:"github_token"`
+		Owner          string            `yaml:"owner" json:"owner"`
+		Repo           string            `yaml:"repo" json:"repo"`
+		Workflow       string            `yaml:"workflow" json:"workflow"`
+		Ref            string            `yaml:"ref" json:"ref"`
+		GitHubToken    string            `yaml:"github_token" json:"github_token"`
+		CredentialRefs map[string]string `yaml:"credential_refs" json:"credential_refs"`
 	} `yaml:"image_tag" json:"image_tag"`
 
 	Hotfix *struct {

--- a/chatops-lark/pkg/config/config.go
+++ b/chatops-lark/pkg/config/config.go
@@ -49,6 +49,16 @@ type Config struct {
 		ApiURL string `yaml:"api_url" json:"api_url"`
 	} `yaml:"devbuild" json:"devbuild"`
 
+	ImageTag *struct {
+		BaseCmdConfig `yaml:",inline" json:",inline"`
+
+		Owner       string `yaml:"owner" json:"owner"`
+		Repo        string `yaml:"repo" json:"repo"`
+		Workflow    string `yaml:"workflow" json:"workflow"`
+		Ref         string `yaml:"ref" json:"ref"`
+		GitHubToken string `yaml:"github_token" json:"github_token"`
+	} `yaml:"image_tag" json:"image_tag"`
+
 	Hotfix *struct {
 		BaseCmdConfig `yaml:",inline" json:",inline"`
 

--- a/chatops-lark/pkg/events/handler/command_response.go
+++ b/chatops-lark/pkg/events/handler/command_response.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	ctxKeyCommandReply        = "command.reply"
+	ctxKeyCommandResponseMeta = "command.response.meta"
+)
+
+type commandReplyFunc func(status, message string) error
+
+type commandResponseMeta struct {
+	Status string
+}
+
+func withCommandReply(ctx context.Context, reply commandReplyFunc) context.Context {
+	return context.WithValue(ctx, ctxKeyCommandReply, reply)
+}
+
+func withCommandResponseMeta(ctx context.Context, meta *commandResponseMeta) context.Context {
+	return context.WithValue(ctx, ctxKeyCommandResponseMeta, meta)
+}
+
+func sendCommandReply(ctx context.Context, status, message string) error {
+	reply, ok := ctx.Value(ctxKeyCommandReply).(commandReplyFunc)
+	if !ok || reply == nil {
+		return fmt.Errorf("command reply hook not found in context")
+	}
+
+	return reply(status, message)
+}
+
+func hasCommandReply(ctx context.Context) bool {
+	reply, ok := ctx.Value(ctxKeyCommandReply).(commandReplyFunc)
+	return ok && reply != nil
+}
+
+func setCommandResponseStatus(ctx context.Context, status string) {
+	if status == "" {
+		return
+	}
+
+	meta, ok := ctx.Value(ctxKeyCommandResponseMeta).(*commandResponseMeta)
+	if !ok || meta == nil {
+		return
+	}
+
+	meta.Status = status
+}

--- a/chatops-lark/pkg/events/handler/devbuild_poll.go
+++ b/chatops-lark/pkg/events/handler/devbuild_poll.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"html/template"
 	"net/url"
 	"strings"
+	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/go-resty/resty/v2"

--- a/chatops-lark/pkg/events/handler/func_lark.go
+++ b/chatops-lark/pkg/events/handler/func_lark.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var larkMarkdownLinkPattern = regexp.MustCompile(`^\[([^\]]+)\]\((.+)\)$`)
+
 // determineMessageType determines the message type and checks if the bot was mentioned
 func determineMessageType(event *larkim.P2MessageReceiveV1, botOpenID string) (msgType string, chatID string, isMentionBot bool) {
 	// Check if the message is from a group chat
@@ -68,7 +70,7 @@ func parseGroupCommand(event *larkim.P2MessageReceiveV1) *Command {
 	argsStr := strings.TrimSpace(matches[2])
 	var args []string
 	if argsStr != "" {
-		args = strings.Fields(argsStr)
+		args = normalizeCommandTokens(strings.Fields(argsStr))
 	}
 
 	return &Command{Name: commandName, Args: args}
@@ -89,7 +91,7 @@ func parsePrivateCommand(event *larkim.P2MessageReceiveV1) *Command {
 		return nil
 	}
 
-	return &Command{Name: messageParts[0], Args: messageParts[1:]}
+	return &Command{Name: messageParts[0], Args: normalizeCommandTokens(messageParts[1:])}
 }
 
 func shouldHandle(event *larkim.P2MessageReceiveV1, botOpenID string) *Command {
@@ -117,4 +119,31 @@ func parseUserCustomAttr(attrID string, info *larkcontact.User) *string {
 	}
 
 	return nil
+}
+
+func normalizeCommandTokens(tokens []string) []string {
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	normalized := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		normalized = append(normalized, normalizeCommandToken(token))
+	}
+
+	return normalized
+}
+
+func normalizeCommandToken(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return token
+	}
+
+	matches := larkMarkdownLinkPattern.FindStringSubmatch(token)
+	if len(matches) != 3 {
+		return token
+	}
+
+	return matches[1]
 }

--- a/chatops-lark/pkg/events/handler/func_lark_test.go
+++ b/chatops-lark/pkg/events/handler/func_lark_test.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"testing"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+func TestNormalizeCommandToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{
+			name:  "plain token",
+			token: "ghcr.io/pingcap/tidb",
+			want:  "ghcr.io/pingcap/tidb",
+		},
+		{
+			name:  "markdown link token",
+			token: "[tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm](http://tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm)",
+			want:  "tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm",
+		},
+		{
+			name:  "invalid markdown link token",
+			token: "[broken-link]",
+			want:  "[broken-link]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCommandToken(tt.token); got != tt.want {
+				t.Fatalf("normalizeCommandToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePrivateCommandNormalizesMarkdownLinkArgs(t *testing.T) {
+	content := `{"text":"/cloud-image query --repo [tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm](http://tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm) --tag v26.3.0-nextgen"}`
+
+	command := parsePrivateCommand(&larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Message: &larkim.EventMessage{
+				Content:  &content,
+				ChatType: stringPtr("p2p"),
+			},
+		},
+	})
+	if command == nil {
+		t.Fatal("expected private command to be parsed")
+	}
+
+	wantArgs := []string{"query", "--repo", "tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm", "--tag", "v26.3.0-nextgen"}
+	if command.Name != "/cloud-image" {
+		t.Fatalf("parsePrivateCommand() name = %q, want %q", command.Name, "/cloud-image")
+	}
+	if len(command.Args) != len(wantArgs) {
+		t.Fatalf("parsePrivateCommand() args len = %d, want %d (%v)", len(command.Args), len(wantArgs), command.Args)
+	}
+	for i := range wantArgs {
+		if command.Args[i] != wantArgs[i] {
+			t.Fatalf("parsePrivateCommand() arg[%d] = %q, want %q; args=%v", i, command.Args[i], wantArgs[i], command.Args)
+		}
+	}
+}
+
+func TestParseGroupCommandNormalizesMarkdownLinkArgs(t *testing.T) {
+	content := `{"text":"@_user_1 /cloud-image query --repo [tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm](http://tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm) --tag v26.3.0-nextgen"}`
+
+	command := parseGroupCommand(&larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Message: &larkim.EventMessage{
+				Content:  &content,
+				ChatType: stringPtr("group"),
+			},
+		},
+	})
+	if command == nil {
+		t.Fatal("expected group command to be parsed")
+	}
+
+	wantArgs := []string{"query", "--repo", "tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm", "--tag", "v26.3.0-nextgen"}
+	if command.Name != "/cloud-image" {
+		t.Fatalf("parseGroupCommand() name = %q, want %q", command.Name, "/cloud-image")
+	}
+	if len(command.Args) != len(wantArgs) {
+		t.Fatalf("parseGroupCommand() args len = %d, want %d (%v)", len(command.Args), len(wantArgs), command.Args)
+	}
+	for i := range wantArgs {
+		if command.Args[i] != wantArgs[i] {
+			t.Fatalf("parseGroupCommand() arg[%d] = %q, want %q; args=%v", i, command.Args[i], wantArgs[i], command.Args)
+		}
+	}
+}
+
+func stringPtr(v string) *string {
+	return &v
+}

--- a/chatops-lark/pkg/events/handler/imagetag.go
+++ b/chatops-lark/pkg/events/handler/imagetag.go
@@ -10,11 +10,10 @@ import (
 )
 
 const (
-	cfgKeyRegistryImageOwner          = "registry_image.owner"
-	cfgKeyRegistryImageRepo           = "registry_image.repo"
-	cfgKeyRegistryImageWorkflow       = "registry_image.workflow"
-	cfgKeyRegistryImageRef            = "registry_image.ref"
-	cfgKeyRegistryImageCredentialRefs = "registry_image.credential_refs"
+	cfgKeyRegistryImageOwner    = "registry_image.owner"
+	cfgKeyRegistryImageRepo     = "registry_image.repo"
+	cfgKeyRegistryImageWorkflow = "registry_image.workflow"
+	cfgKeyRegistryImageRef      = "registry_image.ref"
 
 	defaultRegistryImageOwner    = "tidbcloud"
 	defaultRegistryImageRepo     = "docker-image-controller"
@@ -41,11 +40,10 @@ Use '/cloud-image --help' or '/cloud-image -h' to see this message.
 `
 
 type registryImageWorkflowConfig struct {
-	Owner          string
-	Repo           string
-	Workflow       string
-	Ref            string
-	CredentialRefs map[string]string
+	Owner    string
+	Repo     string
+	Workflow string
+	Ref      string
 }
 
 func runCommandRegistryImage(ctx context.Context, args []string) (string, error) {
@@ -89,7 +87,6 @@ func setupCtxRegistryImage(ctx context.Context, cfg config.Config, _ *CommandAct
 	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageRepo, repo)
 	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageWorkflow, workflow)
 	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageRef, strings.TrimSpace(registryImageCfg.Ref))
-	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageCredentialRefs, normalizeRegistryImageCredentialRefs(registryImageCfg.CredentialRefs))
 
 	return nextCtx
 }
@@ -116,34 +113,11 @@ func loadRegistryImageWorkflowConfig(ctx context.Context) (registryImageWorkflow
 	}
 
 	ref, _ := ctx.Value(cfgKeyRegistryImageRef).(string)
-	credentialRefs, _ := ctx.Value(cfgKeyRegistryImageCredentialRefs).(map[string]string)
 
 	return registryImageWorkflowConfig{
-		Owner:          owner,
-		Repo:           repo,
-		Workflow:       workflow,
-		Ref:            ref,
-		CredentialRefs: credentialRefs,
+		Owner:    owner,
+		Repo:     repo,
+		Workflow: workflow,
+		Ref:      ref,
 	}, token, nil
-}
-
-func normalizeRegistryImageCredentialRefs(credentialRefs map[string]string) map[string]string {
-	if len(credentialRefs) == 0 {
-		return nil
-	}
-
-	normalized := make(map[string]string, len(credentialRefs))
-	for prefix, credentialRef := range credentialRefs {
-		prefix = strings.TrimSpace(prefix)
-		credentialRef = strings.TrimSpace(credentialRef)
-		if prefix == "" || credentialRef == "" {
-			continue
-		}
-		normalized[prefix] = credentialRef
-	}
-	if len(normalized) == 0 {
-		return nil
-	}
-
-	return normalized
 }

--- a/chatops-lark/pkg/events/handler/imagetag.go
+++ b/chatops-lark/pkg/events/handler/imagetag.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	cfgKeyImageTagOwner    = "image_tag.owner"
-	cfgKeyImageTagRepo     = "image_tag.repo"
-	cfgKeyImageTagWorkflow = "image_tag.workflow"
-	cfgKeyImageTagRef      = "image_tag.ref"
+	cfgKeyImageTagOwner          = "image_tag.owner"
+	cfgKeyImageTagRepo           = "image_tag.repo"
+	cfgKeyImageTagWorkflow       = "image_tag.workflow"
+	cfgKeyImageTagRef            = "image_tag.ref"
+	cfgKeyImageTagCredentialRefs = "image_tag.credential_refs"
 
 	defaultImageTagOwner    = "PingCAP-QE"
 	defaultImageTagRepo     = "ci"
@@ -39,10 +40,11 @@ Use '/image-tag --help' or '/image-tag -h' to see this message.
 `
 
 type imageTagWorkflowConfig struct {
-	Owner    string
-	Repo     string
-	Workflow string
-	Ref      string
+	Owner          string
+	Repo           string
+	Workflow       string
+	Ref            string
+	CredentialRefs map[string]string
 }
 
 func runCommandImageTag(ctx context.Context, args []string) (string, error) {
@@ -83,6 +85,7 @@ func setupCtxImageTag(ctx context.Context, cfg config.Config, _ *CommandActor) c
 	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagRepo, repo)
 	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagWorkflow, workflow)
 	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagRef, strings.TrimSpace(cfg.ImageTag.Ref))
+	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagCredentialRefs, normalizeImageTagCredentialRefs(cfg.ImageTag.CredentialRefs))
 
 	return nextCtx
 }
@@ -109,11 +112,34 @@ func loadImageTagWorkflowConfig(ctx context.Context) (imageTagWorkflowConfig, st
 	}
 
 	ref, _ := ctx.Value(cfgKeyImageTagRef).(string)
+	credentialRefs, _ := ctx.Value(cfgKeyImageTagCredentialRefs).(map[string]string)
 
 	return imageTagWorkflowConfig{
-		Owner:    owner,
-		Repo:     repo,
-		Workflow: workflow,
-		Ref:      ref,
+		Owner:          owner,
+		Repo:           repo,
+		Workflow:       workflow,
+		Ref:            ref,
+		CredentialRefs: credentialRefs,
 	}, token, nil
+}
+
+func normalizeImageTagCredentialRefs(credentialRefs map[string]string) map[string]string {
+	if len(credentialRefs) == 0 {
+		return nil
+	}
+
+	normalized := make(map[string]string, len(credentialRefs))
+	for prefix, credentialRef := range credentialRefs {
+		prefix = strings.TrimSpace(prefix)
+		credentialRef = strings.TrimSpace(credentialRef)
+		if prefix == "" || credentialRef == "" {
+			continue
+		}
+		normalized[prefix] = credentialRef
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	return normalized
 }

--- a/chatops-lark/pkg/events/handler/imagetag.go
+++ b/chatops-lark/pkg/events/handler/imagetag.go
@@ -16,8 +16,8 @@ const (
 	cfgKeyImageTagRef            = "image_tag.ref"
 	cfgKeyImageTagCredentialRefs = "image_tag.credential_refs"
 
-	defaultImageTagOwner    = "PingCAP-QE"
-	defaultImageTagRepo     = "ci"
+	defaultImageTagOwner    = "tidbcloud"
+	defaultImageTagRepo     = "docker-image-controller"
 	defaultImageTagWorkflow = "query-image-tag.yml"
 )
 

--- a/chatops-lark/pkg/events/handler/imagetag.go
+++ b/chatops-lark/pkg/events/handler/imagetag.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/PingCAP-QE/ee-apps/chatops-lark/pkg/config"
+)
+
+const (
+	cfgKeyImageTagOwner    = "image_tag.owner"
+	cfgKeyImageTagRepo     = "image_tag.repo"
+	cfgKeyImageTagWorkflow = "image_tag.workflow"
+	cfgKeyImageTagRef      = "image_tag.ref"
+
+	defaultImageTagOwner    = "PingCAP-QE"
+	defaultImageTagRepo     = "ci"
+	defaultImageTagWorkflow = "query-image-tag.yml"
+)
+
+const imageTagHelpText = `Usage: /image-tag <subcommand> [args...]
+
+Subcommands:
+  trigger <registry> <tag>  - Trigger a GitHub Actions image-tag query
+  poll <runID>              - Poll a workflow run
+
+Examples:
+  /image-tag trigger ghcr.io/pingcap/tidb nightly
+  /image-tag trigger registry.example.com/team/image v8.5.0
+  /image-tag poll 123456789
+
+Notes:
+  - <registry> must be the image reference without the tag.
+  - GitHub authentication comes from backend config, never from chat input.
+
+Use '/image-tag --help' or '/image-tag -h' to see this message.
+`
+
+type imageTagWorkflowConfig struct {
+	Owner    string
+	Repo     string
+	Workflow string
+	Ref      string
+}
+
+func runCommandImageTag(ctx context.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", errors.New(imageTagHelpText)
+	}
+
+	switch args[0] {
+	case "trigger":
+		return runCommandImageTagTrigger(ctx, args[1:])
+	case "poll":
+		return runCommandImageTagPoll(ctx, args[1:])
+	case "-h", "--help":
+		return imageTagHelpText, NewInformationError("Requested command usage")
+	default:
+		return "", fmt.Errorf("unknown subcommand: %s", args[0])
+	}
+}
+
+func setupCtxImageTag(ctx context.Context, cfg config.Config, _ *CommandActor) context.Context {
+	owner := strings.TrimSpace(cfg.ImageTag.Owner)
+	if owner == "" {
+		owner = defaultImageTagOwner
+	}
+
+	repo := strings.TrimSpace(cfg.ImageTag.Repo)
+	if repo == "" {
+		repo = defaultImageTagRepo
+	}
+
+	workflow := strings.TrimSpace(cfg.ImageTag.Workflow)
+	if workflow == "" {
+		workflow = defaultImageTagWorkflow
+	}
+
+	nextCtx := context.WithValue(ctx, ctxKeyGithubToken, strings.TrimSpace(cfg.ImageTag.GitHubToken))
+	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagOwner, owner)
+	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagRepo, repo)
+	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagWorkflow, workflow)
+	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagRef, strings.TrimSpace(cfg.ImageTag.Ref))
+
+	return nextCtx
+}
+
+func loadImageTagWorkflowConfig(ctx context.Context) (imageTagWorkflowConfig, string, error) {
+	token, ok := ctx.Value(ctxKeyGithubToken).(string)
+	if !ok || token == "" {
+		return imageTagWorkflowConfig{}, "", fmt.Errorf("GitHub token not found in context")
+	}
+
+	owner, ok := ctx.Value(cfgKeyImageTagOwner).(string)
+	if !ok || owner == "" {
+		return imageTagWorkflowConfig{}, "", fmt.Errorf("image tag owner not found in context")
+	}
+
+	repo, ok := ctx.Value(cfgKeyImageTagRepo).(string)
+	if !ok || repo == "" {
+		return imageTagWorkflowConfig{}, "", fmt.Errorf("image tag repo not found in context")
+	}
+
+	workflow, ok := ctx.Value(cfgKeyImageTagWorkflow).(string)
+	if !ok || workflow == "" {
+		return imageTagWorkflowConfig{}, "", fmt.Errorf("image tag workflow not found in context")
+	}
+
+	ref, _ := ctx.Value(cfgKeyImageTagRef).(string)
+
+	return imageTagWorkflowConfig{
+		Owner:    owner,
+		Repo:     repo,
+		Workflow: workflow,
+		Ref:      ref,
+	}, token, nil
+}

--- a/chatops-lark/pkg/events/handler/imagetag.go
+++ b/chatops-lark/pkg/events/handler/imagetag.go
@@ -10,36 +10,38 @@ import (
 )
 
 const (
-	cfgKeyImageTagOwner          = "image_tag.owner"
-	cfgKeyImageTagRepo           = "image_tag.repo"
-	cfgKeyImageTagWorkflow       = "image_tag.workflow"
-	cfgKeyImageTagRef            = "image_tag.ref"
-	cfgKeyImageTagCredentialRefs = "image_tag.credential_refs"
+	cfgKeyRegistryImageOwner          = "registry_image.owner"
+	cfgKeyRegistryImageRepo           = "registry_image.repo"
+	cfgKeyRegistryImageWorkflow       = "registry_image.workflow"
+	cfgKeyRegistryImageRef            = "registry_image.ref"
+	cfgKeyRegistryImageCredentialRefs = "registry_image.credential_refs"
 
-	defaultImageTagOwner    = "tidbcloud"
-	defaultImageTagRepo     = "docker-image-controller"
-	defaultImageTagWorkflow = "query-image-tag.yml"
+	defaultRegistryImageOwner    = "tidbcloud"
+	defaultRegistryImageRepo     = "docker-image-controller"
+	defaultRegistryImageWorkflow = "query-image-tag.yml"
 )
 
-const imageTagHelpText = `Usage: /image-tag <subcommand> [args...]
+const registryImageHelpText = `Usage: /registry-image <subcommand> [args...]
 
 Subcommands:
-  trigger <registry> <tag>  - Trigger a GitHub Actions image-tag query
-  poll <runID>              - Poll a workflow run
+  query <image:tag>          - Query a cloud registry image by full tag reference
+  query <image> --tag <tag>  - Query a cloud registry image with an explicit tag
+  inspect ...                - Alias for query
 
 Examples:
-  /image-tag trigger ghcr.io/pingcap/tidb nightly
-  /image-tag trigger registry.example.com/team/image v8.5.0
-  /image-tag poll 123456789
+  /registry-image query ghcr.io/pingcap/tidb:nightly
+  /registry-image query registry.example.com/team/image --tag v8.5.0
+  /registry-image inspect tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm:v26.3.0-nextgen
 
 Notes:
-  - <registry> must be the image reference without the tag.
+  - This command checks whether the target tag exists in the cloud registry and returns OCI image metadata when found.
+  - Image Created At (OCI) is OCI image metadata, not the registry push/sync time.
   - GitHub authentication comes from backend config, never from chat input.
 
-Use '/image-tag --help' or '/image-tag -h' to see this message.
+Use '/registry-image --help' or '/registry-image -h' to see this message.
 `
 
-type imageTagWorkflowConfig struct {
+type registryImageWorkflowConfig struct {
 	Owner          string
 	Repo           string
 	Workflow       string
@@ -47,74 +49,77 @@ type imageTagWorkflowConfig struct {
 	CredentialRefs map[string]string
 }
 
-func runCommandImageTag(ctx context.Context, args []string) (string, error) {
+func runCommandRegistryImage(ctx context.Context, args []string) (string, error) {
 	if len(args) == 0 {
-		return "", errors.New(imageTagHelpText)
+		return "", errors.New(registryImageHelpText)
 	}
 
 	switch args[0] {
-	case "trigger":
-		return runCommandImageTagTrigger(ctx, args[1:])
-	case "poll":
-		return runCommandImageTagPoll(ctx, args[1:])
+	case "query", "inspect":
+		return runCommandRegistryImageQuery(ctx, args[1:])
 	case "-h", "--help":
-		return imageTagHelpText, NewInformationError("Requested command usage")
+		return registryImageHelpText, NewInformationError("Requested command usage")
 	default:
 		return "", fmt.Errorf("unknown subcommand: %s", args[0])
 	}
 }
 
-func setupCtxImageTag(ctx context.Context, cfg config.Config, _ *CommandActor) context.Context {
-	owner := strings.TrimSpace(cfg.ImageTag.Owner)
+func setupCtxRegistryImage(ctx context.Context, cfg config.Config, _ *CommandActor) context.Context {
+	registryImageCfg := cfg.EffectiveRegistryImage()
+	if registryImageCfg == nil {
+		return ctx
+	}
+
+	owner := strings.TrimSpace(registryImageCfg.Owner)
 	if owner == "" {
-		owner = defaultImageTagOwner
+		owner = defaultRegistryImageOwner
 	}
 
-	repo := strings.TrimSpace(cfg.ImageTag.Repo)
+	repo := strings.TrimSpace(registryImageCfg.Repo)
 	if repo == "" {
-		repo = defaultImageTagRepo
+		repo = defaultRegistryImageRepo
 	}
 
-	workflow := strings.TrimSpace(cfg.ImageTag.Workflow)
+	workflow := strings.TrimSpace(registryImageCfg.Workflow)
 	if workflow == "" {
-		workflow = defaultImageTagWorkflow
+		workflow = defaultRegistryImageWorkflow
 	}
 
-	nextCtx := context.WithValue(ctx, ctxKeyGithubToken, strings.TrimSpace(cfg.ImageTag.GitHubToken))
-	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagOwner, owner)
-	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagRepo, repo)
-	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagWorkflow, workflow)
-	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagRef, strings.TrimSpace(cfg.ImageTag.Ref))
-	nextCtx = context.WithValue(nextCtx, cfgKeyImageTagCredentialRefs, normalizeImageTagCredentialRefs(cfg.ImageTag.CredentialRefs))
+	nextCtx := context.WithValue(ctx, ctxKeyGithubToken, strings.TrimSpace(registryImageCfg.GitHubToken))
+	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageOwner, owner)
+	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageRepo, repo)
+	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageWorkflow, workflow)
+	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageRef, strings.TrimSpace(registryImageCfg.Ref))
+	nextCtx = context.WithValue(nextCtx, cfgKeyRegistryImageCredentialRefs, normalizeRegistryImageCredentialRefs(registryImageCfg.CredentialRefs))
 
 	return nextCtx
 }
 
-func loadImageTagWorkflowConfig(ctx context.Context) (imageTagWorkflowConfig, string, error) {
+func loadRegistryImageWorkflowConfig(ctx context.Context) (registryImageWorkflowConfig, string, error) {
 	token, ok := ctx.Value(ctxKeyGithubToken).(string)
 	if !ok || token == "" {
-		return imageTagWorkflowConfig{}, "", fmt.Errorf("GitHub token not found in context")
+		return registryImageWorkflowConfig{}, "", fmt.Errorf("GitHub token not found in context")
 	}
 
-	owner, ok := ctx.Value(cfgKeyImageTagOwner).(string)
+	owner, ok := ctx.Value(cfgKeyRegistryImageOwner).(string)
 	if !ok || owner == "" {
-		return imageTagWorkflowConfig{}, "", fmt.Errorf("image tag owner not found in context")
+		return registryImageWorkflowConfig{}, "", fmt.Errorf("registry image owner not found in context")
 	}
 
-	repo, ok := ctx.Value(cfgKeyImageTagRepo).(string)
+	repo, ok := ctx.Value(cfgKeyRegistryImageRepo).(string)
 	if !ok || repo == "" {
-		return imageTagWorkflowConfig{}, "", fmt.Errorf("image tag repo not found in context")
+		return registryImageWorkflowConfig{}, "", fmt.Errorf("registry image repo not found in context")
 	}
 
-	workflow, ok := ctx.Value(cfgKeyImageTagWorkflow).(string)
+	workflow, ok := ctx.Value(cfgKeyRegistryImageWorkflow).(string)
 	if !ok || workflow == "" {
-		return imageTagWorkflowConfig{}, "", fmt.Errorf("image tag workflow not found in context")
+		return registryImageWorkflowConfig{}, "", fmt.Errorf("registry image workflow not found in context")
 	}
 
-	ref, _ := ctx.Value(cfgKeyImageTagRef).(string)
-	credentialRefs, _ := ctx.Value(cfgKeyImageTagCredentialRefs).(map[string]string)
+	ref, _ := ctx.Value(cfgKeyRegistryImageRef).(string)
+	credentialRefs, _ := ctx.Value(cfgKeyRegistryImageCredentialRefs).(map[string]string)
 
-	return imageTagWorkflowConfig{
+	return registryImageWorkflowConfig{
 		Owner:          owner,
 		Repo:           repo,
 		Workflow:       workflow,
@@ -123,7 +128,7 @@ func loadImageTagWorkflowConfig(ctx context.Context) (imageTagWorkflowConfig, st
 	}, token, nil
 }
 
-func normalizeImageTagCredentialRefs(credentialRefs map[string]string) map[string]string {
+func normalizeRegistryImageCredentialRefs(credentialRefs map[string]string) map[string]string {
 	if len(credentialRefs) == 0 {
 		return nil
 	}

--- a/chatops-lark/pkg/events/handler/imagetag.go
+++ b/chatops-lark/pkg/events/handler/imagetag.go
@@ -21,24 +21,23 @@ const (
 	defaultRegistryImageWorkflow = "query-image-tag.yml"
 )
 
-const registryImageHelpText = `Usage: /registry-image <subcommand> [args...]
+const registryImageHelpText = `Usage: /cloud-image query --repo <repo> --tag <tag>
 
 Subcommands:
-  query <image:tag>          - Query a cloud registry image by full tag reference
-  query <image> --tag <tag>  - Query a cloud registry image with an explicit tag
-  inspect ...                - Alias for query
+  query                      - Query OCI image metadata from a cloud registry by repository and tag
 
 Examples:
-  /registry-image query ghcr.io/pingcap/tidb:nightly
-  /registry-image query registry.example.com/team/image --tag v8.5.0
-  /registry-image inspect tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm:v26.3.0-nextgen
+  /cloud-image query --repo ghcr.io/pingcap/tidb --tag nightly
+  /cloud-image query --tag v8.5.0 --repo registry.example.com/team/image
+  /cloud-image query --repo tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm --tag v26.3.0-nextgen
 
 Notes:
-  - This command checks whether the target tag exists in the cloud registry and returns OCI image metadata when found.
+  - This command checks whether the target tag exists in the target cloud registry and returns OCI image metadata when found.
   - Image Created At (OCI) is OCI image metadata, not the registry push/sync time.
   - GitHub authentication comes from backend config, never from chat input.
+  - Use option flags only; positional image:tag arguments are not supported.
 
-Use '/registry-image --help' or '/registry-image -h' to see this message.
+Use '/cloud-image --help' or '/cloud-image -h' to see this message.
 `
 
 type registryImageWorkflowConfig struct {
@@ -55,7 +54,7 @@ func runCommandRegistryImage(ctx context.Context, args []string) (string, error)
 	}
 
 	switch args[0] {
-	case "query", "inspect":
+	case "query":
 		return runCommandRegistryImageQuery(ctx, args[1:])
 	case "-h", "--help":
 		return registryImageHelpText, NewInformationError("Requested command usage")

--- a/chatops-lark/pkg/events/handler/imagetag.go
+++ b/chatops-lark/pkg/events/handler/imagetag.go
@@ -64,7 +64,7 @@ func runCommandRegistryImage(ctx context.Context, args []string) (string, error)
 }
 
 func setupCtxRegistryImage(ctx context.Context, cfg config.Config, _ *CommandActor) context.Context {
-	registryImageCfg := cfg.EffectiveRegistryImage()
+	registryImageCfg := cfg.RegistryImage
 	if registryImageCfg == nil {
 		return ctx
 	}

--- a/chatops-lark/pkg/events/handler/imagetag_poll.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll.go
@@ -5,13 +5,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"html/template"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/google/go-github/v68/github"
@@ -20,16 +19,23 @@ import (
 	_ "embed"
 )
 
-const imageTagArtifactName = "result.json"
+const registryImageArtifactName = "result.json"
 
 //go:embed imagetag_poll.md.tmpl
-var imageTagPollResponseTmpl string
+var registryImageResponseTmpl string
 
-type imageTagPollParams struct {
-	RunID int64
-}
+type registryImageQueryStatus string
 
-type imageTagPollResult struct {
+const (
+	registryImageQueryStatusFound      registryImageQueryStatus = "FOUND"
+	registryImageQueryStatusNotFound   registryImageQueryStatus = "NOT_FOUND"
+	registryImageQueryStatusAuthFailed registryImageQueryStatus = "AUTH_FAILED"
+	registryImageQueryStatusRunning    registryImageQueryStatus = "RUNNING"
+	registryImageQueryStatusTimeout    registryImageQueryStatus = "TIMEOUT"
+	registryImageQueryStatusFailed     registryImageQueryStatus = "FAILED"
+)
+
+type registryImageArtifactResult struct {
 	ImageRef  string         `json:"image_ref"`
 	CreatedAt string         `json:"created_at"`
 	Digest    string         `json:"digest"`
@@ -38,66 +44,292 @@ type imageTagPollResult struct {
 	Labels    map[string]any `json:"labels"`
 }
 
-func runCommandImageTagPoll(ctx context.Context, args []string) (string, error) {
-	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
-		return imageTagHelpText, NewInformationError("Requested command usage")
-	}
-
-	params, err := parseCommandImageTagPoll(args)
-	if err != nil {
-		return "", err
-	}
-
-	cfg, token, err := loadImageTagWorkflowConfig(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	gc, httpClient := newImageTagGitHubClient(token)
-	return pollImageTagWorkflow(ctx, gc, cfg, params.RunID, httpClient)
+type registryImageQueryOutcome struct {
+	Status    registryImageQueryStatus
+	Summary   string
+	ImageRef  string
+	CreatedAt string
+	Digest    string
+	MultiArch bool
+	Platforms []string
+	Labels    map[string]any
+	RunURL    string
 }
 
-func parseCommandImageTagPoll(args []string) (*imageTagPollParams, error) {
-	if len(args) != 1 {
-		return nil, errors.New(imageTagHelpText)
-	}
-
-	runID, err := strconv.ParseInt(strings.TrimSpace(args[0]), 10, 64)
-	if err != nil || runID <= 0 {
-		return nil, fmt.Errorf("invalid run id %q", args[0])
-	}
-
-	return &imageTagPollParams{RunID: runID}, nil
+type registryImageFailureStep struct {
+	JobID      int64
+	JobName    string
+	StepName   string
+	Conclusion string
 }
 
-func pollImageTagWorkflow(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, runID int64, httpClient *http.Client) (string, error) {
-	run, _, err := gc.Actions.GetWorkflowRunByID(ctx, cfg.Owner, cfg.Repo, runID)
-	if err != nil {
-		return "", fmt.Errorf("poll image-tag workflow failed: %w", err)
+func (outcome *registryImageQueryOutcome) responseStatus() string {
+	switch outcome.Status {
+	case registryImageQueryStatusFound:
+		return StatusSuccess
+	case registryImageQueryStatusNotFound, registryImageQueryStatusRunning, registryImageQueryStatusTimeout:
+		return StatusInfo
+	default:
+		return StatusFailure
 	}
-	if err := validateImageTagWorkflowRun(ctx, gc, cfg, run); err != nil {
-		return "", err
-	}
-
-	runURL := buildImageTagRunURL(cfg, runID, run.GetHTMLURL())
-	if run.GetStatus() != "completed" {
-		return fmt.Sprintf("workflow run %d status: %s\nrun: %s", runID, run.GetStatus(), runURL), nil
-	}
-
-	if run.GetConclusion() != "success" {
-		return "", fmt.Errorf("workflow run %d completed with conclusion %q\nrun: %s", runID, run.GetConclusion(), runURL)
-	}
-
-	result, err := downloadImageTagPollResult(ctx, gc, cfg, runID, httpClient)
-	if err != nil {
-		return "", err
-	}
-
-	return renderImageTagPollResponse(result)
 }
 
-func downloadImageTagPollResult(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, runID int64, httpClient *http.Client) (*imageTagPollResult, error) {
-	artifact, err := getImageTagArtifact(ctx, gc, cfg, runID)
+func newRegistryImageRunningOutcome(imageRef, runURL, summary string, launched bool) *registryImageQueryOutcome {
+	if launched {
+		summary = summary + " I will reply in this thread with the final result."
+	} else {
+		summary = summary + " Check the GitHub Actions workflow page for the final result."
+	}
+
+	return &registryImageQueryOutcome{
+		Status:   registryImageQueryStatusRunning,
+		Summary:  summary,
+		ImageRef: imageRef,
+		RunURL:   runURL,
+	}
+}
+
+func newRegistryImageTimeoutOutcome(imageRef, runURL, summary string) *registryImageQueryOutcome {
+	return &registryImageQueryOutcome{
+		Status:   registryImageQueryStatusTimeout,
+		Summary:  summary,
+		ImageRef: imageRef,
+		RunURL:   runURL,
+	}
+}
+
+func newRegistryImageFailedOutcome(imageRef, runURL, summary string) *registryImageQueryOutcome {
+	return &registryImageQueryOutcome{
+		Status:   registryImageQueryStatusFailed,
+		Summary:  summary,
+		ImageRef: imageRef,
+		RunURL:   runURL,
+	}
+}
+
+func waitForRegistryImageWorkflowCompletion(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, runID int64) (*github.WorkflowRun, error) {
+	ticker := time.NewTicker(registryImageWorkflowStatusPollTick)
+	defer ticker.Stop()
+
+	for {
+		run, _, err := gc.Actions.GetWorkflowRunByID(ctx, cfg.Owner, cfg.Repo, runID)
+		if err != nil {
+			return nil, fmt.Errorf("get registry image workflow run failed: %w", err)
+		}
+		if err := validateRegistryImageWorkflowRun(ctx, gc, cfg, run); err != nil {
+			return nil, err
+		}
+		if run.GetStatus() == "completed" {
+			return run, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return run, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func buildRegistryImageQueryOutcome(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, run *github.WorkflowRun, httpClient *http.Client) (*registryImageQueryOutcome, error) {
+	if err := validateRegistryImageWorkflowRun(ctx, gc, cfg, run); err != nil {
+		return nil, err
+	}
+
+	runURL := buildRegistryImageRunURL(cfg, run.GetID(), run.GetHTMLURL())
+	imageRef := registryImageRefFromRun(run)
+	if run.GetConclusion() == "success" {
+		result, err := downloadRegistryImageResult(ctx, gc, cfg, run.GetID(), httpClient)
+		if err != nil {
+			return nil, err
+		}
+
+		return &registryImageQueryOutcome{
+			Status:    registryImageQueryStatusFound,
+			Summary:   "Tag exists in the target registry.",
+			ImageRef:  result.ImageRef,
+			CreatedAt: result.CreatedAt,
+			Digest:    result.Digest,
+			MultiArch: result.MultiArch,
+			Platforms: result.Platforms,
+			Labels:    result.Labels,
+			RunURL:    runURL,
+		}, nil
+	}
+
+	return buildRegistryImageFailureOutcome(ctx, gc, cfg, run, imageRef, runURL, httpClient), nil
+}
+
+func buildRegistryImageFailureOutcome(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, run *github.WorkflowRun, imageRef, runURL string, httpClient *http.Client) *registryImageQueryOutcome {
+	if run == nil {
+		return newRegistryImageFailedOutcome(imageRef, runURL, "GitHub Actions returned no workflow payload.")
+	}
+
+	if run.GetConclusion() == "timed_out" {
+		return newRegistryImageTimeoutOutcome(imageRef, runURL, "GitHub Actions timed out before the registry query finished.")
+	}
+
+	failureStep, logs := inspectRegistryImageFailure(ctx, gc, cfg, run, httpClient)
+	if failureStep != nil {
+		if failureStep.Conclusion == "timed_out" {
+			return newRegistryImageTimeoutOutcome(imageRef, runURL, fmt.Sprintf("The %q step timed out in GitHub Actions.", failureStep.StepName))
+		}
+
+		switch failureStep.StepName {
+		case "Authenticate registry":
+			return &registryImageQueryOutcome{
+				Status:   registryImageQueryStatusAuthFailed,
+				Summary:  "Failed to authenticate to the target registry.",
+				ImageRef: imageRef,
+				RunURL:   runURL,
+			}
+		case "Inspect image and write result artifact":
+			switch {
+			case registryImageLogLooksNotFound(logs):
+				return &registryImageQueryOutcome{
+					Status:   registryImageQueryStatusNotFound,
+					Summary:  "The tag does not exist in the target registry.",
+					ImageRef: imageRef,
+					RunURL:   runURL,
+				}
+			case registryImageLogLooksAuthFailure(logs):
+				return &registryImageQueryOutcome{
+					Status:   registryImageQueryStatusAuthFailed,
+					Summary:  "The registry rejected authentication for this image query.",
+					ImageRef: imageRef,
+					RunURL:   runURL,
+				}
+			}
+		}
+	}
+
+	switch run.GetConclusion() {
+	case "cancelled":
+		return newRegistryImageFailedOutcome(imageRef, runURL, "The GitHub Actions workflow was cancelled before the registry query finished.")
+	default:
+		return newRegistryImageFailedOutcome(imageRef, runURL, fmt.Sprintf("GitHub Actions finished with conclusion %q.", run.GetConclusion()))
+	}
+}
+
+func inspectRegistryImageFailure(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, run *github.WorkflowRun, httpClient *http.Client) (*registryImageFailureStep, string) {
+	jobs, _, err := gc.Actions.ListWorkflowJobs(ctx, cfg.Owner, cfg.Repo, run.GetID(), &github.ListWorkflowJobsOptions{
+		Filter:      "latest",
+		ListOptions: github.ListOptions{PerPage: 100},
+	})
+	if err != nil || jobs == nil {
+		return nil, ""
+	}
+
+	failureStep := findRegistryImageFailureStep(jobs.Jobs)
+	if failureStep == nil {
+		return nil, ""
+	}
+
+	logs, err := downloadRegistryImageJobLogs(ctx, gc, cfg, failureStep.JobID, httpClient)
+	if err != nil {
+		return failureStep, ""
+	}
+
+	return failureStep, logs
+}
+
+func findRegistryImageFailureStep(jobs []*github.WorkflowJob) *registryImageFailureStep {
+	for _, job := range jobs {
+		if job == nil {
+			continue
+		}
+
+		for _, step := range job.Steps {
+			stepName := registryImageTaskStepName(step)
+			conclusion := registryImageTaskStepConclusion(step)
+			if conclusion == "" || conclusion == "success" || conclusion == "skipped" {
+				continue
+			}
+
+			return &registryImageFailureStep{
+				JobID:      job.GetID(),
+				JobName:    job.GetName(),
+				StepName:   stepName,
+				Conclusion: conclusion,
+			}
+		}
+
+		if conclusion := job.GetConclusion(); conclusion != "" && conclusion != "success" && conclusion != "skipped" {
+			return &registryImageFailureStep{
+				JobID:      job.GetID(),
+				JobName:    job.GetName(),
+				StepName:   job.GetName(),
+				Conclusion: conclusion,
+			}
+		}
+	}
+
+	return nil
+}
+
+func registryImageTaskStepName(step *github.TaskStep) string {
+	if step == nil || step.Name == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(*step.Name)
+}
+
+func registryImageTaskStepConclusion(step *github.TaskStep) string {
+	if step == nil || step.Conclusion == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(*step.Conclusion)
+}
+
+func downloadRegistryImageJobLogs(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, jobID int64, httpClient *http.Client) (string, error) {
+	if jobID == 0 {
+		return "", nil
+	}
+
+	logURL, _, err := gc.Actions.GetWorkflowJobLogs(ctx, cfg.Owner, cfg.Repo, jobID, 1)
+	if err != nil {
+		return "", fmt.Errorf("download workflow job logs redirect failed: %w", err)
+	}
+	if logURL == nil {
+		return "", fmt.Errorf("download workflow job logs redirect returned no URL")
+	}
+
+	resp, err := httpClient.Get(logURL.String())
+	if err != nil {
+		return "", fmt.Errorf("download workflow job logs failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download workflow job logs returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read workflow job logs failed: %w", err)
+	}
+
+	return strings.ToLower(string(body)), nil
+}
+
+func registryImageLogLooksNotFound(logs string) bool {
+	return strings.Contains(logs, "not found")
+}
+
+func registryImageLogLooksAuthFailure(logs string) bool {
+	for _, marker := range []string{"unauthorized", "authentication required", "no basic auth credentials", "denied", "forbidden"} {
+		if strings.Contains(logs, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func downloadRegistryImageResult(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, runID int64, httpClient *http.Client) (*registryImageArtifactResult, error) {
+	artifact, err := getRegistryImageArtifact(ctx, gc, cfg, runID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,17 +342,17 @@ func downloadImageTagPollResult(ctx context.Context, gc *github.Client, cfg imag
 		return nil, fmt.Errorf("download result artifact redirect returned no URL")
 	}
 
-	archiveBytes, err := fetchImageTagArtifactArchive(ctx, httpClient, downloadURL.String())
+	archiveBytes, err := fetchRegistryImageArtifactArchive(ctx, httpClient, downloadURL.String())
 	if err != nil {
 		return nil, err
 	}
 
-	resultBytes, err := extractResultJSONFromArtifact(archiveBytes, imageTagArtifactName)
+	resultBytes, err := extractResultJSONFromArtifact(archiveBytes, registryImageArtifactName)
 	if err != nil {
 		return nil, err
 	}
 
-	var result imageTagPollResult
+	var result registryImageArtifactResult
 	if err := json.Unmarshal(resultBytes, &result); err != nil {
 		return nil, fmt.Errorf("decode result.json failed: %w", err)
 	}
@@ -132,12 +364,12 @@ func downloadImageTagPollResult(ctx context.Context, gc *github.Client, cfg imag
 	return &result, nil
 }
 
-func validateImageTagWorkflowRun(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, run *github.WorkflowRun) error {
+func validateRegistryImageWorkflowRun(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, run *github.WorkflowRun) error {
 	if run == nil {
 		return fmt.Errorf("workflow run returned no payload")
 	}
 
-	expectedPath := imageTagWorkflowPath(cfg.Workflow)
+	expectedPath := registryImageWorkflowPath(cfg.Workflow)
 	if workflowPathMatches(run.GetPath(), expectedPath) {
 		return nil
 	}
@@ -149,19 +381,19 @@ func validateImageTagWorkflowRun(ctx context.Context, gc *github.Client, cfg ima
 	if workflow == nil {
 		return fmt.Errorf("workflow metadata for %q returned no payload", cfg.Workflow)
 	}
-	if imageTagWorkflowRunMatches(run, workflow) {
+	if registryImageWorkflowRunMatches(run, workflow) {
 		return nil
 	}
 
 	return fmt.Errorf(
 		"workflow run %d does not belong to %q (got %q)",
 		run.GetID(),
-		describeImageTagWorkflow(workflow, expectedPath),
-		describeImageTagWorkflowRun(run),
+		describeRegistryImageWorkflow(workflow, expectedPath),
+		describeRegistryImageWorkflowRun(run),
 	)
 }
 
-func getImageTagArtifact(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, runID int64) (*github.Artifact, error) {
+func getRegistryImageArtifact(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, runID int64) (*github.Artifact, error) {
 	artifacts, _, err := gc.Actions.ListWorkflowRunArtifacts(ctx, cfg.Owner, cfg.Repo, runID, &github.ListOptions{PerPage: 100})
 	if err != nil {
 		return nil, fmt.Errorf("list workflow run artifacts failed: %w", err)
@@ -174,16 +406,16 @@ func getImageTagArtifact(ctx context.Context, gc *github.Client, cfg imageTagWor
 		if artifact == nil {
 			continue
 		}
-		if artifact.GetName() != imageTagArtifactName || artifact.GetExpired() {
+		if artifact.GetName() != registryImageArtifactName || artifact.GetExpired() {
 			continue
 		}
 		return artifact, nil
 	}
 
-	return nil, fmt.Errorf("workflow run %d did not produce a %s artifact", runID, imageTagArtifactName)
+	return nil, fmt.Errorf("workflow run %d did not produce a %s artifact", runID, registryImageArtifactName)
 }
 
-func imageTagWorkflowRunMatches(run *github.WorkflowRun, workflow *github.Workflow) bool {
+func registryImageWorkflowRunMatches(run *github.WorkflowRun, workflow *github.Workflow) bool {
 	if run == nil || workflow == nil {
 		return false
 	}
@@ -205,7 +437,7 @@ func workflowPathMatches(actualPath, expectedPath string) bool {
 	return actual == expected
 }
 
-func imageTagWorkflowPath(workflow string) string {
+func registryImageWorkflowPath(workflow string) string {
 	path := normalizeWorkflowPath(workflow)
 	if path == "" {
 		return ""
@@ -225,7 +457,7 @@ func normalizeWorkflowPath(path string) string {
 	return path
 }
 
-func describeImageTagWorkflowRun(run *github.WorkflowRun) string {
+func describeRegistryImageWorkflowRun(run *github.WorkflowRun) string {
 	if run == nil {
 		return "unknown workflow"
 	}
@@ -241,7 +473,7 @@ func describeImageTagWorkflowRun(run *github.WorkflowRun) string {
 	return "unknown workflow"
 }
 
-func describeImageTagWorkflow(workflow *github.Workflow, fallbackPath string) string {
+func describeRegistryImageWorkflow(workflow *github.Workflow, fallbackPath string) string {
 	if workflow != nil {
 		if path := normalizeWorkflowPath(workflow.GetPath()); path != "" {
 			return path
@@ -259,7 +491,7 @@ func describeImageTagWorkflow(workflow *github.Workflow, fallbackPath string) st
 	return strings.TrimSpace(fallbackPath)
 }
 
-func fetchImageTagArtifactArchive(ctx context.Context, httpClient *http.Client, archiveURL string) ([]byte, error) {
+func fetchRegistryImageArtifactArchive(ctx context.Context, httpClient *http.Client, archiveURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build artifact download request failed: %w", err)
@@ -317,7 +549,7 @@ func extractResultJSONFromArtifact(archiveBytes []byte, filename string) ([]byte
 	return nil, fmt.Errorf("artifact archive does not contain %s", filename)
 }
 
-func renderImageTagPollResponse(result *imageTagPollResult) (string, error) {
+func renderRegistryImageQueryResponse(outcome *registryImageQueryOutcome) (string, error) {
 	tmpl := template.Must(template.New("markdown").
 		Funcs(sprig.FuncMap()).
 		Funcs(template.FuncMap{
@@ -329,21 +561,60 @@ func renderImageTagPollResponse(result *imageTagPollResult) (string, error) {
 				return strings.TrimSuffix(string(yamlBytes), "\n")
 			},
 		}).
-		Parse(imageTagPollResponseTmpl))
+		Parse(registryImageResponseTmpl))
 
 	data := map[string]any{
-		"image_ref":  result.ImageRef,
-		"created_at": result.CreatedAt,
-		"digest":     result.Digest,
-		"multi_arch": result.MultiArch,
-		"platforms":  result.Platforms,
-		"labels":     result.Labels,
+		"status":     string(outcome.Status),
+		"summary":    outcome.Summary,
+		"image_ref":  outcome.ImageRef,
+		"created_at": outcome.CreatedAt,
+		"digest":     outcome.Digest,
+		"multi_arch": outcome.MultiArch,
+		"platforms":  outcome.Platforms,
+		"labels":     outcome.Labels,
+		"run_url":    outcome.RunURL,
+		"is_found":   outcome.Status == registryImageQueryStatusFound,
 	}
 
 	var sb strings.Builder
 	if err := tmpl.Execute(&sb, data); err != nil {
-		return "", fmt.Errorf("render image-tag reply failed: %w", err)
+		return "", fmt.Errorf("render registry image reply failed: %w", err)
 	}
 
 	return sb.String(), nil
+}
+
+func mustRenderRegistryImageQueryResponse(outcome *registryImageQueryOutcome) string {
+	message, err := renderRegistryImageQueryResponse(outcome)
+	if err == nil {
+		return message
+	}
+
+	lines := []string{
+		fmt.Sprintf("Registry image query: %s", outcome.Status),
+		outcome.Summary,
+	}
+	if outcome.ImageRef != "" {
+		lines = append(lines, fmt.Sprintf("Image: %s", outcome.ImageRef))
+	}
+	if outcome.RunURL != "" {
+		lines = append(lines, fmt.Sprintf("Run: %s", outcome.RunURL))
+	}
+	lines = append(lines, fmt.Sprintf("Render error: %v", err))
+
+	return strings.Join(lines, "\n")
+}
+
+func registryImageRefFromRun(run *github.WorkflowRun) string {
+	if run == nil {
+		return ""
+	}
+
+	title := strings.TrimSpace(run.GetDisplayTitle())
+	const prefix = "query-image-tag "
+	if strings.HasPrefix(title, prefix) {
+		return strings.TrimSpace(strings.TrimPrefix(title, prefix))
+	}
+
+	return ""
 }

--- a/chatops-lark/pkg/events/handler/imagetag_poll.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io"
 	"net/http"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/Masterminds/sprig/v3"
@@ -553,6 +553,38 @@ func renderRegistryImageQueryResponse(outcome *registryImageQueryOutcome) (strin
 	tmpl := template.Must(template.New("markdown").
 		Funcs(sprig.FuncMap()).
 		Funcs(template.FuncMap{
+			"boolLabel": func(v bool) string {
+				if v {
+					return "Yes"
+				}
+				return "No"
+			},
+			"statusIcon": func(status string) string {
+				switch registryImageQueryStatus(status) {
+				case registryImageQueryStatusFound:
+					return "✅"
+				case registryImageQueryStatusNotFound, registryImageQueryStatusRunning, registryImageQueryStatusTimeout:
+					return "🤷"
+				default:
+					return "❌"
+				}
+			},
+			"statusLabel": func(status string) string {
+				switch registryImageQueryStatus(status) {
+				case registryImageQueryStatusFound:
+					return "Found"
+				case registryImageQueryStatusNotFound:
+					return "Not Found"
+				case registryImageQueryStatusAuthFailed:
+					return "Authentication Failed"
+				case registryImageQueryStatusRunning:
+					return "Running"
+				case registryImageQueryStatusTimeout:
+					return "Timed Out"
+				default:
+					return "Failed"
+				}
+			},
 			"toYaml": func(v any) string {
 				yamlBytes, err := yaml.Marshal(v)
 				if err != nil {

--- a/chatops-lark/pkg/events/handler/imagetag_poll.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll.go
@@ -1,0 +1,241 @@
+package handler
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/google/go-github/v68/github"
+	"gopkg.in/yaml.v3"
+
+	_ "embed"
+)
+
+const imageTagArtifactName = "result.json"
+
+//go:embed imagetag_poll.md.tmpl
+var imageTagPollResponseTmpl string
+
+type imageTagPollParams struct {
+	RunID int64
+}
+
+type imageTagPollResult struct {
+	ImageRef  string         `json:"image_ref"`
+	CreatedAt string         `json:"created_at"`
+	Digest    string         `json:"digest"`
+	MultiArch bool           `json:"multi_arch"`
+	Platforms []string       `json:"platforms"`
+	Labels    map[string]any `json:"labels"`
+}
+
+func runCommandImageTagPoll(ctx context.Context, args []string) (string, error) {
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+		return imageTagHelpText, NewInformationError("Requested command usage")
+	}
+
+	params, err := parseCommandImageTagPoll(args)
+	if err != nil {
+		return "", err
+	}
+
+	cfg, token, err := loadImageTagWorkflowConfig(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	gc := github.NewClient(nil).WithAuthToken(token)
+	return pollImageTagWorkflow(ctx, gc, cfg, params.RunID, http.DefaultClient)
+}
+
+func parseCommandImageTagPoll(args []string) (*imageTagPollParams, error) {
+	if len(args) != 1 {
+		return nil, errors.New(imageTagHelpText)
+	}
+
+	runID, err := strconv.ParseInt(strings.TrimSpace(args[0]), 10, 64)
+	if err != nil || runID <= 0 {
+		return nil, fmt.Errorf("invalid run id %q", args[0])
+	}
+
+	return &imageTagPollParams{RunID: runID}, nil
+}
+
+func pollImageTagWorkflow(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, runID int64, httpClient *http.Client) (string, error) {
+	run, _, err := gc.Actions.GetWorkflowRunByID(ctx, cfg.Owner, cfg.Repo, runID)
+	if err != nil {
+		return "", fmt.Errorf("poll image-tag workflow failed: %w", err)
+	}
+
+	runURL := buildImageTagRunURL(cfg, runID, run.GetHTMLURL())
+	if run.GetStatus() != "completed" {
+		return fmt.Sprintf("workflow run %d status: %s\nrun: %s", runID, run.GetStatus(), runURL), nil
+	}
+
+	if run.GetConclusion() != "success" {
+		return "", fmt.Errorf("workflow run %d completed with conclusion %q\nrun: %s", runID, run.GetConclusion(), runURL)
+	}
+
+	result, err := downloadImageTagPollResult(ctx, gc, cfg, runID, httpClient)
+	if err != nil {
+		return "", err
+	}
+
+	return renderImageTagPollResponse(result)
+}
+
+func downloadImageTagPollResult(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, runID int64, httpClient *http.Client) (*imageTagPollResult, error) {
+	artifact, err := getImageTagArtifact(ctx, gc, cfg, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	downloadURL, _, err := gc.Actions.DownloadArtifact(ctx, cfg.Owner, cfg.Repo, artifact.GetID(), 0)
+	if err != nil {
+		return nil, fmt.Errorf("download result artifact redirect failed: %w", err)
+	}
+	if downloadURL == nil {
+		return nil, fmt.Errorf("download result artifact redirect returned no URL")
+	}
+
+	archiveBytes, err := fetchImageTagArtifactArchive(ctx, httpClient, downloadURL.String())
+	if err != nil {
+		return nil, err
+	}
+
+	resultBytes, err := extractResultJSONFromArtifact(archiveBytes, imageTagArtifactName)
+	if err != nil {
+		return nil, err
+	}
+
+	var result imageTagPollResult
+	if err := json.Unmarshal(resultBytes, &result); err != nil {
+		return nil, fmt.Errorf("decode result.json failed: %w", err)
+	}
+
+	if result.Labels == nil {
+		result.Labels = map[string]any{}
+	}
+
+	return &result, nil
+}
+
+func getImageTagArtifact(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, runID int64) (*github.Artifact, error) {
+	artifacts, _, err := gc.Actions.ListWorkflowRunArtifacts(ctx, cfg.Owner, cfg.Repo, runID, &github.ListOptions{PerPage: 100})
+	if err != nil {
+		return nil, fmt.Errorf("list workflow run artifacts failed: %w", err)
+	}
+	if artifacts == nil {
+		return nil, fmt.Errorf("workflow run %d returned no artifacts payload", runID)
+	}
+
+	for _, artifact := range artifacts.Artifacts {
+		if artifact == nil {
+			continue
+		}
+		if artifact.GetName() != imageTagArtifactName || artifact.GetExpired() {
+			continue
+		}
+		return artifact, nil
+	}
+
+	return nil, fmt.Errorf("workflow run %d did not produce a %s artifact", runID, imageTagArtifactName)
+}
+
+func fetchImageTagArtifactArchive(ctx context.Context, httpClient *http.Client, archiveURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build artifact download request failed: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download artifact archive failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download artifact archive failed: unexpected status %s", resp.Status)
+	}
+
+	archiveBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read artifact archive failed: %w", err)
+	}
+
+	return archiveBytes, nil
+}
+
+func extractResultJSONFromArtifact(archiveBytes []byte, filename string) ([]byte, error) {
+	reader, err := zip.NewReader(bytes.NewReader(archiveBytes), int64(len(archiveBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("open artifact archive failed: %w", err)
+	}
+
+	for _, file := range reader.File {
+		if file == nil {
+			continue
+		}
+		if file.Name != filename && !strings.HasSuffix(file.Name, "/"+filename) {
+			continue
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			return nil, fmt.Errorf("open %s from artifact failed: %w", filename, err)
+		}
+
+		body, readErr := io.ReadAll(rc)
+		closeErr := rc.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read %s from artifact failed: %w", filename, readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close %s from artifact failed: %w", filename, closeErr)
+		}
+
+		return body, nil
+	}
+
+	return nil, fmt.Errorf("artifact archive does not contain %s", filename)
+}
+
+func renderImageTagPollResponse(result *imageTagPollResult) (string, error) {
+	tmpl := template.Must(template.New("markdown").
+		Funcs(sprig.FuncMap()).
+		Funcs(template.FuncMap{
+			"toYaml": func(v any) string {
+				yamlBytes, err := yaml.Marshal(v)
+				if err != nil {
+					return fmt.Sprintf("failed to marshal to YAML: %v", err)
+				}
+				return strings.TrimSuffix(string(yamlBytes), "\n")
+			},
+		}).
+		Parse(imageTagPollResponseTmpl))
+
+	data := map[string]any{
+		"image_ref":  result.ImageRef,
+		"created_at": result.CreatedAt,
+		"digest":     result.Digest,
+		"multi_arch": result.MultiArch,
+		"platforms":  result.Platforms,
+		"labels":     result.Labels,
+	}
+
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, data); err != nil {
+		return "", fmt.Errorf("render image-tag reply failed: %w", err)
+	}
+
+	return sb.String(), nil
+}

--- a/chatops-lark/pkg/events/handler/imagetag_poll.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll.go
@@ -53,8 +53,8 @@ func runCommandImageTagPoll(ctx context.Context, args []string) (string, error) 
 		return "", err
 	}
 
-	gc := github.NewClient(nil).WithAuthToken(token)
-	return pollImageTagWorkflow(ctx, gc, cfg, params.RunID, http.DefaultClient)
+	gc, httpClient := newImageTagGitHubClient(token)
+	return pollImageTagWorkflow(ctx, gc, cfg, params.RunID, httpClient)
 }
 
 func parseCommandImageTagPoll(args []string) (*imageTagPollParams, error) {

--- a/chatops-lark/pkg/events/handler/imagetag_poll.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll.go
@@ -75,6 +75,9 @@ func pollImageTagWorkflow(ctx context.Context, gc *github.Client, cfg imageTagWo
 	if err != nil {
 		return "", fmt.Errorf("poll image-tag workflow failed: %w", err)
 	}
+	if err := validateImageTagWorkflowRun(ctx, gc, cfg, run); err != nil {
+		return "", err
+	}
 
 	runURL := buildImageTagRunURL(cfg, runID, run.GetHTMLURL())
 	if run.GetStatus() != "completed" {
@@ -129,6 +132,35 @@ func downloadImageTagPollResult(ctx context.Context, gc *github.Client, cfg imag
 	return &result, nil
 }
 
+func validateImageTagWorkflowRun(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, run *github.WorkflowRun) error {
+	if run == nil {
+		return fmt.Errorf("workflow run returned no payload")
+	}
+
+	expectedPath := imageTagWorkflowPath(cfg.Workflow)
+	if workflowPathMatches(run.GetPath(), expectedPath) {
+		return nil
+	}
+
+	workflow, _, err := gc.Actions.GetWorkflowByFileName(ctx, cfg.Owner, cfg.Repo, cfg.Workflow)
+	if err != nil {
+		return fmt.Errorf("load workflow metadata for %q failed: %w", cfg.Workflow, err)
+	}
+	if workflow == nil {
+		return fmt.Errorf("workflow metadata for %q returned no payload", cfg.Workflow)
+	}
+	if imageTagWorkflowRunMatches(run, workflow) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"workflow run %d does not belong to %q (got %q)",
+		run.GetID(),
+		describeImageTagWorkflow(workflow, expectedPath),
+		describeImageTagWorkflowRun(run),
+	)
+}
+
 func getImageTagArtifact(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, runID int64) (*github.Artifact, error) {
 	artifacts, _, err := gc.Actions.ListWorkflowRunArtifacts(ctx, cfg.Owner, cfg.Repo, runID, &github.ListOptions{PerPage: 100})
 	if err != nil {
@@ -149,6 +181,82 @@ func getImageTagArtifact(ctx context.Context, gc *github.Client, cfg imageTagWor
 	}
 
 	return nil, fmt.Errorf("workflow run %d did not produce a %s artifact", runID, imageTagArtifactName)
+}
+
+func imageTagWorkflowRunMatches(run *github.WorkflowRun, workflow *github.Workflow) bool {
+	if run == nil || workflow == nil {
+		return false
+	}
+	if workflow.GetID() != 0 && run.GetWorkflowID() == workflow.GetID() {
+		return true
+	}
+	if workflow.GetURL() != "" && strings.TrimSpace(run.GetWorkflowURL()) == strings.TrimSpace(workflow.GetURL()) {
+		return true
+	}
+	return workflowPathMatches(run.GetPath(), workflow.GetPath())
+}
+
+func workflowPathMatches(actualPath, expectedPath string) bool {
+	actual := normalizeWorkflowPath(actualPath)
+	expected := normalizeWorkflowPath(expectedPath)
+	if actual == "" || expected == "" {
+		return false
+	}
+	return actual == expected
+}
+
+func imageTagWorkflowPath(workflow string) string {
+	path := normalizeWorkflowPath(workflow)
+	if path == "" {
+		return ""
+	}
+	if strings.Contains(path, "/") {
+		return path
+	}
+	return ".github/workflows/" + path
+}
+
+func normalizeWorkflowPath(path string) string {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, "/")
+	if idx := strings.Index(path, "@"); idx >= 0 {
+		path = path[:idx]
+	}
+	return path
+}
+
+func describeImageTagWorkflowRun(run *github.WorkflowRun) string {
+	if run == nil {
+		return "unknown workflow"
+	}
+	if path := normalizeWorkflowPath(run.GetPath()); path != "" {
+		return path
+	}
+	if url := strings.TrimSpace(run.GetWorkflowURL()); url != "" {
+		return url
+	}
+	if workflowID := run.GetWorkflowID(); workflowID != 0 {
+		return fmt.Sprintf("workflow id %d", workflowID)
+	}
+	return "unknown workflow"
+}
+
+func describeImageTagWorkflow(workflow *github.Workflow, fallbackPath string) string {
+	if workflow != nil {
+		if path := normalizeWorkflowPath(workflow.GetPath()); path != "" {
+			return path
+		}
+		if url := strings.TrimSpace(workflow.GetURL()); url != "" {
+			return url
+		}
+		if workflowID := workflow.GetID(); workflowID != 0 {
+			return fmt.Sprintf("workflow id %d", workflowID)
+		}
+	}
+	if path := normalizeWorkflowPath(fallbackPath); path != "" {
+		return path
+	}
+	return strings.TrimSpace(fallbackPath)
 }
 
 func fetchImageTagArtifactArchive(ctx context.Context, httpClient *http.Client, archiveURL string) ([]byte, error) {

--- a/chatops-lark/pkg/events/handler/imagetag_poll.md.tmpl
+++ b/chatops-lark/pkg/events/handler/imagetag_poll.md.tmpl
@@ -1,25 +1,27 @@
-**Registry Image Query:** `{{ .status }}`
-{{- if .image_ref }}
-**Image Reference:** `{{ .image_ref }}`
-{{- end }}
+**{{ statusIcon .status }} Cloud Image Query**
 {{- if .summary }}
 {{ .summary }}
 {{- end }}
+
+{{- if .image_ref }}
+- **Image Reference:** {{ .image_ref }}
+{{- end }}
+- **Result:** {{ statusLabel .status }}
 {{- if .is_found }}
+- **Image Created At (OCI):** {{ .created_at }}
+- **Digest:** {{ .digest }}
+- **Multi-Arch:** {{ boolLabel .multi_arch }}
+- **Platforms:** {{ if .platforms }}{{ join ", " .platforms }}{{ else }}none{{ end }}
+{{- end }}
+{{- if .run_url }}
+- **Workflow Run:** {{ .run_url }}
+{{- end }}
 
-**Image Created At (OCI):** `{{ .created_at }}`
-This is OCI image metadata, not the registry push/sync time.
+{{- if .is_found }}
+Image Created At (OCI) is OCI image metadata, not the registry push/sync time.
 
-**Digest:** `{{ .digest }}`
-**Multi-Arch:** `{{ .multi_arch }}`
-**Platforms:** {{ if .platforms }}{{ join ", " .platforms }}{{ else }}none{{ end }}
-
-**Labels:**
+**Labels**
 ```yaml
 {{ toYaml .labels }}
 ```
-{{- end }}
-{{- if .run_url }}
-
-**Workflow Run:** {{ .run_url }}
 {{- end }}

--- a/chatops-lark/pkg/events/handler/imagetag_poll.md.tmpl
+++ b/chatops-lark/pkg/events/handler/imagetag_poll.md.tmpl
@@ -1,0 +1,10 @@
+**Image Reference:** `{{ .image_ref }}`
+**Created At:** `{{ .created_at }}`
+**Digest:** `{{ .digest }}`
+**Multi-Arch:** `{{ .multi_arch }}`
+**Platforms:** {{ if .platforms }}{{ join ", " .platforms }}{{ else }}none{{ end }}
+
+**Labels:**
+```yaml
+{{ toYaml .labels }}
+```

--- a/chatops-lark/pkg/events/handler/imagetag_poll.md.tmpl
+++ b/chatops-lark/pkg/events/handler/imagetag_poll.md.tmpl
@@ -1,5 +1,15 @@
+**Registry Image Query:** `{{ .status }}`
+{{- if .image_ref }}
 **Image Reference:** `{{ .image_ref }}`
-**Created At:** `{{ .created_at }}`
+{{- end }}
+{{- if .summary }}
+{{ .summary }}
+{{- end }}
+{{- if .is_found }}
+
+**Image Created At (OCI):** `{{ .created_at }}`
+This is OCI image metadata, not the registry push/sync time.
+
 **Digest:** `{{ .digest }}`
 **Multi-Arch:** `{{ .multi_arch }}`
 **Platforms:** {{ if .platforms }}{{ join ", " .platforms }}{{ else }}none{{ end }}
@@ -8,3 +18,8 @@
 ```yaml
 {{ toYaml .labels }}
 ```
+{{- end }}
+{{- if .run_url }}
+
+**Workflow Run:** {{ .run_url }}
+{{- end }}

--- a/chatops-lark/pkg/events/handler/imagetag_poll_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll_test.go
@@ -9,127 +9,133 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-github/v68/github"
 )
 
-func TestPollImageTagWorkflowSuccess(t *testing.T) {
-	archiveBytes := buildImageTagArtifactArchive(t, `{
-  "image_ref": "ghcr.io/pingcap/tidb:nightly",
-  "created_at": "2026-05-21T04:00:00Z",
-  "digest": "sha256:abc123",
-  "multi_arch": true,
-  "platforms": ["linux/amd64", "linux/arm64"],
-  "labels": {"org.opencontainers.image.revision": "deadbeef"}
-}`)
-
+func TestBuildRegistryImageQueryOutcomeNotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/200", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id":         200,
-			"path":       ".github/workflows/query-image-tag.yml",
-			"status":     "completed",
-			"conclusion": "success",
-			"html_url":   "https://github.com/tidbcloud/docker-image-controller/actions/runs/200",
-		})
-	})
-
-	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/200/artifacts", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/201/jobs", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"total_count": 1,
-			"artifacts": []map[string]any{
+			"jobs": []map[string]any{
 				{
-					"id":      456,
-					"name":    "result.json",
-					"expired": false,
+					"id":         301,
+					"name":       "Inspect image metadata",
+					"conclusion": "failure",
+					"steps": []map[string]any{
+						{
+							"name":       "Inspect image and write result artifact",
+							"conclusion": "failure",
+						},
+					},
 				},
 			},
 		})
 	})
 
-	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/artifacts/456/zip", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, server.URL+"/download/result.zip", http.StatusFound)
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/jobs/301/logs", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, server.URL+"/download/not-found.log", http.StatusFound)
 	})
 
-	mux.HandleFunc("/download/result.zip", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/zip")
-		_, _ = w.Write(archiveBytes)
+	mux.HandleFunc("/download/not-found.log", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("not found: ghcr.io/pingcap/tidb:nightly"))
 	})
 
 	gc := github.NewClient(nil)
 	gc.BaseURL, _ = url.Parse(server.URL + "/")
 
-	resp, err := pollImageTagWorkflow(context.Background(), gc, imageTagWorkflowConfig{
+	outcome, err := buildRegistryImageQueryOutcome(context.Background(), gc, registryImageWorkflowConfig{
 		Owner:    "tidbcloud",
 		Repo:     "docker-image-controller",
 		Workflow: "query-image-tag.yml",
-	}, 200, server.Client())
+	}, &github.WorkflowRun{
+		ID:           github.Int64(201),
+		Path:         github.String(".github/workflows/query-image-tag.yml"),
+		Status:       github.String("completed"),
+		Conclusion:   github.String("failure"),
+		DisplayTitle: github.String("query-image-tag ghcr.io/pingcap/tidb:nightly"),
+		HTMLURL:      github.String("https://github.com/tidbcloud/docker-image-controller/actions/runs/201"),
+	}, server.Client())
 	if err != nil {
-		t.Fatalf("pollImageTagWorkflow() error = %v", err)
+		t.Fatalf("buildRegistryImageQueryOutcome() error = %v", err)
+	}
+	if outcome.Status != registryImageQueryStatusNotFound {
+		t.Fatalf("expected NOT_FOUND outcome, got %s", outcome.Status)
 	}
 
-	for _, fragment := range []string{
-		"ghcr.io/pingcap/tidb:nightly",
-		"sha256:abc123",
-		"linux/amd64, linux/arm64",
-		"org.opencontainers.image.revision",
-	} {
-		if !strings.Contains(resp, fragment) {
-			t.Fatalf("expected response to contain %q, got:\n%s", fragment, resp)
-		}
+	resp, err := renderRegistryImageQueryResponse(outcome)
+	if err != nil {
+		t.Fatalf("renderRegistryImageQueryResponse() error = %v", err)
+	}
+	if !strings.Contains(resp, "NOT_FOUND") {
+		t.Fatalf("expected rendered response to contain NOT_FOUND, got:\n%s", resp)
 	}
 }
 
-func TestPollImageTagWorkflowFailure(t *testing.T) {
+func TestBuildRegistryImageQueryOutcomeAuthFailed(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/201", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/202/jobs", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id":         201,
-			"path":       ".github/workflows/query-image-tag.yml",
-			"status":     "completed",
-			"conclusion": "failure",
-			"html_url":   "https://github.com/tidbcloud/docker-image-controller/actions/runs/201",
+			"total_count": 1,
+			"jobs": []map[string]any{
+				{
+					"id":         302,
+					"name":       "Inspect image metadata",
+					"conclusion": "failure",
+					"steps": []map[string]any{
+						{
+							"name":       "Authenticate registry",
+							"conclusion": "failure",
+						},
+					},
+				},
+			},
 		})
 	})
 
 	gc := github.NewClient(nil)
 	gc.BaseURL, _ = url.Parse(server.URL + "/")
 
-	_, err := pollImageTagWorkflow(context.Background(), gc, imageTagWorkflowConfig{
+	outcome, err := buildRegistryImageQueryOutcome(context.Background(), gc, registryImageWorkflowConfig{
 		Owner:    "tidbcloud",
 		Repo:     "docker-image-controller",
 		Workflow: "query-image-tag.yml",
-	}, 201, server.Client())
-	if err == nil {
-		t.Fatal("expected pollImageTagWorkflow() to fail")
+	}, &github.WorkflowRun{
+		ID:           github.Int64(202),
+		Path:         github.String(".github/workflows/query-image-tag.yml"),
+		Status:       github.String("completed"),
+		Conclusion:   github.String("failure"),
+		DisplayTitle: github.String("query-image-tag ghcr.io/pingcap/tidb:nightly"),
+		HTMLURL:      github.String("https://github.com/tidbcloud/docker-image-controller/actions/runs/202"),
+	}, server.Client())
+	if err != nil {
+		t.Fatalf("buildRegistryImageQueryOutcome() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "conclusion") {
-		t.Fatalf("expected failure to mention conclusion, got: %v", err)
+	if outcome.Status != registryImageQueryStatusAuthFailed {
+		t.Fatalf("expected AUTH_FAILED outcome, got %s", outcome.Status)
 	}
 }
 
-func TestPollImageTagWorkflowRejectsMismatchedWorkflow(t *testing.T) {
-	var artifactListed atomic.Bool
-
+func TestWaitForRegistryImageWorkflowCompletionRejectsMismatchedWorkflow(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/202", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/203", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id":           202,
+			"id":           203,
 			"path":         ".github/workflows/release.yml",
 			"workflow_id":  999,
 			"workflow_url": server.URL + "/repos/tidbcloud/docker-image-controller/actions/workflows/999",
@@ -148,27 +154,19 @@ func TestPollImageTagWorkflowRejectsMismatchedWorkflow(t *testing.T) {
 		})
 	})
 
-	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/202/artifacts", func(w http.ResponseWriter, r *http.Request) {
-		artifactListed.Store(true)
-		http.Error(w, "artifacts should not be queried for mismatched workflows", http.StatusInternalServerError)
-	})
-
 	gc := github.NewClient(nil)
 	gc.BaseURL, _ = url.Parse(server.URL + "/")
 
-	_, err := pollImageTagWorkflow(context.Background(), gc, imageTagWorkflowConfig{
+	_, err := waitForRegistryImageWorkflowCompletion(context.Background(), gc, registryImageWorkflowConfig{
 		Owner:    "tidbcloud",
 		Repo:     "docker-image-controller",
 		Workflow: "query-image-tag.yml",
-	}, 202, server.Client())
+	}, 203)
 	if err == nil {
-		t.Fatal("expected pollImageTagWorkflow() to reject mismatched workflow")
+		t.Fatal("expected waitForRegistryImageWorkflowCompletion() to reject mismatched workflow")
 	}
 	if !strings.Contains(err.Error(), "does not belong") {
 		t.Fatalf("expected mismatched workflow error, got: %v", err)
-	}
-	if artifactListed.Load() {
-		t.Fatal("expected artifact lookup to be skipped for mismatched workflow")
 	}
 }
 

--- a/chatops-lark/pkg/events/handler/imagetag_poll_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll_test.go
@@ -74,8 +74,10 @@ func TestBuildRegistryImageQueryOutcomeNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderRegistryImageQueryResponse() error = %v", err)
 	}
-	if !strings.Contains(resp, "NOT_FOUND") {
-		t.Fatalf("expected rendered response to contain NOT_FOUND, got:\n%s", resp)
+	for _, fragment := range []string{"🤷 Cloud Image Query", "Result:** Not Found", "Image Reference:"} {
+		if !strings.Contains(resp, fragment) {
+			t.Fatalf("expected rendered response to contain %q, got:\n%s", fragment, resp)
+		}
 	}
 }
 
@@ -179,6 +181,40 @@ func TestExtractResultJSONFromArtifact(t *testing.T) {
 	}
 	if string(body) != `{"image_ref":"ghcr.io/pingcap/tidb:nightly"}` {
 		t.Fatalf("unexpected extracted body: %s", string(body))
+	}
+}
+
+func TestRenderRegistryImageQueryResponseFoundPreservesQuotes(t *testing.T) {
+	resp, err := renderRegistryImageQueryResponse(&registryImageQueryOutcome{
+		Status:    registryImageQueryStatusFound,
+		Summary:   "Tag exists in the target registry.",
+		ImageRef:  "tidbcloud-prod-registry.ap-southeast-1.cr.aliyuncs.com/tidbcloud/dm:v26.3.0-nextgen",
+		CreatedAt: "2026-05-21T07:09:20.240911096Z",
+		Digest:    "sha256:22a3c79dad4659fb467e587817c89f10ad26d31d3916eae007d5eecf5344b512",
+		MultiArch: true,
+		Platforms: []string{"linux/amd64", "linux/arm64"},
+		Labels: map[string]any{
+			"version": "9",
+		},
+		RunURL: "https://github.com/tidbcloud/docker-image-controller/actions/runs/200",
+	})
+	if err != nil {
+		t.Fatalf("renderRegistryImageQueryResponse() error = %v", err)
+	}
+
+	for _, fragment := range []string{
+		"✅ Cloud Image Query",
+		"Result:** Found",
+		"Multi-Arch:** Yes",
+		"Platforms:** linux/amd64, linux/arm64",
+		"version: \"9\"",
+	} {
+		if !strings.Contains(resp, fragment) {
+			t.Fatalf("expected rendered response to contain %q, got:\n%s", fragment, resp)
+		}
+	}
+	if strings.Contains(resp, "&#34;") {
+		t.Fatalf("expected rendered response to preserve quotes, got:\n%s", resp)
 	}
 }
 

--- a/chatops-lark/pkg/events/handler/imagetag_poll_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-github/v68/github"
@@ -32,6 +33,7 @@ func TestPollImageTagWorkflowSuccess(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":         200,
+			"path":       ".github/workflows/query-image-tag.yml",
 			"status":     "completed",
 			"conclusion": "success",
 			"html_url":   "https://github.com/tidbcloud/docker-image-controller/actions/runs/200",
@@ -94,6 +96,7 @@ func TestPollImageTagWorkflowFailure(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":         201,
+			"path":       ".github/workflows/query-image-tag.yml",
 			"status":     "completed",
 			"conclusion": "failure",
 			"html_url":   "https://github.com/tidbcloud/docker-image-controller/actions/runs/201",
@@ -113,6 +116,59 @@ func TestPollImageTagWorkflowFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "conclusion") {
 		t.Fatalf("expected failure to mention conclusion, got: %v", err)
+	}
+}
+
+func TestPollImageTagWorkflowRejectsMismatchedWorkflow(t *testing.T) {
+	var artifactListed atomic.Bool
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/202", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":           202,
+			"path":         ".github/workflows/release.yml",
+			"workflow_id":  999,
+			"workflow_url": server.URL + "/repos/tidbcloud/docker-image-controller/actions/workflows/999",
+			"status":       "completed",
+			"conclusion":   "success",
+			"html_url":     "https://github.com/tidbcloud/docker-image-controller/actions/runs/202",
+		})
+	})
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/workflows/query-image-tag.yml", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   123,
+			"path": ".github/workflows/query-image-tag.yml",
+			"url":  server.URL + "/repos/tidbcloud/docker-image-controller/actions/workflows/123",
+		})
+	})
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/202/artifacts", func(w http.ResponseWriter, r *http.Request) {
+		artifactListed.Store(true)
+		http.Error(w, "artifacts should not be queried for mismatched workflows", http.StatusInternalServerError)
+	})
+
+	gc := github.NewClient(nil)
+	gc.BaseURL, _ = url.Parse(server.URL + "/")
+
+	_, err := pollImageTagWorkflow(context.Background(), gc, imageTagWorkflowConfig{
+		Owner:    "tidbcloud",
+		Repo:     "docker-image-controller",
+		Workflow: "query-image-tag.yml",
+	}, 202, server.Client())
+	if err == nil {
+		t.Fatal("expected pollImageTagWorkflow() to reject mismatched workflow")
+	}
+	if !strings.Contains(err.Error(), "does not belong") {
+		t.Fatalf("expected mismatched workflow error, got: %v", err)
+	}
+	if artifactListed.Load() {
+		t.Fatal("expected artifact lookup to be skipped for mismatched workflow")
 	}
 }
 

--- a/chatops-lark/pkg/events/handler/imagetag_poll_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll_test.go
@@ -28,17 +28,17 @@ func TestPollImageTagWorkflowSuccess(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/runs/200", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/200", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":         200,
 			"status":     "completed",
 			"conclusion": "success",
-			"html_url":   "https://github.com/PingCAP-QE/ci/actions/runs/200",
+			"html_url":   "https://github.com/tidbcloud/docker-image-controller/actions/runs/200",
 		})
 	})
 
-	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/runs/200/artifacts", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/200/artifacts", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"total_count": 1,
@@ -52,7 +52,7 @@ func TestPollImageTagWorkflowSuccess(t *testing.T) {
 		})
 	})
 
-	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/artifacts/456/zip", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/artifacts/456/zip", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, server.URL+"/download/result.zip", http.StatusFound)
 	})
 
@@ -65,8 +65,8 @@ func TestPollImageTagWorkflowSuccess(t *testing.T) {
 	gc.BaseURL, _ = url.Parse(server.URL + "/")
 
 	resp, err := pollImageTagWorkflow(context.Background(), gc, imageTagWorkflowConfig{
-		Owner:    "PingCAP-QE",
-		Repo:     "ci",
+		Owner:    "tidbcloud",
+		Repo:     "docker-image-controller",
 		Workflow: "query-image-tag.yml",
 	}, 200, server.Client())
 	if err != nil {
@@ -90,13 +90,13 @@ func TestPollImageTagWorkflowFailure(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/runs/201", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/201", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":         201,
 			"status":     "completed",
 			"conclusion": "failure",
-			"html_url":   "https://github.com/PingCAP-QE/ci/actions/runs/201",
+			"html_url":   "https://github.com/tidbcloud/docker-image-controller/actions/runs/201",
 		})
 	})
 
@@ -104,8 +104,8 @@ func TestPollImageTagWorkflowFailure(t *testing.T) {
 	gc.BaseURL, _ = url.Parse(server.URL + "/")
 
 	_, err := pollImageTagWorkflow(context.Background(), gc, imageTagWorkflowConfig{
-		Owner:    "PingCAP-QE",
-		Repo:     "ci",
+		Owner:    "tidbcloud",
+		Repo:     "docker-image-controller",
 		Workflow: "query-image-tag.yml",
 	}, 201, server.Client())
 	if err == nil {

--- a/chatops-lark/pkg/events/handler/imagetag_poll_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_poll_test.go
@@ -1,0 +1,148 @@
+package handler
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v68/github"
+)
+
+func TestPollImageTagWorkflowSuccess(t *testing.T) {
+	archiveBytes := buildImageTagArtifactArchive(t, `{
+  "image_ref": "ghcr.io/pingcap/tidb:nightly",
+  "created_at": "2026-05-21T04:00:00Z",
+  "digest": "sha256:abc123",
+  "multi_arch": true,
+  "platforms": ["linux/amd64", "linux/arm64"],
+  "labels": {"org.opencontainers.image.revision": "deadbeef"}
+}`)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/runs/200", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         200,
+			"status":     "completed",
+			"conclusion": "success",
+			"html_url":   "https://github.com/PingCAP-QE/ci/actions/runs/200",
+		})
+	})
+
+	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/runs/200/artifacts", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"artifacts": []map[string]any{
+				{
+					"id":      456,
+					"name":    "result.json",
+					"expired": false,
+				},
+			},
+		})
+	})
+
+	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/artifacts/456/zip", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, server.URL+"/download/result.zip", http.StatusFound)
+	})
+
+	mux.HandleFunc("/download/result.zip", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(archiveBytes)
+	})
+
+	gc := github.NewClient(nil)
+	gc.BaseURL, _ = url.Parse(server.URL + "/")
+
+	resp, err := pollImageTagWorkflow(context.Background(), gc, imageTagWorkflowConfig{
+		Owner:    "PingCAP-QE",
+		Repo:     "ci",
+		Workflow: "query-image-tag.yml",
+	}, 200, server.Client())
+	if err != nil {
+		t.Fatalf("pollImageTagWorkflow() error = %v", err)
+	}
+
+	for _, fragment := range []string{
+		"ghcr.io/pingcap/tidb:nightly",
+		"sha256:abc123",
+		"linux/amd64, linux/arm64",
+		"org.opencontainers.image.revision",
+	} {
+		if !strings.Contains(resp, fragment) {
+			t.Fatalf("expected response to contain %q, got:\n%s", fragment, resp)
+		}
+	}
+}
+
+func TestPollImageTagWorkflowFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/runs/201", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         201,
+			"status":     "completed",
+			"conclusion": "failure",
+			"html_url":   "https://github.com/PingCAP-QE/ci/actions/runs/201",
+		})
+	})
+
+	gc := github.NewClient(nil)
+	gc.BaseURL, _ = url.Parse(server.URL + "/")
+
+	_, err := pollImageTagWorkflow(context.Background(), gc, imageTagWorkflowConfig{
+		Owner:    "PingCAP-QE",
+		Repo:     "ci",
+		Workflow: "query-image-tag.yml",
+	}, 201, server.Client())
+	if err == nil {
+		t.Fatal("expected pollImageTagWorkflow() to fail")
+	}
+	if !strings.Contains(err.Error(), "conclusion") {
+		t.Fatalf("expected failure to mention conclusion, got: %v", err)
+	}
+}
+
+func TestExtractResultJSONFromArtifact(t *testing.T) {
+	archiveBytes := buildImageTagArtifactArchive(t, `{"image_ref":"ghcr.io/pingcap/tidb:nightly"}`)
+
+	body, err := extractResultJSONFromArtifact(archiveBytes, "result.json")
+	if err != nil {
+		t.Fatalf("extractResultJSONFromArtifact() error = %v", err)
+	}
+	if string(body) != `{"image_ref":"ghcr.io/pingcap/tidb:nightly"}` {
+		t.Fatalf("unexpected extracted body: %s", string(body))
+	}
+}
+
+func buildImageTagArtifactArchive(t *testing.T, resultJSON string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	fw, err := zw.Create("result.json")
+	if err != nil {
+		t.Fatalf("create zip entry failed: %v", err)
+	}
+	if _, err := fw.Write([]byte(resultJSON)); err != nil {
+		t.Fatalf("write zip entry failed: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip writer failed: %v", err)
+	}
+
+	return buf.Bytes()
+}

--- a/chatops-lark/pkg/events/handler/imagetag_trigger.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger.go
@@ -11,72 +11,106 @@ import (
 	"github.com/google/go-github/v68/github"
 )
 
-const (
-	imageTagWorkflowRunLookupTimeout = 30 * time.Second
-	imageTagWorkflowRunLookupTick    = 2 * time.Second
-	imageTagHTTPTimeout              = 30 * time.Second
+var (
+	registryImageInlineWaitTimeout      = 90 * time.Second
+	registryImageAsyncWaitTimeout       = 15 * time.Minute
+	registryImageWorkflowRunLookupTick  = 2 * time.Second
+	registryImageWorkflowStatusPollTick = 5 * time.Second
+	registryImageHTTPTimeout            = 30 * time.Second
 )
 
-var errImageTagWorkflowRunNotFound = errors.New("dispatched workflow run not found yet")
+var errRegistryImageWorkflowRunNotFound = errors.New("dispatched workflow run not found yet")
 
-type imageTagTriggerParams struct {
-	Registry string
-	Tag      string
+type registryImageQueryParams struct {
+	Repository string
+	Tag        string
+	ImageRef   string
 }
 
-func runCommandImageTagTrigger(ctx context.Context, args []string) (string, error) {
+type registryImageAsyncState struct {
+	Params       *registryImageQueryParams
+	Ref          string
+	MinRunID     int64
+	DispatchedAt time.Time
+	RunID        int64
+}
+
+func runCommandRegistryImageQuery(ctx context.Context, args []string) (string, error) {
 	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
-		return imageTagHelpText, NewInformationError("Requested command usage")
+		return registryImageHelpText, NewInformationError("Requested command usage")
 	}
 
-	params, err := parseCommandImageTagTrigger(args)
+	params, err := parseCommandRegistryImageQuery(args)
 	if err != nil {
 		return "", err
 	}
 
-	cfg, token, err := loadImageTagWorkflowConfig(ctx)
+	cfg, token, err := loadRegistryImageWorkflowConfig(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	gc, _ := newImageTagGitHubClient(token)
-	return triggerImageTagWorkflow(ctx, params, gc, cfg)
+	gc, httpClient := newRegistryImageGitHubClient(token)
+	return queryRegistryImage(ctx, params, gc, cfg, httpClient)
 }
 
-func parseCommandImageTagTrigger(args []string) (*imageTagTriggerParams, error) {
-	if len(args) != 2 {
-		return nil, errors.New(imageTagHelpText)
+func parseCommandRegistryImageQuery(args []string) (*registryImageQueryParams, error) {
+	switch {
+	case len(args) == 1:
+		return parseRegistryImageTaggedReference(args[0])
+	case len(args) == 3 && (args[1] == "--tag" || args[1] == "-t"):
+		return buildRegistryImageQueryParams(args[0], args[2])
+	default:
+		return nil, errors.New(registryImageHelpText)
+	}
+}
+
+func parseRegistryImageTaggedReference(imageRef string) (*registryImageQueryParams, error) {
+	imageRef = strings.TrimSpace(imageRef)
+	if imageRef == "" || strings.Contains(imageRef, "@") {
+		return nil, errors.New(registryImageHelpText)
 	}
 
-	registry := strings.TrimSpace(args[0])
-	tag := strings.TrimSpace(args[1])
-	if registry == "" || tag == "" {
-		return nil, errors.New(imageTagHelpText)
+	lastSlash := strings.LastIndex(imageRef, "/")
+	lastColon := strings.LastIndex(imageRef, ":")
+	if lastColon <= lastSlash || lastColon == len(imageRef)-1 {
+		return nil, errors.New(registryImageHelpText)
 	}
 
-	return &imageTagTriggerParams{
-		Registry: registry,
-		Tag:      tag,
+	return buildRegistryImageQueryParams(imageRef[:lastColon], imageRef[lastColon+1:])
+}
+
+func buildRegistryImageQueryParams(repository, tag string) (*registryImageQueryParams, error) {
+	repository = strings.TrimSpace(repository)
+	tag = strings.TrimSpace(tag)
+	if repository == "" || tag == "" || strings.Contains(repository, "@") {
+		return nil, errors.New(registryImageHelpText)
+	}
+
+	return &registryImageQueryParams{
+		Repository: repository,
+		Tag:        tag,
+		ImageRef:   fmt.Sprintf("%s:%s", repository, tag),
 	}, nil
 }
 
-func triggerImageTagWorkflow(ctx context.Context, params *imageTagTriggerParams, gc *github.Client, cfg imageTagWorkflowConfig) (string, error) {
-	ref, err := resolveImageTagWorkflowRef(ctx, gc, cfg)
+func queryRegistryImage(ctx context.Context, params *registryImageQueryParams, gc *github.Client, cfg registryImageWorkflowConfig, httpClient *http.Client) (string, error) {
+	ref, err := resolveRegistryImageWorkflowRef(ctx, gc, cfg)
 	if err != nil {
 		return "", err
 	}
 
-	maxRunID, err := maxImageTagWorkflowRunID(ctx, gc, cfg)
+	maxRunID, err := maxRegistryImageWorkflowRunID(ctx, gc, cfg)
 	if err != nil {
 		return "", err
 	}
 
 	dispatchedAt := time.Now().UTC()
 	inputs := map[string]interface{}{
-		"registry_url": params.Registry,
+		"registry_url": params.Repository,
 		"image_tag":    params.Tag,
 	}
-	if credentialRef := resolveImageTagCredentialRef(params.Registry, cfg.CredentialRefs); credentialRef != "" {
+	if credentialRef := resolveRegistryImageCredentialRef(params.Repository, cfg.CredentialRefs); credentialRef != "" {
 		inputs["credential_ref"] = credentialRef
 	}
 
@@ -85,19 +119,141 @@ func triggerImageTagWorkflow(ctx context.Context, params *imageTagTriggerParams,
 		Inputs: inputs,
 	})
 	if err != nil {
-		return "", fmt.Errorf("trigger image-tag workflow failed: %w", err)
+		return "", fmt.Errorf("trigger registry image workflow failed: %w", err)
 	}
 
-	run, err := waitForImageTagWorkflowRun(ctx, gc, cfg, ref, params.Registry, params.Tag, maxRunID, dispatchedAt)
+	inlineCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), registryImageInlineWaitTimeout)
+	defer cancel()
+
+	run, err := waitForRegistryImageWorkflowRun(inlineCtx, gc, cfg, ref, params.Repository, params.Tag, maxRunID, dispatchedAt)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			launched := scheduleAsyncRegistryImageQueryReply(ctx, gc, cfg, httpClient, registryImageAsyncState{
+				Params:       params,
+				Ref:          ref,
+				MinRunID:     maxRunID,
+				DispatchedAt: dispatchedAt,
+			})
+			outcome := newRegistryImageRunningOutcome(
+				params.ImageRef,
+				buildWorkflowPageURL(cfg),
+				fmt.Sprintf("GitHub accepted the query, but the workflow run is not visible yet after %s.", registryImageInlineWaitTimeout),
+				launched,
+			)
+			setCommandResponseStatus(ctx, outcome.responseStatus())
+			return renderRegistryImageQueryResponse(outcome)
+		}
+
+		return "", err
+	}
+
+	completedRun, err := waitForRegistryImageWorkflowCompletion(inlineCtx, gc, cfg, run.GetID())
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			launched := scheduleAsyncRegistryImageQueryReply(ctx, gc, cfg, httpClient, registryImageAsyncState{
+				Params:       params,
+				Ref:          ref,
+				MinRunID:     maxRunID,
+				DispatchedAt: dispatchedAt,
+				RunID:        run.GetID(),
+			})
+			outcome := newRegistryImageRunningOutcome(
+				params.ImageRef,
+				buildRegistryImageRunURL(cfg, run.GetID(), run.GetHTMLURL()),
+				fmt.Sprintf("The workflow is still running after %s.", registryImageInlineWaitTimeout),
+				launched,
+			)
+			setCommandResponseStatus(ctx, outcome.responseStatus())
+			return renderRegistryImageQueryResponse(outcome)
+		}
+
+		return "", err
+	}
+
+	outcome, err := buildRegistryImageQueryOutcome(inlineCtx, gc, cfg, completedRun, httpClient)
 	if err != nil {
 		return "", err
 	}
 
-	runURL := buildImageTagRunURL(cfg, run.GetID(), run.GetHTMLURL())
-	return fmt.Sprintf("workflow run id is %d\npoll command: /image-tag poll %d\nrun: %s", run.GetID(), run.GetID(), runURL), nil
+	setCommandResponseStatus(ctx, outcome.responseStatus())
+	return renderRegistryImageQueryResponse(outcome)
 }
 
-func resolveImageTagWorkflowRef(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig) (string, error) {
+func scheduleAsyncRegistryImageQueryReply(parentCtx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, httpClient *http.Client, state registryImageAsyncState) bool {
+	if !hasCommandReply(parentCtx) {
+		return false
+	}
+
+	go func() {
+		asyncCtx, cancel := context.WithTimeout(context.Background(), registryImageAsyncWaitTimeout)
+		defer cancel()
+
+		run, err := awaitRegistryImageQueryCompletion(asyncCtx, gc, cfg, state)
+		if err != nil {
+			outcome := newRegistryImageTimeoutOutcome(
+				state.Params.ImageRef,
+				"",
+				fmt.Sprintf("GitHub Actions did not finish within %s.", registryImageAsyncWaitTimeout),
+			)
+			if run != nil {
+				outcome.RunURL = buildRegistryImageRunURL(cfg, run.GetID(), run.GetHTMLURL())
+			}
+			if !errors.Is(err, context.DeadlineExceeded) {
+				outcome = newRegistryImageFailedOutcome(
+					state.Params.ImageRef,
+					outcome.RunURL,
+					fmt.Sprintf("Unexpected error while waiting for the GitHub Actions result: %v", err),
+				)
+			}
+			_ = sendCommandReply(parentCtx, outcome.responseStatus(), mustRenderRegistryImageQueryResponse(outcome))
+			return
+		}
+
+		outcome, err := buildRegistryImageQueryOutcome(asyncCtx, gc, cfg, run, httpClient)
+		if err != nil {
+			fallback := newRegistryImageFailedOutcome(
+				state.Params.ImageRef,
+				buildRegistryImageRunURL(cfg, run.GetID(), run.GetHTMLURL()),
+				fmt.Sprintf("Unexpected error while loading the GitHub Actions result: %v", err),
+			)
+			_ = sendCommandReply(parentCtx, fallback.responseStatus(), mustRenderRegistryImageQueryResponse(fallback))
+			return
+		}
+
+		_ = sendCommandReply(parentCtx, outcome.responseStatus(), mustRenderRegistryImageQueryResponse(outcome))
+	}()
+
+	return true
+}
+
+func awaitRegistryImageQueryCompletion(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, state registryImageAsyncState) (*github.WorkflowRun, error) {
+	var (
+		run *github.WorkflowRun
+		err error
+	)
+
+	if state.RunID != 0 {
+		run, err = waitForRegistryImageWorkflowCompletion(ctx, gc, cfg, state.RunID)
+		if err != nil {
+			return run, err
+		}
+		return run, nil
+	}
+
+	run, err = waitForRegistryImageWorkflowRun(ctx, gc, cfg, state.Ref, state.Params.Repository, state.Params.Tag, state.MinRunID, state.DispatchedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	run, err = waitForRegistryImageWorkflowCompletion(ctx, gc, cfg, run.GetID())
+	if err != nil {
+		return run, err
+	}
+
+	return run, nil
+}
+
+func resolveRegistryImageWorkflowRef(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig) (string, error) {
 	if cfg.Ref != "" {
 		return cfg.Ref, nil
 	}
@@ -114,7 +270,7 @@ func resolveImageTagWorkflowRef(ctx context.Context, gc *github.Client, cfg imag
 	return repo.GetDefaultBranch(), nil
 }
 
-func maxImageTagWorkflowRunID(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig) (int64, error) {
+func maxRegistryImageWorkflowRunID(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig) (int64, error) {
 	runs, _, err := gc.Actions.ListWorkflowRunsByFileName(ctx, cfg.Owner, cfg.Repo, cfg.Workflow, &github.ListWorkflowRunsOptions{
 		ListOptions: github.ListOptions{PerPage: 1},
 	})
@@ -129,52 +285,49 @@ func maxImageTagWorkflowRunID(ctx context.Context, gc *github.Client, cfg imageT
 	return runs.WorkflowRuns[0].GetID(), nil
 }
 
-func waitForImageTagWorkflowRun(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, ref, registry, tag string, minRunID int64, dispatchedAt time.Time) (*github.WorkflowRun, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, imageTagWorkflowRunLookupTimeout)
-	defer cancel()
-
-	ticker := time.NewTicker(imageTagWorkflowRunLookupTick)
+func waitForRegistryImageWorkflowRun(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, ref, repository, tag string, minRunID int64, dispatchedAt time.Time) (*github.WorkflowRun, error) {
+	ticker := time.NewTicker(registryImageWorkflowRunLookupTick)
 	defer ticker.Stop()
 
 	for {
-		run, err := findDispatchedImageTagWorkflowRun(waitCtx, gc, cfg, ref, registry, tag, minRunID, dispatchedAt)
+		run, err := findDispatchedRegistryImageWorkflowRun(ctx, gc, cfg, ref, repository, tag, minRunID, dispatchedAt)
 		if err == nil {
 			return run, nil
 		}
-		if !errors.Is(err, errImageTagWorkflowRunNotFound) {
+		if !errors.Is(err, errRegistryImageWorkflowRunNotFound) {
 			return nil, err
 		}
 
 		select {
-		case <-waitCtx.Done():
-			return nil, fmt.Errorf("workflow dispatched but run id was not visible yet; check %s", buildWorkflowPageURL(cfg))
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		case <-ticker.C:
 		}
 	}
 }
 
-func findDispatchedImageTagWorkflowRun(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, ref, registry, tag string, minRunID int64, dispatchedAt time.Time) (*github.WorkflowRun, error) {
+func findDispatchedRegistryImageWorkflowRun(ctx context.Context, gc *github.Client, cfg registryImageWorkflowConfig, ref, repository, tag string, minRunID int64, dispatchedAt time.Time) (*github.WorkflowRun, error) {
 	runs, _, err := gc.Actions.ListWorkflowRunsByFileName(ctx, cfg.Owner, cfg.Repo, cfg.Workflow, &github.ListWorkflowRunsOptions{
 		Event:       "workflow_dispatch",
 		ListOptions: github.ListOptions{PerPage: 20},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("list dispatched workflow runs failed: %w", err)
+		return nil, fmt.Errorf("list dispatched registry image workflow runs failed: %w", err)
 	}
 	if runs == nil {
-		return nil, errImageTagWorkflowRunNotFound
+		return nil, errRegistryImageWorkflowRunNotFound
 	}
 
-	expectedTitle := fmt.Sprintf("query-image-tag %s:%s", registry, tag)
-	run := selectImageTagWorkflowRun(runs.WorkflowRuns, ref, expectedTitle, minRunID, dispatchedAt)
+	expectedTitle := fmt.Sprintf("query-image-tag %s:%s", repository, tag)
+	run := selectRegistryImageWorkflowRun(runs.WorkflowRuns, ref, expectedTitle, minRunID, dispatchedAt)
 	if run == nil {
-		return nil, errImageTagWorkflowRunNotFound
+		return nil, errRegistryImageWorkflowRunNotFound
 	}
 
 	return run, nil
 }
 
-func selectImageTagWorkflowRun(runs []*github.WorkflowRun, ref, expectedTitle string, minRunID int64, dispatchedAt time.Time) *github.WorkflowRun {
+func selectRegistryImageWorkflowRun(runs []*github.WorkflowRun, ref, expectedTitle string, minRunID int64, dispatchedAt time.Time) *github.WorkflowRun {
 	var matched *github.WorkflowRun
 
 	for _, run := range runs {
@@ -184,7 +337,7 @@ func selectImageTagWorkflowRun(runs []*github.WorkflowRun, ref, expectedTitle st
 		if run.GetEvent() != "workflow_dispatch" {
 			continue
 		}
-		if !imageTagWorkflowRunMatchesRef(run, ref) {
+		if !registryImageWorkflowRunMatchesRef(run, ref) {
 			continue
 		}
 		if run.CreatedAt != nil && run.CreatedAt.Time.Before(dispatchedAt.Add(-1*time.Minute)) {
@@ -202,7 +355,7 @@ func selectImageTagWorkflowRun(runs []*github.WorkflowRun, ref, expectedTitle st
 	return matched
 }
 
-func imageTagWorkflowRunMatchesRef(run *github.WorkflowRun, ref string) bool {
+func registryImageWorkflowRunMatchesRef(run *github.WorkflowRun, ref string) bool {
 	if ref == "" {
 		return true
 	}
@@ -222,25 +375,25 @@ func imageTagWorkflowRunMatchesRef(run *github.WorkflowRun, ref string) bool {
 	return false
 }
 
-func newImageTagGitHubClient(token string) (*github.Client, *http.Client) {
-	httpClient := &http.Client{Timeout: imageTagHTTPTimeout}
+func newRegistryImageGitHubClient(token string) (*github.Client, *http.Client) {
+	httpClient := &http.Client{Timeout: registryImageHTTPTimeout}
 	return github.NewClient(httpClient).WithAuthToken(token), httpClient
 }
 
-func resolveImageTagCredentialRef(registry string, credentialRefs map[string]string) string {
-	registry = normalizeImageTagRegistryPrefix(registry)
-	if registry == "" {
+func resolveRegistryImageCredentialRef(repository string, credentialRefs map[string]string) string {
+	repository = normalizeRegistryImagePrefix(repository)
+	if repository == "" {
 		return ""
 	}
 
 	var matchedPrefix string
 	var matchedCredentialRef string
 	for prefix, credentialRef := range credentialRefs {
-		normalizedPrefix := normalizeImageTagRegistryPrefix(prefix)
+		normalizedPrefix := normalizeRegistryImagePrefix(prefix)
 		if normalizedPrefix == "" || credentialRef == "" {
 			continue
 		}
-		if !imageTagRegistryPrefixMatches(registry, normalizedPrefix) {
+		if !registryImagePrefixMatches(repository, normalizedPrefix) {
 			continue
 		}
 		if len(normalizedPrefix) > len(matchedPrefix) {
@@ -252,22 +405,22 @@ func resolveImageTagCredentialRef(registry string, credentialRefs map[string]str
 	return matchedCredentialRef
 }
 
-func normalizeImageTagRegistryPrefix(registry string) string {
-	registry = strings.TrimSpace(strings.ToLower(registry))
-	registry = strings.TrimPrefix(registry, "https://")
-	registry = strings.TrimPrefix(registry, "http://")
-	return strings.Trim(registry, "/")
+func normalizeRegistryImagePrefix(repository string) string {
+	repository = strings.TrimSpace(strings.ToLower(repository))
+	repository = strings.TrimPrefix(repository, "https://")
+	repository = strings.TrimPrefix(repository, "http://")
+	return strings.Trim(repository, "/")
 }
 
-func imageTagRegistryPrefixMatches(registry, prefix string) bool {
-	return registry == prefix || strings.HasPrefix(registry, prefix+"/")
+func registryImagePrefixMatches(repository, prefix string) bool {
+	return repository == prefix || strings.HasPrefix(repository, prefix+"/")
 }
 
-func buildWorkflowPageURL(cfg imageTagWorkflowConfig) string {
+func buildWorkflowPageURL(cfg registryImageWorkflowConfig) string {
 	return fmt.Sprintf("https://github.com/%s/%s/actions/workflows/%s", cfg.Owner, cfg.Repo, cfg.Workflow)
 }
 
-func buildImageTagRunURL(cfg imageTagWorkflowConfig, runID int64, htmlURL string) string {
+func buildRegistryImageRunURL(cfg registryImageWorkflowConfig, runID int64, htmlURL string) string {
 	if htmlURL != "" {
 		return htmlURL
 	}

--- a/chatops-lark/pkg/events/handler/imagetag_trigger.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger.go
@@ -120,9 +120,6 @@ func queryRegistryImage(ctx context.Context, params *registryImageQueryParams, g
 		"registry_url": params.Repository,
 		"image_tag":    params.Tag,
 	}
-	if credentialRef := resolveRegistryImageCredentialRef(params.Repository, cfg.CredentialRefs); credentialRef != "" {
-		inputs["credential_ref"] = credentialRef
-	}
 
 	_, err = gc.Actions.CreateWorkflowDispatchEventByFileName(ctx, cfg.Owner, cfg.Repo, cfg.Workflow, github.CreateWorkflowDispatchEventRequest{
 		Ref:    ref,
@@ -388,42 +385,6 @@ func registryImageWorkflowRunMatchesRef(run *github.WorkflowRun, ref string) boo
 func newRegistryImageGitHubClient(token string) (*github.Client, *http.Client) {
 	httpClient := &http.Client{Timeout: registryImageHTTPTimeout}
 	return github.NewClient(httpClient).WithAuthToken(token), httpClient
-}
-
-func resolveRegistryImageCredentialRef(repository string, credentialRefs map[string]string) string {
-	repository = normalizeRegistryImagePrefix(repository)
-	if repository == "" {
-		return ""
-	}
-
-	var matchedPrefix string
-	var matchedCredentialRef string
-	for prefix, credentialRef := range credentialRefs {
-		normalizedPrefix := normalizeRegistryImagePrefix(prefix)
-		if normalizedPrefix == "" || credentialRef == "" {
-			continue
-		}
-		if !registryImagePrefixMatches(repository, normalizedPrefix) {
-			continue
-		}
-		if len(normalizedPrefix) > len(matchedPrefix) {
-			matchedPrefix = normalizedPrefix
-			matchedCredentialRef = credentialRef
-		}
-	}
-
-	return matchedCredentialRef
-}
-
-func normalizeRegistryImagePrefix(repository string) string {
-	repository = strings.TrimSpace(strings.ToLower(repository))
-	repository = strings.TrimPrefix(repository, "https://")
-	repository = strings.TrimPrefix(repository, "http://")
-	return strings.Trim(repository, "/")
-}
-
-func registryImagePrefixMatches(repository, prefix string) bool {
-	return repository == prefix || strings.HasPrefix(repository, prefix+"/")
 }
 
 func buildWorkflowPageURL(cfg registryImageWorkflowConfig) string {

--- a/chatops-lark/pkg/events/handler/imagetag_trigger.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger.go
@@ -175,7 +175,7 @@ func findDispatchedImageTagWorkflowRun(ctx context.Context, gc *github.Client, c
 }
 
 func selectImageTagWorkflowRun(runs []*github.WorkflowRun, ref, expectedTitle string, minRunID int64, dispatchedAt time.Time) *github.WorkflowRun {
-	var fallback *github.WorkflowRun
+	var matched *github.WorkflowRun
 
 	for _, run := range runs {
 		if run == nil || run.GetID() <= minRunID {
@@ -191,16 +191,15 @@ func selectImageTagWorkflowRun(runs []*github.WorkflowRun, ref, expectedTitle st
 			continue
 		}
 
-		if run.GetDisplayTitle() == expectedTitle {
-			return run
+		if run.GetDisplayTitle() != expectedTitle {
+			continue
 		}
-
-		if fallback == nil || run.GetID() > fallback.GetID() {
-			fallback = run
+		if matched == nil || run.GetID() < matched.GetID() {
+			matched = run
 		}
 	}
 
-	return fallback
+	return matched
 }
 
 func imageTagWorkflowRunMatchesRef(run *github.WorkflowRun, ref string) bool {

--- a/chatops-lark/pkg/events/handler/imagetag_trigger.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger.go
@@ -55,32 +55,42 @@ func runCommandRegistryImageQuery(ctx context.Context, args []string) (string, e
 }
 
 func parseCommandRegistryImageQuery(args []string) (*registryImageQueryParams, error) {
-	switch {
-	case len(args) == 1:
-		return parseRegistryImageTaggedReference(args[0])
-	case len(args) == 3 && (args[1] == "--tag" || args[1] == "-t"):
-		return buildRegistryImageQueryParams(args[0], args[2])
-	default:
-		return nil, errors.New(registryImageHelpText)
-	}
-}
-
-func parseRegistryImageTaggedReference(imageRef string) (*registryImageQueryParams, error) {
-	imageRef = strings.TrimSpace(imageRef)
-	if imageRef == "" || strings.Contains(imageRef, "@") {
+	if len(args) == 0 {
 		return nil, errors.New(registryImageHelpText)
 	}
 
-	lastSlash := strings.LastIndex(imageRef, "/")
-	lastColon := strings.LastIndex(imageRef, ":")
-	if lastColon <= lastSlash || lastColon == len(imageRef)-1 {
+	var repository string
+	var tag string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) || args[i+1] == "" {
+				return nil, errors.New(registryImageHelpText)
+			}
+			if repository != "" {
+				return nil, errors.New(registryImageHelpText)
+			}
+			repository = args[i+1]
+			i++
+		case "--tag":
+			if i+1 >= len(args) || args[i+1] == "" {
+				return nil, errors.New(registryImageHelpText)
+			}
+			if tag != "" {
+				return nil, errors.New(registryImageHelpText)
+			}
+			tag = args[i+1]
+			i++
+		default:
+			return nil, errors.New(registryImageHelpText)
+		}
+	}
+
+	if repository == "" || tag == "" {
 		return nil, errors.New(registryImageHelpText)
 	}
 
-	return buildRegistryImageQueryParams(imageRef[:lastColon], imageRef[lastColon+1:])
-}
-
-func buildRegistryImageQueryParams(repository, tag string) (*registryImageQueryParams, error) {
 	repository = strings.TrimSpace(repository)
 	tag = strings.TrimSpace(tag)
 	if repository == "" || tag == "" || strings.Contains(repository, "@") {

--- a/chatops-lark/pkg/events/handler/imagetag_trigger.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger.go
@@ -1,0 +1,229 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+)
+
+const (
+	imageTagWorkflowRunLookupTimeout = 30 * time.Second
+	imageTagWorkflowRunLookupTick    = 2 * time.Second
+)
+
+var errImageTagWorkflowRunNotFound = errors.New("dispatched workflow run not found yet")
+
+type imageTagTriggerParams struct {
+	Registry string
+	Tag      string
+}
+
+func runCommandImageTagTrigger(ctx context.Context, args []string) (string, error) {
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+		return imageTagHelpText, NewInformationError("Requested command usage")
+	}
+
+	params, err := parseCommandImageTagTrigger(args)
+	if err != nil {
+		return "", err
+	}
+
+	cfg, token, err := loadImageTagWorkflowConfig(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	gc := github.NewClient(nil).WithAuthToken(token)
+	return triggerImageTagWorkflow(ctx, params, gc, cfg)
+}
+
+func parseCommandImageTagTrigger(args []string) (*imageTagTriggerParams, error) {
+	if len(args) != 2 {
+		return nil, errors.New(imageTagHelpText)
+	}
+
+	registry := strings.TrimSpace(args[0])
+	tag := strings.TrimSpace(args[1])
+	if registry == "" || tag == "" {
+		return nil, errors.New(imageTagHelpText)
+	}
+
+	return &imageTagTriggerParams{
+		Registry: registry,
+		Tag:      tag,
+	}, nil
+}
+
+func triggerImageTagWorkflow(ctx context.Context, params *imageTagTriggerParams, gc *github.Client, cfg imageTagWorkflowConfig) (string, error) {
+	ref, err := resolveImageTagWorkflowRef(ctx, gc, cfg)
+	if err != nil {
+		return "", err
+	}
+
+	maxRunID, err := maxImageTagWorkflowRunID(ctx, gc, cfg)
+	if err != nil {
+		return "", err
+	}
+
+	dispatchedAt := time.Now().UTC()
+	_, err = gc.Actions.CreateWorkflowDispatchEventByFileName(ctx, cfg.Owner, cfg.Repo, cfg.Workflow, github.CreateWorkflowDispatchEventRequest{
+		Ref: ref,
+		Inputs: map[string]interface{}{
+			"registry_url": params.Registry,
+			"image_tag":    params.Tag,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("trigger image-tag workflow failed: %w", err)
+	}
+
+	run, err := waitForImageTagWorkflowRun(ctx, gc, cfg, ref, params.Registry, params.Tag, maxRunID, dispatchedAt)
+	if err != nil {
+		return "", err
+	}
+
+	runURL := buildImageTagRunURL(cfg, run.GetID(), run.GetHTMLURL())
+	return fmt.Sprintf("workflow run id is %d\npoll command: /image-tag poll %d\nrun: %s", run.GetID(), run.GetID(), runURL), nil
+}
+
+func resolveImageTagWorkflowRef(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig) (string, error) {
+	if cfg.Ref != "" {
+		return cfg.Ref, nil
+	}
+
+	repo, _, err := gc.Repositories.Get(ctx, cfg.Owner, cfg.Repo)
+	if err != nil {
+		return "", fmt.Errorf("resolve default branch for %s/%s failed: %w", cfg.Owner, cfg.Repo, err)
+	}
+
+	if repo.GetDefaultBranch() == "" {
+		return "", fmt.Errorf("repository %s/%s does not report a default branch", cfg.Owner, cfg.Repo)
+	}
+
+	return repo.GetDefaultBranch(), nil
+}
+
+func maxImageTagWorkflowRunID(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig) (int64, error) {
+	runs, _, err := gc.Actions.ListWorkflowRunsByFileName(ctx, cfg.Owner, cfg.Repo, cfg.Workflow, &github.ListWorkflowRunsOptions{
+		ListOptions: github.ListOptions{PerPage: 1},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("list existing workflow runs failed: %w", err)
+	}
+
+	if runs == nil || len(runs.WorkflowRuns) == 0 || runs.WorkflowRuns[0] == nil {
+		return 0, nil
+	}
+
+	return runs.WorkflowRuns[0].GetID(), nil
+}
+
+func waitForImageTagWorkflowRun(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, ref, registry, tag string, minRunID int64, dispatchedAt time.Time) (*github.WorkflowRun, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, imageTagWorkflowRunLookupTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(imageTagWorkflowRunLookupTick)
+	defer ticker.Stop()
+
+	for {
+		run, err := findDispatchedImageTagWorkflowRun(waitCtx, gc, cfg, ref, registry, tag, minRunID, dispatchedAt)
+		if err == nil {
+			return run, nil
+		}
+		if !errors.Is(err, errImageTagWorkflowRunNotFound) {
+			return nil, err
+		}
+
+		select {
+		case <-waitCtx.Done():
+			return nil, fmt.Errorf("workflow dispatched but run id was not visible yet; check %s", buildWorkflowPageURL(cfg))
+		case <-ticker.C:
+		}
+	}
+}
+
+func findDispatchedImageTagWorkflowRun(ctx context.Context, gc *github.Client, cfg imageTagWorkflowConfig, ref, registry, tag string, minRunID int64, dispatchedAt time.Time) (*github.WorkflowRun, error) {
+	runs, _, err := gc.Actions.ListWorkflowRunsByFileName(ctx, cfg.Owner, cfg.Repo, cfg.Workflow, &github.ListWorkflowRunsOptions{
+		Event:       "workflow_dispatch",
+		ListOptions: github.ListOptions{PerPage: 20},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list dispatched workflow runs failed: %w", err)
+	}
+	if runs == nil {
+		return nil, errImageTagWorkflowRunNotFound
+	}
+
+	expectedTitle := fmt.Sprintf("query-image-tag %s:%s", registry, tag)
+	run := selectImageTagWorkflowRun(runs.WorkflowRuns, ref, expectedTitle, minRunID, dispatchedAt)
+	if run == nil {
+		return nil, errImageTagWorkflowRunNotFound
+	}
+
+	return run, nil
+}
+
+func selectImageTagWorkflowRun(runs []*github.WorkflowRun, ref, expectedTitle string, minRunID int64, dispatchedAt time.Time) *github.WorkflowRun {
+	var fallback *github.WorkflowRun
+
+	for _, run := range runs {
+		if run == nil || run.GetID() <= minRunID {
+			continue
+		}
+		if run.GetEvent() != "workflow_dispatch" {
+			continue
+		}
+		if !imageTagWorkflowRunMatchesRef(run, ref) {
+			continue
+		}
+		if run.CreatedAt != nil && run.CreatedAt.Time.Before(dispatchedAt.Add(-1*time.Minute)) {
+			continue
+		}
+
+		if run.GetDisplayTitle() == expectedTitle {
+			return run
+		}
+
+		if fallback == nil || run.GetID() > fallback.GetID() {
+			fallback = run
+		}
+	}
+
+	return fallback
+}
+
+func imageTagWorkflowRunMatchesRef(run *github.WorkflowRun, ref string) bool {
+	if ref == "" {
+		return true
+	}
+
+	if run.GetHeadSHA() == ref || run.GetHeadBranch() == ref {
+		return true
+	}
+
+	if strings.HasPrefix(ref, "refs/heads/") && run.GetHeadBranch() == strings.TrimPrefix(ref, "refs/heads/") {
+		return true
+	}
+
+	if strings.HasPrefix(ref, "refs/tags/") && run.GetHeadBranch() == strings.TrimPrefix(ref, "refs/tags/") {
+		return true
+	}
+
+	return false
+}
+
+func buildWorkflowPageURL(cfg imageTagWorkflowConfig) string {
+	return fmt.Sprintf("https://github.com/%s/%s/actions/workflows/%s", cfg.Owner, cfg.Repo, cfg.Workflow)
+}
+
+func buildImageTagRunURL(cfg imageTagWorkflowConfig, runID int64, htmlURL string) string {
+	if htmlURL != "" {
+		return htmlURL
+	}
+
+	return fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", cfg.Owner, cfg.Repo, runID)
+}

--- a/chatops-lark/pkg/events/handler/imagetag_trigger.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 const (
 	imageTagWorkflowRunLookupTimeout = 30 * time.Second
 	imageTagWorkflowRunLookupTick    = 2 * time.Second
+	imageTagHTTPTimeout              = 30 * time.Second
 )
 
 var errImageTagWorkflowRunNotFound = errors.New("dispatched workflow run not found yet")
@@ -37,7 +39,7 @@ func runCommandImageTagTrigger(ctx context.Context, args []string) (string, erro
 		return "", err
 	}
 
-	gc := github.NewClient(nil).WithAuthToken(token)
+	gc, _ := newImageTagGitHubClient(token)
 	return triggerImageTagWorkflow(ctx, params, gc, cfg)
 }
 
@@ -70,12 +72,17 @@ func triggerImageTagWorkflow(ctx context.Context, params *imageTagTriggerParams,
 	}
 
 	dispatchedAt := time.Now().UTC()
+	inputs := map[string]interface{}{
+		"registry_url": params.Registry,
+		"image_tag":    params.Tag,
+	}
+	if credentialRef := resolveImageTagCredentialRef(params.Registry, cfg.CredentialRefs); credentialRef != "" {
+		inputs["credential_ref"] = credentialRef
+	}
+
 	_, err = gc.Actions.CreateWorkflowDispatchEventByFileName(ctx, cfg.Owner, cfg.Repo, cfg.Workflow, github.CreateWorkflowDispatchEventRequest{
-		Ref: ref,
-		Inputs: map[string]interface{}{
-			"registry_url": params.Registry,
-			"image_tag":    params.Tag,
-		},
+		Ref:    ref,
+		Inputs: inputs,
 	})
 	if err != nil {
 		return "", fmt.Errorf("trigger image-tag workflow failed: %w", err)
@@ -214,6 +221,47 @@ func imageTagWorkflowRunMatchesRef(run *github.WorkflowRun, ref string) bool {
 	}
 
 	return false
+}
+
+func newImageTagGitHubClient(token string) (*github.Client, *http.Client) {
+	httpClient := &http.Client{Timeout: imageTagHTTPTimeout}
+	return github.NewClient(httpClient).WithAuthToken(token), httpClient
+}
+
+func resolveImageTagCredentialRef(registry string, credentialRefs map[string]string) string {
+	registry = normalizeImageTagRegistryPrefix(registry)
+	if registry == "" {
+		return ""
+	}
+
+	var matchedPrefix string
+	var matchedCredentialRef string
+	for prefix, credentialRef := range credentialRefs {
+		normalizedPrefix := normalizeImageTagRegistryPrefix(prefix)
+		if normalizedPrefix == "" || credentialRef == "" {
+			continue
+		}
+		if !imageTagRegistryPrefixMatches(registry, normalizedPrefix) {
+			continue
+		}
+		if len(normalizedPrefix) > len(matchedPrefix) {
+			matchedPrefix = normalizedPrefix
+			matchedCredentialRef = credentialRef
+		}
+	}
+
+	return matchedCredentialRef
+}
+
+func normalizeImageTagRegistryPrefix(registry string) string {
+	registry = strings.TrimSpace(strings.ToLower(registry))
+	registry = strings.TrimPrefix(registry, "https://")
+	registry = strings.TrimPrefix(registry, "http://")
+	return strings.Trim(registry, "/")
+}
+
+func imageTagRegistryPrefixMatches(registry, prefix string) bool {
+	return registry == prefix || strings.HasPrefix(registry, prefix+"/")
 }
 
 func buildWorkflowPageURL(cfg imageTagWorkflowConfig) string {

--- a/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
@@ -1,0 +1,157 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+)
+
+func TestTriggerImageTagWorkflow(t *testing.T) {
+	var dispatchCalls int
+	var listCalls int
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/repos/PingCAP-QE/ci", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"default_branch": "main",
+		})
+	})
+
+	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/workflows/query-image-tag.yml/dispatches", func(w http.ResponseWriter, r *http.Request) {
+		dispatchCalls++
+
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode dispatch payload failed: %v", err)
+		}
+
+		if payload["ref"] != "main" {
+			t.Fatalf("expected dispatch ref main, got %#v", payload["ref"])
+		}
+
+		inputs, ok := payload["inputs"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected dispatch inputs map, got %#v", payload["inputs"])
+		}
+
+		if inputs["registry_url"] != "ghcr.io/pingcap/tidb" {
+			t.Fatalf("unexpected registry_url: %#v", inputs["registry_url"])
+		}
+		if inputs["image_tag"] != "nightly" {
+			t.Fatalf("unexpected image_tag: %#v", inputs["image_tag"])
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/workflows/query-image-tag.yml/runs", func(w http.ResponseWriter, r *http.Request) {
+		listCalls++
+
+		w.Header().Set("Content-Type", "application/json")
+		if dispatchCalls == 0 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 1,
+				"workflow_runs": []map[string]any{
+					{
+						"id":            100,
+						"event":         "workflow_dispatch",
+						"display_title": "query-image-tag ghcr.io/pingcap/tidb:previous",
+						"head_branch":   "main",
+						"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/100",
+						"created_at":    "2026-05-21T03:00:00Z",
+					},
+				},
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 2,
+			"workflow_runs": []map[string]any{
+				{
+					"id":            200,
+					"event":         "workflow_dispatch",
+					"display_title": "query-image-tag ghcr.io/pingcap/tidb:nightly",
+					"head_branch":   "main",
+					"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/200",
+					"created_at":    time.Now().UTC().Format(time.RFC3339),
+				},
+				{
+					"id":            100,
+					"event":         "workflow_dispatch",
+					"display_title": "query-image-tag ghcr.io/pingcap/tidb:previous",
+					"head_branch":   "main",
+					"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/100",
+					"created_at":    "2026-05-21T03:00:00Z",
+				},
+			},
+		})
+	})
+
+	gc := github.NewClient(nil)
+	gc.BaseURL, _ = url.Parse(server.URL + "/")
+
+	resp, err := triggerImageTagWorkflow(context.Background(), &imageTagTriggerParams{
+		Registry: "ghcr.io/pingcap/tidb",
+		Tag:      "nightly",
+	}, gc, imageTagWorkflowConfig{
+		Owner:    "PingCAP-QE",
+		Repo:     "ci",
+		Workflow: "query-image-tag.yml",
+	})
+	if err != nil {
+		t.Fatalf("triggerImageTagWorkflow() error = %v", err)
+	}
+
+	if dispatchCalls != 1 {
+		t.Fatalf("expected 1 dispatch call, got %d", dispatchCalls)
+	}
+	if listCalls < 2 {
+		t.Fatalf("expected at least 2 list calls, got %d", listCalls)
+	}
+	if !strings.Contains(resp, "/image-tag poll 200") {
+		t.Fatalf("expected response to contain poll command, got:\n%s", resp)
+	}
+	if !strings.Contains(resp, "actions/runs/200") {
+		t.Fatalf("expected response to contain run URL, got:\n%s", resp)
+	}
+}
+
+func TestSelectImageTagWorkflowRun(t *testing.T) {
+	dispatchedAt := time.Date(2026, 5, 21, 4, 0, 0, 0, time.UTC)
+	runs := []*github.WorkflowRun{
+		{
+			ID:           github.Int64(101),
+			Event:        github.String("workflow_dispatch"),
+			DisplayTitle: github.String("query-image-tag ghcr.io/pingcap/tidb:nightly"),
+			HeadBranch:   github.String("main"),
+			CreatedAt:    &github.Timestamp{Time: dispatchedAt.Add(10 * time.Second)},
+		},
+		{
+			ID:           github.Int64(102),
+			Event:        github.String("workflow_dispatch"),
+			DisplayTitle: github.String("query-image-tag ghcr.io/pingcap/tidb:other"),
+			HeadBranch:   github.String("main"),
+			CreatedAt:    &github.Timestamp{Time: dispatchedAt.Add(20 * time.Second)},
+		},
+	}
+
+	run := selectImageTagWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
+	if run == nil {
+		t.Fatal("expected a matching run")
+	}
+	if run.GetID() != 101 {
+		t.Fatalf("expected run 101, got %d", run.GetID())
+	}
+}

--- a/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
@@ -51,6 +51,9 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 		if inputs["image_tag"] != "nightly" {
 			t.Fatalf("unexpected image_tag: %#v", inputs["image_tag"])
 		}
+		if inputs["credential_ref"] != "query-image-ghcr" {
+			t.Fatalf("unexpected credential_ref: %#v", inputs["credential_ref"])
+		}
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -109,6 +112,9 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 		Owner:    "PingCAP-QE",
 		Repo:     "ci",
 		Workflow: "query-image-tag.yml",
+		CredentialRefs: map[string]string{
+			"ghcr.io/pingcap": "query-image-ghcr",
+		},
 	})
 	if err != nil {
 		t.Fatalf("triggerImageTagWorkflow() error = %v", err)
@@ -125,6 +131,24 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 	}
 	if !strings.Contains(resp, "actions/runs/200") {
 		t.Fatalf("expected response to contain run URL, got:\n%s", resp)
+	}
+}
+
+func TestResolveImageTagCredentialRef(t *testing.T) {
+	credentialRef := resolveImageTagCredentialRef("https://ghcr.io/pingcap/tidb", map[string]string{
+		"ghcr.io":                    "query-image-public",
+		"ghcr.io/pingcap":            "query-image-ghcr",
+		"ghcr.io/pingcap/tidb-tools": "query-image-tools",
+	})
+	if credentialRef != "query-image-ghcr" {
+		t.Fatalf("expected longest matching credential_ref, got %q", credentialRef)
+	}
+
+	credentialRef = resolveImageTagCredentialRef("registry.pingcap.net/private/tidb", map[string]string{
+		"ghcr.io/pingcap": "query-image-ghcr",
+	})
+	if credentialRef != "" {
+		t.Fatalf("expected empty credential_ref for unmatched registry, got %q", credentialRef)
 	}
 }
 

--- a/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
@@ -79,9 +79,42 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 			return
 		}
 
+		if listCalls == 2 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 2,
+				"workflow_runs": []map[string]any{
+					{
+						"id":            201,
+						"event":         "workflow_dispatch",
+						"display_title": "query-image-tag ghcr.io/pingcap/tidb:other",
+						"head_branch":   "main",
+						"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/201",
+						"created_at":    time.Now().UTC().Format(time.RFC3339),
+					},
+					{
+						"id":            100,
+						"event":         "workflow_dispatch",
+						"display_title": "query-image-tag ghcr.io/pingcap/tidb:previous",
+						"head_branch":   "main",
+						"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/100",
+						"created_at":    "2026-05-21T03:00:00Z",
+					},
+				},
+			})
+			return
+		}
+
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"total_count": 2,
+			"total_count": 3,
 			"workflow_runs": []map[string]any{
+				{
+					"id":            201,
+					"event":         "workflow_dispatch",
+					"display_title": "query-image-tag ghcr.io/pingcap/tidb:other",
+					"head_branch":   "main",
+					"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/201",
+					"created_at":    time.Now().UTC().Format(time.RFC3339),
+				},
 				{
 					"id":            200,
 					"event":         "workflow_dispatch",
@@ -123,8 +156,8 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 	if dispatchCalls != 1 {
 		t.Fatalf("expected 1 dispatch call, got %d", dispatchCalls)
 	}
-	if listCalls < 2 {
-		t.Fatalf("expected at least 2 list calls, got %d", listCalls)
+	if listCalls < 3 {
+		t.Fatalf("expected at least 3 list calls, got %d", listCalls)
 	}
 	if !strings.Contains(resp, "/image-tag poll 200") {
 		t.Fatalf("expected response to contain poll command, got:\n%s", resp)
@@ -177,5 +210,51 @@ func TestSelectImageTagWorkflowRun(t *testing.T) {
 	}
 	if run.GetID() != 101 {
 		t.Fatalf("expected run 101, got %d", run.GetID())
+	}
+}
+
+func TestSelectImageTagWorkflowRunRequiresExactTitle(t *testing.T) {
+	dispatchedAt := time.Date(2026, 5, 21, 4, 0, 0, 0, time.UTC)
+	runs := []*github.WorkflowRun{
+		{
+			ID:           github.Int64(101),
+			Event:        github.String("workflow_dispatch"),
+			DisplayTitle: github.String("query-image-tag ghcr.io/pingcap/tidb:other"),
+			HeadBranch:   github.String("main"),
+			CreatedAt:    &github.Timestamp{Time: dispatchedAt.Add(10 * time.Second)},
+		},
+	}
+
+	run := selectImageTagWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
+	if run != nil {
+		t.Fatalf("expected no run when only fallback candidates are visible, got %d", run.GetID())
+	}
+}
+
+func TestSelectImageTagWorkflowRunPrefersOldestExactMatch(t *testing.T) {
+	dispatchedAt := time.Date(2026, 5, 21, 4, 0, 0, 0, time.UTC)
+	runs := []*github.WorkflowRun{
+		{
+			ID:           github.Int64(102),
+			Event:        github.String("workflow_dispatch"),
+			DisplayTitle: github.String("query-image-tag ghcr.io/pingcap/tidb:nightly"),
+			HeadBranch:   github.String("main"),
+			CreatedAt:    &github.Timestamp{Time: dispatchedAt.Add(20 * time.Second)},
+		},
+		{
+			ID:           github.Int64(101),
+			Event:        github.String("workflow_dispatch"),
+			DisplayTitle: github.String("query-image-tag ghcr.io/pingcap/tidb:nightly"),
+			HeadBranch:   github.String("main"),
+			CreatedAt:    &github.Timestamp{Time: dispatchedAt.Add(10 * time.Second)},
+		},
+	}
+
+	run := selectImageTagWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
+	if run == nil {
+		t.Fatal("expected a matching run")
+	}
+	if run.GetID() != 101 {
+		t.Fatalf("expected the oldest exact match to win, got %d", run.GetID())
 	}
 }

--- a/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
@@ -21,14 +21,14 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	mux.HandleFunc("/repos/PingCAP-QE/ci", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"default_branch": "main",
 		})
 	})
 
-	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/workflows/query-image-tag.yml/dispatches", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/workflows/query-image-tag.yml/dispatches", func(w http.ResponseWriter, r *http.Request) {
 		dispatchCalls++
 
 		var payload map[string]any
@@ -58,7 +58,7 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	mux.HandleFunc("/repos/PingCAP-QE/ci/actions/workflows/query-image-tag.yml/runs", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/workflows/query-image-tag.yml/runs", func(w http.ResponseWriter, r *http.Request) {
 		listCalls++
 
 		w.Header().Set("Content-Type", "application/json")
@@ -71,7 +71,7 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 						"event":         "workflow_dispatch",
 						"display_title": "query-image-tag ghcr.io/pingcap/tidb:previous",
 						"head_branch":   "main",
-						"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/100",
+						"html_url":      "https://github.com/tidbcloud/docker-image-controller/actions/runs/100",
 						"created_at":    "2026-05-21T03:00:00Z",
 					},
 				},
@@ -88,7 +88,7 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 						"event":         "workflow_dispatch",
 						"display_title": "query-image-tag ghcr.io/pingcap/tidb:other",
 						"head_branch":   "main",
-						"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/201",
+						"html_url":      "https://github.com/tidbcloud/docker-image-controller/actions/runs/201",
 						"created_at":    time.Now().UTC().Format(time.RFC3339),
 					},
 					{
@@ -96,7 +96,7 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 						"event":         "workflow_dispatch",
 						"display_title": "query-image-tag ghcr.io/pingcap/tidb:previous",
 						"head_branch":   "main",
-						"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/100",
+						"html_url":      "https://github.com/tidbcloud/docker-image-controller/actions/runs/100",
 						"created_at":    "2026-05-21T03:00:00Z",
 					},
 				},
@@ -112,7 +112,7 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 					"event":         "workflow_dispatch",
 					"display_title": "query-image-tag ghcr.io/pingcap/tidb:other",
 					"head_branch":   "main",
-					"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/201",
+					"html_url":      "https://github.com/tidbcloud/docker-image-controller/actions/runs/201",
 					"created_at":    time.Now().UTC().Format(time.RFC3339),
 				},
 				{
@@ -120,7 +120,7 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 					"event":         "workflow_dispatch",
 					"display_title": "query-image-tag ghcr.io/pingcap/tidb:nightly",
 					"head_branch":   "main",
-					"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/200",
+					"html_url":      "https://github.com/tidbcloud/docker-image-controller/actions/runs/200",
 					"created_at":    time.Now().UTC().Format(time.RFC3339),
 				},
 				{
@@ -128,7 +128,7 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 					"event":         "workflow_dispatch",
 					"display_title": "query-image-tag ghcr.io/pingcap/tidb:previous",
 					"head_branch":   "main",
-					"html_url":      "https://github.com/PingCAP-QE/ci/actions/runs/100",
+					"html_url":      "https://github.com/tidbcloud/docker-image-controller/actions/runs/100",
 					"created_at":    "2026-05-21T03:00:00Z",
 				},
 			},
@@ -142,8 +142,8 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 		Registry: "ghcr.io/pingcap/tidb",
 		Tag:      "nightly",
 	}, gc, imageTagWorkflowConfig{
-		Owner:    "PingCAP-QE",
-		Repo:     "ci",
+		Owner:    "tidbcloud",
+		Repo:     "docker-image-controller",
 		Workflow: "query-image-tag.yml",
 		CredentialRefs: map[string]string{
 			"ghcr.io/pingcap": "query-image-ghcr",

--- a/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
@@ -292,20 +292,24 @@ func TestQueryRegistryImageReturnsRunningWhenWorkflowDoesNotFinishInline(t *test
 }
 
 func TestParseCommandRegistryImageQuery(t *testing.T) {
-	params, err := parseCommandRegistryImageQuery([]string{"ghcr.io/pingcap/tidb:nightly"})
+	params, err := parseCommandRegistryImageQuery([]string{"--repo", "ghcr.io/pingcap/tidb", "--tag", "nightly"})
 	if err != nil {
-		t.Fatalf("parseCommandRegistryImageQuery(tagged) error = %v", err)
+		t.Fatalf("parseCommandRegistryImageQuery(canonical) error = %v", err)
 	}
 	if params.Repository != "ghcr.io/pingcap/tidb" || params.Tag != "nightly" {
-		t.Fatalf("unexpected tagged params: %+v", params)
+		t.Fatalf("unexpected canonical params: %+v", params)
 	}
 
-	params, err = parseCommandRegistryImageQuery([]string{"ghcr.io/pingcap/tidb", "--tag", "nightly"})
+	params, err = parseCommandRegistryImageQuery([]string{"--tag", "nightly", "--repo", "ghcr.io/pingcap/tidb"})
 	if err != nil {
-		t.Fatalf("parseCommandRegistryImageQuery(--tag) error = %v", err)
+		t.Fatalf("parseCommandRegistryImageQuery(reordered) error = %v", err)
 	}
 	if params.Repository != "ghcr.io/pingcap/tidb" || params.Tag != "nightly" {
-		t.Fatalf("unexpected --tag params: %+v", params)
+		t.Fatalf("unexpected reordered params: %+v", params)
+	}
+
+	if _, err := parseCommandRegistryImageQuery([]string{"ghcr.io/pingcap/tidb:nightly"}); err == nil {
+		t.Fatal("expected tagged positional syntax to be rejected")
 	}
 }
 

--- a/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
@@ -13,9 +13,17 @@ import (
 	"github.com/google/go-github/v68/github"
 )
 
-func TestTriggerImageTagWorkflow(t *testing.T) {
+func TestQueryRegistryImageReturnsFoundResult(t *testing.T) {
 	var dispatchCalls int
 	var listCalls int
+	archiveBytes := buildImageTagArtifactArchive(t, `{
+  "image_ref": "ghcr.io/pingcap/tidb:nightly",
+  "created_at": "2026-05-21T04:00:00Z",
+  "digest": "sha256:abc123",
+  "multi_arch": true,
+  "platforms": ["linux/amd64", "linux/arm64"],
+  "labels": {"org.opencontainers.image.revision": "deadbeef"}
+}`)
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -135,22 +143,57 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 		})
 	})
 
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/200", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         200,
+			"path":       ".github/workflows/query-image-tag.yml",
+			"status":     "completed",
+			"conclusion": "success",
+			"html_url":   "https://github.com/tidbcloud/docker-image-controller/actions/runs/200",
+		})
+	})
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/200/artifacts", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"artifacts": []map[string]any{
+				{
+					"id":      456,
+					"name":    "result.json",
+					"expired": false,
+				},
+			},
+		})
+	})
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/artifacts/456/zip", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, server.URL+"/download/result.zip", http.StatusFound)
+	})
+
+	mux.HandleFunc("/download/result.zip", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(archiveBytes)
+	})
+
 	gc := github.NewClient(nil)
 	gc.BaseURL, _ = url.Parse(server.URL + "/")
 
-	resp, err := triggerImageTagWorkflow(context.Background(), &imageTagTriggerParams{
-		Registry: "ghcr.io/pingcap/tidb",
-		Tag:      "nightly",
-	}, gc, imageTagWorkflowConfig{
+	resp, err := queryRegistryImage(context.Background(), &registryImageQueryParams{
+		Repository: "ghcr.io/pingcap/tidb",
+		Tag:        "nightly",
+		ImageRef:   "ghcr.io/pingcap/tidb:nightly",
+	}, gc, registryImageWorkflowConfig{
 		Owner:    "tidbcloud",
 		Repo:     "docker-image-controller",
 		Workflow: "query-image-tag.yml",
 		CredentialRefs: map[string]string{
 			"ghcr.io/pingcap": "query-image-ghcr",
 		},
-	})
+	}, server.Client())
 	if err != nil {
-		t.Fatalf("triggerImageTagWorkflow() error = %v", err)
+		t.Fatalf("queryRegistryImage() error = %v", err)
 	}
 
 	if dispatchCalls != 1 {
@@ -159,16 +202,115 @@ func TestTriggerImageTagWorkflow(t *testing.T) {
 	if listCalls < 3 {
 		t.Fatalf("expected at least 3 list calls, got %d", listCalls)
 	}
-	if !strings.Contains(resp, "/image-tag poll 200") {
-		t.Fatalf("expected response to contain poll command, got:\n%s", resp)
-	}
-	if !strings.Contains(resp, "actions/runs/200") {
-		t.Fatalf("expected response to contain run URL, got:\n%s", resp)
+
+	for _, fragment := range []string{
+		"FOUND",
+		"ghcr.io/pingcap/tidb:nightly",
+		"Image Created At (OCI)",
+		"sha256:abc123",
+		"linux/amd64, linux/arm64",
+	} {
+		if !strings.Contains(resp, fragment) {
+			t.Fatalf("expected response to contain %q, got:\n%s", fragment, resp)
+		}
 	}
 }
 
-func TestResolveImageTagCredentialRef(t *testing.T) {
-	credentialRef := resolveImageTagCredentialRef("https://ghcr.io/pingcap/tidb", map[string]string{
+func TestQueryRegistryImageReturnsRunningWhenWorkflowDoesNotFinishInline(t *testing.T) {
+	oldInlineWaitTimeout := registryImageInlineWaitTimeout
+	oldRunLookupTick := registryImageWorkflowRunLookupTick
+	oldStatusPollTick := registryImageWorkflowStatusPollTick
+	registryImageInlineWaitTimeout = 20 * time.Millisecond
+	registryImageWorkflowRunLookupTick = 5 * time.Millisecond
+	registryImageWorkflowStatusPollTick = 5 * time.Millisecond
+	defer func() {
+		registryImageInlineWaitTimeout = oldInlineWaitTimeout
+		registryImageWorkflowRunLookupTick = oldRunLookupTick
+		registryImageWorkflowStatusPollTick = oldStatusPollTick
+	}()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"default_branch": "main",
+		})
+	})
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/workflows/query-image-tag.yml/dispatches", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/workflows/query-image-tag.yml/runs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"workflow_runs": []map[string]any{
+				{
+					"id":            200,
+					"event":         "workflow_dispatch",
+					"display_title": "query-image-tag ghcr.io/pingcap/tidb:nightly",
+					"head_branch":   "main",
+					"html_url":      "https://github.com/tidbcloud/docker-image-controller/actions/runs/200",
+					"created_at":    time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		})
+	})
+
+	mux.HandleFunc("/repos/tidbcloud/docker-image-controller/actions/runs/200", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       200,
+			"path":     ".github/workflows/query-image-tag.yml",
+			"status":   "in_progress",
+			"html_url": "https://github.com/tidbcloud/docker-image-controller/actions/runs/200",
+		})
+	})
+
+	gc := github.NewClient(nil)
+	gc.BaseURL, _ = url.Parse(server.URL + "/")
+
+	resp, err := queryRegistryImage(context.Background(), &registryImageQueryParams{
+		Repository: "ghcr.io/pingcap/tidb",
+		Tag:        "nightly",
+		ImageRef:   "ghcr.io/pingcap/tidb:nightly",
+	}, gc, registryImageWorkflowConfig{
+		Owner:    "tidbcloud",
+		Repo:     "docker-image-controller",
+		Workflow: "query-image-tag.yml",
+	}, server.Client())
+	if err != nil {
+		t.Fatalf("queryRegistryImage() error = %v", err)
+	}
+	if !strings.Contains(resp, "RUNNING") {
+		t.Fatalf("expected response to contain RUNNING, got:\n%s", resp)
+	}
+}
+
+func TestParseCommandRegistryImageQuery(t *testing.T) {
+	params, err := parseCommandRegistryImageQuery([]string{"ghcr.io/pingcap/tidb:nightly"})
+	if err != nil {
+		t.Fatalf("parseCommandRegistryImageQuery(tagged) error = %v", err)
+	}
+	if params.Repository != "ghcr.io/pingcap/tidb" || params.Tag != "nightly" {
+		t.Fatalf("unexpected tagged params: %+v", params)
+	}
+
+	params, err = parseCommandRegistryImageQuery([]string{"ghcr.io/pingcap/tidb", "--tag", "nightly"})
+	if err != nil {
+		t.Fatalf("parseCommandRegistryImageQuery(--tag) error = %v", err)
+	}
+	if params.Repository != "ghcr.io/pingcap/tidb" || params.Tag != "nightly" {
+		t.Fatalf("unexpected --tag params: %+v", params)
+	}
+}
+
+func TestResolveRegistryImageCredentialRef(t *testing.T) {
+	credentialRef := resolveRegistryImageCredentialRef("https://ghcr.io/pingcap/tidb", map[string]string{
 		"ghcr.io":                    "query-image-public",
 		"ghcr.io/pingcap":            "query-image-ghcr",
 		"ghcr.io/pingcap/tidb-tools": "query-image-tools",
@@ -177,7 +319,7 @@ func TestResolveImageTagCredentialRef(t *testing.T) {
 		t.Fatalf("expected longest matching credential_ref, got %q", credentialRef)
 	}
 
-	credentialRef = resolveImageTagCredentialRef("registry.pingcap.net/private/tidb", map[string]string{
+	credentialRef = resolveRegistryImageCredentialRef("registry.pingcap.net/private/tidb", map[string]string{
 		"ghcr.io/pingcap": "query-image-ghcr",
 	})
 	if credentialRef != "" {
@@ -185,7 +327,7 @@ func TestResolveImageTagCredentialRef(t *testing.T) {
 	}
 }
 
-func TestSelectImageTagWorkflowRun(t *testing.T) {
+func TestSelectRegistryImageWorkflowRun(t *testing.T) {
 	dispatchedAt := time.Date(2026, 5, 21, 4, 0, 0, 0, time.UTC)
 	runs := []*github.WorkflowRun{
 		{
@@ -204,7 +346,7 @@ func TestSelectImageTagWorkflowRun(t *testing.T) {
 		},
 	}
 
-	run := selectImageTagWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
+	run := selectRegistryImageWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
 	if run == nil {
 		t.Fatal("expected a matching run")
 	}
@@ -213,7 +355,7 @@ func TestSelectImageTagWorkflowRun(t *testing.T) {
 	}
 }
 
-func TestSelectImageTagWorkflowRunRequiresExactTitle(t *testing.T) {
+func TestSelectRegistryImageWorkflowRunRequiresExactTitle(t *testing.T) {
 	dispatchedAt := time.Date(2026, 5, 21, 4, 0, 0, 0, time.UTC)
 	runs := []*github.WorkflowRun{
 		{
@@ -225,13 +367,13 @@ func TestSelectImageTagWorkflowRunRequiresExactTitle(t *testing.T) {
 		},
 	}
 
-	run := selectImageTagWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
+	run := selectRegistryImageWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
 	if run != nil {
 		t.Fatalf("expected no run when only fallback candidates are visible, got %d", run.GetID())
 	}
 }
 
-func TestSelectImageTagWorkflowRunPrefersOldestExactMatch(t *testing.T) {
+func TestSelectRegistryImageWorkflowRunPrefersOldestExactMatch(t *testing.T) {
 	dispatchedAt := time.Date(2026, 5, 21, 4, 0, 0, 0, time.UTC)
 	runs := []*github.WorkflowRun{
 		{
@@ -250,7 +392,7 @@ func TestSelectImageTagWorkflowRunPrefersOldestExactMatch(t *testing.T) {
 		},
 	}
 
-	run := selectImageTagWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
+	run := selectRegistryImageWorkflowRun(runs, "main", "query-image-tag ghcr.io/pingcap/tidb:nightly", 100, dispatchedAt)
 	if run == nil {
 		t.Fatal("expected a matching run")
 	}

--- a/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
@@ -59,8 +59,8 @@ func TestQueryRegistryImageReturnsFoundResult(t *testing.T) {
 		if inputs["image_tag"] != "nightly" {
 			t.Fatalf("unexpected image_tag: %#v", inputs["image_tag"])
 		}
-		if inputs["credential_ref"] != "query-image-ghcr" {
-			t.Fatalf("unexpected credential_ref: %#v", inputs["credential_ref"])
+		if _, ok := inputs["credential_ref"]; ok {
+			t.Fatalf("credential_ref should not be provided, got %#v", inputs["credential_ref"])
 		}
 
 		w.WriteHeader(http.StatusNoContent)
@@ -188,9 +188,6 @@ func TestQueryRegistryImageReturnsFoundResult(t *testing.T) {
 		Owner:    "tidbcloud",
 		Repo:     "docker-image-controller",
 		Workflow: "query-image-tag.yml",
-		CredentialRefs: map[string]string{
-			"ghcr.io/pingcap": "query-image-ghcr",
-		},
 	}, server.Client())
 	if err != nil {
 		t.Fatalf("queryRegistryImage() error = %v", err)
@@ -310,24 +307,6 @@ func TestParseCommandRegistryImageQuery(t *testing.T) {
 
 	if _, err := parseCommandRegistryImageQuery([]string{"ghcr.io/pingcap/tidb:nightly"}); err == nil {
 		t.Fatal("expected tagged positional syntax to be rejected")
-	}
-}
-
-func TestResolveRegistryImageCredentialRef(t *testing.T) {
-	credentialRef := resolveRegistryImageCredentialRef("https://ghcr.io/pingcap/tidb", map[string]string{
-		"ghcr.io":                    "query-image-public",
-		"ghcr.io/pingcap":            "query-image-ghcr",
-		"ghcr.io/pingcap/tidb-tools": "query-image-tools",
-	})
-	if credentialRef != "query-image-ghcr" {
-		t.Fatalf("expected longest matching credential_ref, got %q", credentialRef)
-	}
-
-	credentialRef = resolveRegistryImageCredentialRef("registry.pingcap.net/private/tidb", map[string]string{
-		"ghcr.io/pingcap": "query-image-ghcr",
-	})
-	if credentialRef != "" {
-		t.Fatalf("expected empty credential_ref for unmatched registry, got %q", credentialRef)
 	}
 }
 

--- a/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
+++ b/chatops-lark/pkg/events/handler/imagetag_trigger_test.go
@@ -201,7 +201,8 @@ func TestQueryRegistryImageReturnsFoundResult(t *testing.T) {
 	}
 
 	for _, fragment := range []string{
-		"FOUND",
+		"✅ Cloud Image Query",
+		"Result:** Found",
 		"ghcr.io/pingcap/tidb:nightly",
 		"Image Created At (OCI)",
 		"sha256:abc123",
@@ -283,8 +284,10 @@ func TestQueryRegistryImageReturnsRunningWhenWorkflowDoesNotFinishInline(t *test
 	if err != nil {
 		t.Fatalf("queryRegistryImage() error = %v", err)
 	}
-	if !strings.Contains(resp, "RUNNING") {
-		t.Fatalf("expected response to contain RUNNING, got:\n%s", resp)
+	for _, fragment := range []string{"🤷 Cloud Image Query", "Result:** Running"} {
+		if !strings.Contains(resp, fragment) {
+			t.Fatalf("expected response to contain %q, got:\n%s", fragment, resp)
+		}
 	}
 }
 

--- a/chatops-lark/pkg/events/handler/root.go
+++ b/chatops-lark/pkg/events/handler/root.go
@@ -120,11 +120,17 @@ func (r *rootHandler) Handle(ctx context.Context, event *larkim.P2MessageReceive
 			Any("args", command.Args).
 			Str("sender", *event.Event.Sender.SenderId.OpenId).
 			Logger()
+		replyInThread := (chatType == "group")
+		responseMeta := &commandResponseMeta{Status: StatusSuccess}
+		handlerCtx := context.WithoutCancel(ctx)
+		handlerCtx = withCommandReply(handlerCtx, func(status, message string) error {
+			return r.sendResponse(messageID, replyInThread, status, message)
+		})
+		handlerCtx = withCommandResponseMeta(handlerCtx, responseMeta)
 
 		asyncLog.Info().Msg("Processing command")
-		message, err := r.handleCommand(ctx, command)
-		replyInThread := (chatType == "group")
-		r.feedbackCommandResult(messageID, replyInThread, message, err, asyncLog)
+		message, err := r.handleCommand(handlerCtx, command)
+		r.feedbackCommandResult(messageID, replyInThread, message, err, responseMeta.Status, asyncLog)
 	}()
 
 	return nil
@@ -193,12 +199,12 @@ func (r *rootHandler) initialize() error {
 			SetupContext: setupCtxDevbuild,
 		}
 	}
-	if r.Config.ImageTag != nil {
-		r.commandRegistry["/image-tag"] = CommandConfig{
-			Description:  "Query image tag metadata through GitHub Actions",
-			Handler:      runCommandImageTag,
-			Audit:        r.Config.ImageTag.Audit,
-			SetupContext: setupCtxImageTag,
+	if registryImageCfg := r.Config.EffectiveRegistryImage(); registryImageCfg != nil {
+		r.commandRegistry["/registry-image"] = CommandConfig{
+			Description:  "Query cloud registry image metadata through GitHub Actions",
+			Handler:      runCommandRegistryImage,
+			Audit:        registryImageCfg.Audit,
+			SetupContext: setupCtxRegistryImage,
 		}
 	}
 	if r.Config.Ask != nil {
@@ -229,10 +235,13 @@ func (r *rootHandler) initialize() error {
 	return nil
 }
 
-func (r *rootHandler) feedbackCommandResult(messageID string, replyInThread bool, message string, err error, asyncLog zerolog.Logger) {
+func (r *rootHandler) feedbackCommandResult(messageID string, replyInThread bool, message string, err error, successStatus string, asyncLog zerolog.Logger) {
 	if err == nil {
 		asyncLog.Info().Msg("Command processed successfully")
-		r.sendResponse(messageID, replyInThread, StatusSuccess, message)
+		if successStatus == "" {
+			successStatus = StatusSuccess
+		}
+		r.sendResponse(messageID, replyInThread, successStatus, message)
 		return
 	}
 

--- a/chatops-lark/pkg/events/handler/root.go
+++ b/chatops-lark/pkg/events/handler/root.go
@@ -193,6 +193,14 @@ func (r *rootHandler) initialize() error {
 			SetupContext: setupCtxDevbuild,
 		}
 	}
+	if r.Config.ImageTag != nil {
+		r.commandRegistry["/image-tag"] = CommandConfig{
+			Description:  "Query image tag metadata through GitHub Actions",
+			Handler:      runCommandImageTag,
+			Audit:        r.Config.ImageTag.Audit,
+			SetupContext: setupCtxImageTag,
+		}
+	}
 	if r.Config.Ask != nil {
 		r.commandRegistry["/ask"] = CommandConfig{
 			Description:  "Ask a question with LLM",

--- a/chatops-lark/pkg/events/handler/root.go
+++ b/chatops-lark/pkg/events/handler/root.go
@@ -199,7 +199,7 @@ func (r *rootHandler) initialize() error {
 			SetupContext: setupCtxDevbuild,
 		}
 	}
-	if registryImageCfg := r.Config.EffectiveRegistryImage(); registryImageCfg != nil {
+	if registryImageCfg := r.Config.RegistryImage; registryImageCfg != nil {
 		r.commandRegistry["/cloud-image"] = CommandConfig{
 			Description:  "Query image metadata from cloud registries through GitHub Actions",
 			Handler:      runCommandRegistryImage,

--- a/chatops-lark/pkg/events/handler/root.go
+++ b/chatops-lark/pkg/events/handler/root.go
@@ -200,8 +200,8 @@ func (r *rootHandler) initialize() error {
 		}
 	}
 	if registryImageCfg := r.Config.EffectiveRegistryImage(); registryImageCfg != nil {
-		r.commandRegistry["/registry-image"] = CommandConfig{
-			Description:  "Query cloud registry image metadata through GitHub Actions",
+		r.commandRegistry["/cloud-image"] = CommandConfig{
+			Description:  "Query image metadata from cloud registries through GitHub Actions",
 			Handler:      runCommandRegistryImage,
 			Audit:        registryImageCfg.Audit,
 			SetupContext: setupCtxRegistryImage,

--- a/chatops-lark/pkg/response/reply.go
+++ b/chatops-lark/pkg/response/reply.go
@@ -3,7 +3,7 @@ package response
 import (
 	"bytes"
 	"encoding/json"
-	"html/template"
+	"text/template"
 
 	sprig "github.com/Masterminds/sprig/v3"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"

--- a/chatops-lark/pkg/response/reply_test.go
+++ b/chatops-lark/pkg/response/reply_test.go
@@ -1,0 +1,22 @@
+package response
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewLarkCardWithGoTemplatePreservesQuotesInMarkdown(t *testing.T) {
+	card, err := newLarkCardWithGoTemplate(&info{
+		Status:  "success",
+		Message: "version: \"9\"",
+	})
+	if err != nil {
+		t.Fatalf("newLarkCardWithGoTemplate() error = %v", err)
+	}
+	if strings.Contains(card, "&#34;") {
+		t.Fatalf("expected rendered card to preserve quotes, got: %s", card)
+	}
+	if !strings.Contains(card, "\\\"9\\\"") {
+		t.Fatalf("expected rendered card JSON to contain quoted value, got: %s", card)
+	}
+}


### PR DESCRIPTION
## Summary
- add `/image-tag` config and command registration behind `image_tag` config gating
- dispatch the `query-image-tag.yml` GitHub Actions workflow, discover the run id, and poll/download `result.json`
- render Lark replies from a dedicated poll template and cover the trigger/poll flow with handler tests

## Testing
- `docker run --rm -v /Users/pingcap/multica_workspaces/653ba637-3f90-422e-b29d-e6d5d36993db/ac894655/workdir/ee-apps/chatops-lark:/workspace -w /workspace golang:1.23 go test ./...`
