### PR TITLE
feat(cost): reduce BigQuery billing scan cost

### DIFF
--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -257,6 +257,9 @@ def get_unmatched_resources(engine: Engine, filters: CommonFilters) -> dict[str,
         attr_where_clause, attr_params = _build_cost_where(filters, table_alias="c")
         resource_where_clause, resource_params = _build_cost_where(filters, table_alias="r")
         namespace_clause, namespace_params = _build_unallocated_namespace_where("r.namespace")
+        org_match = _null_safe_eq(connection, "m.org", "r.org")
+        repo_match = _null_safe_eq(connection, "m.repo", "r.repo")
+        author_match = _null_safe_eq(connection, "m.author", "r.author")
         rows = connection.execute(
             text(
                 f"""
@@ -303,9 +306,9 @@ def get_unmatched_resources(engine: Engine, filters: CommonFilters) -> dict[str,
                     ON m.usage_date = r.usage_date
                    AND m.vendor = r.vendor
                    AND m.account_id = r.account_id
-                   AND (m.org = r.org OR (m.org IS NULL AND r.org IS NULL))
-                   AND (m.repo = r.repo OR (m.repo IS NULL AND r.repo IS NULL))
-                   AND (m.author = r.author OR (m.author IS NULL AND r.author IS NULL))
+                   AND {org_match}
+                   AND {repo_match}
+                   AND {author_match}
                   WHERE {resource_where_clause}
                     AND r.resource_name IS NOT NULL
                     AND r.resource_name <> ''
@@ -488,6 +491,12 @@ def _like_prefix_expr(connection: Connection, value_expr: str, prefix_expr: str)
     if connection.dialect.name == "sqlite":
         return f"{value_expr} LIKE {prefix_expr} || '%'"
     return f"{value_expr} LIKE CONCAT({prefix_expr}, '%')"
+
+
+def _null_safe_eq(connection: Connection, left_expr: str, right_expr: str) -> str:
+    if connection.dialect.name == "sqlite":
+        return f"{left_expr} IS {right_expr}"
+    return f"{left_expr} <=> {right_expr}"
 
 
 def _repo_key(repo_name: str, index: int) -> str:

--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -255,43 +255,80 @@ def get_engineering_group_share(engine: Engine, filters: CommonFilters) -> dict[
 def get_unmatched_resources(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         attr_where_clause, attr_params = _build_cost_where(filters, table_alias="c")
-        raw_where_clause, raw_params = _build_cost_where(filters, table_alias="r")
+        resource_where_clause, resource_params = _build_cost_where(filters, table_alias="r")
         namespace_clause, namespace_params = _build_unallocated_namespace_where("r.namespace")
         rows = connection.execute(
             text(
                 f"""
-                WITH unmatched_resources AS (
+                WITH unmatched_dimensions AS (
                   SELECT
-                    c.resource_name AS resource_name,
+                    c.usage_date AS usage_date,
+                    c.vendor AS vendor,
+                    c.account_id AS account_id,
+                    c.org AS org,
+                    c.repo AS repo,
+                    c.author AS author,
                     MAX(c.attribution_key) AS attribution_key,
                     MAX(c.attribution_source) AS attribution_source,
                     MAX(c.attribution_status) AS attribution_status
                   FROM cost_attribution_daily c
                   WHERE {attr_where_clause}
                     AND c.employee_id IS NULL
-                    AND c.resource_name IS NOT NULL
-                    AND c.resource_name <> ''
-                  GROUP BY c.resource_name
+                  GROUP BY
+                    c.usage_date,
+                    c.vendor,
+                    c.account_id,
+                    c.org,
+                    c.repo,
+                    c.author
                 ),
-                unallocated_resources AS (
+                unallocated_resource_rows AS (
                   SELECT
                     r.resource_name AS resource_name,
-                    MAX(r.service_name) AS service_name,
-                    MAX(r.sku_name) AS sku_name,
-                    MAX(r.org) AS org_name,
-                    MAX(r.repo) AS repo_name,
-                    MAX(r.author) AS author_name,
-                    MIN(r.usage_date) AS first_seen_date,
-                    MAX(r.usage_date) AS last_seen_date,
-                    GROUP_CONCAT(DISTINCT COALESCE(r.namespace, '<null>')) AS allocation_buckets,
-                    SUM(COALESCE(r.usage_seconds, 0)) AS usage_seconds,
-                    SUM(r.list_cost) AS list_cost
-                  FROM cost_raw_details r
-                  WHERE {raw_where_clause}
+                    r.service_name AS service_name,
+                    r.sku_name AS sku_name,
+                    r.org AS org_name,
+                    r.repo AS repo_name,
+                    r.author AS author_name,
+                    r.usage_date AS usage_date,
+                    r.namespace AS namespace,
+                    r.usage_seconds AS usage_seconds,
+                    r.list_cost AS list_cost,
+                    m.attribution_key AS attribution_key,
+                    m.attribution_source AS attribution_source,
+                    m.attribution_status AS attribution_status
+                  FROM cost_unmatched_resource_daily r
+                  -- Keep attribution as the source of truth; resource rows alone are not roster-filtered.
+                  JOIN unmatched_dimensions m
+                    ON m.usage_date = r.usage_date
+                   AND m.vendor = r.vendor
+                   AND m.account_id = r.account_id
+                   AND (m.org = r.org OR (m.org IS NULL AND r.org IS NULL))
+                   AND (m.repo = r.repo OR (m.repo IS NULL AND r.repo IS NULL))
+                   AND (m.author = r.author OR (m.author IS NULL AND r.author IS NULL))
+                  WHERE {resource_where_clause}
                     AND r.resource_name IS NOT NULL
                     AND r.resource_name <> ''
                     AND ({namespace_clause})
-                  GROUP BY r.resource_name
+                ),
+                unallocated_resources AS (
+                  SELECT
+                    resource_name,
+                    MAX(service_name) AS service_name,
+                    MAX(sku_name) AS sku_name,
+                    MAX(org_name) AS org_name,
+                    MAX(repo_name) AS repo_name,
+                    MAX(author_name) AS author_name,
+                    MIN(usage_date) AS first_seen_date,
+                    MAX(usage_date) AS last_seen_date,
+                    GROUP_CONCAT(DISTINCT COALESCE(namespace, '<null>')) AS allocation_buckets,
+                    SUM(COALESCE(usage_seconds, 0)) AS usage_seconds,
+                    SUM(list_cost) AS list_cost,
+                    MAX(attribution_key) AS attribution_key,
+                    MAX(attribution_source) AS attribution_source,
+                    MAX(attribution_status) AS attribution_status
+                  FROM unallocated_resource_rows
+                  GROUP BY resource_name
                 )
                 SELECT
                   u.resource_name AS resource_name,
@@ -302,22 +339,20 @@ def get_unmatched_resources(engine: Engine, filters: CommonFilters) -> dict[str,
                   u.author_name AS author_name,
                   u.first_seen_date AS first_seen_date,
                   u.last_seen_date AS last_seen_date,
-                  m.attribution_key AS attribution_key,
-                  m.attribution_source AS attribution_source,
-                  m.attribution_status AS attribution_status,
+                  u.attribution_key AS attribution_key,
+                  u.attribution_source AS attribution_source,
+                  u.attribution_status AS attribution_status,
                   u.allocation_buckets AS allocation_buckets,
                   u.usage_seconds AS usage_seconds,
                   u.list_cost AS list_cost
                 FROM unallocated_resources u
-                JOIN unmatched_resources m
-                  ON m.resource_name = u.resource_name
                 ORDER BY list_cost DESC, u.resource_name
                 LIMIT :limit
                 """
             ),
             {
                 **attr_params,
-                **raw_params,
+                **resource_params,
                 **namespace_params,
                 "limit": UNMATCHED_RESOURCE_LIMIT,
             },

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -498,6 +498,57 @@ def _insert_cost_raw_detail(
         )
 
 
+def _insert_cost_unmatched_resource(
+    sqlite_engine,
+    *,
+    usage_date: str,
+    repo: str,
+    resource_name: str,
+    namespace: str | None,
+    list_cost: float,
+    effective_cost: float | None = None,
+    net_cost: float | None = None,
+    author: str | None = "alice",
+    usage_seconds: float = 3600,
+    service_name: str = "Compute Engine",
+    sku_name: str = "runner",
+    source_row_hash: str | None = None,
+) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cost_unmatched_resource_daily (
+                  vendor, account_id, billing_account_id, export_partition_date, usage_date,
+                  service_name, sku_name, namespace, author, org, repo, resource_name,
+                  usage_seconds, list_cost, effective_cost, credit_amount, net_cost,
+                  source_export_time, source_row_hash
+                ) VALUES (
+                  'gcp', 'pingcap-testing-account', 'billing-account-1', :usage_date, :usage_date,
+                  :service_name, :sku_name, :namespace, :author, 'pingcap', :repo, :resource_name,
+                  :usage_seconds, :list_cost, :effective_cost, 0, :net_cost,
+                  '2026-05-19 00:00:00', :source_row_hash
+                )
+                """
+            ),
+            {
+                "usage_date": usage_date,
+                "service_name": service_name,
+                "sku_name": sku_name,
+                "namespace": namespace,
+                "author": author,
+                "repo": repo,
+                "resource_name": resource_name,
+                "usage_seconds": usage_seconds,
+                "list_cost": list_cost,
+                "effective_cost": effective_cost if effective_cost is not None else list_cost,
+                "net_cost": net_cost if net_cost is not None else list_cost,
+                "source_row_hash": source_row_hash
+                or f"{usage_date}-{resource_name}-{namespace}-{list_cost}",
+            },
+        )
+
+
 @pytest.fixture()
 def api_client(sqlite_engine, monkeypatch):
     _insert_build(
@@ -2147,7 +2198,7 @@ def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) ->
         net_cost=0,
         effective_cost=90,
         list_cost=120,
-        resource_name="projects/pingcap-prod/zones/us-central1-a/instances/tidb-ci-runner-1",
+        resource_name=None,
         author=None,
         owner=None,
         attribution_key=None,
@@ -2156,7 +2207,7 @@ def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) ->
         employee_id=None,
         usage_seconds=172800,
     )
-    _insert_cost_raw_detail(
+    _insert_cost_unmatched_resource(
         sqlite_engine,
         usage_date="2026-05-10",
         repo="tidb",
@@ -2176,7 +2227,7 @@ def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) ->
         net_cost=0,
         effective_cost=20,
         list_cost=30,
-        resource_name="//logging.googleapis.com/projects/890604261603/locations/global/buckets/_Default",
+        resource_name=None,
         author=None,
         owner=None,
         attribution_key=None,
@@ -2194,7 +2245,7 @@ def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) ->
         net_cost=0,
         effective_cost=20,
         list_cost=30,
-        resource_name="//logging.googleapis.com/projects/890604261603/locations/global/buckets/_Default",
+        resource_name=None,
         author=None,
         owner=None,
         attribution_key=None,
@@ -2204,7 +2255,7 @@ def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) ->
         usage_seconds=86400,
         dimension_hash="cost-log-bucket-end",
     )
-    _insert_cost_raw_detail(
+    _insert_cost_unmatched_resource(
         sqlite_engine,
         usage_date="2026-05-01",
         repo="platform",
@@ -2217,9 +2268,9 @@ def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) ->
         usage_seconds=86400,
         service_name="Cloud Logging",
         sku_name="Vended Logs Storage",
-        source_row_hash="raw-log-bucket-start",
+        source_row_hash="resource-log-bucket-start",
     )
-    _insert_cost_raw_detail(
+    _insert_cost_unmatched_resource(
         sqlite_engine,
         usage_date="2026-05-31",
         repo="platform",
@@ -2232,7 +2283,7 @@ def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) ->
         usage_seconds=86400,
         service_name="Cloud Logging",
         sku_name="Vended Logs Storage",
-        source_row_hash="raw-log-bucket-end",
+        source_row_hash="resource-log-bucket-end",
     )
     _insert_cost_attribution(
         sqlite_engine,
@@ -2251,7 +2302,7 @@ def test_cost_page_unmatched_resources(sqlite_engine, api_client: TestClient) ->
         employee_id=None,
         usage_seconds=21600,
     )
-    _insert_cost_raw_detail(
+    _insert_cost_unmatched_resource(
         sqlite_engine,
         usage_date="2026-05-11",
         repo="ticdc",

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -39,6 +39,14 @@ def test_get_engine_dependency_caches_underlying_engine(monkeypatch: pytest.Monk
     dependencies_module._cached_engine.cache_clear()
 
 
+def test_cost_null_safe_eq_uses_dialect_specific_operator() -> None:
+    sqlite_connection = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    mysql_connection = SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
+
+    assert cost_queries._null_safe_eq(sqlite_connection, "m.org", "r.org") == "m.org IS r.org"
+    assert cost_queries._null_safe_eq(mysql_connection, "m.org", "r.org") == "m.org <=> r.org"
+
+
 def _insert_build(
     sqlite_engine,
     *,

--- a/ci-dashboard/tests/conftest.py
+++ b/ci-dashboard/tests/conftest.py
@@ -347,6 +347,33 @@ def _create_test_schema(engine: Engine) -> None:
           updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )
         """,
+        """
+        CREATE TABLE cost_unmatched_resource_daily (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          vendor TEXT NOT NULL,
+          account_id TEXT NOT NULL,
+          billing_account_id TEXT NULL,
+          export_partition_date TEXT NOT NULL,
+          usage_date TEXT NOT NULL,
+          service_name TEXT NULL,
+          sku_name TEXT NULL,
+          namespace TEXT NULL,
+          org TEXT NULL,
+          repo TEXT NULL,
+          author TEXT NULL,
+          resource_name TEXT NOT NULL,
+          usage_seconds REAL NULL,
+          list_cost REAL NULL,
+          effective_cost REAL NULL,
+          credit_amount REAL NULL,
+          net_cost REAL NULL,
+          source_export_time TEXT NULL,
+          source_row_hash TEXT NOT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(vendor, account_id, export_partition_date, source_row_hash)
+        )
+        """,
     ]
     with engine.begin() as connection:
         for statement in statements:

--- a/cost-insight/README.md
+++ b/cost-insight/README.md
@@ -10,6 +10,7 @@ logical model later.
 Current design:
 
 - [System design](docs/system-design.md)
+- [BigQuery cost optimization design](docs/bigquery-cost-optimization-design.md)
 
 ## Local Setup
 
@@ -28,7 +29,12 @@ Useful GCP settings:
 | --- | --- |
 | `COST_INSIGHT_GCP_BILLING_TABLE` | `gcp-digital-bi.gcp_billing_detailed.gcp_billing_export_resource_v1_01D088_8F9CF2_8AF1C6` |
 | `COST_INSIGHT_GCP_ACCOUNT_ID` | `pingcap-testing-account` |
+| `COST_INSIGHT_EARLIEST_USAGE_DATE` | `2026-01-01` |
 | `COST_INSIGHT_SYNC_OVERLAP_DAYS` | `3` |
+| `COST_INSIGHT_SYNC_LAG_DAYS` | `5` |
+| `COST_INSIGHT_EXPORT_OVERLAP_DAYS` | `0` |
+| `COST_INSIGHT_SYNC_INITIAL_LOOKBACK_DAYS` | unset |
+| `COST_INSIGHT_UNMATCHED_RESOURCE_LAG_DAYS` | `5` |
 | `COST_INSIGHT_SYNC_PAGE_SIZE` | `5000` |
 
 The Python BigQuery SDK requires Application Default Credentials. For local
@@ -81,3 +87,50 @@ This job reads `cost_raw_details`, joins current `roster_employees` and
 corrections and roster fixes can be reflected by refreshing the same dates.
 Use `--split-by-day` for multi-day ranges to stay under TiDB single-query
 memory limits.
+
+## BigQuery Cost-Optimized Pipeline
+
+The refined pipeline avoids scanning resource-level billing export columns for
+regular dashboard summaries:
+
+```bash
+cost-insight sync-gcp-billing-summary \
+  --export-partition-start 2026-05-17 \
+  --export-partition-end 2026-05-23
+```
+
+After summary rows are imported, refresh attribution from the summary table:
+
+```bash
+cost-insight refresh-cost-attribution-from-summary \
+  --start-date 2026-05-17 \
+  --end-date 2026-05-23 \
+  --split-by-day
+```
+
+Resource-level investigation data is imported separately for a stable usage
+week:
+
+```bash
+cost-insight sync-gcp-unmatched-resources \
+  --usage-start-date 2026-05-17 \
+  --usage-end-date 2026-05-23
+```
+
+To avoid a BigQuery backfill during migration, seed the new tables from the
+existing `cost_raw_details` table:
+
+```bash
+cost-insight backfill-gcp-cost-refine-from-raw \
+  --start-date 2026-01-01 \
+  --end-date 2026-05-20 \
+  --mark-summary-watermark
+```
+
+The backfill synthesizes `export_partition_date` from
+`DATE(source_export_time)`, falling back to `usage_date` when
+`source_export_time` is missing. `--mark-summary-watermark` prevents the new
+summary importer from scanning already-backfilled historical export partitions.
+
+See [docs/bigquery-cost-optimization-design.md](docs/bigquery-cost-optimization-design.md)
+for the detailed table design, query shapes, and cost estimates.

--- a/cost-insight/docs/bigquery-cost-optimization-design.md
+++ b/cost-insight/docs/bigquery-cost-optimization-design.md
@@ -1,0 +1,866 @@
+# BigQuery Cost Optimization Design
+
+## Context
+
+The first Cost Insight collector imports GCP billing details from:
+
+```text
+gcp-digital-bi.gcp_billing_detailed.gcp_billing_export_resource_v1_01D088_8F9CF2_8AF1C6
+```
+
+The current collector reads the detailed billing export, groups by daily cost
+dimensions including `resource_name`, writes `cost_raw_details`, then rebuilds
+`cost_attribution_daily` from TiDB. This is operationally simple, but it makes
+the regular collector pay for resource-level BigQuery reads even though most
+dashboard views only need summary attribution.
+
+The main optimization target is BigQuery query scan cost. TiDB write cost,
+TiDB storage, and dashboard query latency are out of scope for this design.
+
+## Current Query Cost Findings
+
+Dry runs were executed against the current billing export table on
+2026-05-25. Dry runs do not execute the query, but BigQuery returns precise
+`totalBytesProcessed` estimates for scan cost.
+
+The table is day-partitioned, but `bq show` reports no partition field:
+
+```json
+"timePartitioning": {
+  "type": "DAY"
+}
+```
+
+That means the table behaves like an ingestion-time partitioned table. The
+current collector filters only by `DATE(usage_start_time)`, which does not
+prune ingestion-time partitions.
+
+| Query shape | Date filters | Bytes processed |
+| --- | --- | ---: |
+| Current full resource-level query, one usage day | `DATE(usage_start_time) = 2026-05-17` only | 439,825,517,869 |
+| Current full resource-level query, one usage day | `_PARTITIONDATE = 2026-05-17` and usage day | 3,617,177,644 |
+| Summary attribution query, one usage day | `_PARTITIONDATE = 2026-05-17` and usage day | 2,449,889,460 |
+| Summary attribution query, 7 usage days | `_PARTITIONDATE` = same 7 days | 23,821,579,733 |
+| Full resource-level query, 7 usage days | `_PARTITIONDATE` = same 7 days | 33,882,272,158 |
+| Summary attribution query, 7 usage days plus 5-day export lag window | `_PARTITIONDATE` = 13 days, usage = 7 days; useful for a usage-window design, not the recommended export-partition incremental path | 41,149,018,219 |
+| Resource-level unmatched query, 7 usage days plus 5-day export lag window | `_PARTITIONDATE` = 13 days, usage = 7 days | 51,821,083,446 |
+| Summary attribution correction query, 30 usage days | `_PARTITIONDATE` = same 30 days | 86,409,750,092 |
+
+The biggest cost issue is missing partition pruning, not TiDB storage
+granularity. Field trimming helps, but only after the collector prunes
+`_PARTITIONDATE`.
+
+## Product Requirements
+
+1. Cost dashboard views do not need yesterday-level freshness.
+2. Normal trend, repo, group, and budget views need accurate summary cost.
+3. Resource-level unmatched data should still refresh weekly, because resource
+   investigation loses context when it is delayed too long.
+4. Historical billing corrections should update summary cost.
+5. Historical billing corrections do not need resource-level detail.
+
+## Design Goals
+
+- Scan every BigQuery export partition at most once for the regular summary
+  pipeline.
+- Avoid resource-level columns in the regular summary pipeline.
+- Keep resource-level unmatched data as a separate weekly pipeline.
+- Make late-arriving usage and billing corrections additive and idempotent.
+- Keep dashboard APIs mostly backed by `cost_attribution_daily`.
+
+## Proposed Data Model
+
+### `cost_bq_export_summary_daily`
+
+This table stores additive summary facts by BigQuery export partition. It is
+the durable import layer for regular cost summaries.
+
+```sql
+CREATE TABLE cost_bq_export_summary_daily (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  vendor VARCHAR(32) NOT NULL,
+  account_id VARCHAR(128) NOT NULL,
+  billing_account_id VARCHAR(128) NULL,
+  export_partition_date DATE NOT NULL,
+  usage_date DATE NOT NULL,
+  org VARCHAR(255) NULL,
+  repo VARCHAR(255) NULL,
+  author VARCHAR(255) NULL,
+  list_cost DECIMAL(16, 2) NULL,
+  effective_cost DECIMAL(16, 2) NULL,
+  credit_amount DECIMAL(16, 2) NULL,
+  net_cost DECIMAL(16, 2) NULL,
+  source_export_time DATETIME NULL,
+  source_row_hash CHAR(64) NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_cost_bq_export_summary_source_row (
+    vendor,
+    account_id,
+    export_partition_date,
+    source_row_hash
+  ),
+  KEY idx_cost_bq_export_summary_usage_date (usage_date, vendor, account_id),
+  KEY idx_cost_bq_export_summary_export_partition (export_partition_date)
+);
+```
+
+Important behavior:
+
+- `export_partition_date` comes from BigQuery `_PARTITIONDATE`.
+- The job watermark advances by export partition, not by usage date.
+- A late billing row for old `usage_date` lands in a newer
+  `export_partition_date`; the next regular summary import captures it without
+  rescanning older partitions.
+- Queries for final actual cost sum all rows by `usage_date`, regardless of
+  export partition.
+- `source_row_hash` should include `export_partition_date`, `usage_date`,
+  account, billing account, and normalized owner dimensions. It should not
+  include amounts or `source_export_time`.
+- Hash fields:
+  - `vendor`
+  - `account_id`
+  - `billing_account_id`
+  - `export_partition_date`
+  - `usage_date`
+  - `author`
+  - `org`
+  - `repo`
+
+This table is intentionally summary-only. It should not include
+`resource_name`, `service_name`, `sku_name`, `region`, or `usage_seconds` unless
+a dashboard requirement needs those columns in the regular path.
+
+### `cost_unmatched_resource_daily`
+
+This table stores the weekly resource-level investigation data.
+
+```sql
+CREATE TABLE cost_unmatched_resource_daily (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  vendor VARCHAR(32) NOT NULL,
+  account_id VARCHAR(128) NOT NULL,
+  billing_account_id VARCHAR(128) NULL,
+  export_partition_date DATE NOT NULL,
+  usage_date DATE NOT NULL,
+  service_name VARCHAR(255) NULL,
+  sku_name VARCHAR(255) NULL,
+  namespace VARCHAR(255) NULL,
+  org VARCHAR(255) NULL,
+  repo VARCHAR(255) NULL,
+  author VARCHAR(255) NULL,
+  resource_name VARCHAR(512) NOT NULL,
+  usage_seconds DECIMAL(20, 2) NULL,
+  list_cost DECIMAL(16, 2) NULL,
+  effective_cost DECIMAL(16, 2) NULL,
+  credit_amount DECIMAL(16, 2) NULL,
+  net_cost DECIMAL(16, 2) NULL,
+  source_export_time DATETIME NULL,
+  source_row_hash CHAR(64) NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_cost_unmatched_resource_source_row (
+    vendor,
+    account_id,
+    export_partition_date,
+    source_row_hash
+  ),
+  KEY idx_cost_unmatched_resource_usage_date (usage_date, vendor, account_id),
+  KEY idx_cost_unmatched_resource_resource_name (resource_name(255)),
+  KEY idx_cost_unmatched_resource_repo (usage_date, org, repo)
+);
+```
+
+This table is allowed to read resource-level BigQuery columns, but only in the
+weekly unmatched-resource job. Historical correction jobs should not update
+this table.
+
+Hash fields:
+
+- `vendor`
+- `account_id`
+- `billing_account_id`
+- `export_partition_date`
+- `usage_date`
+- `service_name`
+- `sku_name`
+- `namespace`
+- `author`
+- `org`
+- `repo`
+- `resource_name`
+
+The current `cost_raw_details` table can be kept temporarily for compatibility,
+but it should stop being the regular collector's primary output. New dashboard
+code should read `cost_unmatched_resource_daily` for the Top unmatched resources
+panel.
+
+`usage_seconds` should stay in this table. It is useful investigation context,
+and the resource-level query already accepts the extra usage-field scan cost
+because this job is intentionally limited to the weekly unmatched window.
+
+## BigQuery Query Shapes
+
+### Regular Summary Import
+
+Scan new export partitions only:
+
+```sql
+SELECT
+  'gcp' AS vendor,
+  project.id AS account_id,
+  billing_account_id,
+  _PARTITIONDATE AS export_partition_date,
+  DATE(usage_start_time) AS usage_date,
+  ARRAY(
+    SELECT label.value
+    FROM UNNEST(labels) AS label
+    WHERE label.key IN ('k8s-label/author', 'author')
+    LIMIT 1
+  )[SAFE_OFFSET(0)] AS author,
+  ARRAY(
+    SELECT label.value
+    FROM UNNEST(labels) AS label
+    WHERE label.key IN ('k8s-label/org', 'org')
+    LIMIT 1
+  )[SAFE_OFFSET(0)] AS org,
+  ARRAY(
+    SELECT label.value
+    FROM UNNEST(labels) AS label
+    WHERE label.key IN ('k8s-label/repo', 'repo')
+    LIMIT 1
+  )[SAFE_OFFSET(0)] AS repo,
+  ROUND(SUM(cost_at_list), 2) AS list_cost,
+  ROUND(SUM(cost), 2) AS effective_cost,
+  ROUND(SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) AS c), 0)), 2)
+    AS credit_amount,
+  ROUND(SUM(cost + IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) AS c), 0)), 2)
+    AS net_cost,
+  MAX(export_time) AS source_export_time
+FROM `gcp-digital-bi.gcp_billing_detailed.gcp_billing_export_resource_v1_01D088_8F9CF2_8AF1C6`
+WHERE _PARTITIONDATE BETWEEN @export_partition_start AND @export_partition_end
+  AND project.id = @account_id
+  AND DATE(usage_start_time) >= @earliest_usage_date
+GROUP BY
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  author,
+  org,
+  repo;
+```
+
+The regular job should not restrict usage date to a single week. It should scan
+new export partitions and accept any relevant `usage_date` inside those
+partitions. This captures late-arriving usage and correction rows without
+rescanning old partitions.
+
+### Weekly Unmatched Resource Import
+
+Scan resource-level columns only for the latest stable investigation window:
+
+```sql
+SELECT
+  'gcp' AS vendor,
+  project.id AS account_id,
+  billing_account_id,
+  _PARTITIONDATE AS export_partition_date,
+  DATE(usage_start_time) AS usage_date,
+  service.description AS service_name,
+  sku.description AS sku_name,
+  ARRAY(
+    SELECT label.value
+    FROM UNNEST(labels) AS label
+    WHERE label.key IN ('k8s-namespace', 'namespace')
+    LIMIT 1
+  )[SAFE_OFFSET(0)] AS namespace,
+  ARRAY(
+    SELECT label.value
+    FROM UNNEST(labels) AS label
+    WHERE label.key IN ('k8s-label/author', 'author')
+    LIMIT 1
+  )[SAFE_OFFSET(0)] AS author,
+  ARRAY(
+    SELECT label.value
+    FROM UNNEST(labels) AS label
+    WHERE label.key IN ('k8s-label/org', 'org')
+    LIMIT 1
+  )[SAFE_OFFSET(0)] AS org,
+  ARRAY(
+    SELECT label.value
+    FROM UNNEST(labels) AS label
+    WHERE label.key IN ('k8s-label/repo', 'repo')
+    LIMIT 1
+  )[SAFE_OFFSET(0)] AS repo,
+  COALESCE(
+    ARRAY(
+      SELECT label.value
+      FROM UNNEST(labels) AS label
+      WHERE label.key IN ('k8s-workload-name')
+      LIMIT 1
+    )[SAFE_OFFSET(0)],
+    NULLIF(resource.name, ''),
+    NULLIF(resource.global_name, '')
+  ) AS resource_name,
+  CASE
+    WHEN COUNTIF(
+      LOWER(usage.pricing_unit) IS NULL
+      OR LOWER(usage.pricing_unit) NOT IN ('hour', 'minute', 'second')
+    ) > 0 THEN NULL
+    WHEN COUNTIF(LOWER(usage.pricing_unit) = 'hour') = COUNT(*)
+      THEN ROUND(SUM(usage.amount_in_pricing_units) * 3600, 2)
+    WHEN COUNTIF(LOWER(usage.pricing_unit) = 'minute') = COUNT(*)
+      THEN ROUND(SUM(usage.amount_in_pricing_units) * 60, 2)
+    WHEN COUNTIF(LOWER(usage.pricing_unit) = 'second') = COUNT(*)
+      THEN ROUND(SUM(usage.amount_in_pricing_units), 2)
+    ELSE NULL
+  END AS usage_seconds,
+  ROUND(SUM(cost_at_list), 2) AS list_cost,
+  ROUND(SUM(cost), 2) AS effective_cost,
+  ROUND(SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) AS c), 0)), 2)
+    AS credit_amount,
+  ROUND(SUM(cost + IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) AS c), 0)), 2)
+    AS net_cost,
+  MAX(export_time) AS source_export_time
+FROM `gcp-digital-bi.gcp_billing_detailed.gcp_billing_export_resource_v1_01D088_8F9CF2_8AF1C6`
+WHERE _PARTITIONDATE BETWEEN @export_partition_start AND @export_partition_end
+  AND project.id = @account_id
+  AND DATE(usage_start_time) BETWEEN @usage_start_date AND @usage_end_date
+GROUP BY
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  service_name,
+  sku_name,
+  namespace,
+  author,
+  org,
+  repo,
+  resource_name;
+```
+
+The final unmatched-resource filter can happen in TiDB after attribution, so
+the BigQuery query does not need to perfectly know whether the author matches a
+roster employee. The important BigQuery cost boundary is that this query runs
+weekly and never participates in historical correction backfills.
+
+## Attribution Rebuild From Summary
+
+The existing attribution refresh reads `cost_raw_details` and groups by
+`service_name`, `sku_name`, and `resource_name`. The summary path cannot reuse
+that SQL unchanged because `cost_bq_export_summary_daily` intentionally omits
+those resource-level columns.
+
+The implementation should either add a new
+`refresh-cost-attribution-from-summary` command or parameterize the existing
+refresh job with a source table mode. The summary mode should rebuild
+`cost_attribution_daily` with `service_name`, `sku_name`, and `resource_name`
+set to `NULL`. These columns are nullable and current dashboard trend, repo,
+and group views do not depend on them.
+
+The summary attribution query shape is:
+
+```sql
+INSERT INTO cost_attribution_daily (
+  usage_date,
+  vendor,
+  account_id,
+  service_name,
+  sku_name,
+  org,
+  repo,
+  resource_name,
+  author,
+  owner,
+  attribution_key,
+  attribution_source,
+  attribution_status,
+  employee_id,
+  group_id,
+  manager_id,
+  usage_seconds,
+  list_cost,
+  effective_cost,
+  credit_amount,
+  net_cost,
+  source_rows,
+  dimension_hash
+)
+SELECT
+  attributed.usage_date,
+  attributed.vendor,
+  attributed.account_id,
+  NULL AS service_name,
+  NULL AS sku_name,
+  attributed.org,
+  attributed.repo,
+  NULL AS resource_name,
+  attributed.author,
+  attributed.owner,
+  attributed.attribution_key,
+  attributed.attribution_source,
+  attributed.attribution_status,
+  attributed.employee_id,
+  attributed.group_id,
+  attributed.manager_id,
+  NULL AS usage_seconds,
+  SUM(attributed.list_cost) AS list_cost,
+  SUM(attributed.effective_cost) AS effective_cost,
+  SUM(attributed.credit_amount) AS credit_amount,
+  SUM(attributed.net_cost) AS net_cost,
+  COUNT(*) AS source_rows,
+  SHA2(
+    CONCAT_WS(
+      '|',
+      DATE_FORMAT(attributed.usage_date, '%Y-%m-%d'),
+      COALESCE(attributed.vendor, ''),
+      COALESCE(attributed.account_id, ''),
+      '',
+      '',
+      COALESCE(attributed.org, ''),
+      COALESCE(attributed.repo, ''),
+      '',
+      COALESCE(attributed.author, ''),
+      COALESCE(attributed.owner, ''),
+      COALESCE(attributed.attribution_key, ''),
+      COALESCE(attributed.attribution_source, ''),
+      COALESCE(attributed.attribution_status, ''),
+      COALESCE(CAST(attributed.employee_id AS CHAR), ''),
+      COALESCE(CAST(attributed.group_id AS CHAR), ''),
+      COALESCE(CAST(attributed.manager_id AS CHAR), '')
+    ),
+    256
+  ) AS dimension_hash
+FROM (
+  SELECT
+    summary.usage_date,
+    summary.vendor,
+    summary.account_id,
+    summary.org,
+    summary.repo,
+    summary.author,
+    summary.author AS owner,
+    CASE
+      WHEN COALESCE(
+        github_employee.id,
+        email_employee.id,
+        normalized_employee.id
+      ) IS NOT NULL THEN CONCAT(
+        'employee:',
+        CAST(COALESCE(
+          github_employee.id,
+          email_employee.id,
+          normalized_employee.id
+        ) AS CHAR)
+      )
+      WHEN summary.author IS NOT NULL THEN CONCAT('author:', LOWER(summary.author))
+      ELSE 'unattributed'
+    END AS attribution_key,
+    CASE
+      WHEN github_employee.id IS NOT NULL THEN 'author_github'
+      WHEN email_employee.id IS NOT NULL THEN 'author_email'
+      WHEN normalized_employee.id IS NOT NULL THEN 'author_normalized'
+      WHEN summary.author IS NOT NULL THEN 'author_label'
+      ELSE 'missing_author'
+    END AS attribution_source,
+    CASE
+      WHEN COALESCE(
+        github_employee.id,
+        email_employee.id,
+        normalized_employee.id
+      ) IS NOT NULL THEN 'matched'
+      WHEN summary.author IS NOT NULL THEN 'unmatched'
+      ELSE 'unattributed'
+    END AS attribution_status,
+    COALESCE(
+      github_employee.id,
+      email_employee.id,
+      normalized_employee.id
+    ) AS employee_id,
+    COALESCE(
+      github_employee.group_id,
+      email_employee.group_id,
+      normalized_employee.group_id
+    ) AS group_id,
+    COALESCE(
+      github_employee.manager_id,
+      email_employee.manager_id,
+      normalized_employee.manager_id,
+      matched_group.manager_id
+    ) AS manager_id,
+    summary.list_cost,
+    summary.effective_cost,
+    summary.credit_amount,
+    summary.net_cost
+  FROM cost_bq_export_summary_daily summary
+  LEFT JOIN roster_employees github_employee
+    ON github_employee.is_active = 1
+   AND summary.author IS NOT NULL
+   AND github_employee.github_id IS NOT NULL
+   AND LOWER(github_employee.github_id) = LOWER(summary.author)
+  LEFT JOIN roster_employees email_employee
+    ON github_employee.id IS NULL
+   AND email_employee.is_active = 1
+   AND summary.author IS NOT NULL
+   AND email_employee.email IS NOT NULL
+   AND (
+     LOWER(email_employee.email) = LOWER(summary.author)
+     OR LOWER(SUBSTRING_INDEX(email_employee.email, '@', 1)) = LOWER(summary.author)
+   )
+  LEFT JOIN roster_employees normalized_employee
+    ON github_employee.id IS NULL
+   AND email_employee.id IS NULL
+   AND normalized_employee.is_active = 1
+   AND summary.author IS NOT NULL
+   AND (
+     normalized_employee.github_id IS NOT NULL
+     OR normalized_employee.email IS NOT NULL
+     OR normalized_employee.en_name IS NOT NULL
+   )
+   AND (
+     <normalized_summary_author> = <normalized_github_id>
+     OR <normalized_summary_author> = <normalized_email_local>
+     OR <normalized_summary_author> = <normalized_en_name>
+   )
+  LEFT JOIN roster_groups matched_group
+    ON matched_group.is_active = 1
+   AND matched_group.id = COALESCE(
+     github_employee.group_id,
+     email_employee.group_id,
+     normalized_employee.group_id
+   )
+  WHERE summary.usage_date BETWEEN @start_date AND @end_date
+    AND summary.vendor = @vendor
+    AND summary.account_id = @account_id
+) attributed
+GROUP BY
+  attributed.usage_date,
+  attributed.vendor,
+  attributed.account_id,
+  attributed.org,
+  attributed.repo,
+  attributed.author,
+  attributed.owner,
+  attributed.attribution_key,
+  attributed.attribution_source,
+  attributed.attribution_status,
+  attributed.employee_id,
+  attributed.group_id,
+  attributed.manager_id;
+```
+
+The placeholder normalized expressions should reuse the existing
+`normalized_identity_sql()` helper. This keeps author matching behavior aligned
+with the current raw-detail attribution job.
+
+After a summary import, touched usage dates should be discovered from the
+summary table, not inferred from the export partition window:
+
+```sql
+SELECT DISTINCT usage_date
+FROM cost_bq_export_summary_daily
+WHERE export_partition_date BETWEEN @export_partition_start AND @export_partition_end
+  AND vendor = @vendor
+  AND account_id = @account_id
+ORDER BY usage_date;
+```
+
+The refresh command can then rebuild those dates one by one, or merge
+contiguous dates into ranges. One-by-one refresh remains the safer default for
+TiDB memory usage.
+
+## Refresh Schedule
+
+### Recommended Defaults
+
+| Setting | Default | Meaning |
+| --- | ---: | --- |
+| `COST_INSIGHT_SYNC_INTERVAL` | weekly | Run the regular summary import once per week |
+| `COST_INSIGHT_SYNC_LAG_DAYS` | 5 | Only import export partitions up to `today - 5 days` |
+| `COST_INSIGHT_EXPORT_OVERLAP_DAYS` | 0 or 1 | Safety overlap on export partitions, not usage dates |
+| `COST_INSIGHT_SYNC_INITIAL_LOOKBACK_DAYS` | unset | Optional bootstrap window for first run |
+| `COST_INSIGHT_UNMATCHED_RESOURCE_INTERVAL` | weekly | Refresh resource investigation data weekly |
+| `COST_INSIGHT_UNMATCHED_RESOURCE_LAG_DAYS` | 5 | Use the same stable cutoff as regular summary import |
+
+### Regular Weekly Summary Job
+
+1. Read `cost_job_state` for the last imported export partition.
+2. Resolve `export_partition_end = today - sync_lag_days`.
+3. Resolve `export_partition_start = last_export_partition + 1 - overlap`.
+4. Query BigQuery with `_PARTITIONDATE BETWEEN export_partition_start AND
+   export_partition_end`.
+5. Upsert `cost_bq_export_summary_daily`.
+6. Rebuild or incrementally refresh `cost_attribution_daily` for every
+   `usage_date` touched by the imported rows.
+7. Advance the watermark only after TiDB writes and attribution refresh
+   complete.
+
+If there is no prior watermark, the job should require either an explicit
+`--export-partition-start` value or `COST_INSIGHT_SYNC_INITIAL_LOOKBACK_DAYS`.
+When the initial lookback is unset, the automatic first run should import only
+the single stable export partition at `today - sync_lag_days`; full history
+should be loaded by an explicit manual backfill.
+
+For migration, historical rows can be backfilled from the existing TiDB
+`cost_raw_details` table instead of querying BigQuery again:
+
+```bash
+cost-insight backfill-gcp-cost-refine-from-raw \
+  --start-date 2026-01-01 \
+  --end-date 2026-05-20 \
+  --mark-summary-watermark
+```
+
+This local backfill aggregates raw rows into `cost_bq_export_summary_daily` and
+copies grouped resource rows into `cost_unmatched_resource_daily`.
+`cost_raw_details` does not store BigQuery `_PARTITIONDATE`, so the backfill
+uses `DATE(source_export_time)` as a synthetic `export_partition_date`, with
+`usage_date` as a fallback for older/null rows. `--mark-summary-watermark`
+advances the new summary importer state through the synthetic export partition
+end so the normal job starts from new export partitions after the cutover.
+
+### Weekly Unmatched Resource Job
+
+1. Resolve the latest complete stable usage week.
+2. Set `_PARTITIONDATE` to cover the usage week plus lag window.
+3. Query resource-level data and upsert `cost_unmatched_resource_daily`.
+4. Rebuild the dashboard unmatched-resource materialization for that usage
+   week.
+
+### Historical Corrections
+
+No routine 30- or 45-day resource-level correction is needed.
+
+Because regular summary import is export-partition incremental, late usage and
+correction rows are naturally captured from new export partitions and added to
+the summary table. A separate monthly reconciliation job can still exist as a
+safety net, but it should be summary-only and should be used for validation or
+missed-partition repair, not as the normal correction path.
+
+If implemented, monthly reconciliation should be a separate CLI command such
+as `reconcile-gcp-billing-summary`. It should never call the resource-level
+unmatched importer.
+
+## Concurrency Model
+
+The initial implementation should assume one active instance per cost job. A
+job should check `cost_job_state.last_status` before starting and refuse to run
+when the same job is already `running`, unless a force flag is provided for
+manual recovery.
+
+The summary importer and unmatched importer write different tables and can run
+independently. Attribution refresh should not overlap with another attribution
+refresh for the same vendor, account, and usage date range. The simplest safe
+rule is to have the summary importer own the summary attribution refresh inside
+one job flow, and schedule unmatched resource refresh at a different time.
+
+## Dashboard Query Changes
+
+Current dashboard behavior:
+
+- `cost-trend` reads `cost_attribution_daily`.
+- `cost-repo-group-stack` reads `cost_attribution_daily`.
+- `cost-engineering-group-share` reads `cost_attribution_daily` and
+  `roster_groups`.
+- `cost-unmatched-resources` reads both `cost_attribution_daily` and
+  `cost_raw_details`.
+
+Target dashboard behavior:
+
+- Keep trend, repo stack, and group share on `cost_attribution_daily`.
+- Move Top unmatched resource details from `cost_raw_details` to
+  `cost_unmatched_resource_daily`.
+- Keep `cost_attribution_daily` as the source of attribution status. The panel
+  should join unmatched attribution rows to resource detail rows instead of
+  treating every row in `cost_unmatched_resource_daily` as unmatched.
+- Use an inner join for that panel. `cost_unmatched_resource_daily` is weekly
+  resource context, not a roster-aware unmatched table; showing rows without
+  matching `cost_attribution_daily` dimensions would create false positives.
+  The intended run order is summary import, attribution refresh, then weekly
+  resource import before exposing that week's resource details.
+- Keep `cost_raw_details` only for compatibility or one-off debugging during
+  migration.
+
+The target query shape is:
+
+```sql
+WITH unmatched_dimensions AS (
+  SELECT
+    c.usage_date,
+    c.vendor,
+    c.account_id,
+    c.org,
+    c.repo,
+    c.author,
+    MAX(c.attribution_key) AS attribution_key,
+    MAX(c.attribution_source) AS attribution_source,
+    MAX(c.attribution_status) AS attribution_status
+  FROM cost_attribution_daily c
+  WHERE c.usage_date BETWEEN @start_date AND @end_date
+    AND c.vendor = @vendor
+    AND c.account_id = @account_id
+    AND c.employee_id IS NULL
+  GROUP BY c.usage_date, c.vendor, c.account_id, c.org, c.repo, c.author
+),
+unallocated_resource_rows AS (
+  SELECT
+    r.resource_name,
+    r.service_name,
+    r.sku_name,
+    r.org AS org_name,
+    r.repo AS repo_name,
+    r.author AS author_name,
+    r.usage_date,
+    r.namespace,
+    r.usage_seconds,
+    r.list_cost,
+    u.attribution_key,
+    u.attribution_source,
+    u.attribution_status
+  FROM cost_unmatched_resource_daily r
+  JOIN unmatched_dimensions u
+    ON r.usage_date = u.usage_date
+   AND r.vendor = u.vendor
+   AND r.account_id = u.account_id
+   AND (r.org = u.org OR (r.org IS NULL AND u.org IS NULL))
+   AND (r.repo = u.repo OR (r.repo IS NULL AND u.repo IS NULL))
+   AND (r.author = u.author OR (r.author IS NULL AND u.author IS NULL))
+  WHERE r.usage_date BETWEEN @start_date AND @end_date
+    AND r.vendor = @vendor
+    AND r.account_id = @account_id
+    AND r.resource_name IS NOT NULL
+    AND r.resource_name <> ''
+    AND (
+      r.namespace IS NULL
+      OR r.namespace IN (
+        'kube:unallocated',
+        'kube:system-overhead',
+        'goog-k8s-unsupported-sku',
+        'goog-k8s-unknown'
+      )
+    )
+),
+resource_details AS (
+  SELECT
+    resource_name,
+    MAX(service_name) AS service_name,
+    MAX(sku_name) AS sku_name,
+    MAX(org_name) AS org_name,
+    MAX(repo_name) AS repo_name,
+    MAX(author_name) AS author_name,
+    MAX(attribution_key) AS attribution_key,
+    MAX(attribution_source) AS attribution_source,
+    MAX(attribution_status) AS attribution_status,
+    MIN(usage_date) AS first_seen_date,
+    MAX(usage_date) AS last_seen_date,
+    GROUP_CONCAT(DISTINCT COALESCE(namespace, '<null>')) AS allocation_buckets,
+    SUM(COALESCE(usage_seconds, 0)) AS usage_seconds,
+    SUM(list_cost) AS list_cost
+  FROM unallocated_resource_rows
+  GROUP BY resource_name
+)
+SELECT *
+FROM resource_details
+ORDER BY list_cost DESC, resource_name
+LIMIT @limit;
+```
+
+This preserves the current dashboard semantics: attribution status comes from
+the roster-aware attribution table, while resource investigation context comes
+from the weekly resource table.
+
+## Expected Cost Impact
+
+Using the dry-run measurements above:
+
+Current collector:
+
+```text
+439.8 GB per run * 7 daily runs = about 3.08 TB/week
+```
+
+Target weekly jobs with partition pruning:
+
+```text
+Regular summary, 7 new export partitions: about 23.8 GB/week
+Unmatched resource, 7 export partitions: about 30.0 GB/week
+Total without lag window: about 53.8 GB/week
+```
+
+The recommended regular summary path is export-partition incremental. The
+5-day lag delays the export-partition cutoff, but once the job is caught up it
+still scans about 7 new export partitions per weekly run. The unmatched
+resource job is different: it answers a usage-window investigation question, so
+it should scan the usage week plus the lag window.
+
+With a 5-day lag window for the weekly unmatched-resource usage window:
+
+```text
+Regular summary: about 23.8 GB/week
+Unmatched resource: about 51.8 GB/week
+Total with weekly unmatched lag window: about 75.6 GB/week
+```
+
+An optional monthly summary-only reconciliation using the measured 30-day
+summary query would add about 86.4 GB/month, or about 21.6 GB/week amortized:
+
+```text
+Regular summary + weekly unmatched + monthly summary reconciliation:
+23.8 GB + 51.8 GB + 21.6 GB = about 97.2 GB/week
+```
+
+This is roughly 2.5% to 3.2% of the current weekly scan volume if compared with the
+current no-partition-pruning collector. Even if a safety overlap or monthly
+summary reconciliation is added, the expected scan volume should remain far
+below the current daily resource-level collector.
+
+At BigQuery on-demand pricing, scan cost is proportional to bytes processed, so
+the actual dollar savings should track these byte reductions. The exact price
+depends on the account's BigQuery pricing model and free-tier/reservation
+status.
+
+## Migration Plan
+
+1. Add SQL migrations for `cost_bq_export_summary_daily` and
+   `cost_unmatched_resource_daily`.
+2. Add `sync-gcp-billing-summary`:
+   - export-partition watermark
+   - `_PARTITIONDATE` filter
+   - summary-only fields
+   - touched-usage-date output
+3. Add `refresh-cost-attribution-from-summary` or refactor the existing refresh
+   job to read `cost_bq_export_summary_daily`:
+   - set `service_name`, `sku_name`, `resource_name`, and `usage_seconds` to
+     `NULL`
+   - reuse the existing roster matching joins and normalized identity helper
+   - discover touched usage dates from `cost_bq_export_summary_daily`
+   - refresh touched dates one by one by default
+4. Add `sync-gcp-unmatched-resources`:
+   - weekly stable usage window
+   - resource-level fields
+   - no historical correction mode by default
+5. Change `cost-unmatched-resources` API to read
+   `cost_unmatched_resource_daily` joined with `cost_attribution_daily`.
+6. Add `reconcile-gcp-billing-summary` as an optional summary-only validation
+   and repair command.
+7. Keep the existing `sync-gcp-billing-export` raw collector as a manual
+   fallback during rollout, then deprecate it once the new path is verified.
+8. Add job-level running-state checks based on `cost_job_state`.
+9. Add dry-run guardrails to CLI output so operators can see estimated
+   BigQuery bytes before running large backfills.
+
+## Open Questions
+
+- Should regular summary keep `service_name` and `sku_name` for future product
+  views? Current dashboard pages do not need them. Adding them increases
+  BigQuery bytes and output cardinality, so the default should be no.
+- Should `cost_attribution_daily` keep `service_name`, `sku_name`, and
+  `resource_name` nullable under the summary path, or should a new
+  `cost_attribution_summary_daily` table be introduced? Reusing
+  `cost_attribution_daily` is simpler for the dashboard.
+- What is the exact production CronJob schedule in `ee-ops`? This repository
+  does not currently contain a cost-insight CronJob manifest.

--- a/cost-insight/sql/003_create_cost_refine_tables.sql
+++ b/cost-insight/sql/003_create_cost_refine_tables.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS cost_bq_export_summary_daily (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  vendor VARCHAR(32) NOT NULL,
+  account_id VARCHAR(128) NOT NULL,
+  billing_account_id VARCHAR(128) NULL,
+  export_partition_date DATE NOT NULL,
+  usage_date DATE NOT NULL,
+  org VARCHAR(255) NULL,
+  repo VARCHAR(255) NULL,
+  author VARCHAR(255) NULL,
+  list_cost DECIMAL(16, 2) NULL,
+  effective_cost DECIMAL(16, 2) NULL,
+  credit_amount DECIMAL(16, 2) NULL,
+  net_cost DECIMAL(16, 2) NULL,
+  source_export_time DATETIME NULL,
+  source_row_hash CHAR(64) NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_cost_bq_export_summary_source_row (
+    vendor,
+    account_id,
+    export_partition_date,
+    source_row_hash
+  ),
+  KEY idx_cost_bq_export_summary_usage_date (usage_date, vendor, account_id),
+  KEY idx_cost_bq_export_summary_export_partition (export_partition_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS cost_unmatched_resource_daily (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  vendor VARCHAR(32) NOT NULL,
+  account_id VARCHAR(128) NOT NULL,
+  billing_account_id VARCHAR(128) NULL,
+  export_partition_date DATE NOT NULL,
+  usage_date DATE NOT NULL,
+  service_name VARCHAR(255) NULL,
+  sku_name VARCHAR(255) NULL,
+  namespace VARCHAR(255) NULL,
+  org VARCHAR(255) NULL,
+  repo VARCHAR(255) NULL,
+  author VARCHAR(255) NULL,
+  resource_name VARCHAR(512) NOT NULL,
+  usage_seconds DECIMAL(20, 2) NULL,
+  list_cost DECIMAL(16, 2) NULL,
+  effective_cost DECIMAL(16, 2) NULL,
+  credit_amount DECIMAL(16, 2) NULL,
+  net_cost DECIMAL(16, 2) NULL,
+  source_export_time DATETIME NULL,
+  source_row_hash CHAR(64) NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_cost_unmatched_resource_source_row (
+    vendor,
+    account_id,
+    export_partition_date,
+    source_row_hash
+  ),
+  KEY idx_cost_unmatched_resource_usage_date (usage_date, vendor, account_id),
+  KEY idx_cost_unmatched_resource_resource_name (resource_name(255)),
+  KEY idx_cost_unmatched_resource_repo (usage_date, org, repo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from datetime import date
 from functools import lru_cache
 from typing import Mapping
 
@@ -10,6 +11,7 @@ DEFAULT_GCP_BILLING_TABLE = (
     "gcp_billing_export_resource_v1_01D088_8F9CF2_8AF1C6"
 )
 DEFAULT_GCP_ACCOUNT_ID = "pingcap-testing-account"
+DEFAULT_EARLIEST_USAGE_DATE = date(2026, 1, 1)
 
 
 @dataclass(frozen=True)
@@ -27,7 +29,12 @@ class DatabaseSettings:
 class GcpBillingSettings:
     billing_table: str = DEFAULT_GCP_BILLING_TABLE
     account_id: str = DEFAULT_GCP_ACCOUNT_ID
+    earliest_usage_date: date = DEFAULT_EARLIEST_USAGE_DATE
     sync_overlap_days: int = 3
+    sync_lag_days: int = 5
+    export_overlap_days: int = 0
+    sync_initial_lookback_days: int | None = None
+    unmatched_resource_lag_days: int = 5
     page_size: int = 5000
 
 
@@ -60,10 +67,40 @@ def load_settings(
                 "COST_INSIGHT_GCP_ACCOUNT_ID",
                 "COST_GCP_ACCOUNT_ID",
             ),
+            earliest_usage_date=_read_date_any(
+                env,
+                ("COST_INSIGHT_EARLIEST_USAGE_DATE", "COST_EARLIEST_USAGE_DATE"),
+                DEFAULT_EARLIEST_USAGE_DATE,
+            ),
             sync_overlap_days=_read_int_any(
                 env,
                 ("COST_INSIGHT_SYNC_OVERLAP_DAYS", "COST_SYNC_OVERLAP_DAYS"),
                 3,
+            ),
+            sync_lag_days=_read_int_any(
+                env,
+                ("COST_INSIGHT_SYNC_LAG_DAYS", "COST_SYNC_LAG_DAYS"),
+                5,
+            ),
+            export_overlap_days=_read_non_negative_int_any(
+                env,
+                ("COST_INSIGHT_EXPORT_OVERLAP_DAYS", "COST_EXPORT_OVERLAP_DAYS"),
+                0,
+            ),
+            sync_initial_lookback_days=_read_optional_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_SYNC_INITIAL_LOOKBACK_DAYS",
+                    "COST_SYNC_INITIAL_LOOKBACK_DAYS",
+                ),
+            ),
+            unmatched_resource_lag_days=_read_int_any(
+                env,
+                (
+                    "COST_INSIGHT_UNMATCHED_RESOURCE_LAG_DAYS",
+                    "COST_UNMATCHED_RESOURCE_LAG_DAYS",
+                ),
+                5,
             ),
             page_size=_read_int_any(
                 env,
@@ -162,4 +199,58 @@ def _read_int_any(environ: Mapping[str, str], keys: tuple[str, ...], default: in
     for key in keys:
         if key in environ:
             return _read_int(environ, key, default)
+    return default
+
+
+def _read_non_negative_int(
+    environ: Mapping[str, str],
+    key: str,
+    default: int,
+) -> int:
+    raw = environ.get(key, str(default))
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{key} must be an integer, got {raw!r}") from exc
+    if value < 0:
+        raise ValueError(f"{key} must be non-negative, got {raw!r}")
+    return value
+
+
+def _read_non_negative_int_any(
+    environ: Mapping[str, str],
+    keys: tuple[str, ...],
+    default: int,
+) -> int:
+    for key in keys:
+        if key in environ:
+            return _read_non_negative_int(environ, key, default)
+    return default
+
+
+def _read_optional_positive_int_any(
+    environ: Mapping[str, str],
+    keys: tuple[str, ...],
+) -> int | None:
+    for key in keys:
+        raw = environ.get(key)
+        if raw is None or raw.strip() == "":
+            continue
+        return _read_int(environ, key, 1)
+    return None
+
+
+def _read_date_any(
+    environ: Mapping[str, str],
+    keys: tuple[str, ...],
+    default: date,
+) -> date:
+    for key in keys:
+        raw = environ.get(key)
+        if raw is None or raw.strip() == "":
+            continue
+        try:
+            return date.fromisoformat(raw)
+        except ValueError as exc:
+            raise ValueError(f"{key} must be an ISO date, got {raw!r}") from exc
     return default

--- a/cost-insight/src/cost_insight/common/row_utils.py
+++ b/cost-insight/src/cost_insight/common/row_utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+
+def nullable_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def coerce_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return date.fromisoformat(value[:10])
+    raise ValueError(f"Unsupported date value: {value!r}")
+
+
+def coerce_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).replace(tzinfo=None) if value.tzinfo else value
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.astimezone(timezone.utc).replace(tzinfo=None) if parsed.tzinfo else parsed
+    raise ValueError(f"Unsupported datetime value: {value!r}")
+
+
+def hash_value(value: Any) -> str | int | float | None:
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    return str(value)
+
+
+def bind_decimal_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {key: float(value) if isinstance(value, Decimal) else value for key, value in row.items()}
+        for row in rows
+    ]

--- a/cost-insight/src/cost_insight/common/row_utils.py
+++ b/cost-insight/src/cost_insight/common/row_utils.py
@@ -28,11 +28,15 @@ def coerce_datetime(value: Any) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):
-        return value.astimezone(timezone.utc).replace(tzinfo=None) if value.tzinfo else value
+        return to_naive_utc(value)
     if isinstance(value, str):
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        return parsed.astimezone(timezone.utc).replace(tzinfo=None) if parsed.tzinfo else parsed
+        return to_naive_utc(parsed)
     raise ValueError(f"Unsupported datetime value: {value!r}")
+
+
+def to_naive_utc(value: datetime) -> datetime:
+    return value.astimezone(timezone.utc).replace(tzinfo=None) if value.tzinfo else value
 
 
 def hash_value(value: Any) -> str | int | float | None:

--- a/cost-insight/src/cost_insight/jobs/backfill_cost_refine_from_raw.py
+++ b/cost-insight/src/cost_insight/jobs/backfill_cost_refine_from_raw.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from cost_insight.common.config import GcpBillingSettings
+from cost_insight.common.row_utils import coerce_date
+from cost_insight.jobs import state_store
+from cost_insight.jobs.sync_gcp_billing_summary import (
+    JOB_NAME as SUMMARY_JOB_NAME,
+)
+from cost_insight.jobs.sync_gcp_billing_summary import (
+    _normalize_summary_row,
+    _watermark as summary_watermark,
+    write_summary_rows,
+)
+from cost_insight.jobs.sync_gcp_unmatched_resources import (
+    _normalize_resource_row,
+    write_unmatched_resource_rows,
+)
+
+LOG = logging.getLogger(__name__)
+
+JOB_NAME = "backfill_cost_refine_from_raw"
+
+
+@dataclass(frozen=True)
+class BackfillCostRefineFromRawSummary:
+    account_id: str
+    start_date: date
+    end_date: date
+    summary_rows_seen: int
+    summary_rows_written: int
+    unmatched_rows_seen: int
+    unmatched_rows_written: int
+    export_partition_start: date | None
+    export_partition_end: date | None
+    dry_run: bool
+    marked_summary_watermark: bool
+
+
+def run_backfill_cost_refine_from_raw(
+    engine: Engine,
+    *,
+    settings: GcpBillingSettings,
+    start_date: date,
+    end_date: date,
+    include_unmatched_resources: bool = True,
+    mark_summary_watermark: bool = False,
+    dry_run: bool = False,
+) -> BackfillCostRefineFromRawSummary:
+    if start_date > end_date:
+        raise ValueError("start_date must be before or equal to end_date")
+
+    params = {
+        "vendor": "gcp",
+        "account_id": settings.account_id,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+    watermark = {
+        "account_id": settings.account_id,
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+    }
+
+    if not dry_run:
+        with engine.begin() as connection:
+            state_store.mark_job_started(connection, JOB_NAME, watermark)
+
+    try:
+        summary_rows_seen = 0
+        summary_rows_written = 0
+        unmatched_rows_seen = 0
+        unmatched_rows_written = 0
+
+        with engine.connect() as connection:
+            export_range = connection.execute(_SELECT_SYNTHETIC_EXPORT_RANGE, params).mappings().one()
+
+        export_partition_start = coerce_date(export_range["export_partition_start"])
+        export_partition_end = coerce_date(export_range["export_partition_end"])
+
+        with engine.connect() as connection:
+            summary_batch = []
+            for row in connection.execute(_SELECT_SUMMARY_ROWS, params).mappings():
+                summary_rows_seen += 1
+                summary_batch.append(_normalize_summary_row(dict(row)))
+                if len(summary_batch) >= settings.page_size:
+                    summary_rows_written += write_summary_rows(
+                        engine,
+                        summary_batch,
+                        dry_run=dry_run,
+                    )
+                    summary_batch.clear()
+            summary_rows_written += write_summary_rows(engine, summary_batch, dry_run=dry_run)
+
+        if include_unmatched_resources:
+            with engine.connect() as connection:
+                unmatched_batch = []
+                for row in connection.execute(_SELECT_UNMATCHED_RESOURCE_ROWS, params).mappings():
+                    unmatched_rows_seen += 1
+                    unmatched_batch.append(_normalize_resource_row(dict(row)))
+                    if len(unmatched_batch) >= settings.page_size:
+                        unmatched_rows_written += write_unmatched_resource_rows(
+                            engine,
+                            unmatched_batch,
+                            dry_run=dry_run,
+                        )
+                        unmatched_batch.clear()
+                unmatched_rows_written += write_unmatched_resource_rows(
+                    engine,
+                    unmatched_batch,
+                    dry_run=dry_run,
+                )
+
+        marked_summary_watermark = False
+        if (
+            mark_summary_watermark
+            and not dry_run
+            and export_partition_start is not None
+            and export_partition_end is not None
+        ):
+            with engine.begin() as connection:
+                state_store.mark_job_succeeded(
+                    connection,
+                    SUMMARY_JOB_NAME,
+                    summary_watermark(
+                        account_id=settings.account_id,
+                        export_partition_start=export_partition_start,
+                        export_partition_end=export_partition_end,
+                    ),
+                )
+            marked_summary_watermark = True
+
+        if not dry_run:
+            with engine.begin() as connection:
+                state_store.mark_job_succeeded(connection, JOB_NAME, watermark)
+
+        return BackfillCostRefineFromRawSummary(
+            account_id=settings.account_id,
+            start_date=start_date,
+            end_date=end_date,
+            summary_rows_seen=summary_rows_seen,
+            summary_rows_written=summary_rows_written,
+            unmatched_rows_seen=unmatched_rows_seen,
+            unmatched_rows_written=unmatched_rows_written,
+            export_partition_start=export_partition_start,
+            export_partition_end=export_partition_end,
+            dry_run=dry_run,
+            marked_summary_watermark=marked_summary_watermark,
+        )
+    except Exception as exc:
+        LOG.exception("backfill_cost_refine_from_raw failed")
+        if not dry_run:
+            with engine.begin() as connection:
+                state_store.mark_job_failed(connection, JOB_NAME, watermark, repr(exc))
+        raise
+
+
+_SYNTHETIC_EXPORT_PARTITION_DATE = "COALESCE(DATE(source_export_time), usage_date)"
+
+_SELECT_SYNTHETIC_EXPORT_RANGE = text(
+    f"""
+    SELECT
+      MIN({_SYNTHETIC_EXPORT_PARTITION_DATE}) AS export_partition_start,
+      MAX({_SYNTHETIC_EXPORT_PARTITION_DATE}) AS export_partition_end
+    FROM cost_raw_details
+    WHERE vendor = :vendor
+      AND account_id = :account_id
+      AND usage_date BETWEEN :start_date AND :end_date
+    """
+)
+
+_SELECT_SUMMARY_ROWS = text(
+    f"""
+    SELECT
+      vendor,
+      account_id,
+      billing_account_id,
+      {_SYNTHETIC_EXPORT_PARTITION_DATE} AS export_partition_date,
+      usage_date,
+      author,
+      org,
+      repo,
+      ROUND(SUM(list_cost), 2) AS list_cost,
+      ROUND(SUM(effective_cost), 2) AS effective_cost,
+      ROUND(SUM(credit_amount), 2) AS credit_amount,
+      ROUND(SUM(net_cost), 2) AS net_cost,
+      MAX(source_export_time) AS source_export_time
+    FROM cost_raw_details
+    WHERE vendor = :vendor
+      AND account_id = :account_id
+      AND usage_date BETWEEN :start_date AND :end_date
+    GROUP BY
+      vendor,
+      account_id,
+      billing_account_id,
+      export_partition_date,
+      usage_date,
+      author,
+      org,
+      repo
+    ORDER BY export_partition_date, usage_date, author, org, repo
+    """
+)
+
+_SELECT_UNMATCHED_RESOURCE_ROWS = text(
+    f"""
+    SELECT
+      vendor,
+      account_id,
+      billing_account_id,
+      {_SYNTHETIC_EXPORT_PARTITION_DATE} AS export_partition_date,
+      usage_date,
+      service_name,
+      sku_name,
+      namespace,
+      author,
+      org,
+      repo,
+      resource_name,
+      ROUND(SUM(usage_seconds), 2) AS usage_seconds,
+      ROUND(SUM(list_cost), 2) AS list_cost,
+      ROUND(SUM(effective_cost), 2) AS effective_cost,
+      ROUND(SUM(credit_amount), 2) AS credit_amount,
+      ROUND(SUM(net_cost), 2) AS net_cost,
+      MAX(source_export_time) AS source_export_time
+    FROM cost_raw_details
+    WHERE vendor = :vendor
+      AND account_id = :account_id
+      AND usage_date BETWEEN :start_date AND :end_date
+      AND resource_name IS NOT NULL
+      AND resource_name <> ''
+    GROUP BY
+      vendor,
+      account_id,
+      billing_account_id,
+      export_partition_date,
+      usage_date,
+      service_name,
+      sku_name,
+      namespace,
+      author,
+      org,
+      repo,
+      resource_name
+    ORDER BY usage_date, service_name, sku_name, resource_name
+    """
+)

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -9,8 +9,14 @@ from datetime import date, timedelta
 from cost_insight.common.config import get_settings
 from cost_insight.common.db import build_engine
 from cost_insight.common.logging import configure_logging
-from cost_insight.jobs.refresh_attribution_daily import run_refresh_cost_attribution_daily
+from cost_insight.jobs.backfill_cost_refine_from_raw import run_backfill_cost_refine_from_raw
+from cost_insight.jobs.refresh_attribution_daily import (
+    run_refresh_cost_attribution_daily,
+    run_refresh_cost_attribution_from_summary,
+)
+from cost_insight.jobs.sync_gcp_billing_summary import run_sync_gcp_billing_summary
 from cost_insight.jobs.sync_gcp_billing_export import run_sync_gcp_billing_export
+from cost_insight.jobs.sync_gcp_unmatched_resources import run_sync_gcp_unmatched_resources
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -31,6 +37,45 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run one usage date at a time; recommended for backfills.",
     )
 
+    sync_summary = subparsers.add_parser(
+        "sync-gcp-billing-summary",
+        help="Sync GCP billing export partitions into cost_bq_export_summary_daily",
+    )
+    sync_summary.add_argument("--export-partition-start", type=_parse_date, default=None)
+    sync_summary.add_argument("--export-partition-end", type=_parse_date, default=None)
+    sync_summary.add_argument("--earliest-usage-date", type=_parse_date, default=None)
+    sync_summary.add_argument("--dry-run", action="store_true")
+    sync_summary.add_argument("--limit", type=int, default=None)
+
+    sync_unmatched = subparsers.add_parser(
+        "sync-gcp-unmatched-resources",
+        help="Sync weekly GCP resource-level rows for unmatched resource investigation",
+    )
+    sync_unmatched.add_argument("--usage-start-date", type=_parse_date, required=True)
+    sync_unmatched.add_argument("--usage-end-date", type=_parse_date, required=True)
+    sync_unmatched.add_argument("--export-partition-start", type=_parse_date, default=None)
+    sync_unmatched.add_argument("--export-partition-end", type=_parse_date, default=None)
+    sync_unmatched.add_argument("--dry-run", action="store_true")
+    sync_unmatched.add_argument("--limit", type=int, default=None)
+
+    backfill_refine = subparsers.add_parser(
+        "backfill-gcp-cost-refine-from-raw",
+        help="Backfill cost_bq_export_summary_daily and cost_unmatched_resource_daily from cost_raw_details",
+    )
+    backfill_refine.add_argument("--start-date", type=_parse_date, required=True)
+    backfill_refine.add_argument("--end-date", type=_parse_date, required=True)
+    backfill_refine.add_argument(
+        "--skip-unmatched-resources",
+        action="store_true",
+        help="Only backfill cost_bq_export_summary_daily.",
+    )
+    backfill_refine.add_argument(
+        "--mark-summary-watermark",
+        action="store_true",
+        help="Mark sync-gcp-billing-summary succeeded through the synthetic export partition end.",
+    )
+    backfill_refine.add_argument("--dry-run", action="store_true")
+
     refresh_attr = subparsers.add_parser(
         "refresh-cost-attribution-daily",
         help="Rebuild cost_attribution_daily from cost_raw_details and roster tables",
@@ -39,6 +84,19 @@ def build_parser() -> argparse.ArgumentParser:
     refresh_attr.add_argument("--end-date", type=_parse_date, required=True)
     refresh_attr.add_argument("--dry-run", action="store_true")
     refresh_attr.add_argument(
+        "--split-by-day",
+        action="store_true",
+        help="Refresh one usage date at a time; recommended for larger ranges.",
+    )
+
+    refresh_summary_attr = subparsers.add_parser(
+        "refresh-cost-attribution-from-summary",
+        help="Rebuild cost_attribution_daily from cost_bq_export_summary_daily and roster tables",
+    )
+    refresh_summary_attr.add_argument("--start-date", type=_parse_date, required=True)
+    refresh_summary_attr.add_argument("--end-date", type=_parse_date, required=True)
+    refresh_summary_attr.add_argument("--dry-run", action="store_true")
+    refresh_summary_attr.add_argument(
         "--split-by-day",
         action="store_true",
         help="Refresh one usage date at a time; recommended for larger ranges.",
@@ -66,10 +124,80 @@ def main(argv: Sequence[str] | None = None) -> int:
         finally:
             engine.dispose()
 
+    if args.command == "sync-gcp-billing-summary":
+        engine = build_engine(settings)
+        try:
+            summary = run_sync_gcp_billing_summary(
+                engine,
+                settings=settings.gcp_billing,
+                export_partition_start=args.export_partition_start,
+                export_partition_end=args.export_partition_end,
+                earliest_usage_date=args.earliest_usage_date,
+                dry_run=args.dry_run,
+                limit=args.limit,
+            )
+            print(json.dumps(_summary_to_json(summary), indent=2, sort_keys=True))
+            return 0
+        finally:
+            engine.dispose()
+
+    if args.command == "sync-gcp-unmatched-resources":
+        engine = build_engine(settings)
+        try:
+            summary = run_sync_gcp_unmatched_resources(
+                engine,
+                settings=settings.gcp_billing,
+                usage_start_date=args.usage_start_date,
+                usage_end_date=args.usage_end_date,
+                export_partition_start=args.export_partition_start,
+                export_partition_end=args.export_partition_end,
+                dry_run=args.dry_run,
+                limit=args.limit,
+            )
+            print(json.dumps(_summary_to_json(summary), indent=2, sort_keys=True))
+            return 0
+        finally:
+            engine.dispose()
+
+    if args.command == "backfill-gcp-cost-refine-from-raw":
+        engine = build_engine(settings)
+        try:
+            summary = run_backfill_cost_refine_from_raw(
+                engine,
+                settings=settings.gcp_billing,
+                start_date=args.start_date,
+                end_date=args.end_date,
+                include_unmatched_resources=not args.skip_unmatched_resources,
+                mark_summary_watermark=args.mark_summary_watermark,
+                dry_run=args.dry_run,
+            )
+            print(json.dumps(_summary_to_json(summary), indent=2, sort_keys=True))
+            return 0
+        finally:
+            engine.dispose()
+
     if args.command == "refresh-cost-attribution-daily":
         engine = build_engine(settings)
         try:
             summaries = _run_refresh_attribution_command(
+                engine,
+                settings=settings.gcp_billing,
+                args=args,
+            )
+            payload = (
+                [_summary_to_json(summary) for summary in summaries]
+                if args.split_by_day
+                else _summary_to_json(summaries[0])
+            )
+            print(json.dumps(payload, indent=2, sort_keys=True))
+            return 0
+        finally:
+            engine.dispose()
+
+    if args.command == "refresh-cost-attribution-from-summary":
+        engine = build_engine(settings)
+        try:
+            summaries = _run_refresh_attribution_from_summary_command(
                 engine,
                 settings=settings.gcp_billing,
                 args=args,
@@ -166,6 +294,43 @@ def _run_refresh_attribution_command(engine, *, settings, args):
     return [summary]
 
 
+def _run_refresh_attribution_from_summary_command(engine, *, settings, args):
+    logger = logging.getLogger(__name__)
+    if args.split_by_day:
+        summaries = []
+        for usage_date in _date_range(args.start_date, args.end_date):
+            logger.info(
+                "refresh-cost-attribution-from-summary day started",
+                extra={"usage_date": usage_date},
+            )
+            summary = run_refresh_cost_attribution_from_summary(
+                engine,
+                settings=settings,
+                start_date=usage_date,
+                end_date=usage_date,
+                dry_run=args.dry_run,
+            )
+            logger.info(
+                "refresh-cost-attribution-from-summary day finished",
+                extra={"summary": summary.__dict__},
+            )
+            summaries.append(summary)
+        return summaries
+
+    summary = run_refresh_cost_attribution_from_summary(
+        engine,
+        settings=settings,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        dry_run=args.dry_run,
+    )
+    logger.info(
+        "refresh-cost-attribution-from-summary finished",
+        extra={"summary": summary.__dict__},
+    )
+    return [summary]
+
+
 def _date_range(start_date: date, end_date: date):
     if start_date > end_date:
         raise ValueError("--start-date must be before or equal to --end-date")
@@ -178,13 +343,38 @@ def _date_range(start_date: date, end_date: date):
 def _summary_to_json(summary) -> dict[str, object]:
     payload = {
         "account_id": summary.account_id,
-        "start_date": summary.start_date.isoformat(),
-        "end_date": summary.end_date.isoformat(),
         "dry_run": summary.dry_run,
     }
-    for field in ("rows_seen", "rows_written", "rows_deleted", "rows_inserted", "raw_rows"):
+    for field in (
+        "start_date",
+        "end_date",
+        "usage_start_date",
+        "usage_end_date",
+        "export_partition_start",
+        "export_partition_end",
+    ):
+        if hasattr(summary, field) and getattr(summary, field) is not None:
+            payload[field] = getattr(summary, field).isoformat()
+    for field in (
+        "rows_seen",
+        "rows_written",
+        "rows_deleted",
+        "rows_inserted",
+        "raw_rows",
+        "summary_rows",
+        "summary_rows_seen",
+        "summary_rows_written",
+        "unmatched_rows_seen",
+        "unmatched_rows_written",
+    ):
         if hasattr(summary, field) and getattr(summary, field) is not None:
             payload[field] = getattr(summary, field)
+    if hasattr(summary, "marked_summary_watermark"):
+        payload["marked_summary_watermark"] = summary.marked_summary_watermark
+    if hasattr(summary, "touched_usage_dates"):
+        payload["touched_usage_dates"] = [
+            usage_date.isoformat() for usage_date in summary.touched_usage_dates
+        ]
     return payload
 
 

--- a/cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py
+++ b/cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py
@@ -14,6 +14,7 @@ from cost_insight.jobs import state_store
 LOG = logging.getLogger(__name__)
 
 JOB_NAME = "refresh_cost_attribution_daily"
+SUMMARY_JOB_NAME = "refresh_cost_attribution_from_summary"
 VENDOR = "gcp"
 
 
@@ -26,6 +27,7 @@ class RefreshAttributionSummary:
     rows_inserted: int
     dry_run: bool
     raw_rows: int | None = None
+    summary_rows: int | None = None
 
 
 def run_refresh_cost_attribution_daily(
@@ -84,6 +86,62 @@ def run_refresh_cost_attribution_daily(
         raise
 
 
+def run_refresh_cost_attribution_from_summary(
+    engine: Engine,
+    *,
+    settings: GcpBillingSettings,
+    start_date: date,
+    end_date: date,
+    dry_run: bool = False,
+) -> RefreshAttributionSummary:
+    if start_date > end_date:
+        raise ValueError("start_date must be before or equal to end_date")
+
+    params = {
+        "vendor": VENDOR,
+        "account_id": settings.account_id,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+    watermark = _watermark(account_id=settings.account_id, start_date=start_date, end_date=end_date)
+
+    if dry_run:
+        with engine.begin() as connection:
+            summary_rows = connection.execute(_COUNT_SUMMARY_DETAILS, params).scalar_one()
+        return RefreshAttributionSummary(
+            account_id=settings.account_id,
+            start_date=start_date,
+            end_date=end_date,
+            rows_deleted=0,
+            rows_inserted=0,
+            dry_run=True,
+            summary_rows=int(summary_rows),
+        )
+
+    try:
+        with engine.begin() as connection:
+            state_store.mark_job_started(connection, SUMMARY_JOB_NAME, watermark)
+
+        with engine.begin() as connection:
+            delete_result = connection.execute(_DELETE_ATTRIBUTION_DAILY, params)
+            insert_result = connection.execute(_INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY, params)
+            state_store.mark_job_succeeded(connection, SUMMARY_JOB_NAME, watermark)
+
+        return RefreshAttributionSummary(
+            account_id=settings.account_id,
+            start_date=start_date,
+            end_date=end_date,
+            rows_deleted=_positive_rowcount(delete_result.rowcount),
+            rows_inserted=_positive_rowcount(insert_result.rowcount),
+            dry_run=False,
+        )
+    except Exception as exc:
+        LOG.exception("refresh_cost_attribution_from_summary failed")
+        with engine.begin() as connection:
+            state_store.mark_job_failed(connection, SUMMARY_JOB_NAME, watermark, repr(exc))
+        raise
+
+
 def _watermark(*, account_id: str, start_date: date, end_date: date) -> dict[str, Any]:
     return {
         "account_id": account_id,
@@ -120,6 +178,17 @@ _COUNT_RAW_DETAILS = text(
 )
 
 
+_COUNT_SUMMARY_DETAILS = text(
+    """
+    SELECT COUNT(*)
+    FROM cost_bq_export_summary_daily
+    WHERE usage_date BETWEEN :start_date AND :end_date
+      AND vendor = :vendor
+      AND account_id = :account_id
+    """
+)
+
+
 _DELETE_ATTRIBUTION_DAILY = text(
     """
     DELETE FROM cost_attribution_daily
@@ -131,6 +200,7 @@ _DELETE_ATTRIBUTION_DAILY = text(
 
 
 _NORMALIZED_RAW_AUTHOR = normalized_identity_sql("raw.author")
+_NORMALIZED_SUMMARY_AUTHOR = normalized_identity_sql("summary.author")
 _NORMALIZED_GITHUB_ID = normalized_identity_sql("normalized_employee.github_id")
 _NORMALIZED_EMAIL_LOCAL = normalized_identity_sql(
     "SUBSTRING_INDEX(normalized_employee.email, '@', 1)"
@@ -325,6 +395,198 @@ _INSERT_ATTRIBUTION_DAILY = text(
       attributed.org,
       attributed.repo,
       attributed.resource_name,
+      attributed.author,
+      attributed.owner,
+      attributed.attribution_key,
+      attributed.attribution_source,
+      attributed.attribution_status,
+      attributed.employee_id,
+      attributed.group_id,
+      attributed.manager_id
+    """
+)
+
+
+_INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
+    f"""
+    INSERT INTO cost_attribution_daily (
+      usage_date,
+      vendor,
+      account_id,
+      service_name,
+      sku_name,
+      org,
+      repo,
+      resource_name,
+      author,
+      owner,
+      attribution_key,
+      attribution_source,
+      attribution_status,
+      employee_id,
+      group_id,
+      manager_id,
+      usage_seconds,
+      list_cost,
+      effective_cost,
+      credit_amount,
+      net_cost,
+      source_rows,
+      dimension_hash
+    )
+    SELECT
+      attributed.usage_date,
+      attributed.vendor,
+      attributed.account_id,
+      NULL AS service_name,
+      NULL AS sku_name,
+      attributed.org,
+      attributed.repo,
+      NULL AS resource_name,
+      attributed.author,
+      attributed.owner,
+      attributed.attribution_key,
+      attributed.attribution_source,
+      attributed.attribution_status,
+      attributed.employee_id,
+      attributed.group_id,
+      attributed.manager_id,
+      NULL AS usage_seconds,
+      SUM(attributed.list_cost) AS list_cost,
+      SUM(attributed.effective_cost) AS effective_cost,
+      SUM(attributed.credit_amount) AS credit_amount,
+      SUM(attributed.net_cost) AS net_cost,
+      COUNT(*) AS source_rows,
+      SHA2(
+        CONCAT_WS(
+          '|',
+          DATE_FORMAT(attributed.usage_date, '%Y-%m-%d'),
+          COALESCE(attributed.vendor, ''),
+          COALESCE(attributed.account_id, ''),
+          '',
+          '',
+          COALESCE(attributed.org, ''),
+          COALESCE(attributed.repo, ''),
+          '',
+          COALESCE(attributed.author, ''),
+          COALESCE(attributed.owner, ''),
+          COALESCE(attributed.attribution_key, ''),
+          COALESCE(attributed.attribution_source, ''),
+          COALESCE(attributed.attribution_status, ''),
+          COALESCE(CAST(attributed.employee_id AS CHAR), ''),
+          COALESCE(CAST(attributed.group_id AS CHAR), ''),
+          COALESCE(CAST(attributed.manager_id AS CHAR), '')
+        ),
+        256
+      ) AS dimension_hash
+    FROM (
+      SELECT
+        summary.usage_date,
+        summary.vendor,
+        summary.account_id,
+        summary.org,
+        summary.repo,
+        summary.author,
+        summary.author AS owner,
+        CASE
+          WHEN COALESCE(
+            github_employee.id,
+            email_employee.id,
+            normalized_employee.id
+          ) IS NOT NULL THEN CONCAT(
+            'employee:',
+            CAST(COALESCE(
+              github_employee.id,
+              email_employee.id,
+              normalized_employee.id
+            ) AS CHAR)
+          )
+          WHEN summary.author IS NOT NULL THEN CONCAT('author:', LOWER(summary.author))
+          ELSE 'unattributed'
+        END AS attribution_key,
+        CASE
+          WHEN github_employee.id IS NOT NULL THEN 'author_github'
+          WHEN email_employee.id IS NOT NULL THEN 'author_email'
+          WHEN normalized_employee.id IS NOT NULL THEN 'author_normalized'
+          WHEN summary.author IS NOT NULL THEN 'author_label'
+          ELSE 'missing_author'
+        END AS attribution_source,
+        CASE
+          WHEN COALESCE(
+            github_employee.id,
+            email_employee.id,
+            normalized_employee.id
+          ) IS NOT NULL THEN 'matched'
+          WHEN summary.author IS NOT NULL THEN 'unmatched'
+          ELSE 'unattributed'
+        END AS attribution_status,
+        COALESCE(
+          github_employee.id,
+          email_employee.id,
+          normalized_employee.id
+        ) AS employee_id,
+        COALESCE(
+          github_employee.group_id,
+          email_employee.group_id,
+          normalized_employee.group_id
+        ) AS group_id,
+        COALESCE(
+          github_employee.manager_id,
+          email_employee.manager_id,
+          normalized_employee.manager_id,
+          matched_group.manager_id
+        ) AS manager_id,
+        summary.list_cost,
+        summary.effective_cost,
+        summary.credit_amount,
+        summary.net_cost
+      FROM cost_bq_export_summary_daily summary
+      LEFT JOIN roster_employees github_employee
+        ON github_employee.is_active = 1
+       AND summary.author IS NOT NULL
+       AND github_employee.github_id IS NOT NULL
+       AND LOWER(github_employee.github_id) = LOWER(summary.author)
+      LEFT JOIN roster_employees email_employee
+        ON github_employee.id IS NULL
+       AND email_employee.is_active = 1
+       AND summary.author IS NOT NULL
+       AND email_employee.email IS NOT NULL
+       AND (
+         LOWER(email_employee.email) = LOWER(summary.author)
+         OR LOWER(SUBSTRING_INDEX(email_employee.email, '@', 1)) = LOWER(summary.author)
+       )
+      LEFT JOIN roster_employees normalized_employee
+        ON github_employee.id IS NULL
+       AND email_employee.id IS NULL
+       AND normalized_employee.is_active = 1
+       AND summary.author IS NOT NULL
+       AND (
+         normalized_employee.github_id IS NOT NULL
+         OR normalized_employee.email IS NOT NULL
+         OR normalized_employee.en_name IS NOT NULL
+       )
+       AND (
+         {_NORMALIZED_SUMMARY_AUTHOR} = {_NORMALIZED_GITHUB_ID}
+         OR {_NORMALIZED_SUMMARY_AUTHOR} = {_NORMALIZED_EMAIL_LOCAL}
+         OR {_NORMALIZED_SUMMARY_AUTHOR} = {_NORMALIZED_EN_NAME}
+       )
+      LEFT JOIN roster_groups matched_group
+        ON matched_group.is_active = 1
+       AND matched_group.id = COALESCE(
+         github_employee.group_id,
+         email_employee.group_id,
+         normalized_employee.group_id
+       )
+      WHERE summary.usage_date BETWEEN :start_date AND :end_date
+        AND summary.vendor = :vendor
+        AND summary.account_id = :account_id
+    ) attributed
+    GROUP BY
+      attributed.usage_date,
+      attributed.vendor,
+      attributed.account_id,
+      attributed.org,
+      attributed.repo,
       attributed.author,
       attributed.owner,
       attributed.attribution_key,

--- a/cost-insight/src/cost_insight/jobs/sync_gcp_billing_export.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcp_billing_export.py
@@ -6,13 +6,13 @@ import logging
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from decimal import Decimal
 from typing import Any
 
 from sqlalchemy import text
 from sqlalchemy.engine import Connection, Engine
 
 from cost_insight.common.config import GcpBillingSettings
+from cost_insight.common.row_utils import coerce_date, coerce_datetime, hash_value, nullable_text
 from cost_insight.jobs import state_store
 from cost_insight.sources.gcp_billing_export import decimal_or_none, fetch_gcp_billing_rows
 
@@ -188,24 +188,24 @@ def _upsert_cost_source(
 
 def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
     normalized = {
-        "vendor": _nullable_text(row.get("vendor")) or "gcp",
-        "account_id": _nullable_text(row.get("account_id")),
-        "billing_account_id": _nullable_text(row.get("billing_account_id")),
-        "usage_date": _coerce_date(row.get("usage_date")),
-        "service_name": _nullable_text(row.get("service_name")),
-        "sku_name": _nullable_text(row.get("sku_name")),
-        "region": _nullable_text(row.get("region")),
-        "namespace": _nullable_text(row.get("namespace")),
-        "author": _nullable_text(row.get("author")),
-        "org": _nullable_text(row.get("org")),
-        "repo": _nullable_text(row.get("repo")),
-        "resource_name": _nullable_text(row.get("resource_name")),
+        "vendor": nullable_text(row.get("vendor")) or "gcp",
+        "account_id": nullable_text(row.get("account_id")),
+        "billing_account_id": nullable_text(row.get("billing_account_id")),
+        "usage_date": coerce_date(row.get("usage_date")),
+        "service_name": nullable_text(row.get("service_name")),
+        "sku_name": nullable_text(row.get("sku_name")),
+        "region": nullable_text(row.get("region")),
+        "namespace": nullable_text(row.get("namespace")),
+        "author": nullable_text(row.get("author")),
+        "org": nullable_text(row.get("org")),
+        "repo": nullable_text(row.get("repo")),
+        "resource_name": nullable_text(row.get("resource_name")),
         "usage_seconds": decimal_or_none(row.get("usage_seconds")),
         "list_cost": decimal_or_none(row.get("list_cost")),
         "effective_cost": decimal_or_none(row.get("effective_cost")),
         "credit_amount": decimal_or_none(row.get("credit_amount")),
         "net_cost": decimal_or_none(row.get("net_cost")),
-        "source_export_time": _coerce_datetime(row.get("source_export_time")),
+        "source_export_time": coerce_datetime(row.get("source_export_time")),
     }
     if normalized["account_id"] is None:
         raise ValueError(f"Missing account_id in billing row: {row!r}")
@@ -216,21 +216,9 @@ def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_source_row_hash(row: dict[str, Any]) -> str:
-    payload = {field: _hash_value(row.get(field)) for field in HASH_FIELDS}
+    payload = {field: hash_value(row.get(field)) for field in HASH_FIELDS}
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
-
-
-def _hash_value(value: Any) -> str | int | float | None:
-    if value is None:
-        return None
-    if isinstance(value, date):
-        return value.isoformat()
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, Decimal):
-        return str(value)
-    return str(value)
 
 
 def _write_batch(engine: Engine, rows: Sequence[dict[str, Any]], *, dry_run: bool) -> int:
@@ -242,36 +230,6 @@ def _write_batch(engine: Engine, rows: Sequence[dict[str, Any]], *, dry_run: boo
     with engine.begin() as connection:
         connection.execute(_UPSERT_COST_RAW_DETAILS, list(rows))
     return len(rows)
-
-
-def _nullable_text(value: Any) -> str | None:
-    if value is None:
-        return None
-    normalized = str(value).strip()
-    return normalized or None
-
-
-def _coerce_date(value: Any) -> date | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    if isinstance(value, str):
-        return date.fromisoformat(value[:10])
-    raise ValueError(f"Unsupported date value: {value!r}")
-
-
-def _coerce_datetime(value: Any) -> datetime | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.astimezone(timezone.utc).replace(tzinfo=None) if value.tzinfo else value
-    if isinstance(value, str):
-        parsed = datetime.fromisoformat(value)
-        return parsed.astimezone(timezone.utc).replace(tzinfo=None) if parsed.tzinfo else parsed
-    raise ValueError(f"Unsupported datetime value: {value!r}")
 
 
 _SELECT_COST_SOURCE = text(
@@ -378,6 +336,7 @@ _UPSERT_COST_RAW_DETAILS = text(
       :source_row_hash
     )
     ON DUPLICATE KEY UPDATE
+      -- Dimension columns are part of source_row_hash; same hash means same dimensions.
       billing_account_id = VALUES(billing_account_id),
       usage_seconds = VALUES(usage_seconds),
       list_cost = VALUES(list_cost),

--- a/cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+
+from cost_insight.common.config import GcpBillingSettings
+from cost_insight.common.row_utils import (
+    bind_decimal_rows,
+    coerce_date,
+    coerce_datetime,
+    hash_value,
+    nullable_text,
+)
+from cost_insight.jobs import state_store
+from cost_insight.jobs.sync_gcp_billing_export import (
+    _ensure_cost_source_enabled,
+    _upsert_cost_source,
+)
+from cost_insight.sources.gcp_billing_export import (
+    decimal_or_none,
+    fetch_gcp_billing_summary_rows,
+)
+
+LOG = logging.getLogger(__name__)
+
+JOB_NAME = "sync_gcp_billing_summary"
+HASH_FIELDS = (
+    "vendor",
+    "account_id",
+    "billing_account_id",
+    "export_partition_date",
+    "usage_date",
+    "author",
+    "org",
+    "repo",
+)
+
+RowFetcher = Callable[..., Iterable[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class SyncGcpBillingSummaryResult:
+    account_id: str
+    export_partition_start: date
+    export_partition_end: date
+    rows_seen: int
+    rows_written: int
+    dry_run: bool
+    touched_usage_dates: tuple[date, ...] = ()
+
+
+def run_sync_gcp_billing_summary(
+    engine: Engine,
+    *,
+    settings: GcpBillingSettings,
+    export_partition_start: date | None = None,
+    export_partition_end: date | None = None,
+    earliest_usage_date: date | None = None,
+    dry_run: bool = False,
+    limit: int | None = None,
+    fetch_rows: RowFetcher = fetch_gcp_billing_summary_rows,
+) -> SyncGcpBillingSummaryResult:
+    resolved_end = export_partition_end or (
+        datetime.now(timezone.utc).date() - timedelta(days=settings.sync_lag_days)
+    )
+    with engine.begin() as connection:
+        _ensure_cost_source_enabled(connection, settings, dry_run=dry_run)
+        state = state_store.get_job_state(connection, JOB_NAME)
+        resolved_start = export_partition_start or _start_partition_from_state(
+            state.watermark if state else {},
+            end_date=resolved_end,
+            overlap_days=settings.export_overlap_days,
+            initial_lookback_days=settings.sync_initial_lookback_days,
+        )
+        watermark = _watermark(
+            account_id=settings.account_id,
+            export_partition_start=resolved_start,
+            export_partition_end=resolved_end,
+        )
+        if not dry_run:
+            state_store.mark_job_started(connection, JOB_NAME, watermark)
+
+    try:
+        rows_seen = 0
+        rows_written = 0
+        source_billing_account_id: str | None = None
+        batch: list[dict[str, Any]] = []
+        for source_row in fetch_rows(
+            billing_table=settings.billing_table,
+            account_id=settings.account_id,
+            export_partition_start=resolved_start,
+            export_partition_end=resolved_end,
+            earliest_usage_date=earliest_usage_date or settings.earliest_usage_date,
+            page_size=settings.page_size,
+            limit=limit,
+        ):
+            rows_seen += 1
+            normalized = _normalize_summary_row(source_row)
+            source_billing_account_id = source_billing_account_id or normalized[
+                "billing_account_id"
+            ]
+            batch.append(normalized)
+            if len(batch) >= settings.page_size:
+                rows_written += write_summary_rows(engine, batch, dry_run=dry_run)
+                batch.clear()
+        rows_written += write_summary_rows(engine, batch, dry_run=dry_run)
+
+        touched_usage_dates: tuple[date, ...] = ()
+        if not dry_run:
+            with engine.begin() as connection:
+                if source_billing_account_id:
+                    _upsert_cost_source(
+                        connection,
+                        account_id=settings.account_id,
+                        billing_account_id=source_billing_account_id,
+                    )
+                touched_usage_dates = _get_touched_usage_dates(
+                    connection,
+                    account_id=settings.account_id,
+                    export_partition_start=resolved_start,
+                    export_partition_end=resolved_end,
+                )
+                state_store.mark_job_succeeded(connection, JOB_NAME, watermark)
+
+        return SyncGcpBillingSummaryResult(
+            account_id=settings.account_id,
+            export_partition_start=resolved_start,
+            export_partition_end=resolved_end,
+            rows_seen=rows_seen,
+            rows_written=rows_written,
+            dry_run=dry_run,
+            touched_usage_dates=touched_usage_dates,
+        )
+    except Exception as exc:
+        LOG.exception("sync_gcp_billing_summary failed")
+        if not dry_run:
+            with engine.begin() as connection:
+                state_store.mark_job_failed(connection, JOB_NAME, watermark, repr(exc))
+        raise
+
+
+def _start_partition_from_state(
+    watermark: dict[str, Any],
+    *,
+    end_date: date,
+    overlap_days: int,
+    initial_lookback_days: int | None,
+) -> date:
+    last_end_date = watermark.get("export_partition_end")
+    if last_end_date:
+        parsed = date.fromisoformat(str(last_end_date))
+        return min(parsed + timedelta(days=1) - timedelta(days=overlap_days), end_date)
+    if initial_lookback_days is not None:
+        return end_date - timedelta(days=initial_lookback_days - 1)
+    return end_date
+
+
+def _watermark(
+    *,
+    account_id: str,
+    export_partition_start: date,
+    export_partition_end: date,
+) -> dict[str, Any]:
+    return {
+        "account_id": account_id,
+        "export_partition_start": export_partition_start.isoformat(),
+        "export_partition_end": export_partition_end.isoformat(),
+    }
+
+
+def _normalize_summary_row(row: dict[str, Any]) -> dict[str, Any]:
+    normalized = {
+        "vendor": nullable_text(row.get("vendor")) or "gcp",
+        "account_id": nullable_text(row.get("account_id")),
+        "billing_account_id": nullable_text(row.get("billing_account_id")),
+        "export_partition_date": coerce_date(row.get("export_partition_date")),
+        "usage_date": coerce_date(row.get("usage_date")),
+        "author": nullable_text(row.get("author")),
+        "org": nullable_text(row.get("org")),
+        "repo": nullable_text(row.get("repo")),
+        "list_cost": decimal_or_none(row.get("list_cost")),
+        "effective_cost": decimal_or_none(row.get("effective_cost")),
+        "credit_amount": decimal_or_none(row.get("credit_amount")),
+        "net_cost": decimal_or_none(row.get("net_cost")),
+        "source_export_time": coerce_datetime(row.get("source_export_time")),
+    }
+    if normalized["account_id"] is None:
+        raise ValueError(f"Missing account_id in billing summary row: {row!r}")
+    if normalized["export_partition_date"] is None:
+        raise ValueError(f"Missing export_partition_date in billing summary row: {row!r}")
+    if normalized["usage_date"] is None:
+        raise ValueError(f"Missing usage_date in billing summary row: {row!r}")
+    normalized["source_row_hash"] = build_summary_row_hash(normalized)
+    return normalized
+
+
+def build_summary_row_hash(row: dict[str, Any]) -> str:
+    payload = {field: hash_value(row.get(field)) for field in HASH_FIELDS}
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def write_summary_rows(engine: Engine, rows: Sequence[dict[str, Any]], *, dry_run: bool) -> int:
+    if not rows:
+        return 0
+    if dry_run:
+        LOG.info("dry-run skipped cost_bq_export_summary_daily upsert", extra={"row_count": len(rows)})
+        return 0
+    with engine.begin() as connection:
+        connection.execute(_build_upsert_statement(connection), _bind_rows(connection, rows))
+    return len(rows)
+
+
+def _bind_rows(connection: Connection, rows: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    bound_rows = list(rows)
+    if connection.dialect.name != "sqlite":
+        return bound_rows
+    return bind_decimal_rows(bound_rows)
+
+
+def _get_touched_usage_dates(
+    connection: Connection,
+    *,
+    account_id: str,
+    export_partition_start: date,
+    export_partition_end: date,
+) -> tuple[date, ...]:
+    rows = connection.execute(
+        _SELECT_TOUCHED_USAGE_DATES,
+        {
+            "vendor": "gcp",
+            "account_id": account_id,
+            "export_partition_start": export_partition_start,
+            "export_partition_end": export_partition_end,
+        },
+    ).scalars()
+    usage_dates = []
+    for row in rows:
+        usage_date = coerce_date(row)
+        if usage_date is not None:
+            usage_dates.append(usage_date)
+    return tuple(usage_dates)
+
+
+def _build_upsert_statement(connection: Connection):
+    if connection.dialect.name == "sqlite":
+        return text(
+            """
+            INSERT INTO cost_bq_export_summary_daily (
+              vendor,
+              account_id,
+              billing_account_id,
+              export_partition_date,
+              usage_date,
+              org,
+              repo,
+              author,
+              list_cost,
+              effective_cost,
+              credit_amount,
+              net_cost,
+              source_export_time,
+              source_row_hash
+            ) VALUES (
+              :vendor,
+              :account_id,
+              :billing_account_id,
+              :export_partition_date,
+              :usage_date,
+              :org,
+              :repo,
+              :author,
+              :list_cost,
+              :effective_cost,
+              :credit_amount,
+              :net_cost,
+              :source_export_time,
+              :source_row_hash
+            )
+            ON CONFLICT(vendor, account_id, export_partition_date, source_row_hash)
+            DO UPDATE SET
+              billing_account_id = excluded.billing_account_id,
+              list_cost = excluded.list_cost,
+              effective_cost = excluded.effective_cost,
+              credit_amount = excluded.credit_amount,
+              net_cost = excluded.net_cost,
+              source_export_time = excluded.source_export_time,
+              updated_at = CURRENT_TIMESTAMP
+            """
+        )
+    return text(
+        """
+        INSERT INTO cost_bq_export_summary_daily (
+          vendor,
+          account_id,
+          billing_account_id,
+          export_partition_date,
+          usage_date,
+          org,
+          repo,
+          author,
+          list_cost,
+          effective_cost,
+          credit_amount,
+          net_cost,
+          source_export_time,
+          source_row_hash
+        ) VALUES (
+          :vendor,
+          :account_id,
+          :billing_account_id,
+          :export_partition_date,
+          :usage_date,
+          :org,
+          :repo,
+          :author,
+          :list_cost,
+          :effective_cost,
+          :credit_amount,
+          :net_cost,
+          :source_export_time,
+          :source_row_hash
+        )
+        ON DUPLICATE KEY UPDATE
+          -- Dimension columns are part of source_row_hash; same hash means same dimensions.
+          billing_account_id = VALUES(billing_account_id),
+          list_cost = VALUES(list_cost),
+          effective_cost = VALUES(effective_cost),
+          credit_amount = VALUES(credit_amount),
+          net_cost = VALUES(net_cost),
+          source_export_time = VALUES(source_export_time),
+          updated_at = CURRENT_TIMESTAMP
+        """
+    )
+
+
+_SELECT_TOUCHED_USAGE_DATES = text(
+    """
+    SELECT DISTINCT usage_date
+    FROM cost_bq_export_summary_daily
+    WHERE export_partition_date BETWEEN :export_partition_start AND :export_partition_end
+      AND vendor = :vendor
+      AND account_id = :account_id
+    ORDER BY usage_date
+    """
+)

--- a/cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py
@@ -91,7 +91,7 @@ def run_sync_gcp_billing_summary(
     try:
         rows_seen = 0
         rows_written = 0
-        source_billing_account_id: str | None = None
+        source_billing_account_ids: set[str] = set()
         batch: list[dict[str, Any]] = []
         for source_row in fetch_rows(
             billing_table=settings.billing_table,
@@ -104,9 +104,8 @@ def run_sync_gcp_billing_summary(
         ):
             rows_seen += 1
             normalized = _normalize_summary_row(source_row)
-            source_billing_account_id = source_billing_account_id or normalized[
-                "billing_account_id"
-            ]
+            if normalized["billing_account_id"]:
+                source_billing_account_ids.add(normalized["billing_account_id"])
             batch.append(normalized)
             if len(batch) >= settings.page_size:
                 rows_written += write_summary_rows(engine, batch, dry_run=dry_run)
@@ -116,6 +115,7 @@ def run_sync_gcp_billing_summary(
         touched_usage_dates: tuple[date, ...] = ()
         if not dry_run:
             with engine.begin() as connection:
+                source_billing_account_id = _select_billing_account_id(source_billing_account_ids)
                 if source_billing_account_id:
                     _upsert_cost_source(
                         connection,
@@ -174,6 +174,17 @@ def _watermark(
         "export_partition_start": export_partition_start.isoformat(),
         "export_partition_end": export_partition_end.isoformat(),
     }
+
+
+def _select_billing_account_id(billing_account_ids: set[str]) -> str | None:
+    if not billing_account_ids:
+        return None
+    if len(billing_account_ids) > 1:
+        LOG.warning(
+            "multiple billing account ids observed for cost source; keeping the first sorted id",
+            extra={"billing_account_ids": sorted(billing_account_ids)},
+        )
+    return sorted(billing_account_ids)[0]
 
 
 def _normalize_summary_row(row: dict[str, Any]) -> dict[str, Any]:

--- a/cost-insight/src/cost_insight/jobs/sync_gcp_unmatched_resources.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcp_unmatched_resources.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+
+from cost_insight.common.config import GcpBillingSettings
+from cost_insight.common.row_utils import (
+    bind_decimal_rows,
+    coerce_date,
+    coerce_datetime,
+    hash_value,
+    nullable_text,
+)
+from cost_insight.jobs import state_store
+from cost_insight.jobs.sync_gcp_billing_export import (
+    _ensure_cost_source_enabled,
+    _upsert_cost_source,
+)
+from cost_insight.sources.gcp_billing_export import (
+    decimal_or_none,
+    fetch_gcp_unmatched_resource_rows,
+)
+
+LOG = logging.getLogger(__name__)
+
+JOB_NAME = "sync_gcp_unmatched_resources"
+HASH_FIELDS = (
+    "vendor",
+    "account_id",
+    "billing_account_id",
+    "export_partition_date",
+    "usage_date",
+    "service_name",
+    "sku_name",
+    "namespace",
+    "author",
+    "org",
+    "repo",
+    "resource_name",
+)
+
+RowFetcher = Callable[..., Iterable[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class SyncGcpUnmatchedResourcesSummary:
+    account_id: str
+    usage_start_date: date
+    usage_end_date: date
+    export_partition_start: date
+    export_partition_end: date
+    rows_seen: int
+    rows_written: int
+    dry_run: bool
+
+
+def run_sync_gcp_unmatched_resources(
+    engine: Engine,
+    *,
+    settings: GcpBillingSettings,
+    usage_start_date: date,
+    usage_end_date: date,
+    export_partition_start: date | None = None,
+    export_partition_end: date | None = None,
+    dry_run: bool = False,
+    limit: int | None = None,
+    fetch_rows: RowFetcher = fetch_gcp_unmatched_resource_rows,
+) -> SyncGcpUnmatchedResourcesSummary:
+    if usage_start_date > usage_end_date:
+        raise ValueError("usage_start_date must be before or equal to usage_end_date")
+    resolved_export_start = export_partition_start or usage_start_date
+    resolved_export_end = export_partition_end or (
+        usage_end_date + timedelta(days=settings.unmatched_resource_lag_days)
+    )
+    LOG.info(
+        "sync_gcp_unmatched_resources resolved export partition window",
+        extra={
+            "usage_start_date": usage_start_date,
+            "usage_end_date": usage_end_date,
+            "export_partition_start": resolved_export_start,
+            "export_partition_end": resolved_export_end,
+        },
+    )
+    watermark = _watermark(
+        account_id=settings.account_id,
+        usage_start_date=usage_start_date,
+        usage_end_date=usage_end_date,
+        export_partition_start=resolved_export_start,
+        export_partition_end=resolved_export_end,
+    )
+
+    with engine.begin() as connection:
+        _ensure_cost_source_enabled(connection, settings, dry_run=dry_run)
+        if not dry_run:
+            state_store.mark_job_started(connection, JOB_NAME, watermark)
+
+    try:
+        rows_seen = 0
+        rows_written = 0
+        source_billing_account_id: str | None = None
+        batch: list[dict[str, Any]] = []
+        for source_row in fetch_rows(
+            billing_table=settings.billing_table,
+            account_id=settings.account_id,
+            export_partition_start=resolved_export_start,
+            export_partition_end=resolved_export_end,
+            usage_start_date=usage_start_date,
+            usage_end_date=usage_end_date,
+            page_size=settings.page_size,
+            limit=limit,
+        ):
+            rows_seen += 1
+            normalized = _normalize_resource_row(source_row)
+            source_billing_account_id = source_billing_account_id or normalized[
+                "billing_account_id"
+            ]
+            batch.append(normalized)
+            if len(batch) >= settings.page_size:
+                rows_written += write_unmatched_resource_rows(engine, batch, dry_run=dry_run)
+                batch.clear()
+        rows_written += write_unmatched_resource_rows(engine, batch, dry_run=dry_run)
+
+        if not dry_run:
+            with engine.begin() as connection:
+                if source_billing_account_id:
+                    _upsert_cost_source(
+                        connection,
+                        account_id=settings.account_id,
+                        billing_account_id=source_billing_account_id,
+                    )
+                state_store.mark_job_succeeded(connection, JOB_NAME, watermark)
+
+        return SyncGcpUnmatchedResourcesSummary(
+            account_id=settings.account_id,
+            usage_start_date=usage_start_date,
+            usage_end_date=usage_end_date,
+            export_partition_start=resolved_export_start,
+            export_partition_end=resolved_export_end,
+            rows_seen=rows_seen,
+            rows_written=rows_written,
+            dry_run=dry_run,
+        )
+    except Exception as exc:
+        LOG.exception("sync_gcp_unmatched_resources failed")
+        if not dry_run:
+            with engine.begin() as connection:
+                state_store.mark_job_failed(connection, JOB_NAME, watermark, repr(exc))
+        raise
+
+
+def _watermark(
+    *,
+    account_id: str,
+    usage_start_date: date,
+    usage_end_date: date,
+    export_partition_start: date,
+    export_partition_end: date,
+) -> dict[str, Any]:
+    return {
+        "account_id": account_id,
+        "usage_start_date": usage_start_date.isoformat(),
+        "usage_end_date": usage_end_date.isoformat(),
+        "export_partition_start": export_partition_start.isoformat(),
+        "export_partition_end": export_partition_end.isoformat(),
+    }
+
+
+def _normalize_resource_row(row: dict[str, Any]) -> dict[str, Any]:
+    normalized = {
+        "vendor": nullable_text(row.get("vendor")) or "gcp",
+        "account_id": nullable_text(row.get("account_id")),
+        "billing_account_id": nullable_text(row.get("billing_account_id")),
+        "export_partition_date": coerce_date(row.get("export_partition_date")),
+        "usage_date": coerce_date(row.get("usage_date")),
+        "service_name": nullable_text(row.get("service_name")),
+        "sku_name": nullable_text(row.get("sku_name")),
+        "namespace": nullable_text(row.get("namespace")),
+        "author": nullable_text(row.get("author")),
+        "org": nullable_text(row.get("org")),
+        "repo": nullable_text(row.get("repo")),
+        "resource_name": nullable_text(row.get("resource_name")),
+        "usage_seconds": decimal_or_none(row.get("usage_seconds")),
+        "list_cost": decimal_or_none(row.get("list_cost")),
+        "effective_cost": decimal_or_none(row.get("effective_cost")),
+        "credit_amount": decimal_or_none(row.get("credit_amount")),
+        "net_cost": decimal_or_none(row.get("net_cost")),
+        "source_export_time": coerce_datetime(row.get("source_export_time")),
+    }
+    if normalized["account_id"] is None:
+        raise ValueError(f"Missing account_id in unmatched resource row: {row!r}")
+    if normalized["export_partition_date"] is None:
+        raise ValueError(f"Missing export_partition_date in unmatched resource row: {row!r}")
+    if normalized["usage_date"] is None:
+        raise ValueError(f"Missing usage_date in unmatched resource row: {row!r}")
+    if normalized["resource_name"] is None:
+        raise ValueError(f"Missing resource_name in unmatched resource row: {row!r}")
+    normalized["source_row_hash"] = build_unmatched_resource_row_hash(normalized)
+    return normalized
+
+
+def build_unmatched_resource_row_hash(row: dict[str, Any]) -> str:
+    payload = {field: hash_value(row.get(field)) for field in HASH_FIELDS}
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def write_unmatched_resource_rows(
+    engine: Engine,
+    rows: Sequence[dict[str, Any]],
+    *,
+    dry_run: bool,
+) -> int:
+    if not rows:
+        return 0
+    if dry_run:
+        LOG.info("dry-run skipped cost_unmatched_resource_daily upsert", extra={"row_count": len(rows)})
+        return 0
+    with engine.begin() as connection:
+        connection.execute(_build_upsert_statement(connection), _bind_rows(connection, rows))
+    return len(rows)
+
+
+def _bind_rows(connection: Connection, rows: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    bound_rows = list(rows)
+    if connection.dialect.name != "sqlite":
+        return bound_rows
+    return bind_decimal_rows(bound_rows)
+
+
+def _build_upsert_statement(connection: Connection):
+    if connection.dialect.name == "sqlite":
+        return text(
+            """
+            INSERT INTO cost_unmatched_resource_daily (
+              vendor,
+              account_id,
+              billing_account_id,
+              export_partition_date,
+              usage_date,
+              service_name,
+              sku_name,
+              namespace,
+              org,
+              repo,
+              author,
+              resource_name,
+              usage_seconds,
+              list_cost,
+              effective_cost,
+              credit_amount,
+              net_cost,
+              source_export_time,
+              source_row_hash
+            ) VALUES (
+              :vendor,
+              :account_id,
+              :billing_account_id,
+              :export_partition_date,
+              :usage_date,
+              :service_name,
+              :sku_name,
+              :namespace,
+              :org,
+              :repo,
+              :author,
+              :resource_name,
+              :usage_seconds,
+              :list_cost,
+              :effective_cost,
+              :credit_amount,
+              :net_cost,
+              :source_export_time,
+              :source_row_hash
+            )
+            ON CONFLICT(vendor, account_id, export_partition_date, source_row_hash)
+            DO UPDATE SET
+              billing_account_id = excluded.billing_account_id,
+              usage_seconds = excluded.usage_seconds,
+              list_cost = excluded.list_cost,
+              effective_cost = excluded.effective_cost,
+              credit_amount = excluded.credit_amount,
+              net_cost = excluded.net_cost,
+              source_export_time = excluded.source_export_time,
+              updated_at = CURRENT_TIMESTAMP
+            """
+        )
+    return text(
+        """
+        INSERT INTO cost_unmatched_resource_daily (
+          vendor,
+          account_id,
+          billing_account_id,
+          export_partition_date,
+          usage_date,
+          service_name,
+          sku_name,
+          namespace,
+          org,
+          repo,
+          author,
+          resource_name,
+          usage_seconds,
+          list_cost,
+          effective_cost,
+          credit_amount,
+          net_cost,
+          source_export_time,
+          source_row_hash
+        ) VALUES (
+          :vendor,
+          :account_id,
+          :billing_account_id,
+          :export_partition_date,
+          :usage_date,
+          :service_name,
+          :sku_name,
+          :namespace,
+          :org,
+          :repo,
+          :author,
+          :resource_name,
+          :usage_seconds,
+          :list_cost,
+          :effective_cost,
+          :credit_amount,
+          :net_cost,
+          :source_export_time,
+          :source_row_hash
+        )
+        ON DUPLICATE KEY UPDATE
+          -- Dimension columns are part of source_row_hash; same hash means same dimensions.
+          billing_account_id = VALUES(billing_account_id),
+          usage_seconds = VALUES(usage_seconds),
+          list_cost = VALUES(list_cost),
+          effective_cost = VALUES(effective_cost),
+          credit_amount = VALUES(credit_amount),
+          net_cost = VALUES(net_cost),
+          source_export_time = VALUES(source_export_time),
+          updated_at = CURRENT_TIMESTAMP
+        """
+    )

--- a/cost-insight/src/cost_insight/sources/gcp_billing_export.py
+++ b/cost-insight/src/cost_insight/sources/gcp_billing_export.py
@@ -31,6 +31,82 @@ def fetch_gcp_billing_rows(
         yield dict(row.items())
 
 
+def fetch_gcp_billing_summary_rows(
+    *,
+    billing_table: str,
+    account_id: str,
+    export_partition_start: date,
+    export_partition_end: date,
+    earliest_usage_date: date,
+    page_size: int,
+    limit: int | None = None,
+) -> Iterator[dict[str, Any]]:
+    from google.cloud import bigquery
+
+    client = bigquery.Client()
+    query = build_gcp_billing_summary_query(billing_table=billing_table, limit=limit)
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("account_id", "STRING", account_id),
+            bigquery.ScalarQueryParameter(
+                "export_partition_start",
+                "DATE",
+                export_partition_start.isoformat(),
+            ),
+            bigquery.ScalarQueryParameter(
+                "export_partition_end",
+                "DATE",
+                export_partition_end.isoformat(),
+            ),
+            bigquery.ScalarQueryParameter(
+                "earliest_usage_date",
+                "DATE",
+                earliest_usage_date.isoformat(),
+            ),
+        ]
+    )
+    rows = client.query(query, job_config=job_config).result(page_size=page_size)
+    for row in rows:
+        yield dict(row.items())
+
+
+def fetch_gcp_unmatched_resource_rows(
+    *,
+    billing_table: str,
+    account_id: str,
+    export_partition_start: date,
+    export_partition_end: date,
+    usage_start_date: date,
+    usage_end_date: date,
+    page_size: int,
+    limit: int | None = None,
+) -> Iterator[dict[str, Any]]:
+    from google.cloud import bigquery
+
+    client = bigquery.Client()
+    query = build_gcp_unmatched_resource_query(billing_table=billing_table, limit=limit)
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("account_id", "STRING", account_id),
+            bigquery.ScalarQueryParameter(
+                "export_partition_start",
+                "DATE",
+                export_partition_start.isoformat(),
+            ),
+            bigquery.ScalarQueryParameter(
+                "export_partition_end",
+                "DATE",
+                export_partition_end.isoformat(),
+            ),
+            bigquery.ScalarQueryParameter("usage_start_date", "DATE", usage_start_date.isoformat()),
+            bigquery.ScalarQueryParameter("usage_end_date", "DATE", usage_end_date.isoformat()),
+        ]
+    )
+    rows = client.query(query, job_config=job_config).result(page_size=page_size)
+    for row in rows:
+        yield dict(row.items())
+
+
 def build_gcp_billing_query(*, billing_table: str, limit: int | None = None) -> str:
     limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
     return f"""
@@ -98,6 +174,125 @@ GROUP BY
   service_name,
   sku_name,
   region,
+  namespace,
+  author,
+  org,
+  repo,
+  resource_name
+ORDER BY usage_date, service_name, sku_name, resource_name{limit_clause}
+""".strip()
+
+
+def build_gcp_billing_summary_query(*, billing_table: str, limit: int | None = None) -> str:
+    limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
+    return f"""
+SELECT
+  'gcp' AS vendor,
+  project.id AS account_id,
+  billing_account_id,
+  _PARTITIONDATE AS export_partition_date,
+  DATE(usage_start_time) AS usage_date,
+  {_label_expr(("k8s-label/author", "author"))} AS author,
+  {_label_expr(("k8s-label/org", "org"))} AS org,
+  {_label_expr(("k8s-label/repo", "repo"))} AS repo,
+  ROUND(SUM(cost_at_list), 2) AS list_cost,
+  ROUND(SUM(cost), 2) AS effective_cost,
+  ROUND(SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) AS c), 0)), 2)
+    AS credit_amount,
+  ROUND(SUM(cost + IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) AS c), 0)), 2)
+    AS net_cost,
+  MAX(export_time) AS source_export_time
+FROM `{billing_table}`
+WHERE _PARTITIONDATE BETWEEN @export_partition_start AND @export_partition_end
+  AND project.id = @account_id
+  AND DATE(usage_start_time) >= @earliest_usage_date
+GROUP BY
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  author,
+  org,
+  repo
+ORDER BY export_partition_date, usage_date, author, org, repo{limit_clause}
+""".strip()
+
+
+def build_gcp_unmatched_resource_query(*, billing_table: str, limit: int | None = None) -> str:
+    limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
+    namespace_expr = _label_expr(("k8s-namespace", "namespace"))
+    author_expr = _label_expr(("k8s-label/author", "author"))
+    org_expr = _label_expr(("k8s-label/org", "org"))
+    repo_expr = _label_expr(("k8s-label/repo", "repo"))
+    workload_expr = _label_expr(("k8s-workload-name",))
+    return f"""
+WITH normalized AS (
+  SELECT
+    billing_account_id,
+    project.id AS account_id,
+    _PARTITIONDATE AS export_partition_date,
+    DATE(usage_start_time) AS usage_date,
+    service.description AS service_name,
+    sku.description AS sku_name,
+    {namespace_expr} AS namespace,
+    {author_expr} AS author,
+    {org_expr} AS org,
+    {repo_expr} AS repo,
+    COALESCE(
+      {workload_expr},
+      NULLIF(resource.name, ''),
+      NULLIF(resource.global_name, '')
+    ) AS resource_name,
+    LOWER(usage.pricing_unit) AS pricing_unit,
+    usage.amount_in_pricing_units AS amount_in_pricing_units,
+    cost_at_list,
+    cost,
+    IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) AS c), 0) AS credit_amount,
+    export_time
+  FROM `{billing_table}`
+  WHERE _PARTITIONDATE BETWEEN @export_partition_start AND @export_partition_end
+    AND project.id = @account_id
+    AND DATE(usage_start_time) BETWEEN @usage_start_date AND @usage_end_date
+)
+SELECT
+  'gcp' AS vendor,
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  service_name,
+  sku_name,
+  namespace,
+  author,
+  org,
+  repo,
+  resource_name,
+  CASE
+    WHEN COUNTIF(pricing_unit IS NULL OR pricing_unit NOT IN ('hour', 'minute', 'second')) > 0
+      THEN NULL
+    WHEN COUNTIF(pricing_unit = 'hour') = COUNT(*)
+      THEN ROUND(SUM(amount_in_pricing_units) * 3600, 2)
+    WHEN COUNTIF(pricing_unit = 'minute') = COUNT(*)
+      THEN ROUND(SUM(amount_in_pricing_units) * 60, 2)
+    WHEN COUNTIF(pricing_unit = 'second') = COUNT(*)
+      THEN ROUND(SUM(amount_in_pricing_units), 2)
+    ELSE NULL
+  END AS usage_seconds,
+  ROUND(SUM(cost_at_list), 2) AS list_cost,
+  ROUND(SUM(cost), 2) AS effective_cost,
+  ROUND(SUM(credit_amount), 2) AS credit_amount,
+  ROUND(SUM(cost + credit_amount), 2) AS net_cost,
+  MAX(export_time) AS source_export_time
+FROM normalized
+WHERE resource_name IS NOT NULL
+  AND resource_name <> ''
+GROUP BY
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  service_name,
+  sku_name,
   namespace,
   author,
   org,

--- a/cost-insight/tests/test_backfill_cost_refine_from_raw.py
+++ b/cost-insight/tests/test_backfill_cost_refine_from_raw.py
@@ -1,0 +1,222 @@
+from datetime import date
+
+from sqlalchemy import create_engine, text
+
+from cost_insight.common.config import GcpBillingSettings
+from cost_insight.jobs import state_store
+from cost_insight.jobs.backfill_cost_refine_from_raw import (
+    JOB_NAME,
+    run_backfill_cost_refine_from_raw,
+)
+from cost_insight.jobs.sync_gcp_billing_summary import JOB_NAME as SUMMARY_JOB_NAME
+
+
+def _sqlite_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as connection:
+        for statement in (
+            """
+            CREATE TABLE cost_job_state (
+              job_name TEXT PRIMARY KEY,
+              watermark_json TEXT,
+              last_started_at TEXT,
+              last_succeeded_at TEXT,
+              last_status TEXT,
+              last_error TEXT,
+              updated_at TEXT
+            )
+            """,
+            """
+            CREATE TABLE cost_raw_details (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              vendor TEXT NOT NULL,
+              account_id TEXT NOT NULL,
+              billing_account_id TEXT,
+              usage_date TEXT NOT NULL,
+              service_name TEXT,
+              sku_name TEXT,
+              region TEXT,
+              namespace TEXT,
+              author TEXT,
+              org TEXT,
+              repo TEXT,
+              resource_name TEXT,
+              usage_seconds REAL,
+              list_cost REAL,
+              effective_cost REAL,
+              credit_amount REAL,
+              net_cost REAL,
+              source_export_time TEXT,
+              source_row_hash TEXT NOT NULL
+            )
+            """,
+            """
+            CREATE TABLE cost_bq_export_summary_daily (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              vendor TEXT NOT NULL,
+              account_id TEXT NOT NULL,
+              billing_account_id TEXT,
+              export_partition_date TEXT NOT NULL,
+              usage_date TEXT NOT NULL,
+              org TEXT,
+              repo TEXT,
+              author TEXT,
+              list_cost REAL,
+              effective_cost REAL,
+              credit_amount REAL,
+              net_cost REAL,
+              source_export_time TEXT,
+              source_row_hash TEXT NOT NULL,
+              created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              UNIQUE(vendor, account_id, export_partition_date, source_row_hash)
+            )
+            """,
+            """
+            CREATE TABLE cost_unmatched_resource_daily (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              vendor TEXT NOT NULL,
+              account_id TEXT NOT NULL,
+              billing_account_id TEXT,
+              export_partition_date TEXT NOT NULL,
+              usage_date TEXT NOT NULL,
+              service_name TEXT,
+              sku_name TEXT,
+              namespace TEXT,
+              org TEXT,
+              repo TEXT,
+              author TEXT,
+              resource_name TEXT NOT NULL,
+              usage_seconds REAL,
+              list_cost REAL,
+              effective_cost REAL,
+              credit_amount REAL,
+              net_cost REAL,
+              source_export_time TEXT,
+              source_row_hash TEXT NOT NULL,
+              created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              UNIQUE(vendor, account_id, export_partition_date, source_row_hash)
+            )
+            """,
+        ):
+            connection.execute(text(statement))
+        connection.execute(
+            text(
+                """
+                INSERT INTO cost_raw_details (
+                  vendor, account_id, billing_account_id, usage_date, service_name,
+                  sku_name, region, namespace, author, org, repo, resource_name,
+                  usage_seconds, list_cost, effective_cost, credit_amount, net_cost,
+                  source_export_time, source_row_hash
+                ) VALUES
+                  (
+                    'gcp', 'pingcap-testing-account', 'billing-1', '2026-05-17',
+                    'Compute Engine', 'Core running', 'us-central1', 'kube:unallocated',
+                    'alice', 'pingcap', 'tidb', 'runner-1',
+                    3600, 10, 8, -1, 7, '2026-05-20 01:02:03', 'raw-1'
+                  ),
+                  (
+                    'gcp', 'pingcap-testing-account', 'billing-1', '2026-05-17',
+                    'Compute Engine', 'Core running', 'us-central1', 'kube:unallocated',
+                    'alice', 'pingcap', 'tidb', 'runner-1',
+                    1800, 5, 4, -0.5, 3.5, '2026-05-20 02:02:03', 'raw-2'
+                  ),
+                  (
+                    'gcp', 'pingcap-testing-account', 'billing-1', '2026-05-18',
+                    'Cloud Logging', 'Storage', 'global', NULL,
+                    NULL, 'pingcap', 'platform', NULL,
+                    NULL, 2, 2, 0, 2, NULL, 'raw-3'
+                  )
+                """
+            )
+        )
+    return engine
+
+
+def test_backfill_cost_refine_from_raw_writes_summary_and_unmatched_rows() -> None:
+    engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account", page_size=1)
+
+    try:
+        summary = run_backfill_cost_refine_from_raw(
+            engine,
+            settings=settings,
+            start_date=date(2026, 5, 17),
+            end_date=date(2026, 5, 18),
+            mark_summary_watermark=True,
+        )
+
+        assert summary.summary_rows_seen == 2
+        assert summary.summary_rows_written == 2
+        assert summary.unmatched_rows_seen == 1
+        assert summary.unmatched_rows_written == 1
+        assert summary.export_partition_start == date(2026, 5, 18)
+        assert summary.export_partition_end == date(2026, 5, 20)
+        assert summary.marked_summary_watermark is True
+
+        with engine.begin() as connection:
+            summary_cost = connection.execute(
+                text(
+                    """
+                    SELECT list_cost, effective_cost, credit_amount, net_cost
+                    FROM cost_bq_export_summary_daily
+                    WHERE usage_date = '2026-05-17'
+                    """
+                )
+            ).mappings().one()
+            resource = connection.execute(
+                text(
+                    """
+                    SELECT usage_seconds, list_cost
+                    FROM cost_unmatched_resource_daily
+                    WHERE resource_name = 'runner-1'
+                    """
+                )
+            ).mappings().one()
+            job_state = state_store.get_job_state(connection, JOB_NAME)
+            summary_state = state_store.get_job_state(connection, SUMMARY_JOB_NAME)
+
+        assert summary_cost["list_cost"] == 15
+        assert summary_cost["effective_cost"] == 12
+        assert summary_cost["credit_amount"] == -1.5
+        assert summary_cost["net_cost"] == 10.5
+        assert resource["usage_seconds"] == 5400
+        assert resource["list_cost"] == 15
+        assert job_state is not None
+        assert job_state.last_status == "succeeded"
+        assert summary_state is not None
+        assert summary_state.watermark["export_partition_end"] == "2026-05-20"
+    finally:
+        engine.dispose()
+
+
+def test_backfill_cost_refine_from_raw_dry_run_writes_nothing() -> None:
+    engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account")
+
+    try:
+        summary = run_backfill_cost_refine_from_raw(
+            engine,
+            settings=settings,
+            start_date=date(2026, 5, 17),
+            end_date=date(2026, 5, 18),
+            dry_run=True,
+        )
+
+        assert summary.summary_rows_seen == 2
+        assert summary.summary_rows_written == 0
+        assert summary.unmatched_rows_seen == 1
+        assert summary.unmatched_rows_written == 0
+        with engine.begin() as connection:
+            summary_count = connection.execute(
+                text("SELECT COUNT(*) FROM cost_bq_export_summary_daily")
+            ).scalar_one()
+            resource_count = connection.execute(
+                text("SELECT COUNT(*) FROM cost_unmatched_resource_daily")
+            ).scalar_one()
+            assert state_store.get_job_state(connection, JOB_NAME) is None
+        assert summary_count == 0
+        assert resource_count == 0
+    finally:
+        engine.dispose()

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -1,5 +1,7 @@
 import pytest
 
+from datetime import date
+
 from cost_insight.common.config import DEFAULT_GCP_ACCOUNT_ID, DEFAULT_GCP_BILLING_TABLE, load_settings
 
 
@@ -9,12 +11,22 @@ def test_load_settings_uses_cost_database_url() -> None:
             "COST_INSIGHT_DB_URL": "mysql+pymysql://user:pass@127.0.0.1:4000/cost_insight",
             "COST_INSIGHT_GCP_ACCOUNT_ID": "custom-project",
             "COST_INSIGHT_SYNC_OVERLAP_DAYS": "5",
+            "COST_INSIGHT_SYNC_LAG_DAYS": "7",
+            "COST_INSIGHT_EXPORT_OVERLAP_DAYS": "1",
+            "COST_INSIGHT_SYNC_INITIAL_LOOKBACK_DAYS": "30",
+            "COST_INSIGHT_UNMATCHED_RESOURCE_LAG_DAYS": "6",
+            "COST_INSIGHT_EARLIEST_USAGE_DATE": "2026-02-01",
         }
     )
 
     assert settings.database.url == "mysql+pymysql://user:pass@127.0.0.1:4000/cost_insight"
     assert settings.gcp_billing.account_id == "custom-project"
     assert settings.gcp_billing.sync_overlap_days == 5
+    assert settings.gcp_billing.sync_lag_days == 7
+    assert settings.gcp_billing.export_overlap_days == 1
+    assert settings.gcp_billing.sync_initial_lookback_days == 30
+    assert settings.gcp_billing.unmatched_resource_lag_days == 6
+    assert settings.gcp_billing.earliest_usage_date == date(2026, 2, 1)
 
 
 def test_load_settings_can_skip_database_for_validation() -> None:
@@ -69,5 +81,23 @@ def test_load_settings_rejects_invalid_int() -> None:
             {
                 "COST_INSIGHT_DB_URL": "mysql+pymysql://user:pass@127.0.0.1:4000/cost",
                 "COST_INSIGHT_SYNC_OVERLAP_DAYS": "abc",
+            }
+        )
+
+
+def test_load_settings_rejects_invalid_cost_refine_values() -> None:
+    with pytest.raises(ValueError, match="COST_INSIGHT_EXPORT_OVERLAP_DAYS must be non-negative"):
+        load_settings(
+            {
+                "COST_INSIGHT_DB_URL": "mysql+pymysql://user:pass@127.0.0.1:4000/cost",
+                "COST_INSIGHT_EXPORT_OVERLAP_DAYS": "-1",
+            }
+        )
+
+    with pytest.raises(ValueError, match="COST_INSIGHT_EARLIEST_USAGE_DATE must be an ISO date"):
+        load_settings(
+            {
+                "COST_INSIGHT_DB_URL": "mysql+pymysql://user:pass@127.0.0.1:4000/cost",
+                "COST_INSIGHT_EARLIEST_USAGE_DATE": "not-a-date",
             }
         )

--- a/cost-insight/tests/test_db_and_cli.py
+++ b/cost-insight/tests/test_db_and_cli.py
@@ -5,8 +5,11 @@ from cost_insight.common import db
 from cost_insight.common.config import DatabaseSettings, GcpBillingSettings, Settings
 from cost_insight.common.logging import configure_logging
 from cost_insight.jobs import cli
+from cost_insight.jobs.backfill_cost_refine_from_raw import BackfillCostRefineFromRawSummary
 from cost_insight.jobs.refresh_attribution_daily import RefreshAttributionSummary
+from cost_insight.jobs.sync_gcp_billing_summary import SyncGcpBillingSummaryResult
 from cost_insight.jobs.sync_gcp_billing_export import SyncGcpBillingSummary
+from cost_insight.jobs.sync_gcp_unmatched_resources import SyncGcpUnmatchedResourcesSummary
 
 
 def test_build_engine_uses_database_url(monkeypatch) -> None:
@@ -224,6 +227,222 @@ def test_cli_runs_refresh_attribution_command(monkeypatch, capsys) -> None:
     assert captured["dry_run"] is True
     assert '"rows_inserted": 3' in output
     assert '"raw_rows": 10' in output
+
+
+def test_cli_runs_sync_billing_summary_command(monkeypatch, capsys) -> None:
+    disposed = []
+    captured = {}
+
+    class Engine:
+        def dispose(self):
+            disposed.append(True)
+
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        log_level="INFO",
+    )
+
+    def fake_run(engine, **kwargs):
+        captured.update(kwargs)
+        return SyncGcpBillingSummaryResult(
+            account_id=kwargs["settings"].account_id,
+            export_partition_start=kwargs["export_partition_start"],
+            export_partition_end=kwargs["export_partition_end"],
+            rows_seen=2,
+            rows_written=2,
+            dry_run=kwargs["dry_run"],
+            touched_usage_dates=(date(2026, 5, 17),),
+        )
+
+    monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda _settings: Engine())
+    monkeypatch.setattr(cli, "run_sync_gcp_billing_summary", fake_run)
+
+    exit_code = cli.main(
+        [
+            "sync-gcp-billing-summary",
+            "--export-partition-start",
+            "2026-05-17",
+            "--export-partition-end",
+            "2026-05-18",
+            "--earliest-usage-date",
+            "2026-01-01",
+            "--limit",
+            "10",
+            "--dry-run",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert disposed == [True]
+    assert captured["export_partition_start"] == date(2026, 5, 17)
+    assert captured["export_partition_end"] == date(2026, 5, 18)
+    assert captured["earliest_usage_date"] == date(2026, 1, 1)
+    assert captured["limit"] == 10
+    assert '"touched_usage_dates": [' in output
+
+
+def test_cli_runs_sync_unmatched_resources_command(monkeypatch, capsys) -> None:
+    disposed = []
+    captured = {}
+
+    class Engine:
+        def dispose(self):
+            disposed.append(True)
+
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        log_level="INFO",
+    )
+
+    def fake_run(engine, **kwargs):
+        captured.update(kwargs)
+        return SyncGcpUnmatchedResourcesSummary(
+            account_id=kwargs["settings"].account_id,
+            usage_start_date=kwargs["usage_start_date"],
+            usage_end_date=kwargs["usage_end_date"],
+            export_partition_start=date(2026, 5, 17),
+            export_partition_end=date(2026, 5, 24),
+            rows_seen=3,
+            rows_written=3,
+            dry_run=kwargs["dry_run"],
+        )
+
+    monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda _settings: Engine())
+    monkeypatch.setattr(cli, "run_sync_gcp_unmatched_resources", fake_run)
+
+    exit_code = cli.main(
+        [
+            "sync-gcp-unmatched-resources",
+            "--usage-start-date",
+            "2026-05-17",
+            "--usage-end-date",
+            "2026-05-18",
+            "--dry-run",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert disposed == [True]
+    assert captured["usage_start_date"] == date(2026, 5, 17)
+    assert captured["usage_end_date"] == date(2026, 5, 18)
+    assert '"rows_seen": 3' in output
+
+
+def test_cli_runs_backfill_cost_refine_from_raw_command(monkeypatch, capsys) -> None:
+    disposed = []
+    captured = {}
+
+    class Engine:
+        def dispose(self):
+            disposed.append(True)
+
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        log_level="INFO",
+    )
+
+    def fake_run(engine, **kwargs):
+        captured.update(kwargs)
+        return BackfillCostRefineFromRawSummary(
+            account_id=kwargs["settings"].account_id,
+            start_date=kwargs["start_date"],
+            end_date=kwargs["end_date"],
+            summary_rows_seen=2,
+            summary_rows_written=2,
+            unmatched_rows_seen=1,
+            unmatched_rows_written=1,
+            export_partition_start=date(2026, 5, 17),
+            export_partition_end=date(2026, 5, 20),
+            dry_run=kwargs["dry_run"],
+            marked_summary_watermark=kwargs["mark_summary_watermark"],
+        )
+
+    monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda _settings: Engine())
+    monkeypatch.setattr(cli, "run_backfill_cost_refine_from_raw", fake_run)
+
+    exit_code = cli.main(
+        [
+            "backfill-gcp-cost-refine-from-raw",
+            "--start-date",
+            "2026-01-01",
+            "--end-date",
+            "2026-05-20",
+            "--mark-summary-watermark",
+            "--dry-run",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert disposed == [True]
+    assert captured["start_date"] == date(2026, 1, 1)
+    assert captured["end_date"] == date(2026, 5, 20)
+    assert captured["include_unmatched_resources"] is True
+    assert captured["mark_summary_watermark"] is True
+    assert captured["dry_run"] is True
+    assert '"summary_rows_seen": 2' in output
+    assert '"marked_summary_watermark": true' in output
+
+
+def test_cli_runs_refresh_attribution_from_summary_command(monkeypatch, capsys) -> None:
+    disposed = []
+    captured = {}
+
+    class Engine:
+        def dispose(self):
+            disposed.append(True)
+
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        log_level="INFO",
+    )
+
+    def fake_refresh(engine, *, settings, start_date, end_date, dry_run):
+        captured["engine"] = engine
+        captured["settings"] = settings
+        captured["start_date"] = start_date
+        captured["end_date"] = end_date
+        captured["dry_run"] = dry_run
+        return RefreshAttributionSummary(
+            account_id=settings.account_id,
+            start_date=start_date,
+            end_date=end_date,
+            rows_deleted=2,
+            rows_inserted=3,
+            dry_run=dry_run,
+            summary_rows=10 if dry_run else None,
+        )
+
+    monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda _settings: Engine())
+    monkeypatch.setattr(cli, "run_refresh_cost_attribution_from_summary", fake_refresh)
+
+    exit_code = cli.main(
+        [
+            "refresh-cost-attribution-from-summary",
+            "--start-date",
+            "2026-05-09",
+            "--end-date",
+            "2026-05-17",
+            "--dry-run",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert disposed == [True]
+    assert captured["start_date"] == date(2026, 5, 9)
+    assert captured["end_date"] == date(2026, 5, 17)
+    assert '"summary_rows": 10' in output
 
 
 def test_cli_refresh_attribution_split_by_day_runs_each_date(monkeypatch, capsys) -> None:

--- a/cost-insight/tests/test_gcp_billing_export.py
+++ b/cost-insight/tests/test_gcp_billing_export.py
@@ -5,6 +5,8 @@ from decimal import Decimal
 
 from cost_insight.sources.gcp_billing_export import (
     build_gcp_billing_query,
+    build_gcp_billing_summary_query,
+    build_gcp_unmatched_resource_query,
     decimal_or_none,
     fetch_gcp_billing_rows,
 )
@@ -28,6 +30,30 @@ def test_build_gcp_billing_query_without_limit() -> None:
     query = build_gcp_billing_query(billing_table="project.dataset.table")
 
     assert "LIMIT" not in query.splitlines()[-1]
+
+
+def test_build_gcp_billing_summary_query_uses_partition_pruning() -> None:
+    query = build_gcp_billing_summary_query(billing_table="project.dataset.table", limit=20)
+
+    assert "`project.dataset.table`" in query
+    assert "_PARTITIONDATE BETWEEN @export_partition_start AND @export_partition_end" in query
+    assert "DATE(usage_start_time) >= @earliest_usage_date" in query
+    assert "k8s-label/author" in query
+    assert "k8s-label/repo" in query
+    assert "resource_name" not in query
+    assert "service.description" not in query
+    assert "LIMIT 20" in query
+
+
+def test_build_gcp_unmatched_resource_query_keeps_resource_context() -> None:
+    query = build_gcp_unmatched_resource_query(billing_table="project.dataset.table")
+
+    assert "_PARTITIONDATE BETWEEN @export_partition_start AND @export_partition_end" in query
+    assert "DATE(usage_start_time) BETWEEN @usage_start_date AND @usage_end_date" in query
+    assert "k8s-workload-name" in query
+    assert "resource.global_name" in query
+    assert "usage_seconds" in query
+    assert "service.description AS service_name" in query
 
 
 def test_decimal_or_none() -> None:

--- a/cost-insight/tests/test_refresh_attribution_daily.py
+++ b/cost-insight/tests/test_refresh_attribution_daily.py
@@ -8,11 +8,14 @@ from cost_insight.common.config import GcpBillingSettings
 from cost_insight.jobs import state_store
 from cost_insight.jobs.refresh_attribution_daily import (
     JOB_NAME,
+    SUMMARY_JOB_NAME,
     _INSERT_ATTRIBUTION_DAILY,
+    _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY,
     normalized_identity_sql,
     _positive_rowcount,
     _watermark,
     run_refresh_cost_attribution_daily,
+    run_refresh_cost_attribution_from_summary,
 )
 
 
@@ -111,6 +114,51 @@ def test_run_refresh_attribution_dry_run_counts_raw_rows() -> None:
         engine.dispose()
 
 
+def test_run_refresh_attribution_from_summary_dry_run_counts_summary_rows() -> None:
+    engine = _sqlite_engine()
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE cost_bq_export_summary_daily (
+                      usage_date DATE NOT NULL,
+                      vendor TEXT NOT NULL,
+                      account_id TEXT NOT NULL
+                    )
+                    """
+                )
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO cost_bq_export_summary_daily (usage_date, vendor, account_id)
+                    VALUES
+                      ('2026-05-09', 'gcp', 'pingcap-testing-account'),
+                      ('2026-05-10', 'gcp', 'pingcap-testing-account'),
+                      ('2026-05-10', 'aws', '123456789012')
+                    """
+                )
+            )
+
+        summary = run_refresh_cost_attribution_from_summary(
+            engine,
+            settings=GcpBillingSettings(account_id="pingcap-testing-account"),
+            start_date=date(2026, 5, 9),
+            end_date=date(2026, 5, 10),
+            dry_run=True,
+        )
+
+        assert summary.summary_rows == 2
+        assert summary.rows_deleted == 0
+        assert summary.rows_inserted == 0
+        assert summary.dry_run is True
+        with engine.begin() as connection:
+            assert state_store.get_job_state(connection, SUMMARY_JOB_NAME) is None
+    finally:
+        engine.dispose()
+
+
 def test_run_refresh_attribution_marks_success(monkeypatch) -> None:
     engine = _sqlite_engine()
     executed = []
@@ -150,6 +198,50 @@ def test_run_refresh_attribution_marks_success(monkeypatch) -> None:
         assert executed[0][1]["account_id"] == "pingcap-testing-account"
         with engine.begin() as connection:
             state = state_store.get_job_state(connection, JOB_NAME)
+        assert state is not None
+        assert state.last_status == "succeeded"
+    finally:
+        engine.dispose()
+
+
+def test_run_refresh_attribution_from_summary_marks_success(monkeypatch) -> None:
+    engine = _sqlite_engine()
+    executed = []
+
+    def fake_execute(self, statement, params=None, *args, **kwargs):
+        sql = str(statement)
+        if "DELETE FROM cost_attribution_daily" in sql:
+            executed.append(("delete", params))
+
+            class Result:
+                rowcount = 2
+
+            return Result()
+        if "FROM cost_bq_export_summary_daily summary" in sql:
+            executed.append(("insert-summary", params))
+
+            class Result:
+                rowcount = 5
+
+            return Result()
+        return original_execute(self, statement, params, *args, **kwargs)
+
+    original_execute = Connection.execute
+    monkeypatch.setattr("sqlalchemy.engine.base.Connection.execute", fake_execute)
+
+    try:
+        summary = run_refresh_cost_attribution_from_summary(
+            engine,
+            settings=GcpBillingSettings(account_id="pingcap-testing-account"),
+            start_date=date(2026, 5, 9),
+            end_date=date(2026, 5, 10),
+        )
+
+        assert summary.rows_deleted == 2
+        assert summary.rows_inserted == 5
+        assert [kind for kind, _params in executed] == ["delete", "insert-summary"]
+        with engine.begin() as connection:
+            state = state_store.get_job_state(connection, SUMMARY_JOB_NAME)
         assert state is not None
         assert state.last_status == "succeeded"
     finally:
@@ -212,5 +304,20 @@ def test_insert_sql_contains_roster_matching_and_daily_dimensions() -> None:
     assert "author_normalized" in sql
     assert "missing_author" in sql
     assert "resource_name" in sql
+    assert "SHA2(" in sql
+    assert "{normalized_" not in sql
+
+
+def test_summary_insert_sql_uses_summary_source_and_nullable_resource_columns() -> None:
+    sql = str(_INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY)
+
+    assert "FROM cost_bq_export_summary_daily summary" in sql
+    assert "NULL AS service_name" in sql
+    assert "NULL AS sku_name" in sql
+    assert "NULL AS resource_name" in sql
+    assert "NULL AS usage_seconds" in sql
+    assert "LEFT JOIN roster_employees github_employee" in sql
+    assert "LOWER(github_employee.github_id) = LOWER(summary.author)" in sql
+    assert "author_normalized" in sql
     assert "SHA2(" in sql
     assert "{normalized_" not in sql

--- a/cost-insight/tests/test_sync_gcp_billing_export.py
+++ b/cost-insight/tests/test_sync_gcp_billing_export.py
@@ -5,15 +5,12 @@ import pytest
 from sqlalchemy import create_engine, text
 
 from cost_insight.common.config import GcpBillingSettings
+from cost_insight.common.row_utils import coerce_date, coerce_datetime, hash_value, nullable_text
 from cost_insight.jobs import state_store
 from cost_insight.jobs.sync_gcp_billing_export import (
     JOB_NAME,
-    _coerce_date,
-    _coerce_datetime,
     _ensure_cost_source_enabled,
-    _hash_value,
     _normalize_row,
-    _nullable_text,
     _start_date_from_state,
     _watermark,
     _write_batch,
@@ -82,24 +79,24 @@ def test_normalize_row_rejects_missing_required_fields() -> None:
 
 
 def test_coercion_helpers() -> None:
-    assert _nullable_text("  value  ") == "value"
-    assert _nullable_text("   ") is None
-    assert _coerce_date(datetime(2026, 5, 18, 12, 0)) == date(2026, 5, 18)
-    assert _coerce_date(date(2026, 5, 18)) == date(2026, 5, 18)
-    assert _coerce_datetime(datetime(2026, 5, 18, 12, 0)).tzinfo is None
-    assert _coerce_datetime("2026-05-18T12:00:00+08:00") == datetime(2026, 5, 18, 4, 0)
-    assert _coerce_datetime(datetime(2026, 5, 18, 12, 0, tzinfo=timezone.utc)) == datetime(
+    assert nullable_text("  value  ") == "value"
+    assert nullable_text("   ") is None
+    assert coerce_date(datetime(2026, 5, 18, 12, 0)) == date(2026, 5, 18)
+    assert coerce_date(date(2026, 5, 18)) == date(2026, 5, 18)
+    assert coerce_datetime(datetime(2026, 5, 18, 12, 0)).tzinfo is None
+    assert coerce_datetime("2026-05-18T12:00:00+08:00") == datetime(2026, 5, 18, 4, 0)
+    assert coerce_datetime(datetime(2026, 5, 18, 12, 0, tzinfo=timezone.utc)) == datetime(
         2026, 5, 18, 12, 0
     )
-    assert _hash_value(Decimal("1.20")) == "1.20"
+    assert hash_value(Decimal("1.20")) == "1.20"
 
 
 def test_coercion_helpers_reject_invalid_values() -> None:
     with pytest.raises(ValueError, match="Unsupported date value"):
-        _coerce_date(123)
+        coerce_date(123)
 
     with pytest.raises(ValueError, match="Unsupported datetime value"):
-        _coerce_datetime(123)
+        coerce_datetime(123)
 
 
 def test_start_date_from_state_uses_overlap() -> None:

--- a/cost-insight/tests/test_sync_gcp_billing_summary.py
+++ b/cost-insight/tests/test_sync_gcp_billing_summary.py
@@ -1,0 +1,174 @@
+from datetime import date
+
+from sqlalchemy import create_engine, text
+
+from cost_insight.common.config import GcpBillingSettings
+from cost_insight.jobs import state_store
+from cost_insight.jobs.sync_gcp_billing_summary import (
+    JOB_NAME,
+    _normalize_summary_row,
+    _start_partition_from_state,
+    build_summary_row_hash,
+    run_sync_gcp_billing_summary,
+)
+
+
+def _sqlite_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cost_sources (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  vendor TEXT NOT NULL,
+                  account_id TEXT NOT NULL,
+                  billing_account_id TEXT,
+                  display_name TEXT,
+                  is_active INTEGER NOT NULL DEFAULT 1,
+                  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  UNIQUE(vendor, account_id)
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cost_job_state (
+                  job_name TEXT PRIMARY KEY,
+                  watermark_json TEXT,
+                  last_started_at TEXT,
+                  last_succeeded_at TEXT,
+                  last_status TEXT,
+                  last_error TEXT,
+                  updated_at TEXT
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cost_bq_export_summary_daily (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  vendor TEXT NOT NULL,
+                  account_id TEXT NOT NULL,
+                  billing_account_id TEXT,
+                  export_partition_date TEXT NOT NULL,
+                  usage_date TEXT NOT NULL,
+                  org TEXT,
+                  repo TEXT,
+                  author TEXT,
+                  list_cost REAL,
+                  effective_cost REAL,
+                  credit_amount REAL,
+                  net_cost REAL,
+                  source_export_time TEXT,
+                  source_row_hash TEXT NOT NULL,
+                  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  UNIQUE(vendor, account_id, export_partition_date, source_row_hash)
+                )
+                """
+            )
+        )
+    return engine
+
+
+def _summary_row(day: str = "2026-05-18") -> dict[str, object]:
+    return {
+        "vendor": "gcp",
+        "account_id": "pingcap-testing-account",
+        "billing_account_id": "billing-1",
+        "export_partition_date": day,
+        "usage_date": day,
+        "author": "hawkingrei",
+        "org": "pingcap",
+        "repo": "tidb",
+        "list_cost": "10.00",
+        "effective_cost": "8.00",
+        "credit_amount": "-1.00",
+        "net_cost": "7.00",
+        "source_export_time": "2026-05-19T01:02:03Z",
+    }
+
+
+def test_start_partition_from_state_uses_export_overlap() -> None:
+    assert _start_partition_from_state(
+        {},
+        end_date=date(2026, 5, 20),
+        overlap_days=0,
+        initial_lookback_days=None,
+    ) == date(2026, 5, 20)
+    assert _start_partition_from_state(
+        {},
+        end_date=date(2026, 5, 20),
+        overlap_days=0,
+        initial_lookback_days=7,
+    ) == date(2026, 5, 14)
+    assert _start_partition_from_state(
+        {"export_partition_end": "2026-05-18"},
+        end_date=date(2026, 5, 20),
+        overlap_days=1,
+        initial_lookback_days=None,
+    ) == date(2026, 5, 18)
+
+
+def test_summary_hash_ignores_amount_changes() -> None:
+    row = _normalize_summary_row(_summary_row())
+    changed = {**row, "net_cost": "99.00"}
+
+    assert build_summary_row_hash(row) == build_summary_row_hash(changed)
+
+
+def test_run_sync_gcp_billing_summary_writes_rows_and_touched_dates() -> None:
+    engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account", page_size=2)
+
+    try:
+        summary = run_sync_gcp_billing_summary(
+            engine,
+            settings=settings,
+            export_partition_start=date(2026, 5, 18),
+            export_partition_end=date(2026, 5, 19),
+            dry_run=False,
+            fetch_rows=lambda **_kwargs: [_summary_row("2026-05-18"), _summary_row("2026-05-19")],
+        )
+
+        assert summary.rows_seen == 2
+        assert summary.rows_written == 2
+        assert summary.touched_usage_dates == (date(2026, 5, 18), date(2026, 5, 19))
+        with engine.begin() as connection:
+            count = connection.execute(
+                text("SELECT COUNT(*) FROM cost_bq_export_summary_daily")
+            ).scalar_one()
+            state = state_store.get_job_state(connection, JOB_NAME)
+        assert count == 2
+        assert state is not None
+        assert state.last_status == "succeeded"
+    finally:
+        engine.dispose()
+
+
+def test_run_sync_gcp_billing_summary_dry_run_skips_state() -> None:
+    engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account")
+
+    try:
+        summary = run_sync_gcp_billing_summary(
+            engine,
+            settings=settings,
+            export_partition_start=date(2026, 5, 18),
+            export_partition_end=date(2026, 5, 18),
+            dry_run=True,
+            fetch_rows=lambda **_kwargs: [_summary_row()],
+        )
+
+        assert summary.rows_seen == 1
+        assert summary.rows_written == 0
+        with engine.begin() as connection:
+            assert state_store.get_job_state(connection, JOB_NAME) is None
+    finally:
+        engine.dispose()

--- a/cost-insight/tests/test_sync_gcp_billing_summary.py
+++ b/cost-insight/tests/test_sync_gcp_billing_summary.py
@@ -7,6 +7,7 @@ from cost_insight.jobs import state_store
 from cost_insight.jobs.sync_gcp_billing_summary import (
     JOB_NAME,
     _normalize_summary_row,
+    _select_billing_account_id,
     _start_partition_from_state,
     build_summary_row_hash,
     run_sync_gcp_billing_summary,
@@ -121,6 +122,11 @@ def test_summary_hash_ignores_amount_changes() -> None:
     changed = {**row, "net_cost": "99.00"}
 
     assert build_summary_row_hash(row) == build_summary_row_hash(changed)
+
+
+def test_select_billing_account_id_handles_empty_and_multiple_values() -> None:
+    assert _select_billing_account_id(set()) is None
+    assert _select_billing_account_id({"billing-2", "billing-1"}) == "billing-1"
 
 
 def test_run_sync_gcp_billing_summary_writes_rows_and_touched_dates() -> None:

--- a/cost-insight/tests/test_sync_gcp_unmatched_resources.py
+++ b/cost-insight/tests/test_sync_gcp_unmatched_resources.py
@@ -1,0 +1,166 @@
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from cost_insight.common.config import GcpBillingSettings
+from cost_insight.jobs import state_store
+from cost_insight.jobs.sync_gcp_unmatched_resources import (
+    JOB_NAME,
+    _normalize_resource_row,
+    build_unmatched_resource_row_hash,
+    run_sync_gcp_unmatched_resources,
+)
+
+
+def _sqlite_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cost_sources (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  vendor TEXT NOT NULL,
+                  account_id TEXT NOT NULL,
+                  billing_account_id TEXT,
+                  display_name TEXT,
+                  is_active INTEGER NOT NULL DEFAULT 1,
+                  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  UNIQUE(vendor, account_id)
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cost_job_state (
+                  job_name TEXT PRIMARY KEY,
+                  watermark_json TEXT,
+                  last_started_at TEXT,
+                  last_succeeded_at TEXT,
+                  last_status TEXT,
+                  last_error TEXT,
+                  updated_at TEXT
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cost_unmatched_resource_daily (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  vendor TEXT NOT NULL,
+                  account_id TEXT NOT NULL,
+                  billing_account_id TEXT,
+                  export_partition_date TEXT NOT NULL,
+                  usage_date TEXT NOT NULL,
+                  service_name TEXT,
+                  sku_name TEXT,
+                  namespace TEXT,
+                  org TEXT,
+                  repo TEXT,
+                  author TEXT,
+                  resource_name TEXT NOT NULL,
+                  usage_seconds REAL,
+                  list_cost REAL,
+                  effective_cost REAL,
+                  credit_amount REAL,
+                  net_cost REAL,
+                  source_export_time TEXT,
+                  source_row_hash TEXT NOT NULL,
+                  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  UNIQUE(vendor, account_id, export_partition_date, source_row_hash)
+                )
+                """
+            )
+        )
+    return engine
+
+
+def _resource_row() -> dict[str, object]:
+    return {
+        "vendor": "gcp",
+        "account_id": "pingcap-testing-account",
+        "billing_account_id": "billing-1",
+        "export_partition_date": "2026-05-20",
+        "usage_date": "2026-05-18",
+        "service_name": "Compute Engine",
+        "sku_name": "Core running",
+        "namespace": "kube:unallocated",
+        "author": "hawkingrei",
+        "org": "pingcap",
+        "repo": "tidb",
+        "resource_name": "tidb-test-pod-1",
+        "usage_seconds": "3600.00",
+        "list_cost": "10.00",
+        "effective_cost": "8.00",
+        "credit_amount": "-1.00",
+        "net_cost": "7.00",
+        "source_export_time": "2026-05-20T01:02:03Z",
+    }
+
+
+def test_unmatched_resource_hash_ignores_amount_changes() -> None:
+    row = _normalize_resource_row(_resource_row())
+    changed = {**row, "net_cost": "99.00"}
+
+    assert build_unmatched_resource_row_hash(row) == build_unmatched_resource_row_hash(changed)
+
+
+def test_normalize_resource_row_rejects_missing_resource_name() -> None:
+    row = {**_resource_row(), "resource_name": ""}
+
+    with pytest.raises(ValueError, match="Missing resource_name"):
+        _normalize_resource_row(row)
+
+
+def test_run_sync_gcp_unmatched_resources_writes_rows() -> None:
+    engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account", page_size=1)
+
+    try:
+        summary = run_sync_gcp_unmatched_resources(
+            engine,
+            settings=settings,
+            usage_start_date=date(2026, 5, 18),
+            usage_end_date=date(2026, 5, 18),
+            dry_run=False,
+            fetch_rows=lambda **_kwargs: [_resource_row()],
+        )
+
+        assert summary.export_partition_start == date(2026, 5, 18)
+        assert summary.export_partition_end == date(2026, 5, 23)
+        assert summary.rows_seen == 1
+        assert summary.rows_written == 1
+        with engine.begin() as connection:
+            count = connection.execute(
+                text("SELECT COUNT(*) FROM cost_unmatched_resource_daily")
+            ).scalar_one()
+            state = state_store.get_job_state(connection, JOB_NAME)
+        assert count == 1
+        assert state is not None
+        assert state.last_status == "succeeded"
+    finally:
+        engine.dispose()
+
+
+def test_run_sync_gcp_unmatched_resources_rejects_invalid_range() -> None:
+    engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account")
+
+    try:
+        with pytest.raises(ValueError, match="usage_start_date"):
+            run_sync_gcp_unmatched_resources(
+                engine,
+                settings=settings,
+                usage_start_date=date(2026, 5, 19),
+                usage_end_date=date(2026, 5, 18),
+                fetch_rows=lambda **_kwargs: [],
+            )
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Summary
- Add a BigQuery cost-optimized pipeline that imports summary billing rows into `cost_bq_export_summary_daily` and rebuilds `cost_attribution_daily` from that summary layer.
- Add a separate weekly `cost_unmatched_resource_daily` import for resource-level investigation data.
- Move the dashboard unmatched resource query away from `cost_raw_details` and onto `cost_unmatched_resource_daily` joined with roster-aware attribution.
- Add a local `backfill-gcp-cost-refine-from-raw` command so this year's data can be seeded from existing TiDB raw rows without re-querying BigQuery.

## Rollout Plan
1. Deploy the SQL migration `cost-insight/sql/003_create_cost_refine_tables.sql` to create `cost_bq_export_summary_daily` and `cost_unmatched_resource_daily`.
2. Backfill this year's historical data from existing TiDB raw rows, not BigQuery:
   ```bash
   cost-insight backfill-gcp-cost-refine-from-raw \
     --start-date 2026-01-01 \
     --end-date <cutover-stable-date> \
     --mark-summary-watermark
   ```
3. Rebuild attribution from summary for the backfilled range if we want the new serving path fully active for history:
   ```bash
   cost-insight refresh-cost-attribution-from-summary \
     --start-date 2026-01-01 \
     --end-date <cutover-stable-date> \
     --split-by-day
   ```
4. Run the weekly resource context import for the latest stable usage week:
   ```bash
   cost-insight sync-gcp-unmatched-resources \
     --usage-start-date <week-start> \
     --usage-end-date <week-end>
   ```
5. Switch the regular collector schedule from `sync-gcp-billing-export` to `sync-gcp-billing-summary`, then refresh attribution for touched usage dates using `refresh-cost-attribution-from-summary`.
6. Keep `cost_raw_details` and the old raw sync job available for rollback during a short observation window, but stop scheduling the raw collector once summary numbers are validated.
7. After validation, archive or drop `cost_raw_details` in a separate cleanup PR/migration.

## Verification
- `python -m pytest --no-cov` in `cost-insight`: 67 passed
- `PYTHONPATH=src python -m pytest tests/api/test_routes.py -q` in `ci-dashboard`: 29 passed
- `python -m ruff check cost-insight ci-dashboard/src/ci_dashboard/api/queries/cost.py ci-dashboard/tests/conftest.py ci-dashboard/tests/api/test_routes.py`
- `git diff --check`
