### PR TITLE
fix(ci-dashboard): summarize pod abnormal reasons

### DIFF
--- a/ci-dashboard/sql/006_create_ci_l1_pod_lifecycle.sql
+++ b/ci-dashboard/sql/006_create_ci_l1_pod_lifecycle.sql
@@ -11,6 +11,8 @@ CREATE TABLE IF NOT EXISTS ci_l1_pod_lifecycle (
   pod_annotations_json TEXT NULL,
   metadata_observed_at DATETIME NULL,
   pod_created_at DATETIME NULL,
+  abnormal_reason VARCHAR(64) NULL,
+  abnormal_message TEXT NULL,
   pod_author VARCHAR(255) NULL,
   pod_org VARCHAR(255) NULL,
   pod_repo VARCHAR(255) NULL,

--- a/ci-dashboard/sql/022_alter_ci_l1_pod_lifecycle_add_abnormal_summary.sql
+++ b/ci-dashboard/sql/022_alter_ci_l1_pod_lifecycle_add_abnormal_summary.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ci_l1_pod_lifecycle
+  ADD COLUMN IF NOT EXISTS abnormal_reason VARCHAR(64) NULL AFTER pod_created_at;
+
+ALTER TABLE ci_l1_pod_lifecycle
+  ADD COLUMN IF NOT EXISTS abnormal_message TEXT NULL AFTER abnormal_reason;

--- a/ci-dashboard/src/ci_dashboard/jobs/pod_watcher.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/pod_watcher.py
@@ -34,6 +34,7 @@ from ci_dashboard.jobs.sync_pods import (
     _coerce_str,
     _coerce_str_mapping,
     _decode_json_object,
+    _extract_pod_abnormal_summary,
     _get_json,
     _get_kubernetes_api_ca_file,
     _get_kubernetes_api_token,
@@ -64,7 +65,7 @@ DEFAULT_DB_RETRY_ATTEMPTS = 3
 DEFAULT_DB_RETRY_BASE_DELAY_MS = 500
 DEFAULT_DB_RETRY_MAX_DELAY_MS = 5000
 RETRYABLE_MYSQL_ERROR_CODES = frozenset({1205, 1213})
-POD_WATCH_TYPES = frozenset({"ADDED", "MODIFIED"})
+POD_WATCH_TYPES = frozenset({"ADDED", "MODIFIED", "DELETED"})
 EVENT_WATCH_TYPES = frozenset({"ADDED", "MODIFIED"})
 
 logger = logging.getLogger(__name__)
@@ -463,7 +464,10 @@ def _run_pod_worker(
                 pod_object = watch_event.get("object")
                 if not isinstance(pod_object, dict):
                     continue
-                snapshot = _normalize_pod_object(pod_object, context=context)
+                snapshot = _normalize_pod_object(
+                    pod_object,
+                    context=context,
+                )
                 if snapshot is None:
                     continue
                 lifecycle_count = _persist_pod_snapshots(
@@ -849,7 +853,9 @@ def _load_existing_pod_metadata_snapshots(
               lifecycle.pod_labels_json,
               lifecycle.pod_annotations_json,
               lifecycle.metadata_observed_at,
-              lifecycle.pod_created_at
+              lifecycle.pod_created_at,
+              lifecycle.abnormal_reason,
+              lifecycle.abnormal_message
             FROM ci_l1_pod_lifecycle AS lifecycle
             JOIN requested_pods AS requested
               ON lifecycle.source_project = requested.source_project
@@ -866,7 +872,15 @@ def _load_existing_pod_metadata_snapshots(
         labels = _json_loads_str_mapping(row.get("pod_labels_json"))
         annotations = _json_loads_str_mapping(row.get("pod_annotations_json"))
         creation_timestamp = _parse_datetime(row.get("pod_created_at"))
-        if not labels and not annotations and creation_timestamp is None:
+        abnormal_reason = _coerce_str(row.get("abnormal_reason"))
+        abnormal_message = _coerce_str(row.get("abnormal_message"))
+        if (
+            not labels
+            and not annotations
+            and creation_timestamp is None
+            and abnormal_reason is None
+            and abnormal_message is None
+        ):
             continue
         identity = _pod_identity_from_values(
             source_project=_coerce_str(row.get("source_project")) or "",
@@ -881,6 +895,8 @@ def _load_existing_pod_metadata_snapshots(
             observed_at=_parse_datetime(row.get("metadata_observed_at"))
             or datetime.now(UTC).replace(tzinfo=None),
             creation_timestamp=creation_timestamp,
+            abnormal_reason=abnormal_reason,
+            abnormal_message=abnormal_message,
         )
     return snapshots
 
@@ -913,6 +929,7 @@ def _normalize_pod_object(
             annotations=_coerce_str_mapping(metadata.get("annotations")),
             observed_at=observed_at,
             creation_timestamp=_parse_datetime(metadata.get("creationTimestamp")),
+            **_extract_pod_abnormal_summary(pod_object, observed_at=observed_at),
         ),
     )
 

--- a/ci-dashboard/src/ci_dashboard/jobs/sync_pods.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/sync_pods.py
@@ -46,12 +46,28 @@ POD_EVENT_REASONS = (
     "Pulled",
     "Created",
     "Started",
+    "Killing",
+    "Evicted",
+    "NodeLost",
+    "Unhealthy",
+    "Preempting",
     "FailedScheduling",
     "Failed",
     "BackOff",
     "ErrImagePull",
     "ImagePullBackOff",
 )
+
+ABNORMAL_REASON_PRIORITY = (
+    "OOMKilled",
+    "Evicted",
+    "Unhealthy",
+    "NodeLost",
+    "Preempting",
+    "Killing",
+)
+ABNORMAL_REASON_RANK = {reason: index for index, reason in enumerate(ABNORMAL_REASON_PRIORITY)}
+ABNORMAL_EVENT_REASONS = frozenset(ABNORMAL_REASON_PRIORITY[1:])
 
 DEFAULT_POD_EVENT_NAMESPACES = (
     "prow-test-pods",
@@ -117,6 +133,8 @@ class PodMetadataSnapshot:
     annotations: dict[str, str]
     observed_at: datetime
     creation_timestamp: datetime | None = None
+    abnormal_reason: str | None = None
+    abnormal_message: str | None = None
 
     def as_lifecycle_fields(self) -> dict[str, Any]:
         return {
@@ -124,6 +142,8 @@ class PodMetadataSnapshot:
             "pod_annotations_json": _json_dumps_or_none(self.annotations),
             "metadata_observed_at": self.observed_at,
             "pod_created_at": self.creation_timestamp,
+            "abnormal_reason": self.abnormal_reason,
+            "abnormal_message": self.abnormal_message,
             "pod_author": _coerce_str(self.labels.get("author")),
             "pod_org": _coerce_str(self.labels.get("org")),
             "pod_repo": _coerce_str(self.labels.get("repo")),
@@ -138,6 +158,108 @@ class PodMetadataSnapshot:
 class JenkinsPodNameBuildRef:
     pod_prefix: str
     build_number: str
+
+
+def _iter_terminated_container_states(
+    container_statuses: Any,
+    *,
+    observed_at: datetime,
+) -> list[dict[str, Any]]:
+    if not isinstance(container_statuses, list):
+        return []
+
+    terminated_states: list[dict[str, Any]] = []
+    for container_status in container_statuses:
+        if not isinstance(container_status, dict):
+            continue
+        for state_key in ("state", "lastState"):
+            state = container_status.get(state_key)
+            if not isinstance(state, dict):
+                continue
+            terminated = state.get("terminated")
+            if not isinstance(terminated, dict):
+                continue
+            terminated_at = (
+                _parse_datetime(terminated.get("finishedAt"))
+                or _parse_datetime(terminated.get("startedAt"))
+                or observed_at
+            )
+            terminated_states.append(
+                {
+                    "reason": _coerce_str(terminated.get("reason")),
+                    "message": _coerce_str(terminated.get("message")),
+                    "timestamp": terminated_at,
+                }
+            )
+
+    return terminated_states
+
+
+def _select_abnormal_summary(candidates: Iterable[dict[str, Any]]) -> tuple[str | None, str | None]:
+    selected_reason: str | None = None
+    selected_message: str | None = None
+    selected_key: tuple[int, int, int, float] | None = None
+
+    for candidate in candidates:
+        reason = _coerce_str(candidate.get("reason"))
+        if reason not in ABNORMAL_REASON_RANK:
+            continue
+        message = _coerce_str(candidate.get("message"))
+        source_rank = int(candidate.get("source_rank", 1))
+        timestamp = _parse_datetime(candidate.get("timestamp"))
+        timestamp_key = -timestamp.timestamp() if isinstance(timestamp, datetime) else float("inf")
+        # This table is meant to summarize the most actionable diagnosis, so for the same
+        # abnormal reason we prefer a concrete message over an empty higher-authority source.
+        key = (
+            ABNORMAL_REASON_RANK[reason],
+            0 if message else 1,
+            source_rank,
+            timestamp_key,
+        )
+        if selected_key is None or key < selected_key:
+            selected_reason = reason
+            selected_message = message
+            selected_key = key
+
+    return selected_reason, selected_message
+
+
+def _extract_pod_abnormal_summary(
+    pod_object: dict[str, Any],
+    *,
+    observed_at: datetime,
+) -> dict[str, Any]:
+    status = pod_object.get("status")
+    status = status if isinstance(status, dict) else {}
+    candidates = [
+        {
+            "reason": state.get("reason"),
+            "message": state.get("message"),
+            "timestamp": state.get("timestamp"),
+            "source_rank": 0,
+        }
+        for state in _iter_terminated_container_states(
+            status.get("containerStatuses"),
+            observed_at=observed_at,
+        )
+        if _coerce_str(state.get("reason")) == "OOMKilled"
+    ]
+    status_reason = _coerce_str(status.get("reason"))
+    if status_reason in ABNORMAL_EVENT_REASONS:
+        candidates.append(
+            {
+                "reason": status_reason,
+                "message": _coerce_str(status.get("message")),
+                "timestamp": observed_at,
+                "source_rank": 0,
+            }
+        )
+
+    abnormal_reason, abnormal_message = _select_abnormal_summary(candidates)
+    return {
+        "abnormal_reason": abnormal_reason,
+        "abnormal_message": abnormal_message,
+    }
 
 
 def run_sync_pods(engine: Engine, settings: Settings) -> SyncPodsSummary:
@@ -626,6 +748,7 @@ def _build_lifecycle_rows(
     if not lifecycle_rows:
         return []
 
+    abnormal_event_summaries = _load_abnormal_event_summaries(connection, pods)
     build_metadata_by_identity = _load_build_metadata_map(
         connection,
         lifecycle_rows,
@@ -660,6 +783,22 @@ def _build_lifecycle_rows(
             build_meta,
             build_system=_coerce_str(merged.get("build_system")),
         )
+        abnormal_reason, abnormal_message = _select_abnormal_summary(
+            [
+                {
+                    "reason": _coerce_str(merged.get("abnormal_reason")),
+                    "message": _coerce_str(merged.get("abnormal_message")),
+                    "source_rank": 0,
+                },
+                {
+                    "reason": _coerce_str(abnormal_event_summaries.get(identity, {}).get("abnormal_reason")),
+                    "message": _coerce_str(abnormal_event_summaries.get(identity, {}).get("abnormal_message")),
+                    "source_rank": 1,
+                },
+            ]
+        )
+        merged["abnormal_reason"] = abnormal_reason
+        merged["abnormal_message"] = abnormal_message
         schedule_at = _parse_datetime(merged.get("scheduled_at"))
         started_at = _parse_datetime(merged.get("first_started_at"))
         merged["scheduled_at"] = schedule_at
@@ -836,6 +975,77 @@ def _load_single_lifecycle_aggregate(
         },
     ).mappings()
     return [dict(row) for row in rows]
+
+
+def _load_abnormal_event_summaries(
+    connection: Connection,
+    pods: list[tuple[str, str | None, str | None, str | None]],
+) -> dict[tuple[str, str | None, str | None, str | None], dict[str, Any]]:
+    if not pods:
+        return {}
+
+    requested_pods_sql, params = _build_requested_pods_relation(pods)
+    reason_placeholders: list[str] = []
+    for index, reason in enumerate(sorted(ABNORMAL_EVENT_REASONS)):
+        param_name = f"abnormal_reason_{index}"
+        reason_placeholders.append(f":{param_name}")
+        params[param_name] = reason
+
+    rows = connection.execute(
+        text(
+            f"""
+            WITH requested_pods AS (
+              {requested_pods_sql}
+            )
+            SELECT
+              events.source_project,
+              events.namespace_name,
+              events.pod_uid,
+              events.pod_name,
+              events.event_reason,
+              events.event_message,
+              events.event_timestamp
+            FROM {_pod_events_table_expr(connection.dialect.name)}
+            JOIN requested_pods AS requested
+              ON events.source_project = requested.source_project
+             AND {_null_safe_equals_sql('events.namespace_name', 'requested.namespace_name', connection.dialect.name)}
+             AND {_null_safe_equals_sql('events.pod_uid', 'requested.pod_uid', connection.dialect.name)}
+             AND {_null_safe_equals_sql('events.pod_name', 'requested.pod_name', connection.dialect.name)}
+            WHERE events.event_reason IN ({", ".join(reason_placeholders)})
+            """
+        ),
+        params,
+    ).mappings()
+
+    candidates_by_identity: dict[tuple[str, str | None, str | None, str | None], list[dict[str, Any]]] = (
+        defaultdict(list)
+    )
+    for row in rows:
+        identity = _pod_identity_from_values(
+            source_project=_coerce_str(row.get("source_project")) or "",
+            namespace_name=_coerce_str(row.get("namespace_name")),
+            pod_uid=_coerce_str(row.get("pod_uid")),
+            pod_name=_coerce_str(row.get("pod_name")),
+        )
+        candidates_by_identity[identity].append(
+            {
+                "reason": _coerce_str(row.get("event_reason")),
+                "message": _coerce_str(row.get("event_message")),
+                "timestamp": row.get("event_timestamp"),
+                "source_rank": 1,
+            }
+        )
+
+    summaries: dict[tuple[str, str | None, str | None, str | None], dict[str, Any]] = {}
+    for identity, candidates in candidates_by_identity.items():
+        abnormal_reason, abnormal_message = _select_abnormal_summary(candidates)
+        if abnormal_reason is None:
+            continue
+        summaries[identity] = {
+            "abnormal_reason": abnormal_reason,
+            "abnormal_message": abnormal_message,
+        }
+    return summaries
 
 
 def _pod_events_table_expr(dialect_name: str) -> str:
@@ -1267,6 +1477,8 @@ def _empty_pod_metadata_fields() -> dict[str, Any]:
         "pod_annotations_json": None,
         "metadata_observed_at": None,
         "pod_created_at": None,
+        "abnormal_reason": None,
+        "abnormal_message": None,
         "pod_author": None,
         "pod_org": None,
         "pod_repo": None,
@@ -1398,6 +1610,7 @@ def _list_namespace_pod_metadata(
                     annotations=_coerce_str_mapping(metadata.get("annotations")),
                     observed_at=observed_at,
                     creation_timestamp=_parse_datetime(metadata.get("creationTimestamp")),
+                    **_extract_pod_abnormal_summary(item, observed_at=observed_at),
                 )
         metadata_obj = response.get("metadata")
         continue_token = None
@@ -1712,7 +1925,16 @@ def _deserialize_pod_metadata_snapshots_from_lifecycle_rows(
     for lifecycle in lifecycle_rows:
         labels = _json_loads_str_mapping(lifecycle.get("pod_labels_json"))
         annotations = _json_loads_str_mapping(lifecycle.get("pod_annotations_json"))
-        if not labels and not annotations:
+        creation_timestamp = _parse_datetime(lifecycle.get("pod_created_at"))
+        abnormal_reason = _coerce_str(lifecycle.get("abnormal_reason"))
+        abnormal_message = _coerce_str(lifecycle.get("abnormal_message"))
+        if (
+            not labels
+            and not annotations
+            and creation_timestamp is None
+            and abnormal_reason is None
+            and abnormal_message is None
+        ):
             continue
         identity = _pod_identity_from_values(
             source_project=_coerce_str(lifecycle.get("source_project")) or "",
@@ -1726,7 +1948,9 @@ def _deserialize_pod_metadata_snapshots_from_lifecycle_rows(
             labels=labels,
             annotations=annotations,
             observed_at=observed_at,
-            creation_timestamp=_parse_datetime(lifecycle.get("pod_created_at")),
+            creation_timestamp=creation_timestamp,
+            abnormal_reason=abnormal_reason,
+            abnormal_message=abnormal_message,
         )
     return snapshots
 
@@ -1749,6 +1973,7 @@ def _build_pod_lifecycle_upsert_statement(connection: Connection):
             INSERT INTO ci_l1_pod_lifecycle (
               source_project, cluster_name, location, namespace_name, pod_name, pod_uid,
               build_system, pod_labels_json, pod_annotations_json, metadata_observed_at, pod_created_at,
+              abnormal_reason, abnormal_message,
               pod_author, pod_org, pod_repo, jenkins_label, jenkins_label_digest, jenkins_controller, ci_job,
               source_prow_job_id, normalized_build_url, repo_full_name, job_name,
               scheduled_at, first_pulling_at, first_pulled_at, first_created_at, first_started_at,
@@ -1756,6 +1981,7 @@ def _build_pod_lifecycle_upsert_statement(connection: Connection):
             ) VALUES (
               :source_project, :cluster_name, :location, :namespace_name, :pod_name, :pod_uid,
               :build_system, :pod_labels_json, :pod_annotations_json, :metadata_observed_at, :pod_created_at,
+              :abnormal_reason, :abnormal_message,
               :pod_author, :pod_org, :pod_repo, :jenkins_label, :jenkins_label_digest, :jenkins_controller, :ci_job,
               :source_prow_job_id, :normalized_build_url, :repo_full_name, :job_name,
               :scheduled_at, :first_pulling_at, :first_pulled_at, :first_created_at, :first_started_at,
@@ -1769,6 +1995,8 @@ def _build_pod_lifecycle_upsert_statement(connection: Connection):
               pod_annotations_json = excluded.pod_annotations_json,
               metadata_observed_at = excluded.metadata_observed_at,
               pod_created_at = excluded.pod_created_at,
+              abnormal_reason = excluded.abnormal_reason,
+              abnormal_message = excluded.abnormal_message,
               pod_author = excluded.pod_author,
               pod_org = excluded.pod_org,
               pod_repo = excluded.pod_repo,
@@ -1797,6 +2025,7 @@ def _build_pod_lifecycle_upsert_statement(connection: Connection):
         INSERT INTO ci_l1_pod_lifecycle (
           source_project, cluster_name, location, namespace_name, pod_name, pod_uid,
           build_system, pod_labels_json, pod_annotations_json, metadata_observed_at, pod_created_at,
+          abnormal_reason, abnormal_message,
           pod_author, pod_org, pod_repo, jenkins_label, jenkins_label_digest, jenkins_controller, ci_job,
           source_prow_job_id, normalized_build_url, repo_full_name, job_name,
           scheduled_at, first_pulling_at, first_pulled_at, first_created_at, first_started_at,
@@ -1804,6 +2033,7 @@ def _build_pod_lifecycle_upsert_statement(connection: Connection):
         ) VALUES (
           :source_project, :cluster_name, :location, :namespace_name, :pod_name, :pod_uid,
           :build_system, :pod_labels_json, :pod_annotations_json, :metadata_observed_at, :pod_created_at,
+          :abnormal_reason, :abnormal_message,
           :pod_author, :pod_org, :pod_repo, :jenkins_label, :jenkins_label_digest, :jenkins_controller, :ci_job,
           :source_prow_job_id, :normalized_build_url, :repo_full_name, :job_name,
           :scheduled_at, :first_pulling_at, :first_pulled_at, :first_created_at, :first_started_at,
@@ -1817,6 +2047,8 @@ def _build_pod_lifecycle_upsert_statement(connection: Connection):
           pod_annotations_json = VALUES(pod_annotations_json),
           metadata_observed_at = VALUES(metadata_observed_at),
           pod_created_at = VALUES(pod_created_at),
+          abnormal_reason = VALUES(abnormal_reason),
+          abnormal_message = VALUES(abnormal_message),
           pod_author = VALUES(pod_author),
           pod_org = VALUES(pod_org),
           pod_repo = VALUES(pod_repo),

--- a/ci-dashboard/tests/conftest.py
+++ b/ci-dashboard/tests/conftest.py
@@ -251,6 +251,8 @@ def _create_test_schema(engine: Engine) -> None:
           pod_annotations_json TEXT NULL,
           metadata_observed_at TEXT NULL,
           pod_created_at TEXT NULL,
+          abnormal_reason TEXT NULL,
+          abnormal_message TEXT NULL,
           pod_author TEXT NULL,
           pod_org TEXT NULL,
           pod_repo TEXT NULL,

--- a/ci-dashboard/tests/jobs/test_pod_watcher.py
+++ b/ci-dashboard/tests/jobs/test_pod_watcher.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import queue
 import socket
 import threading
 from datetime import datetime
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 
+import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 
@@ -24,6 +26,7 @@ from ci_dashboard.jobs.pod_watcher import (
     _build_lifecycle_rows_for_snapshots,
     _db_batch_size,
     _format_watch_error,
+    _get_jenkins_prefixes_if_needed,
     _is_retryable_db_error,
     _is_resource_version_expired_watch_error,
     _load_runtime_context,
@@ -32,11 +35,16 @@ from ci_dashboard.jobs.pod_watcher import (
     _persist_pod_events,
     _persist_pod_snapshots,
     _read_non_negative_int_env,
+    _run_event_worker,
+    _run_pod_worker,
     _sleep_until_retry,
     _start_health_server,
     _stream_key,
     _stream_watch_json,
+    _worker_guard,
+    run_watch_pods,
 )
+from ci_dashboard.jobs.state_store import get_job_state
 from ci_dashboard.jobs.sync_pods import NormalizedPodEvent, PodMetadataSnapshot
 
 
@@ -73,6 +81,7 @@ def _watched_snapshot(
     annotations: dict[str, str] | None = None,
     observed_at: datetime = datetime(2026, 5, 1, 1, 0, 2),
     creation_timestamp: datetime = datetime(2026, 5, 1, 1, 0, 1),
+    **snapshot_fields: object,
 ) -> WatchedPodSnapshot:
     return WatchedPodSnapshot(
         source_project="pingcap-testing-account",
@@ -87,6 +96,7 @@ def _watched_snapshot(
             annotations=annotations or {},
             observed_at=observed_at,
             creation_timestamp=creation_timestamp,
+            **snapshot_fields,
         ),
     )
 
@@ -121,6 +131,29 @@ def _pod_event(
         reporting_instance=instance,
         source_insert_id=insert_id,
     )
+
+
+class _FakeRecorder:
+    def __init__(self, *, stop_event: threading.Event | None = None) -> None:
+        self.calls: list[dict[str, int]] = []
+        self._stop_event = stop_event
+
+    def add(self, **kwargs: int) -> None:
+        self.calls.append(kwargs)
+        if kwargs.get("watch_restarts") and self._stop_event is not None:
+            self._stop_event.set()
+
+
+class _FakeHealthServer:
+    def __init__(self) -> None:
+        self.shutdown_calls = 0
+        self.close_calls = 0
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+    def server_close(self) -> None:
+        self.close_calls += 1
 
 
 def test_watch_health_state_requires_each_stream_heartbeat() -> None:
@@ -371,6 +404,96 @@ def test_runtime_context_and_helper_edge_cases(monkeypatch) -> None:
     _sleep_until_retry(stop_event)
 
 
+def test_worker_guard_forwards_errors_and_sets_stop_event() -> None:
+    worker_errors: queue.Queue[BaseException] = queue.Queue()
+    stop_event = threading.Event()
+
+    def boom() -> None:
+        raise RuntimeError("worker exploded")
+
+    _worker_guard(
+        worker_errors=worker_errors,
+        stop_event=stop_event,
+        target=boom,
+        target_kwargs={},
+    )
+
+    assert stop_event.is_set() is True
+    exc = worker_errors.get_nowait()
+    assert isinstance(exc, RuntimeError)
+    assert str(exc) == "worker exploded"
+
+
+def test_run_watch_pods_marks_job_succeeded(sqlite_engine, monkeypatch) -> None:
+    pod_calls: list[str] = []
+    event_calls: list[str] = []
+    health_server = _FakeHealthServer()
+
+    monkeypatch.setattr(watcher, "_load_runtime_context", _runtime_context)
+    monkeypatch.setattr(watcher, "_get_kubernetes_api_url", lambda: "https://k8s.example")
+    monkeypatch.setattr(watcher, "_get_kubernetes_api_token", lambda: "token")
+    monkeypatch.setattr(watcher, "_get_kubernetes_api_ca_file", lambda: None)
+    monkeypatch.setattr(watcher, "_load_target_namespaces", lambda connection: ["jenkins-tidb"])
+    monkeypatch.setattr(watcher, "_start_health_server", lambda health_state: health_server)
+
+    def fake_run_pod_worker(**kwargs) -> None:
+        pod_calls.append(kwargs["namespace_name"])
+
+    def fake_run_event_worker(**kwargs) -> None:
+        event_calls.append(kwargs["namespace_name"])
+
+    monkeypatch.setattr(watcher, "_run_pod_worker", fake_run_pod_worker)
+    monkeypatch.setattr(watcher, "_run_event_worker", fake_run_event_worker)
+
+    summary = run_watch_pods(sqlite_engine, _settings())
+
+    assert isinstance(summary, WatchPodsSummary)
+    assert pod_calls == ["jenkins-tidb"]
+    assert event_calls == ["jenkins-tidb"]
+    assert health_server.shutdown_calls == 1
+    assert health_server.close_calls == 1
+    with sqlite_engine.begin() as connection:
+        state = get_job_state(connection, "ci-watch-pods")
+    assert state is not None
+    assert state.last_status == "succeeded"
+    assert state.watermark == {"namespaces": ["jenkins-tidb"]}
+
+
+def test_run_watch_pods_marks_job_failed_when_worker_errors(sqlite_engine, monkeypatch) -> None:
+    health_server = _FakeHealthServer()
+
+    monkeypatch.setattr(watcher, "_load_runtime_context", _runtime_context)
+    monkeypatch.setattr(watcher, "_get_kubernetes_api_url", lambda: "https://k8s.example")
+    monkeypatch.setattr(watcher, "_get_kubernetes_api_token", lambda: "token")
+    monkeypatch.setattr(watcher, "_get_kubernetes_api_ca_file", lambda: None)
+    monkeypatch.setattr(watcher, "_load_target_namespaces", lambda connection: ["jenkins-tidb"])
+    monkeypatch.setattr(watcher, "_start_health_server", lambda health_state: health_server)
+    monkeypatch.setattr(
+        watcher,
+        "_run_pod_worker",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(watcher, "_run_event_worker", lambda **kwargs: None)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run_watch_pods(sqlite_engine, _settings())
+
+    assert health_server.shutdown_calls == 1
+    assert health_server.close_calls == 1
+    with sqlite_engine.begin() as connection:
+        state = get_job_state(connection, "ci-watch-pods")
+    assert state is not None
+    assert state.last_status == "failed"
+    assert state.last_error == "boom"
+
+
+def test_run_watch_pods_validates_max_events(sqlite_engine, monkeypatch) -> None:
+    monkeypatch.setattr(watcher, "_load_runtime_context", _runtime_context)
+
+    with pytest.raises(ValueError, match="max_events must be positive"):
+        run_watch_pods(sqlite_engine, _settings(), max_events=0)
+
+
 def test_normalize_pod_object_preserves_creation_time_and_metadata() -> None:
     snapshot = _normalize_pod_object(
         {
@@ -396,6 +519,43 @@ def test_normalize_pod_object_preserves_creation_time_and_metadata() -> None:
     assert snapshot.snapshot.creation_timestamp == datetime(2026, 5, 1, 1, 2, 3)
     assert snapshot.snapshot.labels == {"org": "pingcap", "repo": "tidb"}
     assert snapshot.snapshot.annotations == {"ci_job": "pingcap/tidb/ghpr_unit_test"}
+
+
+def test_normalize_pod_object_captures_abnormal_summary() -> None:
+    snapshot = _normalize_pod_object(
+        {
+            "metadata": {
+                "namespace": "jenkins-tidb",
+                "name": "agent-pod",
+                "uid": "uid-a",
+                "creationTimestamp": "2026-05-01T01:02:03Z",
+                "deletionTimestamp": "2026-05-01T01:05:00Z",
+            },
+            "status": {
+                "phase": "Failed",
+                "reason": "NodeLost",
+                "message": "Node became unreachable",
+                "containerStatuses": [
+                    {
+                        "restartCount": 2,
+                        "lastState": {
+                            "terminated": {
+                                "reason": "OOMKilled",
+                                "message": "Container was OOM killed",
+                                "finishedAt": "2026-05-01T01:04:30Z",
+                            }
+                        },
+                    },
+                    {"restartCount": 1},
+                ],
+            },
+        },
+        context=_runtime_context(),
+    )
+
+    assert snapshot is not None
+    assert snapshot.snapshot.abnormal_reason == "OOMKilled"
+    assert snapshot.snapshot.abnormal_message == "Container was OOM killed"
 
 
 def test_normalize_kubernetes_event_uses_core_event_fields() -> None:
@@ -434,6 +594,232 @@ def test_normalize_kubernetes_event_uses_core_event_fields() -> None:
     assert normalized.source_insert_id == "kubernetes-event:event-uid:12345"
     assert normalized.reporting_component == "kubelet"
     assert normalized.reporting_instance == "node-a"
+
+
+def test_run_pod_worker_processes_list_and_stream_events(sqlite_engine, monkeypatch) -> None:
+    stop_event = threading.Event()
+    recorder = _FakeRecorder(stop_event=stop_event)
+    health_state = WatchHealthState(stale_after_seconds=60)
+    stream_key = _stream_key("jenkins-tidb", "pods")
+    health_state.register(stream_key)
+    persisted_batches: list[list[str]] = []
+
+    class _FakeClient:
+        def list_collection(self, *, namespace_name: str, resource: str):
+            assert namespace_name == "jenkins-tidb"
+            assert resource == "pods"
+            return (
+                [
+                    {
+                        "metadata": {
+                            "namespace": "jenkins-tidb",
+                            "name": "agent-pod",
+                            "uid": "uid-a",
+                            "creationTimestamp": "2026-05-01T01:02:03Z",
+                        }
+                    }
+                ],
+                "rv-pods",
+            )
+
+        def stream_collection(self, *, namespace_name: str, resource: str, resource_version: str):
+            assert namespace_name == "jenkins-tidb"
+            assert resource == "pods"
+            assert resource_version == "rv-pods"
+            yield {"type": "BOOKMARK"}
+            yield {"type": "ADDED", "object": "not-a-pod"}
+            yield {
+                "type": "ADDED",
+                "object": {
+                    "metadata": {
+                        "namespace": "jenkins-tidb",
+                        "name": "agent-pod-2",
+                        "uid": "uid-b",
+                        "creationTimestamp": "2026-05-01T01:03:03Z",
+                    }
+                },
+            }
+            yield {"type": "ERROR", "object": {"reason": "Gone", "message": "too old", "code": 410}}
+
+    def fake_persist_pod_snapshots(
+        engine,
+        settings,
+        snapshots,
+        *,
+        jenkins_prefix_cache=None,
+        on_batch_persisted=None,
+    ) -> int:
+        del engine, settings, jenkins_prefix_cache
+        persisted_batches.append([snapshot.pod_name for snapshot in snapshots])
+        if on_batch_persisted is not None:
+            on_batch_persisted()
+        return len(snapshots)
+
+    monkeypatch.setattr(watcher, "_persist_pod_snapshots", fake_persist_pod_snapshots)
+
+    _run_pod_worker(
+        engine=sqlite_engine,
+        settings=_settings(),
+        client=_FakeClient(),
+        context=_runtime_context(),
+        namespace_name="jenkins-tidb",
+        stream_key=stream_key,
+        health_state=health_state,
+        recorder=recorder,
+        jenkins_prefix_cache=_JenkinsPodNameUrlPrefixCache(ttl_seconds=900),
+        stop_event=stop_event,
+    )
+
+    assert persisted_batches == [["agent-pod"], ["agent-pod-2"]]
+    assert recorder.calls[0]["pod_snapshots_seen"] == 1
+    assert recorder.calls[1]["pod_snapshots_seen"] == 1
+    assert recorder.calls[2]["watch_restarts"] == 1
+    assert health_state.snapshot()["streams"][stream_key]["healthy"] is True
+
+
+def test_run_event_worker_processes_list_and_stream_events(sqlite_engine, monkeypatch) -> None:
+    stop_event = threading.Event()
+    recorder = _FakeRecorder(stop_event=stop_event)
+    health_state = WatchHealthState(stale_after_seconds=60)
+    stream_key = _stream_key("jenkins-tidb", "events")
+    health_state.register(stream_key)
+    persisted_batches: list[list[str]] = []
+
+    class _FakeClient:
+        def list_collection(self, *, namespace_name: str, resource: str):
+            assert namespace_name == "jenkins-tidb"
+            assert resource == "events"
+            return (
+                [
+                    {
+                        "metadata": {
+                            "namespace": "jenkins-tidb",
+                            "name": "agent-pod.1",
+                            "uid": "event-1",
+                            "resourceVersion": "rv-1",
+                            "creationTimestamp": "2026-05-01T01:02:08Z",
+                        },
+                        "involvedObject": {
+                            "kind": "Pod",
+                            "namespace": "jenkins-tidb",
+                            "name": "agent-pod",
+                            "uid": "uid-a",
+                        },
+                        "reason": "Unhealthy",
+                        "type": "Warning",
+                        "message": "Readiness probe failed",
+                        "lastTimestamp": "2026-05-01T01:02:10Z",
+                    }
+                ],
+                "rv-events",
+            )
+
+        def stream_collection(self, *, namespace_name: str, resource: str, resource_version: str):
+            assert namespace_name == "jenkins-tidb"
+            assert resource == "events"
+            assert resource_version == "rv-events"
+            yield {"type": "BOOKMARK"}
+            yield {"type": "ADDED", "object": "not-an-event"}
+            yield {
+                "type": "ADDED",
+                "object": {
+                    "metadata": {
+                        "namespace": "jenkins-tidb",
+                        "name": "agent-pod.2",
+                        "uid": "event-2",
+                        "resourceVersion": "rv-2",
+                        "creationTimestamp": "2026-05-01T01:03:08Z",
+                    },
+                    "involvedObject": {
+                        "kind": "Pod",
+                        "namespace": "jenkins-tidb",
+                        "name": "agent-pod",
+                        "uid": "uid-a",
+                    },
+                    "reason": "Killing",
+                    "type": "Warning",
+                    "message": "Stopping container",
+                    "lastTimestamp": "2026-05-01T01:03:10Z",
+                },
+            }
+            yield {"type": "ERROR", "object": {"reason": "Gone", "message": "too old", "code": 410}}
+
+    def fake_persist_pod_events(
+        engine,
+        settings,
+        rows,
+        *,
+        jenkins_prefix_cache=None,
+        on_batch_persisted=None,
+    ) -> tuple[int, int, int]:
+        del engine, settings, jenkins_prefix_cache
+        persisted_batches.append([row.event_reason or "" for row in rows])
+        if on_batch_persisted is not None:
+            on_batch_persisted()
+        return len(rows), len(rows), len(rows)
+
+    monkeypatch.setattr(watcher, "_persist_pod_events", fake_persist_pod_events)
+
+    _run_event_worker(
+        engine=sqlite_engine,
+        settings=_settings(),
+        client=_FakeClient(),
+        context=_runtime_context(),
+        namespace_name="jenkins-tidb",
+        stream_key=stream_key,
+        health_state=health_state,
+        recorder=recorder,
+        jenkins_prefix_cache=_JenkinsPodNameUrlPrefixCache(ttl_seconds=900),
+        stop_event=stop_event,
+    )
+
+    assert persisted_batches == [["Unhealthy"], ["Killing"]]
+    assert recorder.calls[0]["event_rows_seen"] == 1
+    assert recorder.calls[1]["event_rows_seen"] == 1
+    assert recorder.calls[2]["watch_restarts"] == 1
+    assert health_state.snapshot()["streams"][stream_key]["healthy"] is True
+
+
+def test_run_event_worker_retries_after_non_expired_watch_error(sqlite_engine, monkeypatch) -> None:
+    stop_event = threading.Event()
+    recorder = _FakeRecorder()
+    health_state = WatchHealthState(stale_after_seconds=60)
+    stream_key = _stream_key("jenkins-tidb", "events")
+    health_state.register(stream_key)
+    sleep_calls = 0
+
+    class _FakeClient:
+        def list_collection(self, *, namespace_name: str, resource: str):
+            assert namespace_name == "jenkins-tidb"
+            assert resource == "events"
+            return ([], "rv-events")
+
+        def stream_collection(self, *, namespace_name: str, resource: str, resource_version: str):
+            del namespace_name, resource, resource_version
+            yield {"type": "ERROR", "object": {"reason": "Forbidden", "message": "denied", "code": 403}}
+
+    def fake_sleep_until_retry(inner_stop_event: threading.Event) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        inner_stop_event.set()
+
+    monkeypatch.setattr(watcher, "_sleep_until_retry", fake_sleep_until_retry)
+
+    _run_event_worker(
+        engine=sqlite_engine,
+        settings=_settings(),
+        client=_FakeClient(),
+        context=_runtime_context(),
+        namespace_name="jenkins-tidb",
+        stream_key=stream_key,
+        health_state=health_state,
+        recorder=recorder,
+        jenkins_prefix_cache=_JenkinsPodNameUrlPrefixCache(ttl_seconds=900),
+        stop_event=stop_event,
+    )
+
+    assert sleep_calls == 1
+    assert any(call.get("watch_restarts") == 1 for call in recorder.calls)
 
 
 def test_snapshot_lifecycle_keeps_metadata_when_events_arrive_later(sqlite_engine) -> None:
@@ -517,6 +903,34 @@ def test_snapshot_lifecycle_keeps_metadata_when_events_arrive_later(sqlite_engin
     assert lifecycle["schedule_to_started_seconds"] == 20
 
 
+def test_persist_pod_snapshots_records_abnormal_summary(sqlite_engine) -> None:
+    snapshot = _watched_snapshot(
+        namespace_name="prow-test-pods",
+        pod_name="status-pod",
+        pod_uid="uid-status",
+        abnormal_reason="OOMKilled",
+        abnormal_message="Container was OOM killed",
+    )
+
+    assert _persist_pod_snapshots(sqlite_engine, _settings(), [snapshot]) == 1
+
+    with sqlite_engine.begin() as connection:
+        lifecycle = connection.execute(
+            text(
+                """
+                SELECT
+                  abnormal_reason,
+                  abnormal_message
+                FROM ci_l1_pod_lifecycle
+                WHERE pod_uid = 'uid-status'
+                """
+            )
+        ).mappings().one()
+
+    assert lifecycle["abnormal_reason"] == "OOMKilled"
+    assert lifecycle["abnormal_message"] == "Container was OOM killed"
+
+
 def test_build_lifecycle_rows_for_snapshots_uses_existing_event_aggregates(sqlite_engine) -> None:
     snapshot = _watched_snapshot(
         namespace_name="prow-test-pods",
@@ -538,6 +952,69 @@ def test_build_lifecycle_rows_for_snapshots_uses_existing_event_aggregates(sqlit
     assert len(rows) == 1
     assert rows[0]["scheduled_at"] == datetime(2026, 5, 1, 1, 0, 5)
     assert rows[0]["pod_created_at"] == datetime(2026, 5, 1, 1, 0, 1)
+
+
+def test_persist_pod_events_records_highest_priority_abnormal_summary(sqlite_engine) -> None:
+    snapshot = _watched_snapshot(
+        namespace_name="prow-test-pods",
+        pod_name="anomaly-pod",
+        pod_uid="uid-anomaly",
+    )
+    assert _persist_pod_snapshots(sqlite_engine, _settings(), [snapshot]) == 1
+
+    events = [
+        _pod_event(
+            namespace_name="prow-test-pods",
+            pod_name="anomaly-pod",
+            pod_uid="uid-anomaly",
+            reason="Killing",
+            timestamp=datetime(2026, 5, 1, 1, 0, 10),
+            insert_id="kubernetes-event:killing",
+            component="kubelet",
+            instance="node-a",
+            message="Stopping container",
+        ),
+        _pod_event(
+            namespace_name="prow-test-pods",
+            pod_name="anomaly-pod",
+            pod_uid="uid-anomaly",
+            reason="Unhealthy",
+            timestamp=datetime(2026, 5, 1, 1, 0, 20),
+            insert_id="kubernetes-event:unhealthy",
+            component="kubelet",
+            instance="node-a",
+            message="Readiness probe failed",
+        ),
+        _pod_event(
+            namespace_name="prow-test-pods",
+            pod_name="anomaly-pod",
+            pod_uid="uid-anomaly",
+            reason="Preempting",
+            timestamp=datetime(2026, 5, 1, 1, 0, 30),
+            insert_id="kubernetes-event:preempting",
+            component="default-scheduler",
+            instance="scheduler",
+            message="Preempting pod",
+        ),
+    ]
+
+    assert _persist_pod_events(sqlite_engine, _settings(), events) == (3, 1, 1)
+
+    with sqlite_engine.begin() as connection:
+        lifecycle = connection.execute(
+            text(
+                """
+                SELECT
+                  abnormal_reason,
+                  abnormal_message
+                FROM ci_l1_pod_lifecycle
+                WHERE pod_uid = 'uid-anomaly'
+                """
+            )
+        ).mappings().one()
+
+    assert lifecycle["abnormal_reason"] == "Unhealthy"
+    assert lifecycle["abnormal_message"] == "Readiness probe failed"
 
 
 def test_persist_paths_cache_jenkins_prefixes_and_refresh_heartbeat(sqlite_engine, monkeypatch) -> None:
@@ -665,3 +1142,32 @@ def test_persist_pod_events_retries_retryable_db_error(sqlite_engine, monkeypatc
     assert calls == 2
     assert heartbeats == 2
     assert sleep_calls == [0.025]
+
+
+def test_get_jenkins_prefixes_if_needed_respects_namespace(sqlite_engine, monkeypatch) -> None:
+    load_calls = 0
+
+    def fake_load_prefixes(connection):
+        del connection
+        nonlocal load_calls
+        load_calls += 1
+        return {"ghpr-unit-test": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/"}
+
+    monkeypatch.setattr(watcher, "_load_jenkins_pod_name_url_prefix_map", fake_load_prefixes)
+    cache = _JenkinsPodNameUrlPrefixCache(ttl_seconds=900)
+
+    with sqlite_engine.begin() as connection:
+        assert _get_jenkins_prefixes_if_needed(
+            connection,
+            [("pingcap-testing-account", "prow-test-pods", "uid-a", "pod-a")],
+            cache,
+        ) is None
+        assert _get_jenkins_prefixes_if_needed(
+            connection,
+            [("pingcap-testing-account", "jenkins-tidb", "uid-a", "pod-a")],
+            cache,
+        ) == {
+            "ghpr-unit-test": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/"
+        }
+
+    assert load_calls == 1

--- a/ci-dashboard/tests/jobs/test_sync_pods.py
+++ b/ci-dashboard/tests/jobs/test_sync_pods.py
@@ -45,6 +45,7 @@ from ci_dashboard.jobs.sync_pods import (
     _read_int_env,
     _request_json,
     _resolve_jenkins_build_metadata,
+    _select_abnormal_summary,
     _upsert_pod_events,
     run_reconcile_pod_linkage_for_time_window,
     run_sync_pods,
@@ -77,6 +78,7 @@ def _pod_metadata(
     annotations: dict[str, str] | None = None,
     pod_uid: str | None = None,
     creation_timestamp: datetime | None = None,
+    **status_fields: object,
 ) -> PodMetadataSnapshot:
     return PodMetadataSnapshot(
         pod_uid=pod_uid,
@@ -84,6 +86,7 @@ def _pod_metadata(
         annotations=annotations or {},
         observed_at=datetime(2026, 4, 21, 9, 45, 0),
         creation_timestamp=creation_timestamp,
+        **status_fields,
     )
 
 
@@ -230,7 +233,17 @@ def test_sync_pod_helper_functions_cover_common_edge_cases(sqlite_engine, monkey
     assert _null_safe_equals_sql("a", "b", "mysql") == "a <=> b"
     assert _pod_events_table_expr("sqlite") == "ci_l1_pod_events AS events"
     assert _pod_events_table_expr("mysql") == "ci_l1_pod_events events USE INDEX(idx_ci_l1_pod_events_identity_time)"
-    assert {"Failed", "BackOff", "ErrImagePull", "ImagePullBackOff"}.issubset(POD_EVENT_REASONS)
+    assert {
+        "Failed",
+        "BackOff",
+        "ErrImagePull",
+        "ImagePullBackOff",
+        "Killing",
+        "Evicted",
+        "NodeLost",
+        "Unhealthy",
+        "Preempting",
+    }.issubset(POD_EVENT_REASONS)
     relation_sql, params = _build_requested_pods_relation([("p1", "ns", "uid", "pod")])
     assert "UNION ALL" not in relation_sql
     assert params == {
@@ -319,7 +332,31 @@ def test_sync_pods_http_and_kubernetes_helpers(monkeypatch: pytest.MonkeyPatch) 
     assert _get_kubernetes_api_ca_file() is None
 
 
+def test_select_abnormal_summary_prefers_diagnostic_message_for_same_reason() -> None:
+    reason, message = _select_abnormal_summary(
+        [
+            {
+                "reason": "Evicted",
+                "message": None,
+                "source_rank": 0,
+                "timestamp": "2026-04-20T12:54:35Z",
+            },
+            {
+                "reason": "Evicted",
+                "message": "The node had condition: [MemoryPressure].",
+                "source_rank": 1,
+                "timestamp": "2026-04-20T12:54:34Z",
+            },
+        ]
+    )
+
+    assert reason == "Evicted"
+    assert message == "The node had condition: [MemoryPressure]."
+
+
 def test_sync_pods_build_matching_helpers_cover_jenkins_paths(sqlite_engine, monkeypatch) -> None:
+    monkeypatch.setenv("CI_DASHBOARD_JENKINS_POD_NAME_PREFIX_LOOKBACK_DAYS", "90")
+
     assert _normalize_jenkins_runtime_url("https://do.pingcap.net/jenkins/job/a/1/") is None
     assert _normalize_jenkins_runtime_url("https://prow.tidb.net/jenkins/job/a/1/") == "https://prow.tidb.net/jenkins/job/a/1/"
     assert _infer_pod_build_system("jenkins-tidb") == "JENKINS"
@@ -478,6 +515,242 @@ def test_sync_pods_metadata_fetch_and_logging_entry_normalization(monkeypatch: p
     assert snapshots["pod-a"].labels == {"author": "alice"}
     assert snapshots["pod-a"].annotations == {"ci_job": "pingcap/tidb/test-a"}
     assert snapshots["pod-a"].creation_timestamp == datetime(2026, 4, 20, 12, 49, 30)
+
+
+def test_sync_pods_metadata_fetch_extracts_status_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed_at = datetime(2026, 4, 20, 13, 0, 0)
+    pages = iter(
+        [
+            {
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "pod-a",
+                            "uid": "uid-a",
+                            "creationTimestamp": "2026-04-20T12:49:30Z",
+                            "deletionTimestamp": "2026-04-20T13:00:05Z",
+                            "labels": {"author": "alice"},
+                            "annotations": {"ci_job": "pingcap/tidb/test-a"},
+                        },
+                        "status": {
+                            "phase": "Failed",
+                            "reason": "Evicted",
+                            "message": "The node had condition: [MemoryPressure].",
+                            "containerStatuses": [
+                                {
+                                    "restartCount": 2,
+                                    "lastState": {
+                                        "terminated": {
+                                            "reason": "OOMKilled",
+                                            "message": "Container was OOM killed",
+                                            "finishedAt": "2026-04-20T12:59:30Z",
+                                        }
+                                    },
+                                },
+                                {"restartCount": 1},
+                            ],
+                        },
+                    }
+                ],
+                "metadata": {},
+            }
+        ]
+    )
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods._get_json", lambda *args, **kwargs: next(pages))
+
+    snapshots = _list_namespace_pod_metadata(
+        namespace_name="jenkins-tidb",
+        requested_pod_names={"pod-a"},
+        base_url="https://k8s.internal",
+        token="token",
+        ca_file=None,
+        observed_at=observed_at,
+    )
+
+    snapshot = snapshots["pod-a"]
+    assert snapshot.abnormal_reason == "OOMKilled"
+    assert snapshot.abnormal_message == "Container was OOM killed"
+
+
+def test_sync_pods_end_to_end_records_abnormal_summary(sqlite_engine, monkeypatch) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_builds (
+                  source_prow_row_id, source_prow_job_id, namespace, job_name, job_type, state,
+                  optional, report, org, repo, repo_full_name, url, normalized_build_url,
+                  pod_name, start_time, cloud_phase, build_system
+                ) VALUES (
+                  11, 'prow-job-status-1', 'prow-test-pods', 'ghpr_unit_test', 'presubmit', 'failure',
+                  0, 1, 'pingcap', 'tidb', 'pingcap/tidb',
+                  'https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/pingcap_tidb/66207/ghpr_unit_test/11/',
+                  'https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/pingcap_tidb/66207/ghpr_unit_test/11/',
+                  'pod-status', '2026-04-20T12:50:00Z', 'GCP', 'PROW_NATIVE'
+                )
+                """
+            )
+        )
+
+    entries = [
+        {
+            "insertId": "status-ins-1",
+            "logName": "projects/pingcap-testing-account/logs/events",
+            "timestamp": "2026-04-20T12:53:49Z",
+            "receiveTimestamp": "2026-04-20T12:53:54Z",
+            "resource": {
+                "labels": {
+                    "cluster_name": "prow",
+                    "location": "us-central1-c",
+                    "namespace_name": "prow-test-pods",
+                    "pod_name": "pod-status",
+                }
+            },
+            "jsonPayload": {
+                "reason": "Scheduled",
+                "type": "Normal",
+                "message": "Successfully assigned",
+                "reportingComponent": "default-scheduler",
+                "reportingInstance": "gke-node-1",
+                "involvedObject": {"uid": "uid-status"},
+                "firstTimestamp": "2026-04-20T12:53:49Z",
+                "lastTimestamp": "2026-04-20T12:53:49Z",
+            },
+        },
+        {
+            "insertId": "status-ins-2",
+            "logName": "projects/pingcap-testing-account/logs/events",
+            "timestamp": "2026-04-20T12:54:10Z",
+            "receiveTimestamp": "2026-04-20T12:54:11Z",
+            "resource": {
+                "labels": {
+                    "cluster_name": "prow",
+                    "location": "us-central1-c",
+                    "namespace_name": "prow-test-pods",
+                    "pod_name": "pod-status",
+                }
+            },
+            "jsonPayload": {
+                "reason": "Killing",
+                "type": "Warning",
+                "message": "Stopping container test",
+                "reportingComponent": "kubelet",
+                "reportingInstance": "gke-node-1",
+                "involvedObject": {"uid": "uid-status"},
+                "firstTimestamp": "2026-04-20T12:54:10Z",
+                "lastTimestamp": "2026-04-20T12:54:10Z",
+            },
+        },
+        {
+            "insertId": "status-ins-3",
+            "logName": "projects/pingcap-testing-account/logs/events",
+            "timestamp": "2026-04-20T12:54:20Z",
+            "receiveTimestamp": "2026-04-20T12:54:21Z",
+            "resource": {
+                "labels": {
+                    "cluster_name": "prow",
+                    "location": "us-central1-c",
+                    "namespace_name": "prow-test-pods",
+                    "pod_name": "pod-status",
+                }
+            },
+            "jsonPayload": {
+                "reason": "Unhealthy",
+                "type": "Warning",
+                "message": "Readiness probe failed",
+                "reportingComponent": "kubelet",
+                "reportingInstance": "gke-node-1",
+                "involvedObject": {"uid": "uid-status"},
+                "firstTimestamp": "2026-04-20T12:54:20Z",
+                "lastTimestamp": "2026-04-20T12:54:20Z",
+            },
+        },
+        {
+            "insertId": "status-ins-4",
+            "logName": "projects/pingcap-testing-account/logs/events",
+            "timestamp": "2026-04-20T12:54:30Z",
+            "receiveTimestamp": "2026-04-20T12:54:31Z",
+            "resource": {
+                "labels": {
+                    "cluster_name": "prow",
+                    "location": "us-central1-c",
+                    "namespace_name": "prow-test-pods",
+                    "pod_name": "pod-status",
+                }
+            },
+            "jsonPayload": {
+                "reason": "Preempting",
+                "type": "Warning",
+                "message": "Preempting pod",
+                "reportingComponent": "default-scheduler",
+                "reportingInstance": "gke-node-1",
+                "involvedObject": {"uid": "uid-status"},
+                "firstTimestamp": "2026-04-20T12:54:30Z",
+                "lastTimestamp": "2026-04-20T12:54:30Z",
+            },
+        },
+        {
+            "insertId": "status-ins-5",
+            "logName": "projects/pingcap-testing-account/logs/events",
+            "timestamp": "2026-04-20T12:54:35Z",
+            "receiveTimestamp": "2026-04-20T12:54:36Z",
+            "resource": {
+                "labels": {
+                    "cluster_name": "prow",
+                    "location": "us-central1-c",
+                    "namespace_name": "prow-test-pods",
+                    "pod_name": "pod-status",
+                }
+            },
+            "jsonPayload": {
+                "reason": "Evicted",
+                "type": "Warning",
+                "message": "The node had condition: [MemoryPressure].",
+                "reportingComponent": "kubelet",
+                "reportingInstance": "gke-node-1",
+                "involvedObject": {"uid": "uid-status"},
+                "firstTimestamp": "2026-04-20T12:54:35Z",
+                "lastTimestamp": "2026-04-20T12:54:35Z",
+            },
+        },
+    ]
+
+    monkeypatch.setattr("ci_dashboard.jobs.sync_pods._fetch_pod_event_entries", lambda **_: entries)
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_pods._load_pod_metadata_snapshots",
+        lambda _pods: {
+            _pod_identity("prow-test-pods", "uid-status", "pod-status"): _pod_metadata(
+                pod_uid="uid-status",
+                creation_timestamp=datetime(2026, 4, 20, 12, 49, 30),
+                abnormal_reason="OOMKilled",
+                abnormal_message="Container was OOM killed",
+            )
+        },
+    )
+
+    summary = run_sync_pods(sqlite_engine, _settings(batch_size=10))
+    assert summary.lifecycle_rows_upserted == 1
+    assert summary.pods_touched == 1
+
+    with sqlite_engine.begin() as connection:
+        lifecycle = connection.execute(
+            text(
+                """
+                SELECT
+                  pod_created_at,
+                  abnormal_reason,
+                  abnormal_message
+                FROM ci_l1_pod_lifecycle
+                WHERE source_project = 'pingcap-testing-account'
+                  AND namespace_name = 'prow-test-pods'
+                  AND pod_uid = 'uid-status'
+                """
+            )
+        ).mappings().one()
+
+    assert str(lifecycle["pod_created_at"]) == "2026-04-20 12:49:30"
+    assert lifecycle["abnormal_reason"] == "OOMKilled"
+    assert lifecycle["abnormal_message"] == "Container was OOM killed"
 
 
 def test_sync_pods_end_to_end_and_idempotent(sqlite_engine, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- reduce pod lifecycle abnormal state storage to `abnormal_reason` and `abnormal_message`
- derive the highest-signal abnormal summary from pod status and pod events
- expand sync and watcher tests around abnormal summary selection and watch worker flows

## Testing
- `PYTHONPATH=src pytest tests/jobs/test_sync_pods.py tests/jobs/test_pod_watcher.py tests/api/test_runtime_insights.py`
- `ruff check src/ci_dashboard/jobs/sync_pods.py src/ci_dashboard/jobs/pod_watcher.py tests/jobs/test_sync_pods.py tests/jobs/test_pod_watcher.py tests/conftest.py`