### PR TITLE
fix(dashboard): revise Jenkins error taxonomy

### DIFF
--- a/ci-dashboard/src/ci_dashboard/jobs/analyze_errors.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/analyze_errors.py
@@ -10,12 +10,17 @@ from sqlalchemy.engine import Engine
 from ci_dashboard.common.config import Settings
 from ci_dashboard.common.models import AnalyzeErrorsSummary, ErrorClassification, ReviewErrorSummary
 from ci_dashboard.jobs.gcs_client import GCSReader, parse_gcs_uri
+from ci_dashboard.jobs.jenkins_client import JenkinsClient
 from ci_dashboard.jobs.llm_classifier import LLMClassifier, build_llm_classifier
 from ci_dashboard.jobs.rule_engine import RuleEngine
 
 LOG = logging.getLogger(__name__)
 
 FAILURE_LIKE_STATES = ("failure", "error", "timeout", "timed_out", "aborted")
+REMOTING_RULE_SOURCES = {
+    "rule:infra_jenkins_agent_offline",
+    "rule:infra_jenkins_remoting",
+}
 
 FETCH_CANDIDATE_BUILDS_SCAN = text(
     """
@@ -193,6 +198,7 @@ def run_analyze_errors(
     build_id: int | None = None,
     force: bool = False,
     reader: GCSReader | Any | None = None,
+    jenkins_fetcher: JenkinsClient | Any | None = None,
     rule_engine: RuleEngine | None = None,
     llm_classifier: LLMClassifier | None = None,
 ) -> AnalyzeErrorsSummary:
@@ -235,47 +241,54 @@ def run_analyze_errors(
         allowed_classifications=resolved_rule_engine.allowed_classifications,
     )
     resolved_reader = reader or GCSReader()
+    resolved_jenkins_fetcher = jenkins_fetcher or JenkinsClient(settings.jenkins)
+    owns_jenkins_fetcher = jenkins_fetcher is None and hasattr(resolved_jenkins_fetcher, "close")
 
-    for build in candidates:
-        summary.builds_scanned += 1
-        enriched_build = _enrich_build_evidence(build)
-        if not force and not _should_refresh_existing_machine_classification(enriched_build):
-            summary.builds_skipped += 1
-            continue
-        try:
-            classification_source, classification = _classify_single_build(
-                enriched_build,
-                reader=resolved_reader,
-                rule_engine=resolved_rule_engine,
-                llm_classifier=resolved_classifier,
-            )
-        except Exception:
-            summary.builds_failed += 1
-            LOG.exception("failed to analyze archived Jenkins error log", extra={"build_id": build["id"]})
-            continue
+    try:
+        for build in candidates:
+            summary.builds_scanned += 1
+            enriched_build = _enrich_build_evidence(build)
+            if not force and not _should_refresh_existing_machine_classification(enriched_build):
+                summary.builds_skipped += 1
+                continue
+            try:
+                classification_source, classification = _classify_single_build(
+                    enriched_build,
+                    reader=resolved_reader,
+                    jenkins_fetcher=resolved_jenkins_fetcher,
+                    rule_engine=resolved_rule_engine,
+                    llm_classifier=resolved_classifier,
+                )
+            except Exception:
+                summary.builds_failed += 1
+                LOG.exception("failed to analyze archived Jenkins error log", extra={"build_id": build["id"]})
+                continue
 
-        if classification_source == "rule" and classification is not None:
-            pending_updates.append(
-                {
-                    "id": int(build["id"]),
-                    "error_l1_category": classification.l1_category,
-                    "error_l2_subcategory": classification.l2_subcategory,
-                }
-            )
-            summary.builds_classified += 1
-            summary.builds_rule_classified += 1
-        elif classification_source == "llm" and classification is not None:
-            pending_updates.append(
-                {
-                    "id": int(build["id"]),
-                    "error_l1_category": classification.l1_category,
-                    "error_l2_subcategory": classification.l2_subcategory,
-                }
-            )
-            summary.builds_classified += 1
-            summary.builds_llm_classified += 1
-        else:
-            summary.builds_skipped += 1
+            if classification_source == "rule" and classification is not None:
+                pending_updates.append(
+                    {
+                        "id": int(build["id"]),
+                        "error_l1_category": classification.l1_category,
+                        "error_l2_subcategory": classification.l2_subcategory,
+                    }
+                )
+                summary.builds_classified += 1
+                summary.builds_rule_classified += 1
+            elif classification_source == "llm" and classification is not None:
+                pending_updates.append(
+                    {
+                        "id": int(build["id"]),
+                        "error_l1_category": classification.l1_category,
+                        "error_l2_subcategory": classification.l2_subcategory,
+                    }
+                )
+                summary.builds_classified += 1
+                summary.builds_llm_classified += 1
+            else:
+                summary.builds_skipped += 1
+    finally:
+        if owns_jenkins_fetcher:
+            resolved_jenkins_fetcher.close()
 
     if pending_updates:
         with engine.begin() as connection:
@@ -310,6 +323,7 @@ def _classify_single_build(
     build: Mapping[str, Any],
     *,
     reader: Any,
+    jenkins_fetcher: Any,
     rule_engine: RuleEngine,
     llm_classifier: LLMClassifier,
 ) -> tuple[str, ErrorClassification | None]:
@@ -324,6 +338,17 @@ def _classify_single_build(
 
     log_text = reader.download_text(bucket=object_ref.bucket, object_name=object_ref.object_name)
     classification = rule_engine.classify(log_text=log_text, build=build)
+    if classification is not None and classification.source in REMOTING_RULE_SOURCES:
+        combined_log = _append_live_signal_excerpts(
+            log_text,
+            build=build,
+            jenkins_fetcher=jenkins_fetcher,
+        )
+        if combined_log != log_text:
+            reclassified = rule_engine.classify(log_text=combined_log, build=build)
+            if reclassified is not None:
+                classification = reclassified
+            log_text = combined_log
     if classification is None:
         classification = llm_classifier.classify(log_text=log_text, build=build)
         classification_source = "llm"
@@ -399,3 +424,23 @@ def _normalize_review_category(value: str) -> str:
     if not normalized:
         raise ValueError("review category values must be non-empty")
     return normalized
+
+
+def _append_live_signal_excerpts(
+    log_text: str,
+    *,
+    build: Mapping[str, Any],
+    jenkins_fetcher: Any,
+) -> str:
+    fetch_console_signal_excerpts = getattr(jenkins_fetcher, "fetch_console_signal_excerpts", None)
+    if not callable(fetch_console_signal_excerpts):
+        return log_text
+
+    build_url = str(build.get("url") or "").strip()
+    if not build_url:
+        return log_text
+
+    signal_excerpts = fetch_console_signal_excerpts(build_url)
+    if not str(signal_excerpts or "").strip():
+        return log_text
+    return f"{log_text.rstrip()}\n{signal_excerpts}"

--- a/ci-dashboard/src/ci_dashboard/jobs/archive_error_logs.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/archive_error_logs.py
@@ -11,7 +11,7 @@ from sqlalchemy.engine import Engine
 from ci_dashboard.common.config import Settings
 from ci_dashboard.common.models import ArchiveErrorLogsSummary
 from ci_dashboard.jobs.gcs_client import GCSUploader, parse_gcs_uri
-from ci_dashboard.jobs.jenkins_client import JenkinsClient
+from ci_dashboard.jobs.jenkins_client import JenkinsClient, extract_console_signal_excerpts
 
 LOG = logging.getLogger(__name__)
 
@@ -59,6 +59,12 @@ VAR_LIB_JENKINS_USER_RE = re.compile(r"(?i)/var/lib/jenkins/workspace/[^/\s]+")
 TOKEN_QUERY_RE = re.compile(r"(?i)([?&](?:token|access_token|api_key|apikey)=)([^&\s]+)")
 INTERNAL_IP_RE = re.compile(
     r"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b"
+)
+REMOTING_SYMPTOM_RE = re.compile(
+    r"hudson\.remoting|channel is already closed|agent .* went offline|Timeout waiting for agent to come back|"
+    r"AgentOfflineException: Unable to create live FilePath|was marked offline: Connection was broken|"
+    r"cannot contact .*: java\.io\.IOException|closedchannelexception",
+    flags=re.IGNORECASE,
 )
 
 
@@ -222,6 +228,11 @@ def _archive_single_build(
         build_url=build_url,
         fetcher=fetcher,
     )
+    raw_log = _append_console_signal_excerpts(
+        raw_log,
+        build_url=build_url,
+        fetcher=fetcher,
+    )
     redacted_tail = redact_console_log(raw_log)
     bucket, object_name = build_archive_object_ref(build, settings, force=force)
     log_gcs_uri = uploader.upload_text(
@@ -249,3 +260,19 @@ def _append_failed_node_logs(raw_tail: str, *, build_url: str, fetcher: Any) -> 
     if not str(failed_node_logs or "").strip():
         return raw_tail
     return f"{raw_tail.rstrip()}\n{failed_node_logs}"
+
+
+def _append_console_signal_excerpts(raw_log: str, *, build_url: str, fetcher: Any) -> str:
+    if not REMOTING_SYMPTOM_RE.search(raw_log):
+        return raw_log
+    if extract_console_signal_excerpts(raw_log).strip():
+        return raw_log
+
+    fetch_console_signal_excerpts = getattr(fetcher, "fetch_console_signal_excerpts", None)
+    if not callable(fetch_console_signal_excerpts):
+        return raw_log
+
+    signal_excerpts = fetch_console_signal_excerpts(build_url)
+    if not str(signal_excerpts or "").strip():
+        return raw_log
+    return f"{raw_log.rstrip()}\n{signal_excerpts}"

--- a/ci-dashboard/src/ci_dashboard/jobs/error_classification_guidance.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_classification_guidance.py
@@ -24,7 +24,7 @@ ERROR_CLASSIFICATION_GUIDANCE = """Decision guidance:
 - BR integration matrix TEST_GROUP failures are IT/TEST_FAILURE, even if the failed case logs local 127.0.0.1 PD/TiKV connection-refused or timeout symptoms.
 - Kubelet final pod failures such as `TerminationByKubelet` with `imminent node shutdown` are INFRA/K8S and should beat later Jenkins remoting or agent-offline noise.
 - Jenkins Groovy/runtime/cache/websocket/controller persistence errors are INFRA subcategories, not product BUILD failures.
-- Agent disconnect/remoting failures such as `Timeout waiting for agent to come back`, `AgentOfflineException`, or `was marked offline: Connection was broken` are INFRA/JENKINS when there is no earlier stronger root cause.
+- Agent disconnect/remoting failures such as `Timeout waiting for agent to come back`, `AgentOfflineException`, or `was marked offline: Connection was broken` are INFRA/JENKINS_AGENT_OFFLINE when there is no earlier stronger root cause.
 - Disk-full evidence such as "No space left on device" is INFRA/DISK_FULL even when it appears while Jenkins saves pipeline state.
 - Prow superseded aborts are OTHERS/SUPERSEDED_BY_NEWER_BUILD when Prow marks the job aborted because a newer same-PR same-job version is running, or when an admin-abort log has same-PR same-job newer different-SHA build evidence; this overrides downstream noise.
 - Admin aborts are OTHERS/ABORT_BY_ADMIN and override downstream matrix, network, or interrupted-process symptoms.

--- a/ci-dashboard/src/ci_dashboard/jobs/error_classification_guidance.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_classification_guidance.py
@@ -13,6 +13,8 @@ ERROR_CLASSIFICATION_GUIDANCE = """Decision guidance:
 - Go compiler errors such as "undefined:" or "has no field or method" are BUILD/COMPILE, even when they appear inside Bazel or wrapper output.
 - Bazel/unit summaries such as "FAILED TO BUILD", "fails to build", or "0 failing out of 0 test cases" point to an upstream build problem, not a UT test failure by themselves.
 - Failpoint rewrite/parser errors such as "Rewrite error ... expected declaration/statement, found '<<'" are BUILD/COMPILE.
+- Raw merge-conflict markers that leak into source after pre-merge, such as `malformed module path "<<<<<<<"` or `syntax error: unexpected <<`, are OTHERS/CODE_CONFLICT rather than BUILD/COMPILE.
+- Missing internal TiDB package imports such as `no required module provides package github.com/pingcap/tidb/...` are BUILD/COMPILE, while generic module hygiene failures such as `go mod tidy` or strict-deps drift stay BUILD/DEPENDENCY.
 - Dependency hygiene failures such as "updates to go.mod needed", "missing strict dependencies", "No dependencies were provided", or imports/deps mismatch are BUILD/DEPENDENCY.
 - Nogo or build-time static-analysis validation failures such as "Validating nogo output" or "Running nogo on //... failed" are BUILD/FORMAT_CHECK, including ghpr_build, ghpr_check2, pull_build_next_gen, and pull_unit_test jobs; do not leave them in BUILD/PIPELINE_CONFIG or move them to BUILD/COMPILE.
 - Repository/archive download failures such as "Error downloading", "Error computing the main repository mapping", or 429/502/503 while fetching Bazel/GitHub dependencies are INFRA/EXTERNAL_DEP even if matrix branches later show test interruptions.

--- a/ci-dashboard/src/ci_dashboard/jobs/error_classification_guidance.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_classification_guidance.py
@@ -15,7 +15,8 @@ ERROR_CLASSIFICATION_GUIDANCE = """Decision guidance:
 - Failpoint rewrite/parser errors such as "Rewrite error ... expected declaration/statement, found '<<'" are BUILD/COMPILE.
 - Raw merge-conflict markers that leak into source after pre-merge, such as `malformed module path "<<<<<<<"` or `syntax error: unexpected <<`, are OTHERS/CODE_CONFLICT rather than BUILD/COMPILE.
 - Missing internal TiDB package imports such as `no required module provides package github.com/pingcap/tidb/...` are BUILD/COMPILE, while generic module hygiene failures such as `go mod tidy` or strict-deps drift stay BUILD/DEPENDENCY.
-- Dependency hygiene failures such as "updates to go.mod needed", "missing strict dependencies", "No dependencies were provided", or imports/deps mismatch are BUILD/DEPENDENCY.
+- Dependency hygiene failures such as "updates to go.mod needed", "missing strict dependencies", "No dependencies were provided", imports/deps mismatch, or `invalid version: unknown revision` are BUILD/DEPENDENCY.
+- Support-repo checkout failures that log `tidb-test=<40-hex-sha>` and then `Couldn't find any revision to build` are BUILD/PIPELINE_CONFIG; treat them as CI checkout/refspec logic failures rather than INFRA/GIT noise.
 - Nogo or build-time static-analysis validation failures such as "Validating nogo output" or "Running nogo on //... failed" are BUILD/FORMAT_CHECK, including ghpr_build, ghpr_check2, pull_build_next_gen, and pull_unit_test jobs; do not leave them in BUILD/PIPELINE_CONFIG or move them to BUILD/COMPILE.
 - Repository/archive download failures such as "Error downloading", "Error computing the main repository mapping", or 429/502/503 while fetching Bazel/GitHub dependencies are INFRA/EXTERNAL_DEP even if matrix branches later show test interruptions.
 - For integration job families, Jenkins/test wrapper timeout evidence such as "Timeout has been exceeded" is IT/TIMEOUT, not INFRA/NETWORK.

--- a/ci-dashboard/src/ci_dashboard/jobs/error_classification_guidance.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_classification_guidance.py
@@ -10,6 +10,7 @@ ERROR_CLASSIFICATION_GUIDANCE = """Decision guidance:
 - Container termination reason OOMKilled is INFRA/OOMKILLED, even when Jenkins later reports a matrix branch failure or agent disconnect.
 - Use job names as strong hints for test families: ghpr/pull unit/mysql jobs are UT, integration/realcluster/lightning/br/dm integration jobs are IT.
 - ghpr_check2 test-failure evidence should usually stay in the UT family because that job behaves like a unit-style mixed check job; do not move it to IT unless the failing evidence is explicitly integration-specific.
+- ghpr_check2 timeout evidence can move to IT/TIMEOUT when the failing branch is explicitly integration-specific, for example `run_real_tikv_tests.sh ...` or `integrationtest_with_tikv.sh ...`, even though the outer job name is ghpr_check2.
 - Go compiler errors such as "undefined:" or "has no field or method" are BUILD/COMPILE, even when they appear inside Bazel or wrapper output.
 - Bazel/unit summaries such as "FAILED TO BUILD", "fails to build", or "0 failing out of 0 test cases" point to an upstream build problem, not a UT test failure by themselves.
 - Failpoint rewrite/parser errors such as "Rewrite error ... expected declaration/statement, found '<<'" are BUILD/COMPILE.
@@ -21,7 +22,9 @@ ERROR_CLASSIFICATION_GUIDANCE = """Decision guidance:
 - Repository/archive download failures such as "Error downloading", "Error computing the main repository mapping", or 429/502/503 while fetching Bazel/GitHub dependencies are INFRA/EXTERNAL_DEP even if matrix branches later show test interruptions.
 - For integration job families, Jenkins/test wrapper timeout evidence such as "Timeout has been exceeded" is IT/TIMEOUT, not INFRA/NETWORK.
 - BR integration matrix TEST_GROUP failures are IT/TEST_FAILURE, even if the failed case logs local 127.0.0.1 PD/TiKV connection-refused or timeout symptoms.
+- Kubelet final pod failures such as `TerminationByKubelet` with `imminent node shutdown` are INFRA/K8S and should beat later Jenkins remoting or agent-offline noise.
 - Jenkins Groovy/runtime/cache/websocket/controller persistence errors are INFRA subcategories, not product BUILD failures.
+- Agent disconnect/remoting failures such as `Timeout waiting for agent to come back`, `AgentOfflineException`, or `was marked offline: Connection was broken` are INFRA/JENKINS when there is no earlier stronger root cause.
 - Disk-full evidence such as "No space left on device" is INFRA/DISK_FULL even when it appears while Jenkins saves pipeline state.
 - Prow superseded aborts are OTHERS/SUPERSEDED_BY_NEWER_BUILD when Prow marks the job aborted because a newer same-PR same-job version is running, or when an admin-abort log has same-PR same-job newer different-SHA build evidence; this overrides downstream noise.
 - Admin aborts are OTHERS/ABORT_BY_ADMIN and override downstream matrix, network, or interrupted-process symptoms.

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -407,13 +407,15 @@
       ]
     },
     {
-      "name": "infra_jenkins_remoting",
+      "name": "infra_jenkins_agent_offline",
       "l1": "INFRA",
-      "l2": "JENKINS",
+      "l2": "JENKINS_AGENT_OFFLINE",
       "text_patterns": [
-        "hudson\\.remoting",
-        "channel is already closed",
+        "hudson\\.remoting\\.ChannelClosedException: channel is already closed",
+        "hudson\\.remoting\\.RequestAbortedException: java\\.nio\\.channels\\.ClosedChannelException",
         "agent .* went offline",
+        "Agent went offline during the build",
+        "seems to be removed or offline",
         "Timeout waiting for agent to come back",
         "AgentOfflineException: Unable to create live FilePath",
         "was marked offline: Connection was broken",

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -469,6 +469,7 @@
         "go: updates to go\\.mod needed; to update it:",
         "missing go\\.sum entry for module providing package",
         "no required module provides package",
+        "invalid version: unknown revision",
         "cannot find module",
         "compilepkg: missing strict dependencies:",
         "No dependencies were provided\\.",
@@ -505,6 +506,14 @@
         "archive/tar",
         "failed to push image",
         "buildx failed"
+      ]
+    },
+    {
+      "name": "build_support_repo_commit_checkout_pipeline_config_failure",
+      "l1": "BUILD",
+      "l2": "PIPELINE_CONFIG",
+      "text_patterns": [
+        "computeBranchFromPR component: tidb-test,[\\s\\S]*tidb-test=[0-9a-f]{40}[\\s\\S]*Couldn't find any revision to build\\. Verify the repository and branch configuration for this job\\."
       ]
     },
     {

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -68,7 +68,9 @@
       "text_patterns": [
         "CONFLICT \\([^\\r\\n]+\\): Merge conflict in ",
         "Automatic merge failed; fix conflicts and then commit the result\\.",
-        "error: could not apply [0-9a-f]+"
+        "error: could not apply [0-9a-f]+",
+        "malformed module path \\\"<<<<<<<\\\": invalid char '<'",
+        "syntax error: unexpected <<, expected [^\\r\\n]+"
       ]
     },
     {
@@ -446,6 +448,17 @@
         "syntax error",
         "error: expected",
         "fatal error:"
+      ]
+    },
+    {
+      "name": "build_internal_package_missing_compile_failure",
+      "l1": "BUILD",
+      "l2": "COMPILE",
+      "job_name_patterns": [
+        "^pingcap/tidb/"
+      ],
+      "text_patterns": [
+        "no required module provides package github\\.com/pingcap/tidb/"
       ]
     },
     {

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -172,6 +172,19 @@
       ]
     },
     {
+      "name": "ghpr_check2_realtikv_timeout",
+      "l1": "IT",
+      "l2": "TIMEOUT",
+      "job_name_patterns": [
+        "(^|/)ghpr_check2$",
+        "(^|_)ghpr_check2($|_)"
+      ],
+      "text_patterns": [
+        "Timeout has been exceeded[\\s\\S]*(run_real_tikv_tests\\.sh|integrationtest_with_tikv\\.sh)",
+        "(run_real_tikv_tests\\.sh|integrationtest_with_tikv\\.sh)[\\s\\S]*Timeout has been exceeded"
+      ]
+    },
+    {
       "name": "br_integration_test_output_failure",
       "l1": "IT",
       "l2": "TEST_FAILURE",
@@ -387,6 +400,7 @@
       "l1": "INFRA",
       "l2": "K8S",
       "text_patterns": [
+        "Pod \\[Failed\\]\\[TerminationByKubelet\\] Pod was terminated in response to imminent node shutdown\\.",
         "Pod \\[Failed\\]\\[[^\\]]*Evicted[^\\]]*\\]",
         "Container \\[[^\\]]+\\] terminated \\[Evicted\\]",
         "Reason: Evicted"
@@ -400,6 +414,9 @@
         "hudson\\.remoting",
         "channel is already closed",
         "agent .* went offline",
+        "Timeout waiting for agent to come back",
+        "AgentOfflineException: Unable to create live FilePath",
+        "was marked offline: Connection was broken",
         "cannot contact .*: java\\.io\\.IOException",
         "closedchannelexception"
       ]

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -70,7 +70,7 @@
         "Automatic merge failed; fix conflicts and then commit the result\\.",
         "error: could not apply [0-9a-f]+",
         "malformed module path \\\"<<<<<<<\\\": invalid char '<'",
-        "syntax error: unexpected <<, expected [^\\r\\n]+"
+        "syntax error: unexpected <<"
       ]
     },
     {
@@ -474,7 +474,7 @@
       "l1": "BUILD",
       "l2": "COMPILE",
       "job_name_patterns": [
-        "^pingcap/tidb/"
+        "(^|/)pull_mysql_client_test(_next_gen)?$"
       ],
       "text_patterns": [
         "no required module provides package github\\.com/pingcap/tidb/"

--- a/ci-dashboard/src/ci_dashboard/jobs/jenkins_client.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/jenkins_client.py
@@ -12,7 +12,21 @@ from ci_dashboard.common.config import JenkinsSettings
 
 DEFAULT_FAILED_NODE_LOG_LIMIT = 4
 DEFAULT_FAILED_NODE_LOG_BYTES = 64 * 1024
+DEFAULT_CONSOLE_SIGNAL_EXCERPT_BYTES = 16 * 1024
+DEFAULT_CONSOLE_SIGNAL_CONTEXT_LINES = 4
+DEFAULT_CONSOLE_SIGNAL_MATCH_LIMIT = 6
 CONSOLE_OUTPUT_RE = re.compile(r'<pre class="console-output">(.*?)</pre>', flags=re.DOTALL)
+CONSOLE_SIGNAL_PATTERNS = (
+    re.compile(r"Container \[[^\]]+\] terminated \[OOMKilled\]", flags=re.IGNORECASE),
+    re.compile(r"Pod \[Failed\]\[[^\]]*OOMKilled[^\]]*\]", flags=re.IGNORECASE),
+    re.compile(r"Reason: OOMKilled", flags=re.IGNORECASE),
+    re.compile(r"Pod \[Failed\]\[TerminationByKubelet\]", flags=re.IGNORECASE),
+    re.compile(r"The node was low on resource: memory", flags=re.IGNORECASE),
+    re.compile(r"Container .* was using .* request is .* larger consumption of memory", flags=re.IGNORECASE),
+    re.compile(r"Pod \[Failed\]\[[^\]]*Evicted[^\]]*\]", flags=re.IGNORECASE),
+    re.compile(r"Container \[[^\]]+\] terminated \[Evicted\]", flags=re.IGNORECASE),
+    re.compile(r"Reason: Evicted", flags=re.IGNORECASE),
+)
 
 
 @dataclass(frozen=True)
@@ -123,6 +137,21 @@ class JenkinsClient:
                 text = console_text
         return _tail_text(text, max_bytes=max_bytes)
 
+    def fetch_console_signal_excerpts(
+        self,
+        build_url: str,
+        *,
+        max_bytes: int = DEFAULT_CONSOLE_SIGNAL_EXCERPT_BYTES,
+    ) -> str:
+        console_url = build_api_url(
+            build_url,
+            "consoleText",
+            internal_base_url=self._settings.internal_base_url,
+        )
+        response = self._client.get(console_url)
+        response.raise_for_status()
+        return extract_console_signal_excerpts(response.text, max_bytes=max_bytes)
+
     def _fetch_progressive_chunk(self, progressive_url: str, start: int) -> ProgressiveTextChunk:
         response = self._client.get(progressive_url, params={"start": start})
         response.raise_for_status()
@@ -206,6 +235,45 @@ def rewrite_build_url_host(build_url: str, *, internal_base_url: str) -> str:
     return rewritten
 
 
+def extract_console_signal_excerpts(
+    console_text: str,
+    *,
+    context_lines: int = DEFAULT_CONSOLE_SIGNAL_CONTEXT_LINES,
+    max_matches: int = DEFAULT_CONSOLE_SIGNAL_MATCH_LIMIT,
+    max_bytes: int = DEFAULT_CONSOLE_SIGNAL_EXCERPT_BYTES,
+) -> str:
+    lines = console_text.splitlines()
+    matched_ranges: list[tuple[int, int]] = []
+
+    for index, line in enumerate(lines):
+        if not any(pattern.search(line) for pattern in CONSOLE_SIGNAL_PATTERNS):
+            continue
+        matched_ranges.append(
+            (
+                max(0, index - context_lines),
+                min(len(lines), index + context_lines + 1),
+            )
+        )
+        if len(matched_ranges) >= max_matches:
+            break
+
+    merged_ranges = _merge_line_ranges(matched_ranges)
+    if not merged_ranges:
+        return ""
+
+    parts = ["===== Jenkins console signal excerpts ====="]
+    for start, end in merged_ranges:
+        block = [f"----- lines {start + 1}-{end} -----", *lines[start:end]]
+        candidate = "\n".join([*parts, *block])
+        if len(candidate.encode("utf-8", errors="replace")) > max_bytes:
+            if len(parts) == 1:
+                return _head_text(candidate, max_bytes=max_bytes)
+            break
+        parts.extend(block)
+
+    return "\n".join(parts)
+
+
 def _failed_flow_nodes(stage_description: dict[str, Any]) -> list[dict[str, Any]]:
     nodes = stage_description.get("stageFlowNodes")
     if isinstance(nodes, list):
@@ -230,6 +298,27 @@ def _tail_text(text: str, *, max_bytes: int) -> str:
     if len(encoded) <= max_bytes:
         return text
     return encoded[-max_bytes:].decode("utf-8", errors="replace")
+
+
+def _head_text(text: str, *, max_bytes: int) -> str:
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[:max_bytes].decode("utf-8", errors="replace")
+
+
+def _merge_line_ranges(ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    if not ranges:
+        return []
+
+    merged: list[list[int]] = []
+    for start, end in ranges:
+        if not merged or start > merged[-1][1]:
+            merged.append([start, end])
+            continue
+        merged[-1][1] = max(merged[-1][1], end)
+
+    return [(start, end) for start, end in merged]
 
 
 def _format_failed_node_log_header(stage: dict[str, Any], node: dict[str, Any]) -> str:

--- a/ci-dashboard/tests/jobs/test_analyze_errors.py
+++ b/ci-dashboard/tests/jobs/test_analyze_errors.py
@@ -56,6 +56,16 @@ class _FakeClassifier:
         return self.classification
 
 
+class _FakeJenkinsFetcher:
+    def __init__(self, excerpts_by_url: dict[str, str]) -> None:
+        self.excerpts_by_url = excerpts_by_url
+        self.calls: list[str] = []
+
+    def fetch_console_signal_excerpts(self, build_url: str) -> str:
+        self.calls.append(build_url)
+        return self.excerpts_by_url.get(build_url, "")
+
+
 def _insert_build(
     sqlite_engine,
     *,
@@ -621,6 +631,73 @@ def test_run_analyze_errors_force_overwrites_machine_classification(sqlite_engin
 
     assert row["error_l1_category"] == "UT"
     assert row["error_l2_subcategory"] == "TEST_FAILURE"
+
+
+def test_run_analyze_errors_reclassifies_remoting_archive_with_live_oom_excerpt(sqlite_engine) -> None:
+    build_id = 451
+    job_name = "pull_cdc_storage_integration_light"
+    build_url = f"https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/{job_name}/{build_id}/"
+    _insert_build(
+        sqlite_engine,
+        build_id=build_id,
+        job_name=job_name,
+        log_gcs_uri="gcs://ci-dashboard-test/2605/451.log",
+        error_l1_category="INFRA",
+        error_l2_subcategory="JENKINS",
+    )
+    reader = _FakeReader(
+        {
+            (
+                "ci-dashboard-test",
+                "2605/451.log",
+            ): (
+                "hudson.remoting.ChannelClosedException\n"
+                "removed or offline for 5 min\n"
+                "Timeout waiting for agent to come back\n"
+            ),
+        }
+    )
+    jenkins_fetcher = _FakeJenkinsFetcher(
+        {
+            build_url: (
+                "===== Jenkins console signal excerpts =====\n"
+                "----- lines 1880-1884 -----\n"
+                "Container [golang] terminated [OOMKilled]\n"
+            )
+        }
+    )
+    classifier = _FakeClassifier(
+        ErrorClassification(
+            l1_category="OTHERS",
+            l2_subcategory="UNCLASSIFIED",
+            source="llm:test",
+        )
+    )
+
+    summary = run_analyze_errors(
+        sqlite_engine,
+        _settings(),
+        force=True,
+        reader=reader,
+        jenkins_fetcher=jenkins_fetcher,
+        rule_engine=RuleEngine.from_file(),
+        llm_classifier=classifier,
+    )
+
+    assert summary.builds_scanned == 1
+    assert summary.builds_rule_classified == 1
+    assert summary.builds_llm_classified == 0
+    assert reader.calls == [("ci-dashboard-test", "2605/451.log")]
+    assert jenkins_fetcher.calls == [build_url]
+    assert classifier.calls == []
+
+    with sqlite_engine.begin() as connection:
+        row = connection.execute(
+            text("SELECT error_l1_category, error_l2_subcategory FROM ci_l1_builds WHERE id = 451")
+        ).mappings().one()
+
+    assert row["error_l1_category"] == "INFRA"
+    assert row["error_l2_subcategory"] == "OOMKILLED"
 
 
 def test_review_error_classification_updates_revise_fields(sqlite_engine) -> None:

--- a/ci-dashboard/tests/jobs/test_archive_error_logs.py
+++ b/ci-dashboard/tests/jobs/test_archive_error_logs.py
@@ -61,6 +61,17 @@ class _FakeFetcherWithFailedNodes(_FakeFetcher):
         return self.failed_node_text
 
 
+class _FakeFetcherWithSignalExcerpts(_FakeFetcher):
+    def __init__(self, text: str, signal_text: str) -> None:
+        super().__init__(text)
+        self.signal_text = signal_text
+        self.signal_calls: list[str] = []
+
+    def fetch_console_signal_excerpts(self, build_url: str) -> str:
+        self.signal_calls.append(build_url)
+        return self.signal_text
+
+
 class _FakeUploader:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, str]] = []
@@ -201,6 +212,34 @@ def test_run_archive_error_logs_appends_failed_pipeline_node_logs(sqlite_engine)
     ]
     assert "Connection reset by peer" in uploader.calls[0][2]
     assert "Build completed, 1 test FAILED" in uploader.calls[0][2]
+
+
+def test_run_archive_error_logs_appends_live_signal_excerpts_for_remoting_tail(sqlite_engine) -> None:
+    _insert_build(sqlite_engine, build_id=161)
+    fetcher = _FakeFetcherWithSignalExcerpts(
+        "hudson.remoting.ChannelClosedException\nTimeout waiting for agent to come back\n",
+        (
+            "===== Jenkins console signal excerpts =====\n"
+            "----- lines 101-103 -----\n"
+            "Container [golang] terminated [OOMKilled]\n"
+        ),
+    )
+    uploader = _FakeUploader()
+
+    summary = run_archive_error_logs(
+        sqlite_engine,
+        _settings(),
+        build_id=161,
+        fetcher=fetcher,
+        uploader=uploader,
+    )
+
+    assert summary.builds_archived == 1
+    assert fetcher.signal_calls == [
+        "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/161/display/redirect"
+    ]
+    assert "Timeout waiting for agent to come back" in uploader.calls[0][2]
+    assert "Container [golang] terminated [OOMKilled]" in uploader.calls[0][2]
 
 
 def test_run_archive_error_logs_skips_existing_archive_without_force(sqlite_engine) -> None:

--- a/ci-dashboard/tests/jobs/test_jenkins_client.py
+++ b/ci-dashboard/tests/jobs/test_jenkins_client.py
@@ -8,6 +8,7 @@ from ci_dashboard.jobs.jenkins_client import (
     build_api_url,
     build_progressive_text_url,
     canonicalize_build_url,
+    extract_console_signal_excerpts,
     rewrite_build_url_host,
 )
 
@@ -254,3 +255,67 @@ def test_jenkins_client_fetch_failed_node_logs_collects_aborted_matrix_node_cons
     assert "stage: Test (44)" in text
     assert "node: G11 (55)" in text
     assert "TEST FAILED: OUTPUT DOES NOT CONTAIN" in text
+
+
+def test_extract_console_signal_excerpts_returns_kube_failure_context() -> None:
+    console_text = "\n".join(
+        [
+            "random prefix",
+            "still starting",
+            "Pod xyz status update",
+            "Container [golang] terminated [OOMKilled]",
+            "removed or offline for 5 min",
+            "Timeout waiting for agent to come back",
+        ]
+    )
+
+    excerpts = extract_console_signal_excerpts(
+        console_text,
+        context_lines=1,
+        max_matches=2,
+        max_bytes=4096,
+    )
+
+    assert "===== Jenkins console signal excerpts =====" in excerpts
+    assert "----- lines 3-5 -----" in excerpts
+    assert "Pod xyz status update" in excerpts
+    assert "Container [golang] terminated [OOMKilled]" in excerpts
+    assert "removed or offline for 5 min" in excerpts
+    assert "Timeout waiting for agent to come back" not in excerpts
+
+
+def test_jenkins_client_fetch_console_signal_excerpts_uses_console_text_endpoint() -> None:
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path.endswith("/consoleText"):
+            return httpx.Response(
+                200,
+                text=(
+                    "startup line\n"
+                    "Pod status update\n"
+                    "Container [golang] terminated [OOMKilled]\n"
+                    "tail line\n"
+                ),
+            )
+        return httpx.Response(404)
+
+    client = JenkinsClient(
+        JenkinsSettings(http_timeout_seconds=5),
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+    try:
+        excerpts = client.fetch_console_signal_excerpts(
+            "https://prow.tidb.net/jenkins/job/pingcap/job/tiflow/job/pull_cdc_storage_integration_light/1357/",
+            max_bytes=4096,
+        )
+    finally:
+        client.close()
+
+    assert excerpts.startswith("===== Jenkins console signal excerpts =====")
+    assert "Container [golang] terminated [OOMKilled]" in excerpts
+    assert seen_paths == [
+        "/jenkins/job/pingcap/job/tiflow/job/pull_cdc_storage_integration_light/1357/consoleText"
+    ]

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -740,7 +740,7 @@ def test_rule_engine_classifies_kubelet_node_shutdown_as_k8s_infra() -> None:
     assert classification.source == "rule:infra_k8s_runtime"
 
 
-def test_rule_engine_classifies_agent_offline_as_jenkins_infra() -> None:
+def test_rule_engine_classifies_agent_offline_as_jenkins_agent_offline() -> None:
     engine = RuleEngine.from_file()
 
     classification = engine.classify(
@@ -761,8 +761,8 @@ def test_rule_engine_classifies_agent_offline_as_jenkins_infra() -> None:
 
     assert classification is not None
     assert classification.l1_category == "INFRA"
-    assert classification.l2_subcategory == "JENKINS"
-    assert classification.source == "rule:infra_jenkins_remoting"
+    assert classification.l2_subcategory == "JENKINS_AGENT_OFFLINE"
+    assert classification.source == "rule:infra_jenkins_agent_offline"
 
 
 def test_rule_engine_prefers_jenkins_groovy_over_remoting_noise() -> None:

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -1095,6 +1095,60 @@ def test_rule_engine_matches_missing_go_sum_dependency_failure() -> None:
     assert classification.source == "rule:build_dependency_failure"
 
 
+def test_rule_engine_classifies_go_unknown_revision_as_dependency_failure() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "go: github.com/pingcap/tipb@v0.0.0-20260511103949-52a408fd6ab8: "
+            "invalid version: unknown revision 52a408fd6ab8\n"
+            "+ pushd tidb\n"
+            "/home/jenkins/agent/workspace/pingcap/tidb/ghpr_build@tmp/durable-af434c3f/"
+            "script.sh.copy: line 6: pushd: tidb: No such file or directory\n"
+            "make: *** tidb: No such file or directory.  Stop.\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/ghpr_build",
+            "url": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_build/2713/",
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "DEPENDENCY"
+    assert classification.source == "rule:build_dependency_failure"
+
+
+def test_rule_engine_classifies_support_repo_commit_checkout_failure_as_pipeline_config() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "computeBranchFromPR component: tidb-test, prTargetBranch: feature/fts, "
+            "prTitle: planner: avoid invalid TiCI FTS request for null match pattern | "
+            "tidb-test=42c2474b6e2e1ef3430d07a1743ca7e17fd97acc tiflash=feature-fts "
+            "tikv=feature-fts, trunkBranch: master\n"
+            "Fetching upstream changes from git@github.com:PingCAP-QE/tidb-test.git\n"
+            "ERROR: Couldn't find any revision to build. Verify the repository and branch "
+            "configuration for this job.\n"
+            "ERROR: Maximum checkout retry attempts reached, aborting\n"
+            "Finished: FAILURE\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_mysql_client_test",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_mysql_client_test/2883/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "PIPELINE_CONFIG"
+    assert classification.source == "rule:build_support_repo_commit_checkout_pipeline_config_failure"
+
+
 def test_rule_engine_prefers_go_plugin_abi_mismatch_over_jenkins_remoting_warning() -> None:
     engine = RuleEngine.from_file()
 

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -277,6 +277,64 @@ def test_rule_engine_prefers_code_conflict_over_pipeline_config_noise() -> None:
     assert classification.source == "rule:others_code_conflict"
 
 
+def test_rule_engine_classifies_go_mod_conflict_markers_as_code_conflict() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "CGO_ENABLED=1 GO111MODULE=on go build -tags codes,nextgen "
+            "-o 'bin/tidb-server' ./cmd/tidb-server\n"
+            "go: errors parsing go.mod:\n"
+            "go.mod:127: malformed module path \"<<<<<<<\": invalid char '<'\n"
+            "go.mod:130: usage: require module/path v1.2.3\n"
+            "go.mod:133: usage: require module/path v1.2.3\n"
+            "make: *** [Makefile:249: server] Error 1\n"
+            "ERROR: script returned exit code 2\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_mysql_client_test_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_mysql_client_test_next_gen/2605/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "OTHERS"
+    assert classification.l2_subcategory == "CODE_CONFLICT"
+    assert classification.source == "rule:others_code_conflict"
+
+
+def test_rule_engine_classifies_go_source_conflict_markers_as_code_conflict() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "# github.com/pingcap/tidb/pkg/executor/importer\n"
+            "pkg/executor/importer/sampler.go:364:1: syntax error: unexpected <<, expected }\n"
+            "pkg/executor/importer/sampler.go:370:1: syntax error: unexpected ==, expected }\n"
+            "pkg/executor/importer/sampler.go:373:1: syntax error: unexpected >>, expected }\n"
+            "pkg/executor/importer/sampler.go:373:82: invalid character U+0023 '#'\n"
+            "pkg/executor/importer/sampler.go:376:3: syntax error: non-declaration statement outside function body\n"
+            "make: *** [Makefile:249: server] Error 1\n"
+            "ERROR: script returned exit code 2\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_mysql_client_test_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_mysql_client_test_next_gen/2779/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "OTHERS"
+    assert classification.l2_subcategory == "CODE_CONFLICT"
+    assert classification.source == "rule:others_code_conflict"
+
+
 def test_rule_engine_prefers_disk_full_over_dm_integration_and_jenkins_noise() -> None:
     engine = RuleEngine.from_file()
 
@@ -951,6 +1009,32 @@ def test_rule_engine_matches_go_mod_tidy_dependency_failure() -> None:
     assert classification.l1_category == "BUILD"
     assert classification.l2_subcategory == "DEPENDENCY"
     assert classification.source == "rule:build_dependency_failure"
+
+
+def test_rule_engine_classifies_missing_internal_tidb_package_as_build_compile() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "pkg/server/handler/user_admin_handler.go:36:2: "
+            "no required module provides package github.com/pingcap/tidb/pkg/session/types; to add it:\n"
+            "\tgo get github.com/pingcap/tidb/pkg/session/types\n"
+            "make: *** [Makefile:249: server] Error 1\n"
+            "ERROR: script returned exit code 2\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_mysql_client_test_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_mysql_client_test_next_gen/2762/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "COMPILE"
+    assert classification.source == "rule:build_internal_package_missing_compile_failure"
 
 
 def test_rule_engine_matches_bazel_strict_dependency_failure() -> None:

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -709,6 +709,62 @@ def test_rule_engine_prefers_final_k8s_failure_over_jenkins_disconnect_noise() -
     assert classification.source == "rule:infra_k8s_runtime"
 
 
+def test_rule_engine_classifies_kubelet_node_shutdown_as_k8s_infra() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "pingcap-tidb-pull-build-next-gen-2748-lbvc2-2csfh-rgklc seems to be removed or offline "
+            "(hudson.remoting.RequestAbortedException: java.nio.channels.ClosedChannelException); "
+            "will wait for 5 min 0 sec for it to come back online\n"
+            "[PodInfo] jenkins-tidb/pingcap-tidb-pull-build-next-gen-2748-lbvc2-2csfh-rgklc\n"
+            "Container [golang] terminated [Completed] No message\n"
+            "Container [jnlp] terminated [Error] No message\n"
+            "Pod [Failed][TerminationByKubelet] Pod was terminated in response to imminent node shutdown.\n"
+            "Pod [Failed][PodFailed] No message\n"
+            "Timeout waiting for agent to come back\n"
+            "Finished: ABORTED\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_build_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_build_next_gen/2748/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "INFRA"
+    assert classification.l2_subcategory == "K8S"
+    assert classification.source == "rule:infra_k8s_runtime"
+
+
+def test_rule_engine_classifies_agent_offline_as_jenkins_infra() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "Failed in branch Matrix - SCRIPT_AND_ARGS = 'run_real_tikv_tests.sh bazel_brietest'\n"
+            "Timeout waiting for agent to come back\n"
+            "org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException: "
+            "Unable to create live FilePath for pingcap-tidb-ghpr-check2-3353-3xd83-mbdh3-jv9zn; "
+            "pingcap-tidb-ghpr-check2-3353-3xd83-mbdh3-jv9zn was marked offline: "
+            "Connection was broken\n"
+            "Finished: ABORTED\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/ghpr_check2",
+            "url": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_check2/3353/",
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "INFRA"
+    assert classification.l2_subcategory == "JENKINS"
+    assert classification.source == "rule:infra_jenkins_remoting"
+
+
 def test_rule_engine_prefers_jenkins_groovy_over_remoting_noise() -> None:
     engine = RuleEngine.from_file()
 
@@ -1604,6 +1660,28 @@ def test_rule_engine_prefers_external_dependency_over_ghpr_check2_noise() -> Non
     assert classification.l1_category == "INFRA"
     assert classification.l2_subcategory == "EXTERNAL_DEP"
     assert classification.source == "rule:infra_external_dependency_bazel_fetch_failure"
+
+
+def test_rule_engine_classifies_ghpr_check2_realtikv_timeout_as_integration_timeout() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "Matrix - SCRIPT_AND_ARGS = 'run_real_tikv_tests.sh bazel_importintotest4'\n"
+            "Matrix - SCRIPT_AND_ARGS = 'integrationtest_with_tikv.sh y'\n"
+            "Timeout has been exceeded\n"
+            "Finished: ABORTED\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/ghpr_check2",
+            "url": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_check2/3563/",
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "IT"
+    assert classification.l2_subcategory == "TIMEOUT"
+    assert classification.source == "rule:ghpr_check2_realtikv_timeout"
 
 
 def test_rule_engine_does_not_treat_passed_test_names_with_fail_suffix_as_failures() -> None:

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -335,6 +335,31 @@ def test_rule_engine_classifies_go_source_conflict_markers_as_code_conflict() ->
     assert classification.source == "rule:others_code_conflict"
 
 
+def test_rule_engine_classifies_short_go_source_conflict_marker_as_code_conflict() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "# github.com/pingcap/tidb/pkg/executor/importer\n"
+            "pkg/executor/importer/sampler.go:364:1: syntax error: unexpected <<\n"
+            "make: *** [Makefile:249: server] Error 1\n"
+            "ERROR: script returned exit code 2\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_mysql_client_test_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_mysql_client_test_next_gen/2779/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "OTHERS"
+    assert classification.l2_subcategory == "CODE_CONFLICT"
+    assert classification.source == "rule:others_code_conflict"
+
+
 def test_rule_engine_prefers_disk_full_over_dm_integration_and_jenkins_noise() -> None:
     engine = RuleEngine.from_file()
 
@@ -1083,6 +1108,32 @@ def test_rule_engine_classifies_missing_internal_tidb_package_as_build_compile()
             "url": (
                 "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
                 "pull_mysql_client_test_next_gen/2762/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "COMPILE"
+    assert classification.source == "rule:build_internal_package_missing_compile_failure"
+
+
+def test_rule_engine_classifies_missing_internal_tidb_package_for_unprefixed_job_name() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "pkg/server/handler/user_admin_handler.go:36:2: "
+            "no required module provides package github.com/pingcap/tidb/pkg/session/types; to add it:\n"
+            "\tgo get github.com/pingcap/tidb/pkg/session/types\n"
+            "make: *** [Makefile:249: server] Error 1\n"
+            "ERROR: script returned exit code 2\n"
+        ),
+        build={
+            "job_name": "pull_mysql_client_test",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_mysql_client_test/2954/"
             ),
         },
     )


### PR DESCRIPTION
## Summary
- classify raw conflict markers in mysql client next-gen logs as `OTHERS/CODE_CONFLICT`
- classify missing internal TiDB package imports as `BUILD/COMPILE` instead of generic dependency drift
- classify `invalid version: unknown revision` module failures as `BUILD/DEPENDENCY`
- classify support-repo checkout failures with `tidb-test=<40-hex-sha>` and `Couldn't find any revision to build` as `BUILD/PIPELINE_CONFIG`
- classify kubelet final pod failures with `TerminationByKubelet` and `imminent node shutdown` as `INFRA/K8S`
- add regression coverage for reviewed mysql-client, pull-build, and ghpr-build cases, and align fallback guidance

## Test
- `uv run --extra dev pytest tests/jobs/test_rule_engine.py -q`
- `uv run --extra dev ruff check src/ci_dashboard/jobs/error_classification_guidance.py src/ci_dashboard/jobs/error_taxonomy.json tests/jobs/test_rule_engine.py`