### PR TITLE
feat(roster): add weekly change summary notification

### DIFF
--- a/roster/README.md
+++ b/roster/README.md
@@ -25,6 +25,13 @@ Compare synced roster rows with historical employee identity tables:
 python -m roster.jobs.cli validate-history --details-limit 20
 ```
 
+Print or send the weekly roster change summary:
+
+```bash
+python -m roster.jobs.cli weekly-summary
+python -m roster.jobs.cli weekly-summary --send-lark
+```
+
 Database configuration accepts either a SQLAlchemy URL:
 
 ```bash
@@ -53,6 +60,7 @@ Optional Lark settings:
 
 ```bash
 ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID=...
+ROSTER_LARK_NOTIFY_OPEN_ID=...
 ROSTER_LARK_ROOT_DEPARTMENT_ID=0
 ```
 

--- a/roster/docs/schema-design.md
+++ b/roster/docs/schema-design.md
@@ -11,6 +11,7 @@ The schema keeps the first version small:
 - no identity table
 - no closure table
 - no multi-group relation table for now
+- a small change-event table for weekly roster notifications
 
 Hierarchy queries use materialized path columns.
 
@@ -97,6 +98,40 @@ Field notes:
 - `is_active`: active group flag.
 - `last_seen_at`: last successful sync time when this group was returned by Lark.
 
+### `roster_employee_change_events`
+
+Stores employee-level changes detected during sync. This table is intentionally not a
+full snapshot; it only records the changes needed for weekly notifications.
+
+```sql
+CREATE TABLE roster_employee_change_events (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  event_type VARCHAR(32) NOT NULL,
+  employee_lark_id VARCHAR(128) NOT NULL,
+  employee_name VARCHAR(255) NOT NULL,
+  employee_email VARCHAR(255) NULL,
+  manager_name VARCHAR(255) NULL,
+  manager_email VARCHAR(255) NULL,
+  group_name VARCHAR(255) NULL,
+  group_path VARCHAR(1024) NULL,
+  previous_group_name VARCHAR(255) NULL,
+  previous_group_path VARCHAR(1024) NULL,
+  event_at DATETIME NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_roster_employee_change_events_event_at (event_at),
+  KEY idx_roster_employee_change_events_type_time (event_type, event_at),
+  KEY idx_roster_employee_change_events_employee (employee_lark_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+Field notes:
+
+- `event_type`: one of `hire`, `leave`, or `group_change`.
+- `employee_*`, `manager_*`, and `group_*`: denormalized display fields for notifications.
+- `previous_group_*`: previous department fields for `group_change` events.
+- `event_at`: sync time when the change was detected.
+
 ## Hierarchy Queries
 
 Find all direct and indirect reports of a manager:
@@ -179,6 +214,9 @@ Inactive handling:
   `idx_roster_employees_employee_no` to a unique key.
 - Because `group_path` is denormalized onto employees, every full sync must refresh it after
   group paths are rebuilt.
+- Employee change events are recorded after reference fields and inactive flags are refreshed:
+  a new or reactivated employee emits `hire`, a stale employee newly marked inactive emits
+  `leave`, and a primary group change emits `group_change`.
 
 ## Current Tradeoffs
 

--- a/roster/sql/001_create_roster_tables.sql
+++ b/roster/sql/001_create_roster_tables.sql
@@ -40,3 +40,23 @@ CREATE TABLE IF NOT EXISTS roster_groups (
   KEY idx_roster_groups_parent (parent_id),
   KEY idx_roster_groups_manager (manager_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS roster_employee_change_events (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  event_type VARCHAR(32) NOT NULL,
+  employee_lark_id VARCHAR(128) NOT NULL,
+  employee_name VARCHAR(255) NOT NULL,
+  employee_email VARCHAR(255) NULL,
+  manager_name VARCHAR(255) NULL,
+  manager_email VARCHAR(255) NULL,
+  group_name VARCHAR(255) NULL,
+  group_path VARCHAR(1024) NULL,
+  previous_group_name VARCHAR(255) NULL,
+  previous_group_path VARCHAR(1024) NULL,
+  event_at DATETIME NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_roster_employee_change_events_event_at (event_at),
+  KEY idx_roster_employee_change_events_type_time (event_type, event_at),
+  KEY idx_roster_employee_change_events_employee (employee_lark_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/roster/sql/004_create_roster_employee_change_events.sql
+++ b/roster/sql/004_create_roster_employee_change_events.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS roster_employee_change_events (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  event_type VARCHAR(32) NOT NULL,
+  employee_lark_id VARCHAR(128) NOT NULL,
+  employee_name VARCHAR(255) NOT NULL,
+  employee_email VARCHAR(255) NULL,
+  manager_name VARCHAR(255) NULL,
+  manager_email VARCHAR(255) NULL,
+  group_name VARCHAR(255) NULL,
+  group_path VARCHAR(1024) NULL,
+  previous_group_name VARCHAR(255) NULL,
+  previous_group_path VARCHAR(1024) NULL,
+  event_at DATETIME NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_roster_employee_change_events_event_at (event_at),
+  KEY idx_roster_employee_change_events_type_time (event_type, event_at),
+  KEY idx_roster_employee_change_events_employee (employee_lark_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/roster/src/roster/common/config.py
+++ b/roster/src/roster/common/config.py
@@ -40,6 +40,7 @@ class LarkSettings:
     app_id: str | None = None
     app_secret: str | None = None
     github_custom_attr_id: str | None = None
+    notify_open_id: str | None = None
     root_department_id: str = "0"
 
     @property
@@ -97,6 +98,7 @@ def load_settings(
             app_id=env.get("ROSTER_LARK_APP_ID") or None,
             app_secret=env.get("ROSTER_LARK_APP_SECRET") or None,
             github_custom_attr_id=env.get("ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID") or None,
+            notify_open_id=env.get("ROSTER_LARK_NOTIFY_OPEN_ID") or None,
             root_department_id=env.get("ROSTER_LARK_ROOT_DEPARTMENT_ID") or "0",
         ),
         log_level=(env.get("ROSTER_LOG_LEVEL") or "INFO").upper(),

--- a/roster/src/roster/jobs/cli.py
+++ b/roster/src/roster/jobs/cli.py
@@ -11,6 +11,11 @@ from roster.common.logging import configure_logging
 from roster.jobs.sync_roster import run_sync_roster
 from roster.jobs.validate_history import validate_historical_employees
 from roster.jobs.validate_lark import validate_lark_roster
+from roster.jobs.weekly_summary import (
+    DEFAULT_WEEKLY_SUMMARY_DAYS,
+    load_weekly_roster_summary,
+    send_weekly_roster_summary_to_lark,
+)
 from roster.sources.lark import LarkApiClient, LarkRosterSource
 
 
@@ -18,6 +23,21 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Roster job runner")
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("sync-roster", help="Sync Lark roster data into roster tables")
+    weekly_summary = subparsers.add_parser(
+        "weekly-summary",
+        help="Build the roster weekly change summary and optionally send it to Lark",
+    )
+    weekly_summary.add_argument(
+        "--days",
+        type=int,
+        default=DEFAULT_WEEKLY_SUMMARY_DAYS,
+        help="Number of days to include in the weekly roster summary",
+    )
+    weekly_summary.add_argument(
+        "--send-lark",
+        action="store_true",
+        help="Send the weekly summary to ROSTER_LARK_NOTIFY_OPEN_ID",
+    )
     subparsers.add_parser("validate-lark", help="Fetch Lark roster data and print field quality summary")
     validate_history = subparsers.add_parser(
         "validate-history",
@@ -34,7 +54,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    settings = get_settings(require_database=args.command in {"sync-roster", "validate-history"})
+    settings = get_settings(
+        require_database=args.command in {"sync-roster", "weekly-summary", "validate-history"}
+    )
     configure_logging(settings.log_level)
 
     if args.command == "sync-roster":
@@ -45,6 +67,33 @@ def main(argv: Sequence[str] | None = None) -> int:
             logging.getLogger(__name__).info(
                 "sync-roster finished",
                 extra={"summary": summary.__dict__},
+            )
+            return 0
+        finally:
+            engine.dispose()
+
+    if args.command == "weekly-summary":
+        engine = build_engine(settings)
+        try:
+            summary = load_weekly_roster_summary(engine, days=args.days)
+            if args.send_lark:
+                if not settings.lark.is_configured:
+                    raise SystemExit(
+                        "weekly-summary --send-lark requires "
+                        "ROSTER_LARK_APP_ID and ROSTER_LARK_APP_SECRET"
+                    )
+                if not settings.lark.notify_open_id:
+                    raise SystemExit("weekly-summary --send-lark requires ROSTER_LARK_NOTIFY_OPEN_ID")
+                send_weekly_roster_summary_to_lark(
+                    summary,
+                    client=LarkApiClient(settings.lark.app_id, settings.lark.app_secret),
+                    open_id=settings.lark.notify_open_id,
+                )
+            else:
+                print(json.dumps(summary.to_dict(), indent=2, sort_keys=True))
+            logging.getLogger(__name__).info(
+                "weekly-summary finished",
+                extra={"summary_count": summary.total_count, "sent_lark": args.send_lark},
             )
             return 0
         finally:

--- a/roster/src/roster/jobs/sync_roster.py
+++ b/roster/src/roster/jobs/sync_roster.py
@@ -29,6 +29,7 @@ from sqlalchemy.engine import Connection
 LOG = logging.getLogger(__name__)
 
 RosterSyncStatus = Literal["not_implemented", "success", "failed", "partial"]
+RosterEmployeeChangeType = Literal["hire", "leave", "group_change"]
 DEFAULT_INACTIVE_GRACE = timedelta(days=2)
 BULK_UPDATE_CHUNK_SIZE = 500
 
@@ -72,6 +73,24 @@ groups_table = Table(
     Column("last_seen_at", DateTime),
     Column("created_at", DateTime, nullable=False, default=_utcnow_naive),
     Column("updated_at", DateTime, nullable=False, default=_utcnow_naive),
+)
+
+employee_change_events_table = Table(
+    "roster_employee_change_events",
+    metadata,
+    Column("id", BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True),
+    Column("event_type", String(32), nullable=False),
+    Column("employee_lark_id", String(128), nullable=False),
+    Column("employee_name", String(255), nullable=False),
+    Column("employee_email", String(255)),
+    Column("manager_name", String(255)),
+    Column("manager_email", String(255)),
+    Column("group_name", String(255)),
+    Column("group_path", String(1024)),
+    Column("previous_group_name", String(255)),
+    Column("previous_group_path", String(1024)),
+    Column("event_at", DateTime, nullable=False),
+    Column("created_at", DateTime, nullable=False, default=_utcnow_naive),
 )
 
 
@@ -159,6 +178,7 @@ def _sync_roster_rows(
     sync_time: datetime,
     inactive_grace: timedelta,
 ) -> None:
+    previous_employee_state_by_lark_id = _employee_state_map(connection)
     group_rows = [_group_pass1_row(group, sync_time) for group in roster.groups]
     employee_rows = _employee_pass1_rows(roster.employees, sync_time)
 
@@ -185,6 +205,13 @@ def _sync_roster_rows(
         connection,
         sync_time=sync_time,
         inactive_grace=inactive_grace,
+    )
+    _record_employee_change_events(
+        connection,
+        previous_employee_state_by_lark_id=previous_employee_state_by_lark_id,
+        current_employee_state_by_lark_id=_employee_state_map(connection),
+        fetched_employee_lark_ids={employee.lark_id for employee in roster.employees},
+        event_at=sync_time,
     )
 
 
@@ -464,6 +491,97 @@ def _bulk_update_by_id(
                 for row in chunk
             ],
         )
+
+
+def _record_employee_change_events(
+    connection: Connection,
+    *,
+    previous_employee_state_by_lark_id: dict[str, dict[str, object]],
+    current_employee_state_by_lark_id: dict[str, dict[str, object]],
+    fetched_employee_lark_ids: set[str],
+    event_at: datetime,
+) -> None:
+    event_rows: list[dict[str, object]] = []
+
+    for lark_id in sorted(fetched_employee_lark_ids):
+        current = current_employee_state_by_lark_id.get(lark_id)
+        if current is None:
+            continue
+        previous = previous_employee_state_by_lark_id.get(lark_id)
+        if previous is None or not _state_is_active(previous):
+            event_rows.append(_employee_change_event_row("hire", current, event_at=event_at))
+        elif previous.get("group_id") != current.get("group_id"):
+            event_rows.append(
+                _employee_change_event_row(
+                    "group_change",
+                    current,
+                    event_at=event_at,
+                    previous=previous,
+                )
+            )
+
+    for lark_id, previous in sorted(previous_employee_state_by_lark_id.items()):
+        if lark_id in fetched_employee_lark_ids or not _state_is_active(previous):
+            continue
+        current = current_employee_state_by_lark_id.get(lark_id)
+        if current is not None and not _state_is_active(current):
+            event_rows.append(_employee_change_event_row("leave", current, event_at=event_at))
+
+    if event_rows:
+        connection.execute(employee_change_events_table.insert(), event_rows)
+
+
+def _employee_change_event_row(
+    event_type: RosterEmployeeChangeType,
+    current: dict[str, object],
+    *,
+    event_at: datetime,
+    previous: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "event_type": event_type,
+        "employee_lark_id": current["lark_id"],
+        "employee_name": current["name"],
+        "employee_email": current.get("email"),
+        "manager_name": current.get("manager_name"),
+        "manager_email": current.get("manager_email"),
+        "group_name": current.get("group_name"),
+        "group_path": current.get("group_path"),
+        "previous_group_name": previous.get("group_name") if previous else None,
+        "previous_group_path": previous.get("group_path") if previous else None,
+        "event_at": event_at,
+        "created_at": event_at,
+    }
+
+
+def _employee_state_map(connection: Connection) -> dict[str, dict[str, object]]:
+    manager = employees_table.alias("manager")
+    rows = connection.execute(
+        select(
+            employees_table.c.lark_id,
+            employees_table.c.name,
+            employees_table.c.email,
+            employees_table.c.is_active,
+            employees_table.c.manager_id,
+            employees_table.c.group_id,
+            employees_table.c.group_path,
+            manager.c.name.label("manager_name"),
+            manager.c.email.label("manager_email"),
+            groups_table.c.name.label("group_name"),
+        )
+        .select_from(
+            employees_table.outerjoin(manager, employees_table.c.manager_id == manager.c.id)
+            .outerjoin(groups_table, employees_table.c.group_id == groups_table.c.id)
+        )
+    ).all()
+    return {
+        str(row.lark_id): dict(row._mapping)
+        for row in rows
+    }
+
+
+def _state_is_active(state: dict[str, object]) -> bool:
+    return bool(state.get("is_active"))
 
 
 def _chunks(

--- a/roster/src/roster/jobs/weekly_summary.py
+++ b/roster/src/roster/jobs/weekly_summary.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import and_, select
+from sqlalchemy.engine import Engine
+
+from roster.jobs.sync_roster import employee_change_events_table
+from roster.sources.lark import LarkApiClient
+
+DEFAULT_WEEKLY_SUMMARY_DAYS = 7
+DEFAULT_DISPLAY_TIMEZONE = ZoneInfo("Asia/Shanghai")
+
+
+@dataclass(frozen=True)
+class RosterChangeItem:
+    event_type: str
+    employee_name: str
+    employee_email: str | None
+    manager_name: str | None
+    manager_email: str | None
+    group_name: str | None
+    previous_group_name: str | None
+    event_at: datetime
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "event_type": self.event_type,
+            "employee_name": self.employee_name,
+            "employee_email": self.employee_email,
+            "manager_name": self.manager_name,
+            "manager_email": self.manager_email,
+            "group_name": self.group_name,
+            "previous_group_name": self.previous_group_name,
+            "event_at": self.event_at.isoformat(),
+        }
+
+
+@dataclass(frozen=True)
+class WeeklyRosterSummary:
+    since: datetime
+    until: datetime
+    hires: Sequence[RosterChangeItem]
+    leaves: Sequence[RosterChangeItem]
+    group_changes: Sequence[RosterChangeItem]
+
+    @property
+    def total_count(self) -> int:
+        return len(self.hires) + len(self.leaves) + len(self.group_changes)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "since": self.since.isoformat(),
+            "until": self.until.isoformat(),
+            "hires": [item.to_dict() for item in self.hires],
+            "leaves": [item.to_dict() for item in self.leaves],
+            "group_changes": [item.to_dict() for item in self.group_changes],
+        }
+
+    def render_text(self) -> str:
+        since = _format_display_date(self.since)
+        until = _format_display_date(self.until)
+        lines = [
+            f"Roster 周报（{since} ~ {until}）",
+            f"入职 {len(self.hires)} 人，离职 {len(self.leaves)} 人，换组 {len(self.group_changes)} 人",
+        ]
+        if self.total_count == 0:
+            lines.append("本周没有入职、离职、换组记录。")
+            return "\n".join(lines)
+
+        _append_section(lines, "入职", self.hires)
+        _append_section(lines, "离职", self.leaves)
+        _append_section(lines, "换组", self.group_changes)
+        return "\n".join(lines)
+
+
+def load_weekly_roster_summary(
+    engine: Engine,
+    *,
+    now: datetime | None = None,
+    days: int = DEFAULT_WEEKLY_SUMMARY_DAYS,
+) -> WeeklyRosterSummary:
+    until = now or datetime.now(UTC).replace(tzinfo=None)
+    since = until - timedelta(days=days)
+    with engine.connect() as connection:
+        rows = connection.execute(
+            select(employee_change_events_table)
+            .where(
+                and_(
+                    employee_change_events_table.c.event_at >= since,
+                    employee_change_events_table.c.event_at < until,
+                )
+            )
+            .order_by(
+                employee_change_events_table.c.event_type,
+                employee_change_events_table.c.event_at,
+                employee_change_events_table.c.employee_name,
+            )
+        ).all()
+
+    items = [_row_to_change_item(row._mapping) for row in rows]
+    return WeeklyRosterSummary(
+        since=since,
+        until=until,
+        hires=[item for item in items if item.event_type == "hire"],
+        leaves=[item for item in items if item.event_type == "leave"],
+        group_changes=[item for item in items if item.event_type == "group_change"],
+    )
+
+
+def send_weekly_roster_summary_to_lark(
+    summary: WeeklyRosterSummary,
+    *,
+    client: LarkApiClient,
+    open_id: str,
+) -> None:
+    token = client.tenant_access_token()
+    client.post(
+        "/im/v1/messages",
+        params={"receive_id_type": "open_id"},
+        json_body={
+            "receive_id": open_id,
+            "msg_type": "text",
+            "content": json.dumps({"text": summary.render_text()}, ensure_ascii=False),
+        },
+        token=token,
+    )
+
+
+def _row_to_change_item(row) -> RosterChangeItem:
+    return RosterChangeItem(
+        event_type=row["event_type"],
+        employee_name=row["employee_name"],
+        employee_email=row["employee_email"],
+        manager_name=row["manager_name"],
+        manager_email=row["manager_email"],
+        group_name=row["group_name"],
+        previous_group_name=row["previous_group_name"],
+        event_at=row["event_at"],
+    )
+
+
+def _append_section(
+    lines: list[str],
+    title: str,
+    items: Sequence[RosterChangeItem],
+) -> None:
+    if not items:
+        return
+    lines.append("")
+    lines.append(f"{title}:")
+    for item in items:
+        lines.append(f"- {_format_change_item(item)}")
+
+
+def _format_change_item(item: RosterChangeItem) -> str:
+    manager = _person_text(item.manager_name, item.manager_email)
+    department = item.group_name or "-"
+    if item.event_type == "group_change":
+        previous_department = item.previous_group_name or "-"
+        department = f"{previous_department} -> {department}"
+    return (
+        f"{item.employee_name} | 邮箱: {item.employee_email or '-'} | "
+        f"主管: {manager} | 部门: {department}"
+    )
+
+
+def _person_text(name: str | None, email: str | None) -> str:
+    if name and email:
+        return f"{name} <{email}>"
+    return name or email or "-"
+
+
+def _format_display_date(value: datetime) -> str:
+    aware = value.replace(tzinfo=UTC)
+    return aware.astimezone(DEFAULT_DISPLAY_TIMEZONE).strftime("%Y-%m-%d")

--- a/roster/src/roster/sources/lark.py
+++ b/roster/src/roster/sources/lark.py
@@ -98,6 +98,22 @@ class LarkApiClient:
             headers={"Authorization": f"Bearer {token}"},
         )
 
+    def post(
+        self,
+        path: str,
+        *,
+        params: dict[str, object] | None = None,
+        json_body: dict[str, object] | None = None,
+        token: str,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            path,
+            params=params,
+            json_body=json_body,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
     def _request(
         self,
         method: str,

--- a/roster/tests/test_cli.py
+++ b/roster/tests/test_cli.py
@@ -11,6 +11,14 @@ def test_parser_exposes_sync_roster_command() -> None:
     assert args.command == "sync-roster"
 
 
+def test_parser_exposes_weekly_summary_command() -> None:
+    args = cli.build_parser().parse_args(["weekly-summary", "--days", "14", "--send-lark"])
+
+    assert args.command == "weekly-summary"
+    assert args.days == 14
+    assert args.send_lark is True
+
+
 def test_parser_exposes_validate_lark_command() -> None:
     args = cli.build_parser().parse_args(["validate-lark"])
 
@@ -114,6 +122,69 @@ def test_main_builds_lark_source_when_configured(monkeypatch) -> None:
         "client": ("cli_xxx", "secret"),
         "source_args": (client, "github_attr", "od-root"),
         "sync": (engine, source),
+        "disposed": True,
+    }
+
+
+def test_main_weekly_summary_prints_json_and_disposes_engine(monkeypatch, capsys) -> None:
+    calls: dict[str, object] = {}
+    settings = SimpleNamespace(log_level="INFO", lark=SimpleNamespace(is_configured=False))
+    engine = SimpleNamespace(dispose=lambda: calls.setdefault("disposed", True))
+    summary = SimpleNamespace(total_count=0, to_dict=lambda: {"hires": []})
+
+    monkeypatch.setattr(cli, "get_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda log_level: calls.setdefault("log", log_level))
+    monkeypatch.setattr(cli, "build_engine", lambda resolved: calls.setdefault("engine", engine))
+
+    def fake_load_weekly_roster_summary(built_engine, *, days):
+        calls["summary"] = (built_engine, days)
+        return summary
+
+    monkeypatch.setattr(cli, "load_weekly_roster_summary", fake_load_weekly_roster_summary)
+
+    assert cli.main(["weekly-summary", "--days", "14"]) == 0
+
+    assert calls == {
+        "log": "INFO",
+        "engine": engine,
+        "summary": (engine, 14),
+        "disposed": True,
+    }
+    assert capsys.readouterr().out == '{\n  "hires": []\n}\n'
+
+
+def test_main_weekly_summary_sends_lark(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+    lark_settings = SimpleNamespace(
+        is_configured=True,
+        app_id="cli_xxx",
+        app_secret="secret",
+        notify_open_id="ou_xxx",
+    )
+    settings = SimpleNamespace(log_level="INFO", lark=lark_settings)
+    engine = SimpleNamespace(dispose=lambda: calls.setdefault("disposed", True))
+    summary = SimpleNamespace(total_count=3, to_dict=lambda: {"hires": []})
+    client = object()
+
+    monkeypatch.setattr(cli, "get_settings", lambda *args, **kwargs: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda log_level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda resolved: engine)
+    monkeypatch.setattr(cli, "load_weekly_roster_summary", lambda built_engine, *, days: summary)
+    monkeypatch.setattr(
+        cli,
+        "LarkApiClient",
+        lambda app_id, app_secret: calls.setdefault("client", (app_id, app_secret)) and client,
+    )
+
+    def fake_send(summary_arg, *, client, open_id):
+        calls["send"] = (summary_arg, client, open_id)
+
+    monkeypatch.setattr(cli, "send_weekly_roster_summary_to_lark", fake_send)
+
+    assert cli.main(["weekly-summary", "--send-lark"]) == 0
+    assert calls == {
+        "client": ("cli_xxx", "secret"),
+        "send": (summary, client, "ou_xxx"),
         "disposed": True,
     }
 

--- a/roster/tests/test_config_and_db.py
+++ b/roster/tests/test_config_and_db.py
@@ -28,6 +28,7 @@ def test_load_settings_builds_tidb_fields() -> None:
             "ROSTER_LARK_APP_ID": "cli_xxx",
             "ROSTER_LARK_APP_SECRET": "secret",
             "ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID": "github_attr",
+            "ROSTER_LARK_NOTIFY_OPEN_ID": "ou_xxx",
             "ROSTER_LARK_ROOT_DEPARTMENT_ID": "od-root",
         }
     )
@@ -41,6 +42,7 @@ def test_load_settings_builds_tidb_fields() -> None:
     assert settings.lark.app_id == "cli_xxx"
     assert settings.lark.app_secret == "secret"
     assert settings.lark.github_custom_attr_id == "github_attr"
+    assert settings.lark.notify_open_id == "ou_xxx"
     assert settings.lark.root_department_id == "od-root"
     assert settings.log_level == "DEBUG"
 

--- a/roster/tests/test_lark_source.py
+++ b/roster/tests/test_lark_source.py
@@ -225,6 +225,29 @@ def test_lark_api_client_raises_when_token_missing() -> None:
         client.tenant_access_token()
 
 
+def test_lark_api_client_posts_authenticated_json() -> None:
+    transport = FakeTransport([{"code": 0, "data": {"message_id": "om_xxx"}}])
+    client = LarkApiClient("app_id", "app_secret", transport=transport)
+
+    response = client.post(
+        "/im/v1/messages",
+        params={"receive_id_type": "open_id"},
+        json_body={"receive_id": "ou_xxx"},
+        token="token",
+    )
+
+    assert response["data"]["message_id"] == "om_xxx"
+    assert transport.calls == [
+        {
+            "method": "POST",
+            "path": "/im/v1/messages",
+            "params": {"receive_id_type": "open_id"},
+            "json_body": {"receive_id": "ou_xxx"},
+            "headers": {"Authorization": "Bearer token"},
+        }
+    ]
+
+
 def test_lark_api_client_rejects_authenticated_request_without_headers() -> None:
     client = LarkApiClient("app_id", "app_secret", transport=FakeTransport([]))
 

--- a/roster/tests/test_sql_schema.py
+++ b/roster/tests/test_sql_schema.py
@@ -10,6 +10,11 @@ JOIN_TIME_SQL_PATH = (
 EN_NAME_SQL_PATH = (
     Path(__file__).resolve().parents[1] / "sql" / "003_alter_roster_employees_add_en_name.sql"
 )
+CHANGE_EVENTS_SQL_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "sql"
+    / "004_create_roster_employee_change_events.sql"
+)
 
 
 def test_schema_migration_creates_expected_tables() -> None:
@@ -17,7 +22,8 @@ def test_schema_migration_creates_expected_tables() -> None:
 
     assert "CREATE TABLE IF NOT EXISTS roster_employees" in sql
     assert "CREATE TABLE IF NOT EXISTS roster_groups" in sql
-    assert sql.count("ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci") == 2
+    assert "CREATE TABLE IF NOT EXISTS roster_employee_change_events" in sql
+    assert sql.count("ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci") == 3
 
 
 def test_employee_schema_has_join_keys_and_paths() -> None:
@@ -61,3 +67,15 @@ def test_en_name_alter_sql_adds_employee_column() -> None:
 
     assert "ALTER TABLE roster_employees" in sql
     assert "ADD COLUMN en_name VARCHAR(255) NULL AFTER name" in sql
+
+
+def test_change_events_sql_creates_weekly_summary_table() -> None:
+    sql = CHANGE_EVENTS_SQL_PATH.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS roster_employee_change_events" in sql
+    assert "event_type VARCHAR(32) NOT NULL" in sql
+    assert "employee_name VARCHAR(255) NOT NULL" in sql
+    assert "manager_name VARCHAR(255) NULL" in sql
+    assert "group_name VARCHAR(255) NULL" in sql
+    assert "previous_group_name VARCHAR(255) NULL" in sql
+    assert "KEY idx_roster_employee_change_events_type_time (event_type, event_at)" in sql

--- a/roster/tests/test_sync_roster.py
+++ b/roster/tests/test_sync_roster.py
@@ -13,6 +13,7 @@ from roster.jobs.sync_roster import (
     RosterSyncStatus,
     StaticRosterSource,
     SyncRosterSummary,
+    employee_change_events_table,
     employees_table,
     groups_table,
     metadata,
@@ -335,6 +336,94 @@ def test_run_sync_roster_marks_missing_rows_inactive_after_grace_period() -> Non
 
     assert employee_is_active is False
     assert group_is_active is False
+
+
+def test_run_sync_roster_records_employee_change_events() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    original_time = _dt("2026-05-10T08:00:00")
+    first = StaticRosterSource(
+        FetchedRoster(
+            groups=[
+                FetchedGroup(lark_group_id="eng", name="Engineering"),
+                FetchedGroup(lark_group_id="db", name="Database"),
+            ],
+            employees=[
+                FetchedEmployee(
+                    lark_id="manager",
+                    name="Manager",
+                    email="manager@example.com",
+                    group_lark_id="eng",
+                ),
+                FetchedEmployee(
+                    lark_id="alice",
+                    name="Alice",
+                    email="alice@example.com",
+                    manager_lark_id="manager",
+                    group_lark_id="eng",
+                ),
+            ],
+        )
+    )
+    second = StaticRosterSource(
+        FetchedRoster(
+            groups=[
+                FetchedGroup(lark_group_id="eng", name="Engineering"),
+                FetchedGroup(lark_group_id="db", name="Database"),
+            ],
+            employees=[
+                FetchedEmployee(
+                    lark_id="manager",
+                    name="Manager",
+                    email="manager@example.com",
+                    group_lark_id="eng",
+                ),
+                FetchedEmployee(
+                    lark_id="alice",
+                    name="Alice",
+                    email="alice@example.com",
+                    manager_lark_id="manager",
+                    group_lark_id="db",
+                ),
+            ],
+        )
+    )
+
+    run_sync_roster(engine, source=first, now=original_time)
+    run_sync_roster(engine, source=second, now=original_time + timedelta(days=1))
+    run_sync_roster(
+        engine,
+        source=StaticRosterSource(FetchedRoster(groups=[], employees=[])),
+        now=original_time + timedelta(days=4),
+        inactive_grace=timedelta(days=2),
+    )
+
+    with engine.connect() as conn:
+        events = [
+            row._mapping
+            for row in conn.execute(
+                select(employee_change_events_table).order_by(
+                    employee_change_events_table.c.event_at,
+                    employee_change_events_table.c.employee_lark_id,
+                    employee_change_events_table.c.event_type,
+                )
+            ).all()
+        ]
+
+    alice_events = [event for event in events if event["employee_lark_id"] == "alice"]
+    assert [event["event_type"] for event in alice_events] == [
+        "hire",
+        "group_change",
+        "leave",
+    ]
+    assert alice_events[0]["employee_name"] == "Alice"
+    assert alice_events[0]["employee_email"] == "alice@example.com"
+    assert alice_events[0]["manager_name"] == "Manager"
+    assert alice_events[0]["manager_email"] == "manager@example.com"
+    assert alice_events[0]["group_name"] == "Engineering"
+    assert alice_events[1]["previous_group_name"] == "Engineering"
+    assert alice_events[1]["group_name"] == "Database"
+    assert alice_events[2]["group_name"] == "Database"
 
 
 def test_run_sync_roster_normalizes_empty_join_keys_to_null() -> None:

--- a/roster/tests/test_weekly_summary.py
+++ b/roster/tests/test_weekly_summary.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine
+
+from roster.jobs.sync_roster import employee_change_events_table, metadata
+from roster.jobs.weekly_summary import (
+    load_weekly_roster_summary,
+    send_weekly_roster_summary_to_lark,
+)
+from roster.sources.lark import LarkApiClient
+
+
+class FakeTransport:
+    def __init__(self, responses: list[dict]):
+        self.responses = responses
+        self.calls: list[dict] = []
+
+    def request_json(self, method, path, *, params=None, json_body=None, headers=None):
+        self.calls.append(
+            {
+                "method": method,
+                "path": path,
+                "params": params or {},
+                "json_body": json_body or {},
+                "headers": headers or {},
+            }
+        )
+        return self.responses.pop(0)
+
+
+def test_load_weekly_roster_summary_filters_and_renders_change_types() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    now = datetime.fromisoformat("2026-05-25T01:00:00")
+    with engine.begin() as connection:
+        connection.execute(
+            employee_change_events_table.insert(),
+            [
+                _event_row(
+                    "old",
+                    "hire",
+                    employee_name="Old",
+                    event_at=now - timedelta(days=8),
+                ),
+                _event_row(
+                    "alice",
+                    "hire",
+                    employee_name="Alice",
+                    employee_email="alice@example.com",
+                    manager_name="Manager",
+                    group_name="Engineering",
+                    event_at=now - timedelta(days=6),
+                ),
+                _event_row(
+                    "bob",
+                    "leave",
+                    employee_name="Bob",
+                    employee_email="bob@example.com",
+                    manager_name="Manager",
+                    group_name="Database",
+                    event_at=now - timedelta(days=3),
+                ),
+                _event_row(
+                    "carol",
+                    "group_change",
+                    employee_name="Carol",
+                    employee_email="carol@example.com",
+                    manager_name="Lead",
+                    previous_group_name="Engineering",
+                    group_name="Database",
+                    event_at=now - timedelta(days=1),
+                ),
+            ],
+        )
+
+    summary = load_weekly_roster_summary(engine, now=now, days=7)
+
+    assert [item.employee_name for item in summary.hires] == ["Alice"]
+    assert [item.employee_name for item in summary.leaves] == ["Bob"]
+    assert [item.employee_name for item in summary.group_changes] == ["Carol"]
+    rendered = summary.render_text()
+    assert "入职 1 人，离职 1 人，换组 1 人" in rendered
+    assert "Alice | 邮箱: alice@example.com | 主管: Manager | 部门: Engineering" in rendered
+    assert "Carol | 邮箱: carol@example.com | 主管: Lead | 部门: Engineering -> Database" in rendered
+
+
+def test_send_weekly_roster_summary_to_lark_sends_text_message() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    now = datetime.fromisoformat("2026-05-25T01:00:00")
+    summary = load_weekly_roster_summary(engine, now=now, days=7)
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {"code": 0, "data": {"message_id": "om_xxx"}},
+        ]
+    )
+
+    send_weekly_roster_summary_to_lark(
+        summary,
+        client=LarkApiClient("app_id", "app_secret", transport=transport),
+        open_id="ou_xxx",
+    )
+
+    message_call = transport.calls[1]
+    assert message_call["method"] == "POST"
+    assert message_call["path"] == "/im/v1/messages"
+    assert message_call["params"] == {"receive_id_type": "open_id"}
+    assert message_call["headers"] == {"Authorization": "Bearer token"}
+    assert message_call["json_body"]["receive_id"] == "ou_xxx"
+    assert message_call["json_body"]["msg_type"] == "text"
+    content = json.loads(message_call["json_body"]["content"])
+    assert "本周没有入职、离职、换组记录。" in content["text"]
+
+
+def _event_row(
+    employee_lark_id: str,
+    event_type: str,
+    *,
+    employee_name: str,
+    event_at: datetime,
+    employee_email: str | None = None,
+    manager_name: str | None = None,
+    group_name: str | None = None,
+    previous_group_name: str | None = None,
+) -> dict[str, object]:
+    return {
+        "event_type": event_type,
+        "employee_lark_id": employee_lark_id,
+        "employee_name": employee_name,
+        "employee_email": employee_email,
+        "manager_name": manager_name,
+        "manager_email": None,
+        "group_name": group_name,
+        "group_path": None,
+        "previous_group_name": previous_group_name,
+        "previous_group_path": None,
+        "event_at": event_at,
+        "created_at": event_at,
+    }


### PR DESCRIPTION
## Summary
- record roster employee hire, leave, and group-change events during sync
- add `weekly-summary` command to render/send the last 7 days of changes to Lark
- add SQL migration and docs for `roster_employee_change_events`

## Tests
- `ruff check .`
- `pytest`