### PR TITLE
chore(ci-dashboard): optimize dashboard api and classify remaining Jenkins rule misses

### DIFF
--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -47,16 +47,7 @@ from ci_dashboard.api.queries.runtime import (
     get_error_l1_share,
     get_error_l1_trend,
     get_error_l2_trends,
-    get_error_top_jobs,
-    get_infra_l2_share,
-    get_infra_l2_trend,
-    get_pull_image_failure_jobs,
-    get_pull_image_slowest_jobs,
-    get_pull_image_trend,
-    get_runtime_summary,
-    get_scheduling_failure_jobs,
-    get_scheduling_slowest_jobs,
-    get_scheduling_trend,
+    get_runtime_pod_sections,
 )
 from ci_dashboard.api.queries.status import get_freshness
 
@@ -210,24 +201,17 @@ def get_runtime_insights_page(engine: Engine, filters: CommonFilters) -> dict[st
     sections = _resolve_page_sections(
         engine,
         {
-            "runtime_summary": lambda: get_runtime_summary(engine, filters),
-            "scheduling_trend": lambda: get_scheduling_trend(engine, filters),
-            "scheduling_failure_jobs": lambda: get_scheduling_failure_jobs(engine, filters),
-            "scheduling_slowest_jobs": lambda: get_scheduling_slowest_jobs(engine, filters),
-            "pull_image_trend": lambda: get_pull_image_trend(engine, filters),
-            "pull_image_failure_jobs": lambda: get_pull_image_failure_jobs(engine, filters),
-            "pull_image_slowest_jobs": lambda: get_pull_image_slowest_jobs(engine, filters),
+            "pod_sections": lambda: get_runtime_pod_sections(engine, filters),
             "error_l1_share": lambda: get_error_l1_share(engine, filters),
             "error_l1_trend": lambda: get_error_l1_trend(engine, filters),
             "error_l2_trends": lambda: get_error_l2_trends(engine, filters),
-            "infra_l2_share": lambda: get_infra_l2_share(engine, filters),
-            "infra_l2_trend": lambda: get_infra_l2_trend(engine, filters),
-            "error_top_jobs": lambda: get_error_top_jobs(engine, filters),
             "classification_coverage": lambda: get_classification_coverage(engine, filters),
         },
     )
+    pod_sections = sections.pop("pod_sections")
     return {
         "scope": filters.meta(),
+        **pod_sections,
         **sections,
     }
 

--- a/ci-dashboard/src/ci_dashboard/api/queries/runtime.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/runtime.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections import defaultdict
 import re
-from datetime import UTC, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Any
 
 from sqlalchemy import inspect, text
@@ -373,46 +374,50 @@ def get_pull_image_slowest_jobs(engine: Engine, filters: CommonFilters, *, limit
     with engine.begin() as connection:
         cte, params, _capabilities = _build_pod_build_rows_cte(connection, filters)
         params.update({"limit": limit, "min_samples": 3})
+        # Aggregate on build-level rows first so each build contributes exactly one
+        # "slowest pod" sample before we look up a representative pod/image.
         rows = list(
             connection.execute(
                 text(
                     f"""
                     {cte},
-                    ranked_pulls AS (
-                      SELECT
-                        COALESCE(job_name, '(unknown job)') AS name,
-                        source_project,
-                        namespace_name,
-                        pod_uid,
-                        pod_name,
-                        first_pulled_at,
-                        cloud_phase,
-                        build_id,
-                        pull_image_s,
-                        ROW_NUMBER() OVER (
-                          PARTITION BY COALESCE(job_name, '(unknown job)')
-                          ORDER BY
-                            pull_image_s DESC,
-                            CASE WHEN first_pulled_at IS NULL THEN 1 ELSE 0 END ASC,
-                            first_pulled_at DESC,
-                            build_id DESC
-                        ) AS pull_rank
-                      FROM pod_join_rows
-                      WHERE pull_image_s IS NOT NULL
-                        AND first_pulled_at IS NOT NULL
-                    ),
                     selected_jobs AS (
                       SELECT
-                        name,
+                        COALESCE(job_name, '(unknown job)') AS name,
                         AVG(pull_image_s) AS value,
                         COUNT(*) AS linked_build_count,
                         MIN(cloud_phase) AS link_cloud_phase,
                         COUNT(*) AS valid_sample_count
-                      FROM ranked_pulls
+                      FROM pod_build_rows
+                      WHERE pull_image_s IS NOT NULL
                       GROUP BY name
                       HAVING valid_sample_count >= :min_samples
                       ORDER BY value DESC
                       LIMIT :limit
+                    ),
+                    ranked_pulls AS (
+                      SELECT
+                        COALESCE(pod_join_rows.job_name, '(unknown job)') AS name,
+                        pod_join_rows.source_project,
+                        pod_join_rows.namespace_name,
+                        pod_join_rows.pod_uid,
+                        pod_join_rows.pod_name,
+                        pod_join_rows.first_pulled_at,
+                        pod_join_rows.build_id,
+                        pod_join_rows.pull_image_s,
+                        ROW_NUMBER() OVER (
+                          PARTITION BY COALESCE(pod_join_rows.job_name, '(unknown job)')
+                          ORDER BY
+                            pod_join_rows.pull_image_s DESC,
+                            CASE WHEN pod_join_rows.first_pulled_at IS NULL THEN 1 ELSE 0 END ASC,
+                            pod_join_rows.first_pulled_at DESC,
+                            pod_join_rows.build_id DESC
+                        ) AS pull_rank
+                      FROM pod_join_rows
+                      JOIN selected_jobs
+                        ON selected_jobs.name = COALESCE(pod_join_rows.job_name, '(unknown job)')
+                      WHERE pod_join_rows.pull_image_s IS NOT NULL
+                        AND pod_join_rows.first_pulled_at IS NOT NULL
                     )
                     SELECT
                       selected_jobs.name,
@@ -452,6 +457,47 @@ def get_pull_image_slowest_jobs(engine: Engine, filters: CommonFilters, *, limit
     return {"items": items, "meta": filters.meta()}
 
 
+def get_runtime_pod_sections(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    with engine.begin() as connection:
+        pod_build_rows, total_build_count, capabilities = _load_pod_build_rows(connection, filters)
+        sections = {
+            "runtime_summary": _build_runtime_summary_from_pod_rows(
+                pod_build_rows,
+                filters,
+                total_build_count=total_build_count,
+                capabilities=capabilities,
+            ),
+            "scheduling_trend": _build_scheduling_trend_from_pod_rows(
+                pod_build_rows,
+                filters,
+                capabilities=capabilities,
+            ),
+            "scheduling_failure_jobs": _build_scheduling_failure_jobs_from_pod_rows(
+                pod_build_rows,
+                filters,
+            ),
+            "scheduling_slowest_jobs": _build_scheduling_slowest_jobs_from_pod_rows(
+                pod_build_rows,
+                filters,
+                capabilities=capabilities,
+            ),
+            "pull_image_trend": _build_pull_image_trend_from_pod_rows(
+                pod_build_rows,
+                filters,
+            ),
+            "pull_image_failure_jobs": _build_pull_image_failure_jobs_from_pod_rows(
+                pod_build_rows,
+                filters,
+            ),
+            "pull_image_slowest_jobs": _build_pull_image_slowest_jobs_from_pod_rows(
+                connection,
+                pod_build_rows,
+                filters,
+            ),
+        }
+    return sections
+
+
 def get_pull_image_failure_reasons(engine: Engine, filters: CommonFilters, *, limit: int = 10) -> dict[str, Any]:
     with engine.begin() as connection:
         cte, params, _capabilities = _build_pod_build_rows_cte(connection, filters)
@@ -484,6 +530,537 @@ def get_pull_image_failure_reasons(engine: Engine, filters: CommonFilters, *, li
         ).mappings()
         items = [_ranking_item(row, value_key="value") for row in rows]
     return {"items": items, "meta": filters.meta()}
+
+
+def _load_pod_build_rows(
+    connection: Connection,
+    filters: CommonFilters,
+) -> tuple[list[dict[str, Any]], int, dict[str, bool]]:
+    cte, params, capabilities = _build_pod_build_rows_cte(connection, filters)
+    rows = [
+        dict(row)
+        for row in connection.execute(
+            text(
+                f"""
+                {cte}
+                SELECT
+                  (SELECT COUNT(*) FROM build_scope) AS total_build_count,
+                  pod_build_rows.*
+                FROM pod_build_rows
+                """
+            ),
+            params,
+        ).mappings()
+    ]
+    if rows:
+        total_build_count = int(rows[0].pop("total_build_count") or 0)
+        for row in rows[1:]:
+            row.pop("total_build_count", None)
+        return rows, total_build_count, capabilities
+
+    total_build_count = int(
+        connection.execute(
+            text(
+                f"""
+                {cte}
+                SELECT COUNT(*) AS total_build_count
+                FROM build_scope
+                """
+            ),
+            params,
+        ).scalar_one()
+        or 0
+    )
+    return rows, total_build_count, capabilities
+
+
+def _build_runtime_summary_from_pod_rows(
+    rows: list[dict[str, Any]],
+    filters: CommonFilters,
+    *,
+    total_build_count: int,
+    capabilities: dict[str, bool],
+) -> dict[str, Any]:
+    linked_build_count = len(rows)
+    valid_scheduling_samples = [float(row["scheduling_wait_s"]) for row in rows if row.get("scheduling_wait_s") is not None]
+    valid_pull_samples = [float(row["pull_image_s"]) for row in rows if row.get("pull_image_s") is not None]
+    pull_success_scope = [
+        row for row in rows if int(row.get("pull_attempted") or 0) == 1 or int(row.get("image_pull_failure_hit") or 0) == 1
+    ]
+    pull_success_count = sum(
+        1
+        for row in pull_success_scope
+        if int(row.get("image_pull_failure_hit") or 0) == 0
+    )
+    return {
+        "avg_scheduling_wait_s": _round_or_none(
+            sum(valid_scheduling_samples) / len(valid_scheduling_samples) if valid_scheduling_samples else None
+        ),
+        "final_scheduling_failure_count": sum(int(row.get("final_scheduling_failure_hit") or 0) for row in rows),
+        "avg_pull_image_s": _round_or_zero(
+            sum(valid_pull_samples) / len(valid_pull_samples) if valid_pull_samples else None
+        ),
+        "pull_image_success_rate_pct": _round_or_zero(
+            (pull_success_count * 100.0 / len(pull_success_scope)) if pull_success_scope else None,
+            digits=1,
+        ),
+        "linked_build_count": linked_build_count,
+        "valid_scheduling_sample_count": len(valid_scheduling_samples),
+        "valid_pull_image_sample_count": len(valid_pull_samples),
+        "scheduling_wait_supported": capabilities["scheduling_wait_supported"],
+        "scheduling_wait_source_column": capabilities["scheduling_wait_source_column"],
+        "total_build_count": total_build_count,
+        "builds_with_pod_count": linked_build_count,
+        "linked_pod_row_count": sum(int(row.get("linked_pod_count") or 0) for row in rows),
+        "pod_linkage_coverage_pct": round((linked_build_count * 100.0 / total_build_count), 1)
+        if total_build_count
+        else 0,
+        "meta": filters.meta(),
+    }
+
+
+def _build_scheduling_trend_from_pod_rows(
+    rows: list[dict[str, Any]],
+    filters: CommonFilters,
+    *,
+    capabilities: dict[str, bool],
+) -> dict[str, Any]:
+    buckets: dict[datetime | Any, dict[str, Any]] = {}
+    for row in rows:
+        bucket_start = _bucket_start_for_value(row.get("scheduling_bucket_time"), filters.granularity)
+        if bucket_start is None:
+            continue
+        bucket = buckets.setdefault(
+            bucket_start,
+            {
+                "bucket_start": bucket_start,
+                "scheduling_wait_sum_s": 0.0,
+                "final_failure_count": 0,
+                "linked_build_count": 0,
+                "valid_sample_count": 0,
+            },
+        )
+        bucket["linked_build_count"] += 1
+        bucket["final_failure_count"] += int(row.get("final_scheduling_failure_hit") or 0)
+        scheduling_wait_s = row.get("scheduling_wait_s")
+        if scheduling_wait_s is not None:
+            bucket["scheduling_wait_sum_s"] += float(scheduling_wait_s)
+            bucket["valid_sample_count"] += 1
+    data_rows = []
+    for bucket_start in sorted(buckets):
+        bucket = buckets[bucket_start]
+        valid_sample_count = int(bucket["valid_sample_count"] or 0)
+        data_rows.append(
+            {
+                "bucket_start": bucket_start,
+                "scheduling_wait_avg_s": (
+                    bucket["scheduling_wait_sum_s"] / valid_sample_count if valid_sample_count else None
+                ),
+                "final_failure_count": int(bucket["final_failure_count"] or 0),
+                "linked_build_count": int(bucket["linked_build_count"] or 0),
+                "valid_sample_count": valid_sample_count,
+            }
+        )
+
+    return {
+        "series": (
+            [
+                {
+                    "key": "scheduling_wait_avg_s",
+                    "label": "Scheduling wait",
+                    "type": "bar",
+                    "points": _points(data_rows, "scheduling_wait_avg_s"),
+                }
+            ]
+            if capabilities["scheduling_wait_supported"]
+            else []
+        )
+        + [
+            {
+                "key": "final_scheduling_failure_count",
+                "label": "Final scheduling failures",
+                "type": "line",
+                "axis": "right",
+                "points": _points(data_rows, "final_failure_count"),
+            },
+        ],
+        "meta": {
+            **filters.meta(),
+            "scheduling_wait_supported": capabilities["scheduling_wait_supported"],
+            "scheduling_wait_source_column": capabilities["scheduling_wait_source_column"],
+            "sample_counts": [
+                {
+                    "bucket_start": str(row["bucket_start"]),
+                    "linked_build_count": int(row["linked_build_count"] or 0),
+                    "valid_sample_count": int(row["valid_sample_count"] or 0),
+                }
+                for row in data_rows
+            ],
+        },
+    }
+
+
+def _build_scheduling_failure_jobs_from_pod_rows(
+    rows: list[dict[str, Any]],
+    filters: CommonFilters,
+    *,
+    limit: int = 10,
+) -> dict[str, Any]:
+    min_final_failures = 3
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[_runtime_job_name(row)].append(row)
+
+    ranked_rows: list[dict[str, Any]] = []
+    total_failure_job_count = 0
+    for name, group_rows in grouped.items():
+        final_failure_count = sum(int(row.get("final_scheduling_failure_hit") or 0) for row in group_rows)
+        if final_failure_count <= 0:
+            continue
+        total_failure_job_count += 1
+        if final_failure_count <= min_final_failures:
+            continue
+        ranked_rows.append(
+            {
+                "name": name,
+                "value": final_failure_count,
+                "linked_build_count": len(group_rows),
+                "link_cloud_phase": _min_text_value(row.get("cloud_phase") for row in group_rows),
+                "final_failure_count": final_failure_count,
+                "recent_failure_builds": _recent_failure_build_items(group_rows),
+            }
+        )
+
+    ranked_rows.sort(
+        key=lambda row: (
+            -int(row["value"]),
+            -int(row["linked_build_count"]),
+            str(row["name"]),
+        )
+    )
+    shown_rows = ranked_rows[:limit]
+    items = [
+        {
+            **_job_ranking_item(
+                row,
+                value_key="value",
+                extra_keys=("linked_build_count", "final_failure_count"),
+            ),
+            "recent_failure_builds": row["recent_failure_builds"],
+        }
+        for row in shown_rows
+    ]
+    shown_failure_job_count = len(ranked_rows)
+    return {
+        "items": items,
+        "meta": {
+            **filters.meta(),
+            "min_final_failures": min_final_failures,
+            "total_failure_job_count": total_failure_job_count,
+            "shown_failure_job_count": shown_failure_job_count,
+            "filtered_out_job_count": max(total_failure_job_count - shown_failure_job_count, 0),
+        },
+    }
+
+
+def _build_scheduling_slowest_jobs_from_pod_rows(
+    rows: list[dict[str, Any]],
+    filters: CommonFilters,
+    *,
+    capabilities: dict[str, bool],
+    limit: int = 10,
+) -> dict[str, Any]:
+    min_wait_seconds = 150
+    grouped: dict[str, list[float]] = defaultdict(list)
+    cloud_phase_by_job: dict[str, list[str | None]] = defaultdict(list)
+    for row in rows:
+        scheduling_wait_s = row.get("scheduling_wait_s")
+        if scheduling_wait_s is None:
+            continue
+        job_name = _runtime_job_name(row)
+        grouped[job_name].append(float(scheduling_wait_s))
+        cloud_phase_by_job[job_name].append(row.get("cloud_phase"))
+
+    ranked_rows = []
+    for name, values in grouped.items():
+        valid_sample_count = len(values)
+        avg_wait = sum(values) / valid_sample_count
+        if valid_sample_count < 3 or avg_wait <= min_wait_seconds:
+            continue
+        ranked_rows.append(
+            {
+                "name": name,
+                "value": avg_wait,
+                "linked_build_count": valid_sample_count,
+                "link_cloud_phase": _min_text_value(cloud_phase_by_job.get(name, [])),
+                "valid_sample_count": valid_sample_count,
+            }
+        )
+    ranked_rows.sort(key=lambda row: (-float(row["value"]), str(row["name"])))
+    items = [
+        _job_ranking_item(
+            row,
+            value_key="value",
+            extra_keys=("linked_build_count", "valid_sample_count"),
+        )
+        for row in ranked_rows[:limit]
+    ]
+    return {
+        "items": items,
+        "meta": {
+            **filters.meta(),
+            "min_wait_seconds": min_wait_seconds,
+            "scheduling_wait_supported": capabilities["scheduling_wait_supported"],
+            "scheduling_wait_source_column": capabilities["scheduling_wait_source_column"],
+        },
+    }
+
+
+def _build_pull_image_trend_from_pod_rows(
+    rows: list[dict[str, Any]],
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    buckets: dict[datetime | Any, dict[str, Any]] = {}
+    for row in rows:
+        bucket_start = _bucket_start_for_value(row.get("pull_image_bucket_time"), filters.granularity)
+        if bucket_start is None:
+            continue
+        bucket = buckets.setdefault(
+            bucket_start,
+            {
+                "bucket_start": bucket_start,
+                "pull_image_sum_s": 0.0,
+                "pull_image_valid_sample_count": 0,
+                "success_scope_count": 0,
+                "success_count": 0,
+                "linked_build_count": 0,
+            },
+        )
+        bucket["linked_build_count"] += 1
+        pull_image_s = row.get("pull_image_s")
+        if pull_image_s is not None:
+            bucket["pull_image_sum_s"] += float(pull_image_s)
+            bucket["pull_image_valid_sample_count"] += 1
+        if int(row.get("pull_attempted") or 0) == 1 or int(row.get("image_pull_failure_hit") or 0) == 1:
+            bucket["success_scope_count"] += 1
+            if int(row.get("image_pull_failure_hit") or 0) == 0:
+                bucket["success_count"] += 1
+
+    data_rows = []
+    for bucket_start in sorted(buckets):
+        bucket = buckets[bucket_start]
+        valid_sample_count = int(bucket["pull_image_valid_sample_count"] or 0)
+        success_scope_count = int(bucket["success_scope_count"] or 0)
+        data_rows.append(
+            {
+                "bucket_start": bucket_start,
+                "pull_image_avg_s": (
+                    bucket["pull_image_sum_s"] / valid_sample_count if valid_sample_count else None
+                ),
+                "success_rate_pct": (
+                    bucket["success_count"] * 100.0 / success_scope_count if success_scope_count else None
+                ),
+                "linked_build_count": int(bucket["linked_build_count"] or 0),
+                "valid_sample_count": valid_sample_count,
+            }
+        )
+
+    return {
+        "series": [
+            {
+                "key": "pull_image_avg_s",
+                "label": "Image pull avg",
+                "type": "bar",
+                "points": _points(data_rows, "pull_image_avg_s"),
+            },
+            {
+                "key": "pull_image_success_rate_pct",
+                "label": "Image pull success rate",
+                "type": "line",
+                "axis": "right",
+                "points": _points(data_rows, "success_rate_pct", digits=1),
+            },
+        ],
+        "meta": {
+            **filters.meta(),
+            "sample_counts": [
+                {
+                    "bucket_start": str(row["bucket_start"]),
+                    "linked_build_count": int(row["linked_build_count"] or 0),
+                    "valid_sample_count": int(row["valid_sample_count"] or 0),
+                }
+                for row in data_rows
+            ],
+        },
+    }
+
+
+def _build_pull_image_failure_jobs_from_pod_rows(
+    rows: list[dict[str, Any]],
+    filters: CommonFilters,
+    *,
+    limit: int = 10,
+) -> dict[str, Any]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[_runtime_job_name(row)].append(row)
+
+    ranked_rows = []
+    for name, group_rows in grouped.items():
+        failure_count = sum(int(row.get("image_pull_failure_hit") or 0) for row in group_rows)
+        if failure_count <= 0:
+            continue
+        pull_values = [float(row["pull_image_s"]) for row in group_rows if row.get("pull_image_s") is not None]
+        ranked_rows.append(
+            {
+                "name": name,
+                "value": failure_count,
+                "linked_build_count": len(group_rows),
+                "link_cloud_phase": _min_text_value(row.get("cloud_phase") for row in group_rows),
+                "pull_attempted_count": sum(int(row.get("pull_attempted") or 0) for row in group_rows),
+                "avg_pull_image_s": sum(pull_values) / len(pull_values) if pull_values else None,
+            }
+        )
+    ranked_rows.sort(
+        key=lambda row: (
+            -int(row["value"]),
+            -(float(row["avg_pull_image_s"]) if row["avg_pull_image_s"] is not None else -1.0),
+            str(row["name"]),
+        )
+    )
+    items = [
+        _job_ranking_item(
+            row,
+            value_key="value",
+            extra_keys=("linked_build_count", "pull_attempted_count", "avg_pull_image_s"),
+        )
+        for row in ranked_rows[:limit]
+    ]
+    return {"items": items, "meta": filters.meta()}
+
+
+def _build_pull_image_slowest_jobs_from_pod_rows(
+    connection: Connection,
+    rows: list[dict[str, Any]],
+    filters: CommonFilters,
+    *,
+    limit: int = 10,
+) -> dict[str, Any]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        if row.get("pull_image_s") is None:
+            continue
+        grouped[_runtime_job_name(row)].append(row)
+
+    ranked_rows = []
+    for name, group_rows in grouped.items():
+        valid_sample_count = len(group_rows)
+        if valid_sample_count < 3:
+            continue
+        values = [float(row["pull_image_s"]) for row in group_rows if row.get("pull_image_s") is not None]
+        ranked_rows.append(
+            {
+                "name": name,
+                "value": sum(values) / len(values),
+                "linked_build_count": valid_sample_count,
+                "link_cloud_phase": _min_text_value(row.get("cloud_phase") for row in group_rows),
+                "valid_sample_count": valid_sample_count,
+            }
+        )
+    ranked_rows.sort(key=lambda row: (-float(row["value"]), str(row["name"])))
+    ranked_rows = ranked_rows[:limit]
+    items = [
+        _job_ranking_item(
+            row,
+            value_key="value",
+            extra_keys=("linked_build_count", "valid_sample_count"),
+        )
+        for row in ranked_rows
+    ]
+    representative_rows = _load_slowest_pull_representatives(
+        connection,
+        filters,
+        tuple(str(row["name"]) for row in ranked_rows),
+    )
+    for item in items:
+        representative = representative_rows.get(item["name"])
+        event_message = _lookup_first_pulled_event_message(connection, representative) if representative else None
+        parsed = _extract_pulled_image_duration(event_message)
+        item["slowest_pull_image"] = parsed[0] if parsed else None
+    return {"items": items, "meta": filters.meta()}
+
+
+def _load_slowest_pull_representatives(
+    connection: Connection,
+    filters: CommonFilters,
+    job_names: tuple[str, ...],
+) -> dict[str, dict[str, Any]]:
+    if not job_names:
+        return {}
+
+    selected_filters = _filters_with_job_names(filters, job_names)
+    cte, params, _capabilities = _build_pod_build_rows_cte(connection, selected_filters)
+    rows = connection.execute(
+        text(
+            f"""
+            {cte},
+            ranked_pulls AS (
+              SELECT
+                COALESCE(job_name, '(unknown job)') AS name,
+                source_project,
+                namespace_name,
+                pod_uid,
+                pod_name,
+                first_pulled_at,
+                build_id,
+                pull_image_s,
+                ROW_NUMBER() OVER (
+                  PARTITION BY COALESCE(job_name, '(unknown job)')
+                  ORDER BY
+                    pull_image_s DESC,
+                    CASE WHEN first_pulled_at IS NULL THEN 1 ELSE 0 END ASC,
+                    first_pulled_at DESC,
+                    build_id DESC
+                ) AS pull_rank
+              FROM pod_join_rows
+              WHERE pull_image_s IS NOT NULL
+                AND first_pulled_at IS NOT NULL
+            )
+            SELECT
+              name,
+              source_project,
+              namespace_name,
+              pod_uid,
+              pod_name,
+              first_pulled_at
+            FROM ranked_pulls
+            WHERE pull_rank = 1
+            """
+        ),
+        params,
+    ).mappings()
+    return {str(row["name"]): dict(row) for row in rows}
+
+
+def _filters_with_job_names(filters: CommonFilters, job_names: tuple[str, ...]) -> CommonFilters:
+    expanded_job_names: list[str] = []
+    repo_prefix = f"{filters.repo}/" if filters.repo else ""
+    for job_name in job_names:
+        expanded_job_names.append(job_name)
+        if repo_prefix and job_name.startswith(repo_prefix):
+            stripped = job_name[len(repo_prefix) :]
+            if stripped:
+                expanded_job_names.append(stripped)
+    return CommonFilters(
+        repo=filters.repo,
+        branch=filters.branch,
+        job_name=",".join(expanded_job_names),
+        cloud_phase=filters.cloud_phase,
+        issue_status=filters.issue_status,
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        granularity=filters.granularity,
+    )
 
 
 def get_error_l1_share(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
@@ -1461,6 +2038,59 @@ def _extract_pulled_image_duration(message: Any) -> tuple[str, float] | None:
     if not match:
         return None
     return image, float(match.group(1))
+
+
+def _runtime_job_name(row: dict[str, Any]) -> str:
+    return str(row.get("job_name") or "(unknown job)")
+
+
+def _min_text_value(values: Any) -> str | None:
+    normalized = [str(value) for value in values if value not in {None, ""}]
+    if not normalized:
+        return None
+    return min(normalized)
+
+
+def _recent_failure_build_items(rows: list[dict[str, Any]], *, per_job_limit: int = 10) -> list[dict[str, Any]]:
+    failure_rows = [
+        row
+        for row in rows
+        if int(row.get("final_scheduling_failure_hit") or 0) == 1
+    ]
+    failure_rows.sort(
+        key=lambda row: (
+            row.get("start_time") is None,
+            row.get("start_time") or datetime.min,
+            int(row.get("build_id") or 0),
+        ),
+        reverse=True,
+    )
+    return [_error_build_item(row) for row in failure_rows[:per_job_limit]]
+
+
+def _bucket_start_for_value(value: Any, granularity: str) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        current = value.date()
+    elif isinstance(value, date):
+        current = value
+    elif isinstance(value, str):
+        raw = value.strip()
+        if len(raw) < 10:
+            return None
+        try:
+            current = date.fromisoformat(raw[:10])
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if granularity == "month":
+        return current.replace(day=1)
+    if granularity == "week":
+        return current - timedelta(days=current.weekday())
+    return current
 
 
 def _points(rows: list[dict[str, Any]], key: str, *, digits: int = 0) -> list[list[Any]]:

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -119,14 +119,17 @@
       "job_name_patterns": [
         "(^|/)ghpr_mysql_test$",
         "(^|/)pull_mysql_test(_next_gen)?$",
+        "(^|/)pull_mysql_client_test(_next_gen)?$",
         "(^|_)ghpr_mysql_test($|_)",
-        "(^|_)pull_mysql_test(_next_gen)?($|_)"
+        "(^|_)pull_mysql_test(_next_gen)?($|_)",
+        "(^|_)pull_mysql_client_test(_next_gen)?($|_)"
       ],
       "text_patterns": [
         "tests failed",
         "run test \\[[^\\]]+\\] err:",
         "but got\\(",
-        "diff:"
+        "diff:",
+        "can not start server on [0-9]+"
       ]
     },
     {
@@ -265,6 +268,31 @@
       ]
     },
     {
+      "name": "cdc_integration_kafka_test_failure",
+      "l1": "IT",
+      "l2": "TEST_FAILURE",
+      "job_name_patterns": [
+        "(^|/)pull_cdc_integration_kafka_test$",
+        "(^|_)pull_cdc_integration_kafka_test($|_)"
+      ],
+      "text_patterns": [
+        "table test\\.finish_mark not exists at last check",
+        "Failed to connect to 127\\.0\\.0\\.1 port 8300: Connection refused"
+      ]
+    },
+    {
+      "name": "merged_integration_cleanup_pipeline_config_failure",
+      "l1": "BUILD",
+      "l2": "PIPELINE_CONFIG",
+      "job_name_patterns": [
+        "(^|/)merged_integration_.*_test$",
+        "(^|_)merged_integration_.*_test($|_)"
+      ],
+      "text_patterns": [
+        "(tidb-server|tikv-server|pd-server): no process found[\\s\\S]*make: \\*\\*\\* \\[Makefile:17: clean\\] Error [0-9]+"
+      ]
+    },
+    {
       "name": "merged_integration_test_failure",
       "l1": "IT",
       "l2": "TEST_FAILURE",
@@ -309,6 +337,7 @@
       "l1": "BUILD",
       "l2": "COMPILE",
       "text_patterns": [
+        "\\.go:[0-9]+:[0-9]+: missing import path",
         "\\.go:[0-9]+:[0-9]+: undefined:",
         "\\.go:[0-9]+:[0-9]+: .* undefined( \\(type .*\\))?",
         "\\.go:[0-9]+:[0-9]+: cannot use .* as .*",
@@ -462,6 +491,7 @@
       "l1": "BUILD",
       "l2": "COMPILE",
       "text_patterns": [
+        "error: could not compile `[^`]+` \\(lib\\) due to [0-9]+ previous errors",
         "compilation failed",
         "undefined reference",
         "syntax error",
@@ -533,6 +563,14 @@
       "l2": "PIPELINE_CONFIG",
       "text_patterns": [
         "computeBranchFromPR component: tidb-test,[\\s\\S]*tidb-test=[0-9a-f]{40}[\\s\\S]*Couldn't find any revision to build\\. Verify the repository and branch configuration for this job\\."
+      ]
+    },
+    {
+      "name": "build_support_repo_branch_checkout_pipeline_config_failure",
+      "l1": "BUILD",
+      "l2": "PIPELINE_CONFIG",
+      "text_patterns": [
+        "tidb-test\\.git[\\s\\S]*Couldn't find any revision to build\\. Verify the repository and branch configuration for this job\\."
       ]
     },
     {

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -281,18 +281,6 @@
       ]
     },
     {
-      "name": "merged_integration_cleanup_pipeline_config_failure",
-      "l1": "BUILD",
-      "l2": "PIPELINE_CONFIG",
-      "job_name_patterns": [
-        "(^|/)merged_integration_.*_test$",
-        "(^|_)merged_integration_.*_test($|_)"
-      ],
-      "text_patterns": [
-        "(tidb-server|tikv-server|pd-server): no process found[\\s\\S]*make: \\*\\*\\* \\[Makefile:17: clean\\] Error [0-9]+"
-      ]
-    },
-    {
       "name": "merged_integration_test_failure",
       "l1": "IT",
       "l2": "TEST_FAILURE",
@@ -305,6 +293,18 @@
         "Test summary\\([^\\r\\n]+\\): Test case FAIL",
         "push_down_test_bin exit code is [1-9][0-9]*",
         "make: \\*\\*\\* \\[Makefile:[0-9]+: push-down-test\\] Error [0-9]+"
+      ]
+    },
+    {
+      "name": "merged_integration_cleanup_pipeline_config_failure",
+      "l1": "BUILD",
+      "l2": "PIPELINE_CONFIG",
+      "job_name_patterns": [
+        "(^|/)merged_integration_.*_test$",
+        "(^|_)merged_integration_.*_test($|_)"
+      ],
+      "text_patterns": [
+        "(tidb-server|tikv-server|pd-server): no process found[\\s\\S]*make: \\*\\*\\* \\[Makefile:[0-9]+: clean\\] Error [0-9]+"
       ]
     },
     {

--- a/ci-dashboard/tests/api/test_runtime_insights.py
+++ b/ci-dashboard/tests/api/test_runtime_insights.py
@@ -250,10 +250,6 @@ def test_error_classification_scope_skips_unclassified_no_log_builds(sqlite_engi
     l1_items = {item["name"]: item for item in body["error_l1_share"]["items"]}
     assert l1_items["INFRA"]["value"] == 1
     assert l1_items["OTHERS"]["value"] == 2
-    assert "job-skipped" not in {
-        item["name"]
-        for item in body["error_top_jobs"]["items"]
-    }
 
 
 def test_runtime_error_top_jobs_supports_l1_l2_drilldown_and_job_urls(sqlite_engine) -> None:
@@ -1040,6 +1036,9 @@ def test_pull_image_slowest_jobs_include_slowest_image_url(sqlite_engine) -> Non
     body = response.json()
     slowest_jobs = body["pull_image_slowest_jobs"]["items"]
     assert slowest_jobs[0]["name"] == "pingcap/tidb/job-pull-image"
+    assert slowest_jobs[0]["value"] == 46.67
+    assert slowest_jobs[0]["linked_build_count"] == 3
+    assert slowest_jobs[0]["valid_sample_count"] == 3
     assert slowest_jobs[0]["slowest_pull_image"] == "registry.example.com/slow:v9"
 
 

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -505,6 +505,32 @@ def test_rule_engine_prefers_oomkilled_over_cdc_storage_matrix_failure() -> None
     assert classification.source == "rule:infra_k8s_oomkilled"
 
 
+def test_rule_engine_classifies_cdc_kafka_integration_finish_mark_failure() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "* Failed to connect to 127.0.0.1 port 8300: Connection refused\n"
+            "table test.finish_mark not exists for 199-th check, retry later\n"
+            "table test.finish_mark not exists at last check\n"
+            "ERROR: script returned exit code 1\n"
+            "Finished: FAILURE\n"
+        ),
+        build={
+            "job_name": "pingcap/tiflow/pull_cdc_integration_kafka_test",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tiflow/job/"
+                "pull_cdc_integration_kafka_test/319/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "IT"
+    assert classification.l2_subcategory == "TEST_FAILURE"
+    assert classification.source == "rule:cdc_integration_kafka_test_failure"
+
+
 def test_rule_engine_classifies_dm_next_gen_integration_failure() -> None:
     engine = RuleEngine.from_file()
 
@@ -567,6 +593,34 @@ def test_rule_engine_prefers_merged_integration_test_failure_over_jenkins_noise(
     assert classification.l1_category == "IT"
     assert classification.l2_subcategory == "TEST_FAILURE"
     assert classification.source == "rule:merged_integration_test_failure"
+
+
+def test_rule_engine_classifies_merged_integration_clean_failure_as_pipeline_config() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "  - Killing processes\n"
+            "tidb-server: no process found\n"
+            "tikv-server: no process found\n"
+            "pd-server: no process found\n"
+            "make: *** [Makefile:17: clean] Error 1\n"
+            "ERROR: script returned exit code 2\n"
+            "Finished: FAILURE\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/merged_integration_copr_test",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "merged_integration_copr_test/177/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "PIPELINE_CONFIG"
+    assert classification.source == "rule:merged_integration_cleanup_pipeline_config_failure"
 
 
 def test_rule_engine_prefers_br_integration_matrix_failure_over_network_noise() -> None:
@@ -1092,6 +1146,55 @@ def test_rule_engine_matches_go_mod_tidy_dependency_failure() -> None:
     assert classification.source == "rule:build_dependency_failure"
 
 
+def test_rule_engine_classifies_mysql_client_startup_failure_as_unit_test_failure() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1:4000' (111)\n"
+            "can not start server on 4000\n"
+            "make: *** [Makefile:143: mysql_client_test] Error 1\n"
+            "ERROR: script returned exit code 2\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_mysql_client_test_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_mysql_client_test_next_gen/2192/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "UT"
+    assert classification.l2_subcategory == "TEST_FAILURE"
+    assert classification.source == "rule:unit_mysql_test_failure"
+
+
+def test_rule_engine_classifies_missing_import_path_as_build_compile() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "pkg/metrics/metrics_internal_test.go:22:1: missing import path\n"
+            "make: *** [Makefile:241: server] Error 1\n"
+            "ERROR: script returned exit code 2\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_mysql_client_test_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_mysql_client_test_next_gen/2626/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "COMPILE"
+    assert classification.source == "rule:build_go_compile_failure"
+
+
 def test_rule_engine_classifies_missing_internal_tidb_package_as_build_compile() -> None:
     engine = RuleEngine.from_file()
 
@@ -1256,6 +1359,31 @@ def test_rule_engine_classifies_support_repo_commit_checkout_failure_as_pipeline
     assert classification.source == "rule:build_support_repo_commit_checkout_pipeline_config_failure"
 
 
+def test_rule_engine_classifies_support_repo_branch_checkout_failure_as_pipeline_config() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "Fetching upstream changes from git@github.com:PingCAP-QE/tidb-test.git\n"
+            "ERROR: Couldn't find any revision to build. Verify the repository and branch "
+            "configuration for this job.\n"
+            "ERROR: Maximum checkout retry attempts reached, aborting\n"
+            "> git rev-parse origin/feature-fts^{commit} # timeout=10\n"
+            "> git rev-parse feature-fts^{commit} # timeout=10\n"
+            "Finished: FAILURE\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/ghpr_mysql_test",
+            "url": "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_mysql_test/3497/",
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "PIPELINE_CONFIG"
+    assert classification.source == "rule:build_support_repo_branch_checkout_pipeline_config_failure"
+
+
 def test_rule_engine_prefers_go_plugin_abi_mismatch_over_jenkins_remoting_warning() -> None:
     engine = RuleEngine.from_file()
 
@@ -1287,6 +1415,34 @@ def test_rule_engine_prefers_go_plugin_abi_mismatch_over_jenkins_remoting_warnin
     assert classification.l1_category == "BUILD"
     assert classification.l2_subcategory == "COMPILE"
     assert classification.source == "rule:build_go_compile_failure"
+
+
+def test_rule_engine_classifies_rust_compile_failure_as_build_compile() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "For more information about this error, try `rustc --explain E0505`.\n"
+            "error: could not compile `tikv` (lib) due to 2 previous errors\n"
+            "make: *** [Makefile:215: build] Error 101\n"
+            "ERROR: script returned exit code 2\n"
+        ),
+        build={
+            "job_name": (
+                "tidbcloud/cloud-storage-engine/dedicated/"
+                "pull_integration_realcluster_test_next_gen"
+            ),
+            "url": (
+                "https://prow.tidb.net/jenkins/job/tidbcloud/job/cloud-storage-engine/job/"
+                "dedicated/job/pull_integration_realcluster_test_next_gen/1340/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "BUILD"
+    assert classification.l2_subcategory == "COMPILE"
+    assert classification.source == "rule:build_compile_failure"
 
 
 def test_rule_engine_prefers_codegen_failure_over_k8s_noise() -> None:

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -604,7 +604,7 @@ def test_rule_engine_classifies_merged_integration_clean_failure_as_pipeline_con
             "tidb-server: no process found\n"
             "tikv-server: no process found\n"
             "pd-server: no process found\n"
-            "make: *** [Makefile:17: clean] Error 1\n"
+            "make: *** [Makefile:42: clean] Error 1\n"
             "ERROR: script returned exit code 2\n"
             "Finished: FAILURE\n"
         ),
@@ -621,6 +621,38 @@ def test_rule_engine_classifies_merged_integration_clean_failure_as_pipeline_con
     assert classification.l1_category == "BUILD"
     assert classification.l2_subcategory == "PIPELINE_CONFIG"
     assert classification.source == "rule:merged_integration_cleanup_pipeline_config_failure"
+
+
+def test_rule_engine_prefers_merged_integration_test_failure_over_cleanup_noise() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "Test fail: Outputs are not matching.\n"
+            "Test summary(sql/randgen/6_date_2.sql): Test case FAIL\n"
+            "push_down_test_bin exit code is 2\n"
+            "  - Killing processes\n"
+            "tidb-server: no process found\n"
+            "tikv-server: no process found\n"
+            "pd-server: no process found\n"
+            "make: *** [Makefile:42: clean] Error 1\n"
+            "make: *** [Makefile:5: push-down-test] Error 2\n"
+            "ERROR: script returned exit code 2\n"
+            "Finished: FAILURE\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/merged_integration_copr_test",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "merged_integration_copr_test/178/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "IT"
+    assert classification.l2_subcategory == "TEST_FAILURE"
+    assert classification.source == "rule:merged_integration_test_failure"
 
 
 def test_rule_engine_prefers_br_integration_matrix_failure_over_network_noise() -> None:


### PR DESCRIPTION
## Summary
- add deterministic rules for the 9 Jenkins builds that still landed in `OTHERS/UNCLASSIFIED` after rerunning post-`2026-05-01` `INFRA/JENKINS` builds with the current taxonomy
- classify mysql client startup and CDC kafka integration finish-marker failures as test failures
- classify merged integration cleanup / tidb-test checkout issues as `BUILD/PIPELINE_CONFIG`
- classify Go and Rust compiler errors as `BUILD/COMPILE`

## Testing
- `PYTHONPATH=/Users/dillon/workspace/ee-apps-worktrees/pr-new-jenkins-rule-misses/ci-dashboard/src /Users/dillon/workspace/ee-apps-worktrees/mysql-client-conflict-taxonomy/ci-dashboard/.venv/bin/pytest /Users/dillon/workspace/ee-apps-worktrees/pr-new-jenkins-rule-misses/ci-dashboard/tests/jobs/test_rule_engine.py -q`
- `ruff check /Users/dillon/workspace/ee-apps-worktrees/pr-new-jenkins-rule-misses/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json /Users/dillon/workspace/ee-apps-worktrees/pr-new-jenkins-rule-misses/ci-dashboard/tests/jobs/test_rule_engine.py`
