### PR TITLE
fix(ci-dashboard): classify git auth checkout failures

### DIFF
--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -477,7 +477,8 @@
         "hudson\\.plugins\\.git\\.GitException: Command \"git fetch [^\"]+\" returned status code 128",
         "fatal: unable to access 'https://github\\.com/[^']+': The requested URL returned error: 5[0-9]{2}",
         "error: RPC failed; HTTP 5[0-9]{2} curl 22 The requested URL returned error: 5[0-9]{2}",
-        "fatal: couldn't find remote ref refs/pull/[0-9]+/head"
+        "fatal: couldn't find remote ref refs/pull/[0-9]+/head",
+        "ERROR: internal error performing authentication[\\s\\S]*fatal: Could not read from remote repository\\."
       ]
     },
     {

--- a/ci-dashboard/tests/jobs/test_rule_engine.py
+++ b/ci-dashboard/tests/jobs/test_rule_engine.py
@@ -1274,6 +1274,38 @@ def test_rule_engine_prefers_missing_pull_ref_checkout_over_realcluster_matrix_n
     assert classification.source == "rule:infra_git_checkout_failure"
 
 
+def test_rule_engine_classifies_git_auth_checkout_failure_as_infra_git() -> None:
+    engine = RuleEngine.from_file()
+
+    classification = engine.classify(
+        log_text=(
+            "stage: Checkout (25)\n"
+            "node: Checkout and merge pull request(s) to target if exist (39)\n"
+            "git version 2.43.5\n"
+            "Reinitialized existing Git repository in "
+            "/home/jenkins/agent/workspace/pingcap/tidb/pull_unit_test_next_gen/tidb/.git/\n"
+            ".git\n"
+            "HEAD is now at 721229bcd9 executor: estimate analyze NDV from singleton sketches\n"
+            "ERROR: internal error performing authentication\n"
+            "fatal: Could not read from remote repository.\n\n"
+            "Please make sure you have the correct access rights\n"
+            "and the repository exists.\n"
+        ),
+        build={
+            "job_name": "pingcap/tidb/pull_unit_test_next_gen",
+            "url": (
+                "https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/"
+                "pull_unit_test_next_gen/3049/"
+            ),
+        },
+    )
+
+    assert classification is not None
+    assert classification.l1_category == "INFRA"
+    assert classification.l2_subcategory == "GIT"
+    assert classification.source == "rule:infra_git_checkout_failure"
+
+
 def test_rule_engine_prefers_go_compile_error_over_jenkins_remoting_warning() -> None:
     engine = RuleEngine.from_file()
 


### PR DESCRIPTION
## Summary
- classify Jenkins checkout failures with `ERROR: internal error performing authentication` and `fatal: Could not read from remote repository.` as `INFRA/GIT`
- keep the existing missing `refs/pull/.../head` handling in the same git checkout taxonomy rule
- add a regression test covering the `pull_unit_test_next_gen/3049` auth failure pattern

## Testing
- PYTHONPATH=src uv run pytest tests/jobs/test_rule_engine.py -q