### PR TITLE
feat(cost): cost dashboard add weekly summary and revise cost data

### DIFF
--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-dashboard"
-version = "0.3.3"
+version = "0.3.5"
 description = "CI dashboard jobs and API scaffold"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
+++ b/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: ci-dashboard
-Version: 0.3.2
+Version: 0.3.5
 Summary: CI dashboard jobs and API scaffold
 Requires-Python: >=3.11
 Description-Content-Type: text/markdown

--- a/ci-dashboard/src/ci_dashboard/__init__.py
+++ b/ci-dashboard/src/ci_dashboard/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.3"
+__version__ = "0.3.5"

--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -129,6 +129,107 @@ def get_cost_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     }
 
 
+def get_weekly_overview(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    cost_filters = _cost_filters(filters)
+    previous_start, previous_end = _previous_window(cost_filters)
+    previous_filters = CommonFilters(
+        start_date=previous_start,
+        end_date=previous_end,
+        granularity=cost_filters.granularity,
+    )
+    if engine.dialect.name == "sqlite":
+        with engine.begin() as connection:
+            current_summary = _cost_summary(connection, cost_filters)
+            previous_summary = _cost_summary(connection, previous_filters)
+            service_share = _service_share_by_threshold(
+                connection,
+                cost_filters,
+                min_share_pct=1.0,
+            )
+            level2_share = _engineering_share_by_level_threshold(
+                connection,
+                cost_filters,
+                level=2,
+                min_share_pct=1.0,
+            )
+    else:
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = {
+                "current_summary": executor.submit(_get_cost_summary, engine, cost_filters),
+                "previous_summary": executor.submit(_get_cost_summary, engine, previous_filters),
+                "service_share": executor.submit(
+                    _get_service_share_by_threshold,
+                    engine,
+                    cost_filters,
+                    min_share_pct=1.0,
+                ),
+                "level2_share": executor.submit(
+                    _get_engineering_share_by_level_threshold,
+                    engine,
+                    cost_filters,
+                    level=2,
+                    min_share_pct=1.0,
+                ),
+            }
+            sections = {name: future.result() for name, future in futures.items()}
+        current_summary = sections["current_summary"]
+        previous_summary = sections["previous_summary"]
+        service_share = sections["service_share"]
+        level2_share = sections["level2_share"]
+
+    return {
+        "scope": cost_filters.meta(),
+        "previous_scope": previous_filters.meta(),
+        "summary": {
+            "list_cost": current_summary["list_cost"],
+            "net_cost": current_summary["net_cost"],
+            "previous_list_cost": previous_summary["list_cost"],
+            "previous_net_cost": previous_summary["net_cost"],
+            "list_cost_wow_pct": rate_pct(
+                current_summary["list_cost"] - previous_summary["list_cost"],
+                previous_summary["list_cost"],
+            ),
+            "net_cost_wow_pct": rate_pct(
+                current_summary["net_cost"] - previous_summary["net_cost"],
+                previous_summary["net_cost"],
+            ),
+        },
+        "service_share": service_share,
+        "level2_share": level2_share,
+    }
+
+
+def _get_cost_summary(engine: Engine, filters: CommonFilters) -> dict[str, float]:
+    with engine.begin() as connection:
+        return _cost_summary(connection, filters)
+
+
+def _get_service_share_by_threshold(
+    engine: Engine,
+    filters: CommonFilters,
+    *,
+    min_share_pct: float,
+) -> dict[str, Any]:
+    with engine.begin() as connection:
+        return _service_share_by_threshold(connection, filters, min_share_pct=min_share_pct)
+
+
+def _get_engineering_share_by_level_threshold(
+    engine: Engine,
+    filters: CommonFilters,
+    *,
+    level: int,
+    min_share_pct: float,
+) -> dict[str, Any]:
+    with engine.begin() as connection:
+        return _engineering_share_by_level_threshold(
+            connection,
+            filters,
+            level=level,
+            min_share_pct=min_share_pct,
+        )
+
+
 def get_repo_group_cost_stack(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
     with engine.begin() as connection:
         where_clause, params = _build_cost_where(filters, table_alias="c")
@@ -459,6 +560,160 @@ def _engineering_share_by_level(
             "total_list_cost": round(total, 2),
         },
     }
+
+
+def _engineering_share_by_level_threshold(
+    connection: Connection,
+    filters: CommonFilters,
+    *,
+    level: int,
+    min_share_pct: float,
+) -> dict[str, Any]:
+    root = connection.execute(
+        text(
+            """
+            SELECT id, path
+            FROM roster_groups
+            WHERE name = :group_name
+              AND is_active = 1
+            ORDER BY id
+            LIMIT 1
+            """
+        ),
+        {"group_name": ENGINEERING_GROUP_NAME},
+    ).mappings().first()
+    if root is None:
+        return {
+            "items": [],
+            "meta": {
+                **filters.meta(),
+                "group_name": ENGINEERING_GROUP_NAME,
+                "level": level,
+                "min_share_pct": min_share_pct,
+                "total_list_cost": 0.0,
+            },
+        }
+
+    share = _engineering_share_by_level(connection, filters, root, level=level)
+    return {
+        "items": _share_items_above_threshold_with_others(
+            share["items"],
+            min_share_pct=min_share_pct,
+            total=_number_or_zero(share["meta"].get("total_list_cost")),
+        ),
+        "meta": {
+            **share["meta"],
+            "min_share_pct": min_share_pct,
+        },
+    }
+
+
+def _cost_summary(connection: Connection, filters: CommonFilters) -> dict[str, float]:
+    where_clause, params = _build_cost_where(filters, table_alias="c")
+    row = connection.execute(
+        text(
+            f"""
+            SELECT
+              SUM(c.list_cost) AS list_cost,
+              SUM(c.net_cost) AS net_cost
+            FROM cost_attribution_daily c
+            WHERE {where_clause}
+            """
+        ),
+        params,
+    ).mappings().first()
+    return {
+        "list_cost": _money(row["list_cost"]) if row else 0.0,
+        "net_cost": _money(row["net_cost"]) if row else 0.0,
+    }
+
+
+def _service_share_by_threshold(
+    connection: Connection,
+    filters: CommonFilters,
+    *,
+    min_share_pct: float,
+) -> dict[str, Any]:
+    where_clause, params = _build_cost_where(filters, table_alias="c")
+    rows = connection.execute(
+        text(
+            f"""
+            SELECT
+              COALESCE(NULLIF(c.service_name, ''), '(no service)') AS service_name,
+              SUM(c.list_cost) AS list_cost
+            FROM cost_attribution_daily c
+            WHERE {where_clause}
+            GROUP BY service_name
+            ORDER BY list_cost DESC, service_name
+            """
+        ),
+        params,
+    ).mappings()
+    all_items = [
+        {
+            "name": str(row["service_name"]),
+            "value": _money(row["list_cost"]),
+        }
+        for row in rows
+    ]
+    total = sum(item["value"] for item in all_items)
+    for item in all_items:
+        item["share_pct"] = rate_pct(item["value"], total)
+        item["interactive"] = False
+    return {
+        "items": _share_items_above_threshold_with_others(
+            all_items,
+            min_share_pct=min_share_pct,
+            total=total,
+        ),
+        "meta": {
+            **filters.meta(),
+            "min_share_pct": min_share_pct,
+            "total_list_cost": round(total, 2),
+        },
+    }
+
+
+def _share_items_above_threshold_with_others(
+    all_items: list[dict[str, Any]],
+    *,
+    min_share_pct: float,
+    total: float,
+) -> list[dict[str, Any]]:
+    items = [
+        item
+        for item in all_items
+        if _number_or_zero(item.get("share_pct")) > min_share_pct
+    ]
+    if len(items) == len(all_items):
+        return items
+
+    others_value = total - sum(_number_or_zero(item.get("value")) for item in items)
+    if others_value <= 0:
+        return items
+
+    return [
+        *items,
+        {
+            "name": "Others",
+            "value": _money(others_value),
+            "share_pct": rate_pct(others_value, total),
+            "interactive": False,
+        },
+    ]
+
+
+def _previous_window(filters: CommonFilters) -> tuple[date | None, date | None]:
+    if filters.start_date is None or filters.end_date is None:
+        return None, None
+    span_days = max((filters.end_date - filters.start_date).days + 1, 1)
+    previous_end = filters.start_date - timedelta(days=1)
+    previous_start = previous_end - timedelta(days=span_days - 1)
+    return previous_start, previous_end
+
+
+def _number_or_zero(value: Any) -> float:
+    return float(to_number(value) or 0)
 
 
 def _cost_filters(filters: CommonFilters) -> CommonFilters:

--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -24,6 +24,7 @@ from ci_dashboard.api.queries.cost import (
     get_engineering_group_share,
     get_repo_group_cost_stack,
     get_unmatched_resources,
+    get_weekly_overview,
 )
 from ci_dashboard.api.queries.failures import (
     get_failure_category_share,
@@ -232,6 +233,13 @@ def get_cost_trend_page(
     filters: CommonFilters,
 ) -> dict[str, Any]:
     return get_cost_trend(engine, _normalize_cost_filters(filters))
+
+
+def get_cost_weekly_overview_page(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any]:
+    return get_weekly_overview(engine, _normalize_cost_filters(filters))
 
 
 def get_cost_repo_group_stack_page(

--- a/ci-dashboard/src/ci_dashboard/api/routes/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/pages.py
@@ -13,6 +13,7 @@ from ci_dashboard.api.queries.pages import (
     get_cost_repo_group_stack_page,
     get_cost_trend_page,
     get_cost_unmatched_resources_page,
+    get_cost_weekly_overview_page,
     get_flaky_page,
     get_overview_page,
     get_runtime_insights_page,
@@ -81,6 +82,14 @@ def cost_trend_page(
     engine: Engine = Depends(get_engine),
 ) -> dict[str, object]:
     return get_cost_trend_page(engine, filters)
+
+
+@router.get("/cost-weekly-overview")
+def cost_weekly_overview_page(
+    filters: CommonFilters = Depends(get_common_filters),
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return get_cost_weekly_overview_page(engine, filters)
 
 
 @router.get("/cost-repo-group-stack")

--- a/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
+++ b/ci-dashboard/src/ci_dashboard/jobs/error_taxonomy.json
@@ -456,7 +456,9 @@
         "Failed in branch Matrix - [^\\r\\n]+[\\s\\S]*TEST FAILED: OUTPUT (?:DOES NOT CONTAIN|CONTAINS)",
         "Failed in branch Matrix - [^\\r\\n]+[\\s\\S]*org\\.jooq\\.exception\\.DataAccessException: SQL \\[[^\\r\\n]+Duplicate entry",
         "Failed in branch Matrix - [^\\r\\n]+[\\s\\S]*SQLIntegrityConstraintViolationException: Duplicate entry",
-        "Failed in branch Matrix - [^\\r\\n]+[\\s\\S]*(?:retryable storage error|store backup failed|\\[BR:Common:ErrFailedToConnect\\] failed to make connection to store|\\[health check\\] check health error)"
+        "Failed in branch Matrix - [^\\r\\n]+[\\s\\S]*(?:retryable storage error|store backup failed|\\[BR:Common:ErrFailedToConnect\\] failed to make connection to store|\\[health check\\] check health error)",
+        "(?:org\\.jooq\\.exception\\.DataAccessException: SQL \\[[^\\r\\n]+Duplicate entry|SQLIntegrityConstraintViolationException: Duplicate entry)[\\s\\S]*Failed in branch Matrix - [^\\r\\n]+",
+        "(?:retryable storage error|store backup failed|\\[BR:Common:ErrFailedToConnect\\] failed to make connection to store|\\[health check\\] check health error)[\\s\\S]*Failed in branch Matrix - [^\\r\\n]+"
       ]
     },
     {

--- a/ci-dashboard/src/ci_dashboard/jobs/sync_pods.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/sync_pods.py
@@ -297,9 +297,18 @@ def run_sync_pods(engine: Engine, settings: Settings) -> SyncPodsSummary:
         if affected_pods:
             pod_metadata_by_identity = _load_pod_metadata_snapshots(sorted(affected_pods))
             if any(_infer_pod_build_system(namespace_name) == "JENKINS" for _, namespace_name, _, _ in affected_pods):
+                jenkins_event_times = [
+                    row.event_timestamp
+                    for row in normalized_rows
+                    if _infer_pod_build_system(row.namespace_name) == "JENKINS"
+                ]
+                jenkins_reference_time = min(jenkins_event_times) if jenkins_event_times else None
                 with engine.begin() as connection:
                     # Learn the prefix mapping once per run instead of rescanning build history per lifecycle batch.
-                    jenkins_pod_name_url_prefixes = _load_jenkins_pod_name_url_prefix_map(connection)
+                    jenkins_pod_name_url_prefixes = _load_jenkins_pod_name_url_prefix_map_for_reference(
+                        connection,
+                        reference_time=jenkins_reference_time,
+                    )
             for group in chunked(sorted(affected_pods), settings.jobs.batch_size):
                 with engine.begin() as connection:
                     lifecycle_rows = _build_lifecycle_rows(
@@ -1081,6 +1090,18 @@ def _null_safe_equals_sql(left: str, right: str, dialect_name: str) -> str:
     return f"{left} <=> {right}"
 
 
+def _datetime_lower_bound_sql(column: str, parameter: str, dialect_name: str) -> str:
+    if dialect_name == "sqlite":
+        return f"datetime({column}) >= datetime({parameter})"
+    return f"{column} >= {parameter}"
+
+
+def _datetime_upper_bound_sql(column: str, parameter: str, dialect_name: str) -> str:
+    if dialect_name == "sqlite":
+        return f"datetime({column}) < datetime({parameter})"
+    return f"{column} < {parameter}"
+
+
 def _load_build_metadata_map(
     connection: Connection,
     lifecycle_rows: list[dict[str, Any]],
@@ -1124,9 +1145,18 @@ def _load_build_metadata_map(
 
     if jenkins_rows_by_identity:
         pod_name_url_prefixes = jenkins_pod_name_url_prefixes
-        if pod_name_url_prefixes is None:
-            pod_name_url_prefixes = _load_jenkins_pod_name_url_prefix_map(connection)
         candidate_urls_by_identity: dict[tuple[str, str | None, str | None, str | None], list[str]] = {}
+        jenkins_scheduled_ats = [
+            payload.get("scheduled_at")
+            for payload in jenkins_rows_by_identity.values()
+            if isinstance(payload.get("scheduled_at"), datetime)
+        ]
+        earliest_scheduled = min(jenkins_scheduled_ats) if jenkins_scheduled_ats else None
+        if pod_name_url_prefixes is None:
+            pod_name_url_prefixes = _load_jenkins_pod_name_url_prefix_map_for_reference(
+                connection,
+                reference_time=earliest_scheduled,
+            )
         for identity, payload in jenkins_rows_by_identity.items():
             candidate_urls: list[str] = []
             metadata_url = _extract_normalized_build_url_from_metadata(payload.get("pod_metadata"))
@@ -1144,13 +1174,7 @@ def _load_build_metadata_map(
             if candidate_urls:
                 candidate_urls_by_identity[identity] = candidate_urls
 
-        jenkins_scheduled_ats = [
-            payload.get("scheduled_at")
-            for payload in jenkins_rows_by_identity.values()
-            if isinstance(payload.get("scheduled_at"), datetime)
-        ]
-        if jenkins_scheduled_ats:
-            earliest_scheduled = min(jenkins_scheduled_ats)
+        if earliest_scheduled:
             lookback_days = _read_int_env(
                 "CI_DASHBOARD_BUILD_URL_LOOKBACK_DAYS",
                 BUILD_URL_LOOKBACK_DAYS,
@@ -1262,6 +1286,11 @@ def _load_build_candidates_by_normalized_url(
         placeholders.append(f":{param_name}")
         params[param_name] = normalized_build_url
 
+    start_time_clause = _datetime_lower_bound_sql(
+        "start_time",
+        ":start_time_cutoff",
+        connection.dialect.name,
+    )
     rows = connection.execute(
         text(
             f"""
@@ -1277,7 +1306,7 @@ def _load_build_candidates_by_normalized_url(
             FROM ci_l1_builds
             WHERE normalized_build_url IS NOT NULL
               AND normalized_build_url IN ({", ".join(placeholders)})
-              AND start_time >= :start_time_cutoff
+              AND {start_time_clause}
             ORDER BY start_time DESC
             """
         ),
@@ -1293,15 +1322,37 @@ def _load_build_candidates_by_normalized_url(
     return dict(grouped)
 
 
-def _load_jenkins_pod_name_url_prefix_map(connection: Connection) -> dict[str, str]:
+def _load_jenkins_pod_name_url_prefix_map_for_reference(
+    connection: Connection,
+    *,
+    reference_time: datetime | None,
+) -> dict[str, str]:
+    try:
+        return _load_jenkins_pod_name_url_prefix_map(
+            connection,
+            reference_time=reference_time,
+        )
+    except TypeError as exc:
+        if "reference_time" not in str(exc):
+            raise
+        return _load_jenkins_pod_name_url_prefix_map(connection)
+
+
+def _load_jenkins_pod_name_url_prefix_map(
+    connection: Connection,
+    *,
+    reference_time: datetime | None = None,
+) -> dict[str, str]:
     lookback_days = _read_int_env(
         "CI_DASHBOARD_JENKINS_POD_NAME_PREFIX_LOOKBACK_DAYS",
         JENKINS_POD_NAME_PREFIX_LOOKBACK_DAYS,
     )
-    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=lookback_days)
+    resolved_reference_time = reference_time or datetime.now(UTC).replace(tzinfo=None)
+    cutoff = resolved_reference_time - timedelta(days=lookback_days)
+    start_time_clause = _datetime_lower_bound_sql("start_time", ":cutoff", connection.dialect.name)
     rows = connection.execute(
         text(
-            """
+            f"""
             SELECT
               pod_name,
               normalized_build_url,
@@ -1310,7 +1361,7 @@ def _load_jenkins_pod_name_url_prefix_map(connection: Connection) -> dict[str, s
             WHERE build_system = 'JENKINS'
               AND pod_name IS NOT NULL
               AND normalized_build_url IS NOT NULL
-              AND start_time >= :cutoff
+              AND {start_time_clause}
             ORDER BY start_time DESC
             """
         ),
@@ -1746,7 +1797,10 @@ def _reconcile_lifecycle_rows_in_time_window(
             _infer_pod_build_system(_coerce_str(lifecycle.get("namespace_name"))) == "JENKINS"
             for lifecycle in lifecycle_rows
         ):
-            cached_prefix_map = _load_jenkins_pod_name_url_prefix_map(connection)
+            cached_prefix_map = _load_jenkins_pod_name_url_prefix_map_for_reference(
+                connection,
+                reference_time=start_time_to or start_time_from,
+            )
 
         pod_metadata_by_identity = _deserialize_pod_metadata_snapshots_from_lifecycle_rows(lifecycle_rows)
         build_metadata_by_identity = _load_build_metadata_map(
@@ -1862,8 +1916,15 @@ def _load_lifecycle_rows_for_reconcile(
     }
     end_clause = ""
     if start_time_to is not None:
-        end_clause = "  AND scheduled_at < :start_time_to\n"
+        end_clause = (
+            f"  AND {_datetime_upper_bound_sql('scheduled_at', ':start_time_to', connection.dialect.name)}\n"
+        )
         params["start_time_to"] = start_time_to
+    start_time_from_clause = _datetime_lower_bound_sql(
+        "scheduled_at",
+        ":start_time_from",
+        connection.dialect.name,
+    )
 
     rows = connection.execute(
         text(
@@ -1888,7 +1949,7 @@ def _load_lifecycle_rows_for_reconcile(
               repo_full_name,
               job_name
             FROM ci_l1_pod_lifecycle
-            WHERE scheduled_at >= :start_time_from
+            WHERE {start_time_from_clause}
 {end_clause}              AND id > :after_lifecycle_id
               AND (
                 source_prow_job_id IS NULL

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -420,6 +420,7 @@ def _insert_cost_attribution(
     attribution_status: str = "matched",
     employee_id: int | None = 1,
     usage_seconds: float = 3600,
+    service_name: str = "Compute Engine",
 ) -> None:
     with sqlite_engine.begin() as connection:
         connection.execute(
@@ -431,7 +432,7 @@ def _insert_cost_attribution(
                   attribution_status, employee_id, group_id, manager_id, usage_seconds,
                   list_cost, effective_cost, credit_amount, net_cost, source_rows, dimension_hash
                 ) VALUES (
-                  :usage_date, 'gcp', 'pingcap-testing-account', 'Compute Engine', 'runner',
+                  :usage_date, 'gcp', 'pingcap-testing-account', :service_name, 'runner',
                   'pingcap', :repo, :resource_name, :author, :owner, :attribution_key, :attribution_source,
                   :attribution_status, :employee_id, :group_id, NULL, :usage_seconds, :list_cost, :effective_cost,
                   0, :net_cost, 1, :dimension_hash
@@ -450,6 +451,7 @@ def _insert_cost_attribution(
                 "attribution_status": attribution_status,
                 "employee_id": employee_id,
                 "usage_seconds": usage_seconds,
+                "service_name": service_name,
                 "list_cost": list_cost if list_cost is not None else net_cost,
                 "effective_cost": effective_cost if effective_cost is not None else net_cost,
                 "net_cost": net_cost,
@@ -2449,6 +2451,109 @@ def test_cost_page_supporting_routes(sqlite_engine, api_client: TestClient) -> N
     ]
 
 
+def test_cost_weekly_overview_route(sqlite_engine, api_client: TestClient) -> None:
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=100,
+        lark_group_id="eng",
+        name="Engineering Group",
+        path="/100/",
+    )
+    for group_id, lark_group_id, name, parent_id, path in [
+        (110, "database", "Database", 100, "/100/110/"),
+        (111, "tidb", "TiDB", 110, "/100/110/111/"),
+        (112, "storage", "Storage", 110, "/100/110/112/"),
+        (120, "infra", "Infra", 100, "/100/120/"),
+        (121, "platform", "Platform", 120, "/100/120/121/"),
+        (122, "data", "Data", 120, "/100/120/122/"),
+        (123, "tiny-parent", "Tiny Parent", 100, "/100/123/"),
+        (124, "tiny", "Tiny", 123, "/100/123/124/"),
+    ]:
+        _insert_roster_group(
+            sqlite_engine,
+            group_id=group_id,
+            lark_group_id=lark_group_id,
+            name=name,
+            parent_id=parent_id,
+            path=path,
+        )
+
+    for service_name, group_id, list_cost, net_cost in [
+        ("Compute Engine", 111, 490, 330),
+        ("Cloud Storage", 112, 250, 175),
+        ("Cloud SQL", 121, 100, 70),
+        ("BigQuery", 122, 80, 56),
+        ("Networking", 111, 70, 49),
+        ("Cloud Monitoring", 111, 20, 0),
+        ("Cloud Logging", 124, 10, 20),
+    ]:
+        _insert_cost_attribution(
+            sqlite_engine,
+            usage_date="2026-05-18",
+            repo="tidb",
+            group_id=group_id,
+            list_cost=list_cost,
+            net_cost=net_cost,
+            service_name=service_name,
+            dimension_hash=f"current-{service_name}",
+        )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-12",
+        repo="tidb",
+        group_id=111,
+        list_cost=500,
+        net_cost=350,
+        service_name="Compute Engine",
+        dimension_hash="previous-compute",
+    )
+
+    response = api_client.get(
+        "/api/v1/pages/cost-weekly-overview",
+        params={
+            "start_date": "2026-05-16",
+            "end_date": "2026-05-22",
+            "granularity": "day",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scope"]["start_date"] == "2026-05-16"
+    assert body["scope"]["end_date"] == "2026-05-22"
+    assert body["scope"]["granularity"] == "week"
+    assert body["previous_scope"]["start_date"] == "2026-05-09"
+    assert body["previous_scope"]["end_date"] == "2026-05-15"
+    assert body["summary"] == {
+        "list_cost": 1020.0,
+        "net_cost": 700.0,
+        "previous_list_cost": 500.0,
+        "previous_net_cost": 350.0,
+        "list_cost_wow_pct": 104.0,
+        "net_cost_wow_pct": 100.0,
+    }
+    assert [item["name"] for item in body["service_share"]["items"]] == [
+        "Compute Engine",
+        "Cloud Storage",
+        "Cloud SQL",
+        "BigQuery",
+        "Networking",
+        "Cloud Monitoring",
+        "Others",
+    ]
+    service_others = body["service_share"]["items"][-1]
+    assert service_others["name"] == "Others"
+    assert service_others["value"] == 10.0
+    assert service_others["share_pct"] == pytest.approx(0.98)
+    assert service_others["interactive"] is False
+    assert body["service_share"]["meta"]["min_share_pct"] == 1.0
+    assert body["service_share"]["meta"]["total_list_cost"] == 1020.0
+    level2_names = [item["name"] for item in body["level2_share"]["items"]]
+    assert level2_names == ["TiDB", "Storage", "Platform", "Data", "Others"]
+    assert "Tiny" not in level2_names
+    assert body["level2_share"]["items"][-1]["value"] == 10.0
+
+
 def test_cost_query_page_helpers_cover_parallel_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     assert page_queries._get_previous_date_range(CommonFilters()) == (None, None)
     assert page_queries._get_previous_date_range(
@@ -2557,6 +2662,79 @@ def test_get_cost_page_parallelizes_for_non_sqlite(monkeypatch: pytest.MonkeyPat
     assert result["repo_group_stack"] == {"name": "stack", "granularity": "week"}
     assert result["engineering_group_share"] == {"name": "share", "granularity": "week"}
     assert captured_granularities == ["week", "week", "week"]
+
+
+def test_get_weekly_overview_parallelizes_for_non_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _ImmediateFuture:
+        def __init__(self, value):
+            self._value = value
+
+        def result(self):
+            return self._value
+
+    class _InlineExecutor:
+        def __init__(self, *, max_workers: int):
+            self.max_workers = max_workers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def submit(self, task, *args, **kwargs):
+            return _ImmediateFuture(task(*args, **kwargs))
+
+    class _Begin:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class _Engine:
+        dialect = SimpleNamespace(name="mysql")
+
+        def begin(self):
+            return _Begin()
+
+    def _summary(_connection, filters: CommonFilters):
+        if filters.start_date == date(2026, 5, 16):
+            return {"list_cost": 120.0, "net_cost": 90.0}
+        return {"list_cost": 100.0, "net_cost": 80.0}
+
+    monkeypatch.setattr(cost_queries, "ThreadPoolExecutor", _InlineExecutor)
+    monkeypatch.setattr(cost_queries, "_cost_summary", _summary)
+    monkeypatch.setattr(
+        cost_queries,
+        "_service_share_by_threshold",
+        lambda _connection, _filters, *, min_share_pct: {
+            "items": [{"name": "Compute Engine", "value": 120.0, "share_pct": 100.0}],
+            "meta": {"min_share_pct": min_share_pct, "total_list_cost": 120.0},
+        },
+    )
+    monkeypatch.setattr(
+        cost_queries,
+        "_engineering_share_by_level_threshold",
+        lambda _connection, _filters, *, level, min_share_pct: {
+            "items": [{"name": "TiDB", "value": 120.0, "share_pct": 100.0}],
+            "meta": {"level": level, "min_share_pct": min_share_pct, "total_list_cost": 120.0},
+        },
+    )
+
+    result = cost_queries.get_weekly_overview(
+        _Engine(),
+        CommonFilters(
+            start_date=date(2026, 5, 16),
+            end_date=date(2026, 5, 22),
+            granularity="day",
+        ),
+    )
+
+    assert result["summary"]["list_cost_wow_pct"] == 20.0
+    assert result["summary"]["net_cost_wow_pct"] == 12.5
+    assert result["service_share"]["items"][0]["name"] == "Compute Engine"
+    assert result["level2_share"]["items"][0]["name"] == "TiDB"
 
 
 def test_cost_query_helpers_cover_edge_cases(sqlite_engine) -> None:

--- a/ci-dashboard/web/package-lock.json
+++ b/ci-dashboard/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-dashboard-web",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -914,6 +914,7 @@ export function DonutShareChart({
   totalLabel = "builds",
   emptyMessage = "No share data for the current filters.",
   onItemSelect,
+  headerAction,
 }) {
   if (!items?.length) {
     return <EmptyState message={emptyMessage} compact />;
@@ -937,10 +938,13 @@ export function DonutShareChart({
           <strong>{title}</strong>
           {subtitle ? <p>{subtitle}</p> : null}
         </div>
-        <span className="panel-badge">
-          <strong>{formatCompact(total)}</strong>
-          {totalLabel}
-        </span>
+        <div className="donut-card__header-actions">
+          {headerAction}
+          <span className="panel-badge">
+            <strong>{formatCompact(total)}</strong>
+            {totalLabel}
+          </span>
+        </div>
       </header>
 
       <div className="donut-card__body">
@@ -1022,6 +1026,186 @@ export function DonutShareChart({
           })}
         </div>
       </div>
+    </article>
+  );
+}
+
+export function LabeledDonutShareChart({
+  title,
+  subtitle,
+  items,
+  totalValue,
+  totalLabel = "builds",
+  emptyMessage = "No share data for the current filters.",
+  onItemSelect,
+  headerAction,
+}) {
+  if (!items?.length) {
+    return <EmptyState message={emptyMessage} compact />;
+  }
+
+  const total = items.reduce((sum, item) => sum + Number(item.value || 0), 0);
+  const chartTotal = Number(totalValue || 0) > 0 ? Number(totalValue) : total;
+  if (!chartTotal) {
+    return <EmptyState message={emptyMessage} compact />;
+  }
+
+  const width = 640;
+  const height = 390;
+  const centerX = width / 2;
+  const centerY = 205;
+  const radius = 106;
+  const innerRadius = 64;
+  const labelRadius = 128;
+  const labelWidth = 178;
+  const rightLabelX = width - labelWidth - 12;
+  const leftLabelX = 12;
+  let startAngle = -Math.PI / 2;
+
+  const segments = items.map((item, index) => {
+    const value = Number(item.value || 0);
+    const angle = (value / chartTotal) * Math.PI * 2;
+    const endAngle = startAngle + angle;
+    const midAngle = startAngle + angle / 2;
+    const segment = {
+      item,
+      index,
+      value,
+      percent: Number(item.share_pct || 0),
+      startAngle,
+      endAngle,
+      midAngle,
+      fill: donutColor(item.name, index),
+      nameLines: wrapLabel(item.name, 20),
+    };
+    startAngle = endAngle;
+    return segment;
+  });
+
+  const labels = arrangeDonutLabels(
+    segments.map((segment) => {
+      const side = Math.cos(segment.midAngle) >= 0 ? "right" : "left";
+      return {
+        ...segment,
+        side,
+        rawY: centerY + Math.sin(segment.midAngle) * labelRadius,
+        height: segment.nameLines.length * 15 + 18,
+      };
+    }),
+    height,
+  );
+
+  return (
+    <article className="donut-card donut-card--labeled">
+      <header className="donut-card__header">
+        <div>
+          <strong>{title}</strong>
+          {subtitle ? <p>{subtitle}</p> : null}
+        </div>
+        <div className="donut-card__header-actions">
+          {headerAction}
+          <span className="panel-badge">
+            <strong>{formatCompact(chartTotal)}</strong>
+            {totalLabel}
+          </span>
+        </div>
+      </header>
+
+      <svg
+        className="labeled-donut-chart"
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label={`${title} share chart`}
+      >
+        {segments.map((segment) => {
+          const interactive = typeof onItemSelect === "function" && segment.item.interactive !== false;
+          return (
+            <path
+              key={`${title}-${segment.item.name}-segment`}
+              d={describeDonutArc(
+                centerX,
+                centerY,
+                innerRadius,
+                radius,
+                segment.startAngle,
+                segment.endAngle,
+              )}
+              fill={segment.fill}
+              className={interactive ? "donut-chart__segment donut-chart__segment--interactive" : "donut-chart__segment"}
+              role={interactive ? "button" : undefined}
+              tabIndex={interactive ? 0 : undefined}
+              aria-label={`${segment.item.name}: ${formatCompact(segment.value)} ${totalLabel}, ${formatPercent(segment.percent)}`}
+              onClick={interactive ? () => onItemSelect(segment.item) : undefined}
+              onKeyDown={
+                interactive
+                  ? (event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        onItemSelect(segment.item);
+                      }
+                    }
+                  : undefined
+              }
+            />
+          );
+        })}
+        <circle cx={centerX} cy={centerY} r={innerRadius - 4} fill="#fcf7ef" />
+        <text x={centerX} y={centerY - 7} textAnchor="middle" className="donut-chart__center-value">
+          {formatCompact(chartTotal)}
+        </text>
+        <text x={centerX} y={centerY + 17} textAnchor="middle" className="donut-chart__center-label">
+          {totalLabel}
+        </text>
+
+        {labels.map((label) => {
+          const interactive = typeof onItemSelect === "function" && label.item.interactive !== false;
+          const start = polarToCartesian(centerX, centerY, radius + 5, label.midAngle);
+          const elbow = polarToCartesian(centerX, centerY, radius + 25, label.midAngle);
+          const labelX = label.side === "right" ? rightLabelX : leftLabelX;
+          const anchorX = label.side === "right" ? labelX : labelX + labelWidth;
+          const endX = label.side === "right" ? labelX - 8 : labelX + labelWidth + 8;
+          const textAnchor = label.side === "right" ? "start" : "end";
+          const metric = `${formatCompact(label.value)} · ${formatPercent(label.percent)}`;
+
+          return (
+            <g
+              key={`${title}-${label.item.name}-label`}
+              className={interactive ? "labeled-donut-chart__label labeled-donut-chart__label--interactive" : "labeled-donut-chart__label"}
+              role={interactive ? "button" : undefined}
+              tabIndex={interactive ? 0 : undefined}
+              aria-label={`${label.item.name}: ${formatCompact(label.value)} ${totalLabel}, ${formatPercent(label.percent)}`}
+              onClick={interactive ? () => onItemSelect(label.item) : undefined}
+              onKeyDown={
+                interactive
+                  ? (event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        onItemSelect(label.item);
+                      }
+                    }
+                  : undefined
+              }
+            >
+              <polyline
+                points={`${start.x},${start.y} ${elbow.x},${elbow.y} ${endX},${label.y}`}
+                fill="none"
+                stroke={label.fill}
+              />
+              <circle cx={start.x} cy={start.y} r="2.3" fill={label.fill} />
+              <text x={anchorX} y={label.y - (label.nameLines.length - 1) * 7} textAnchor={textAnchor}>
+                {label.nameLines.map((line, lineIndex) => (
+                  <tspan key={line} x={anchorX} dy={lineIndex === 0 ? 0 : 15}>
+                    {line}
+                  </tspan>
+                ))}
+                <tspan x={anchorX} dy="17" className="labeled-donut-chart__label-metric">
+                  {metric}
+                </tspan>
+              </text>
+            </g>
+          );
+        })}
+      </svg>
     </article>
   );
 }
@@ -1497,6 +1681,60 @@ function describeDonutArc(cx, cy, innerRadius, outerRadius, startAngle, endAngle
     `A ${innerRadius} ${innerRadius} 0 ${largeArcFlag} 1 ${innerEnd.x} ${innerEnd.y}`,
     "Z",
   ].join(" ");
+}
+
+function wrapLabel(value, maxLength) {
+  const words = String(value || "").split(/\s+/).filter(Boolean);
+  if (!words.length) {
+    return [""];
+  }
+
+  const lines = [];
+  let current = "";
+  for (const word of words) {
+    if (!current) {
+      current = word;
+    } else if (`${current} ${word}`.length <= maxLength) {
+      current = `${current} ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current) {
+    lines.push(current);
+  }
+  return lines;
+}
+
+function arrangeDonutLabels(labels, height) {
+  const minY = 36;
+  const maxY = height - 28;
+  const minGap = 48;
+
+  return ["left", "right"].flatMap((side) => {
+    const sideLabels = labels
+      .filter((label) => label.side === side)
+      .sort((a, b) => a.rawY - b.rawY)
+      .map((label) => ({
+        ...label,
+        y: Math.min(maxY, Math.max(minY, label.rawY)),
+      }));
+
+    for (let index = 1; index < sideLabels.length; index += 1) {
+      sideLabels[index].y = Math.max(sideLabels[index].y, sideLabels[index - 1].y + minGap);
+    }
+    for (let index = sideLabels.length - 2; index >= 0; index -= 1) {
+      if (sideLabels[index + 1].y > maxY) {
+        sideLabels[index + 1].y = maxY;
+      }
+      sideLabels[index].y = Math.min(sideLabels[index].y, sideLabels[index + 1].y - minGap);
+    }
+    return sideLabels.map((label) => ({
+      ...label,
+      y: Math.min(maxY, Math.max(minY, label.y)),
+    }));
+  });
 }
 
 function polarToCartesian(cx, cy, radius, angleInRadians) {

--- a/ci-dashboard/web/src/lib/api.js
+++ b/ci-dashboard/web/src/lib/api.js
@@ -53,6 +53,19 @@ export function getPreviousDateRange(startDate, endDate) {
   };
 }
 
+export function getPreviousCompleteSaturdayWeek(referenceDate = new Date()) {
+  const end = new Date(referenceDate);
+  end.setHours(0, 0, 0, 0);
+  const daysSinceFriday = (end.getDay() - 5 + 7) % 7 || 7;
+  end.setDate(end.getDate() - daysSinceFriday);
+  const start = new Date(end);
+  start.setDate(start.getDate() - 6);
+  return {
+    start_date: toDateInputValue(start),
+    end_date: toDateInputValue(end),
+  };
+}
+
 export function toDateInputValue(value) {
   const year = value.getFullYear();
   const month = String(value.getMonth() + 1).padStart(2, "0");

--- a/ci-dashboard/web/src/pages/CostPage.jsx
+++ b/ci-dashboard/web/src/pages/CostPage.jsx
@@ -1,11 +1,16 @@
+import { useState } from "react";
+
 import {
   formatCompactCurrency,
   formatCurrency,
+  formatDateRangeLabel,
   formatPercent,
+  getPreviousCompleteSaturdayWeek,
   useApiData,
 } from "../lib/api";
 import {
   DonutShareChart,
+  LabeledDonutShareChart,
   PageIntro,
   Panel,
   StatCard,
@@ -15,13 +20,22 @@ import {
 
 const ANNUAL_GCP_BUDGET = 17300 * 12;
 const ANNUAL_TICDC_BUDGET = 4500 * 12;
+const SHARED_COST_GROUP = "Efficiency & Quality";
 
 export default function CostPage({ filters }) {
+  const [isWeeklyLevel2Shared, setIsWeeklyLevel2Shared] = useState(false);
+  const [isSelectedLevel2Shared, setIsSelectedLevel2Shared] = useState(false);
+  const weeklyOverviewRange = getPreviousCompleteSaturdayWeek();
+  const weeklyOverviewFilters = {
+    ...weeklyOverviewRange,
+    granularity: "week",
+  };
   const costFilters = {
     start_date: filters.start_date,
     end_date: filters.end_date,
     granularity: filters.granularity === "month" ? "month" : "week",
   };
+  const weeklyOverview = useApiData("/api/v1/pages/cost-weekly-overview", weeklyOverviewFilters);
   const trend = useApiData("/api/v1/pages/cost-trend", costFilters);
   const repoGroupStack = useApiData("/api/v1/pages/cost-repo-group-stack", costFilters);
   const engineeringGroupShare = useApiData("/api/v1/pages/cost-engineering-group-share", costFilters);
@@ -37,6 +51,14 @@ export default function CostPage({ filters }) {
     trend.data?.series,
     costFilters.granularity,
   );
+  const weeklyLevel2Items = withSharedCostAllocation(
+    weeklyOverview.data?.level2_share?.items,
+    isWeeklyLevel2Shared,
+  );
+  const selectedLevel2Items = withSharedCostAllocation(
+    engineeringGroupShare.data?.level2?.items,
+    isSelectedLevel2Shared,
+  );
 
   return (
     <div className="page-stack">
@@ -46,6 +68,71 @@ export default function CostPage({ filters }) {
         description="A first read on GCP cost attribution after raw billing rows are joined with roster ownership."
         kicker={`${costFilters.granularity} buckets`}
       />
+
+      <Panel
+        title="Weekly overview"
+        subtitle={formatDateRangeLabel(weeklyOverviewRange.start_date, weeklyOverviewRange.end_date)}
+        loading={weeklyOverview.loading}
+        error={weeklyOverview.error}
+        className="cost-weekly-overview"
+      >
+        <div className="cost-weekly-overview__grid">
+          <div className="cost-weekly-overview__cards">
+            <StatCard
+              label="List cost"
+              value={formatCurrency(weeklyOverview.data?.summary?.list_cost)}
+              detail="Previous complete week"
+              delta={formatDelta(weeklyOverview.data?.summary?.list_cost_wow_pct)}
+              tone="teal"
+            />
+            <StatCard
+              label="Net cost"
+              value={formatCurrency(weeklyOverview.data?.summary?.net_cost)}
+              detail={`Weekly budget ${formatCurrency(ANNUAL_GCP_BUDGET / 52)}`}
+              delta={formatDelta(weeklyOverview.data?.summary?.net_cost_wow_pct)}
+              tone="amber"
+            />
+          </div>
+          <div className="cost-weekly-overview__charts">
+            <LabeledDonutShareChart
+              title="GCP services"
+              subtitle="Services above 1% of list cost."
+              items={weeklyOverview.data?.service_share?.items}
+              totalValue={weeklyOverview.data?.service_share?.meta?.total_list_cost}
+              totalLabel="list cost"
+              emptyMessage="No service cost data for the previous complete week."
+            />
+            <LabeledDonutShareChart
+              title="Level 2 groups"
+              subtitle={
+                isWeeklyLevel2Shared
+                  ? `${SHARED_COST_GROUP} cost redistributed proportionally.`
+                  : "Groups above 1% of list cost."
+              }
+              items={weeklyLevel2Items}
+              totalValue={weeklyOverview.data?.level2_share?.meta?.total_list_cost}
+              totalLabel="list cost"
+              emptyMessage="No Level 2 group above 1% for the previous complete week."
+              onItemSelect={(item) => {
+                if (item.name === SHARED_COST_GROUP) {
+                  setIsWeeklyLevel2Shared(true);
+                }
+              }}
+              headerAction={
+                isWeeklyLevel2Shared ? (
+                  <button
+                    type="button"
+                    className="donut-card__action"
+                    onClick={() => setIsWeeklyLevel2Shared(false)}
+                  >
+                    Reset
+                  </button>
+                ) : null
+              }
+            />
+          </div>
+        </div>
+      </Panel>
 
       <section className="stats-grid">
         <StatCard
@@ -125,10 +212,30 @@ export default function CostPage({ filters }) {
           />
           <DonutShareChart
             title="Level 2 groups"
-            subtitle="Second-level teams under Engineering Group."
-            items={engineeringGroupShare.data?.level2?.items}
+            subtitle={
+              isSelectedLevel2Shared
+                ? `${SHARED_COST_GROUP} cost redistributed proportionally.`
+                : "Second-level teams under Engineering Group."
+            }
+            items={selectedLevel2Items}
             totalLabel="list cost"
             emptyMessage="No Engineering Group level-2 cost share data yet."
+            onItemSelect={(item) => {
+              if (item.name === SHARED_COST_GROUP) {
+                setIsSelectedLevel2Shared(true);
+              }
+            }}
+            headerAction={
+              isSelectedLevel2Shared ? (
+                <button
+                  type="button"
+                  className="donut-card__action"
+                  onClick={() => setIsSelectedLevel2Shared(false)}
+                >
+                  Reset
+                </button>
+              ) : null
+            }
           />
         </div>
       </Panel>
@@ -143,6 +250,42 @@ export default function CostPage({ filters }) {
       </Panel>
     </div>
   );
+}
+
+function withSharedCostAllocation(items, enabled) {
+  if (!items?.length) {
+    return items;
+  }
+
+  const originalTotal = items.reduce((sum, item) => sum + Number(item.value || 0), 0);
+  const sharedItem = items.find((item) => item.name === SHARED_COST_GROUP);
+  const sharedValue = Number(sharedItem?.value || 0);
+  const recipients = items.filter((item) => item.name !== SHARED_COST_GROUP);
+  const recipientTotal = recipients.reduce((sum, item) => sum + Number(item.value || 0), 0);
+
+  if (!enabled || !sharedItem || !sharedValue || !recipientTotal || !originalTotal) {
+    return items.map((item) => ({
+      ...item,
+      interactive: item.name === SHARED_COST_GROUP,
+    }));
+  }
+
+  return recipients.map((item) => {
+    const originalValue = Number(item.value || 0);
+    const value = originalValue + sharedValue * (originalValue / recipientTotal);
+    return {
+      ...item,
+      value,
+      share_pct: (value / originalTotal) * 100,
+      interactive: false,
+    };
+  });
+}
+
+function formatDelta(value) {
+  const numeric = Number(value || 0);
+  const sign = numeric > 0 ? "+" : "";
+  return `WoW ${sign}${formatPercent(numeric)}`;
 }
 
 function withBudgetSeries(series, granularity) {

--- a/ci-dashboard/web/src/styles.css
+++ b/ci-dashboard/web/src/styles.css
@@ -414,6 +414,26 @@ select {
   color: var(--muted);
 }
 
+.cost-weekly-overview__grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.7fr) minmax(0, 2fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.cost-weekly-overview__cards {
+  display: grid;
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.cost-weekly-overview__charts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+  min-width: 0;
+}
+
 @media (max-width: 900px) {
   .scope-note__grid {
     grid-template-columns: 1fr;
@@ -1026,6 +1046,30 @@ select {
   align-items: flex-start;
 }
 
+.donut-card__header-actions {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.donut-card__action {
+  min-height: 2.25rem;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid rgba(49, 87, 114, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--navy);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.donut-card__action:hover,
+.donut-card__action:focus {
+  border-color: rgba(15, 124, 130, 0.28);
+  background: rgba(255, 255, 255, 0.95);
+}
+
 .donut-card__header strong {
   display: block;
   font-size: 1.02rem;
@@ -1055,6 +1099,36 @@ select {
   width: 100%;
   max-width: 240px;
   height: auto;
+}
+
+.donut-card--labeled {
+  min-height: 370px;
+}
+
+.labeled-donut-chart {
+  width: 100%;
+  height: auto;
+  min-height: 285px;
+  overflow: visible;
+}
+
+.labeled-donut-chart__label polyline {
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.8;
+}
+
+.labeled-donut-chart__label text {
+  fill: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.labeled-donut-chart__label-metric {
+  fill: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
 .donut-chart__segment {
@@ -1640,6 +1714,7 @@ select {
 
   .stats-grid,
   .progress-summary-grid,
+  .cost-weekly-overview__grid,
   .page-grid--overview,
   .flaky-highlight-row,
   .page-grid--two-column {
@@ -1647,6 +1722,7 @@ select {
   }
 
   .donut-grid,
+  .cost-weekly-overview__charts,
   .runtime-compare-grid,
   .donut-card__body {
     grid-template-columns: 1fr;
@@ -1671,6 +1747,8 @@ select {
   .filter-grid,
   .stats-grid,
   .progress-summary-grid,
+  .cost-weekly-overview__grid,
+  .cost-weekly-overview__charts,
   .page-grid--overview,
   .flaky-highlight-row,
   .flaky-highlight-stack,

--- a/cost-insight/docs/bigquery-cost-optimization-design.md
+++ b/cost-insight/docs/bigquery-cost-optimization-design.md
@@ -64,6 +64,14 @@ granularity. Field trimming helps, but only after the collector prunes
 - Scan every BigQuery export partition at most once for the regular summary
   pipeline.
 - Avoid resource-level columns in the regular summary pipeline.
+- Preserve service and SKU dimensions in the regular summary pipeline so
+  dashboard attribution can still answer service-level cost questions without
+  reading deprecated raw detail tables.
+- Apply source-side owner overrides for cost lines that cannot be labeled on
+  GCP resources. For now, unlabeled Cloud Logging and
+  `Compute Flexible Committed Use Discounts - 3 Year` rows are assigned to
+  `author=wei_zheng`, which fuzzy-matches the `wei.zheng@pingcap.com` roster
+  identity and maps to the EQ roster group during attribution.
 - Keep resource-level unmatched data as a separate weekly pipeline.
 - Make late-arriving usage and billing corrections additive and idempotent.
 - Keep dashboard APIs mostly backed by `cost_attribution_daily`.
@@ -83,6 +91,8 @@ CREATE TABLE cost_bq_export_summary_daily (
   billing_account_id VARCHAR(128) NULL,
   export_partition_date DATE NOT NULL,
   usage_date DATE NOT NULL,
+  service_name VARCHAR(255) NULL,
+  sku_name VARCHAR(255) NULL,
   org VARCHAR(255) NULL,
   repo VARCHAR(255) NULL,
   author VARCHAR(255) NULL,
@@ -353,14 +363,13 @@ weekly and never participates in historical correction backfills.
 The existing attribution refresh reads `cost_raw_details` and groups by
 `service_name`, `sku_name`, and `resource_name`. The summary path cannot reuse
 that SQL unchanged because `cost_bq_export_summary_daily` intentionally omits
-those resource-level columns.
+resource-level columns, while keeping the service and SKU dimensions.
 
 The implementation should either add a new
 `refresh-cost-attribution-from-summary` command or parameterize the existing
 refresh job with a source table mode. The summary mode should rebuild
-`cost_attribution_daily` with `service_name`, `sku_name`, and `resource_name`
-set to `NULL`. These columns are nullable and current dashboard trend, repo,
-and group views do not depend on them.
+`cost_attribution_daily` with `service_name` and `sku_name` from the summary
+rows and `resource_name` set to `NULL`.
 
 The summary attribution query shape is:
 
@@ -394,8 +403,8 @@ SELECT
   attributed.usage_date,
   attributed.vendor,
   attributed.account_id,
-  NULL AS service_name,
-  NULL AS sku_name,
+  attributed.service_name,
+  attributed.sku_name,
   attributed.org,
   attributed.repo,
   NULL AS resource_name,

--- a/cost-insight/sql/003_create_cost_refine_tables.sql
+++ b/cost-insight/sql/003_create_cost_refine_tables.sql
@@ -5,6 +5,8 @@ CREATE TABLE IF NOT EXISTS cost_bq_export_summary_daily (
   billing_account_id VARCHAR(128) NULL,
   export_partition_date DATE NOT NULL,
   usage_date DATE NOT NULL,
+  service_name VARCHAR(255) NULL,
+  sku_name VARCHAR(255) NULL,
   org VARCHAR(255) NULL,
   repo VARCHAR(255) NULL,
   author VARCHAR(255) NULL,
@@ -24,6 +26,7 @@ CREATE TABLE IF NOT EXISTS cost_bq_export_summary_daily (
     source_row_hash
   ),
   KEY idx_cost_bq_export_summary_usage_date (usage_date, vendor, account_id),
+  KEY idx_cost_bq_export_summary_service (usage_date, service_name),
   KEY idx_cost_bq_export_summary_export_partition (export_partition_date)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/cost-insight/sql/004_alter_cost_bq_export_summary_add_service.sql
+++ b/cost-insight/sql/004_alter_cost_bq_export_summary_add_service.sql
@@ -1,0 +1,6 @@
+ALTER TABLE cost_bq_export_summary_daily
+  ADD COLUMN IF NOT EXISTS service_name VARCHAR(255) NULL AFTER usage_date,
+  ADD COLUMN IF NOT EXISTS sku_name VARCHAR(255) NULL AFTER service_name;
+
+CREATE INDEX IF NOT EXISTS idx_cost_bq_export_summary_service
+  ON cost_bq_export_summary_daily (usage_date, service_name);

--- a/cost-insight/src/cost_insight/jobs/backfill_cost_refine_from_raw.py
+++ b/cost-insight/src/cost_insight/jobs/backfill_cost_refine_from_raw.py
@@ -183,6 +183,8 @@ _SELECT_SUMMARY_ROWS = text(
       billing_account_id,
       {_SYNTHETIC_EXPORT_PARTITION_DATE} AS export_partition_date,
       usage_date,
+      service_name,
+      sku_name,
       author,
       org,
       repo,
@@ -201,10 +203,12 @@ _SELECT_SUMMARY_ROWS = text(
       billing_account_id,
       export_partition_date,
       usage_date,
+      service_name,
+      sku_name,
       author,
       org,
       repo
-    ORDER BY export_partition_date, usage_date, author, org, repo
+    ORDER BY export_partition_date, usage_date, service_name, sku_name, author, org, repo
     """
 )
 

--- a/cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py
+++ b/cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py
@@ -161,9 +161,11 @@ def normalized_identity_sql(expression: str) -> str:
     return (
         "REPLACE("
         "REPLACE("
-        f"REPLACE({base}, '-', '_'), "
-        "'.', '_'), "
-        "' ', '_')"
+        "REPLACE("
+        f"REPLACE({base}, '-', ''), "
+        "'.', ''), "
+        "'_', ''), "
+        "' ', '')"
     )
 
 
@@ -206,6 +208,20 @@ _NORMALIZED_EMAIL_LOCAL = normalized_identity_sql(
     "SUBSTRING_INDEX(normalized_employee.email, '@', 1)"
 )
 _NORMALIZED_EN_NAME = normalized_identity_sql("normalized_employee.en_name")
+_RAW_AUTHOR_OVERRIDE_EMAIL = """
+CASE LOWER(raw.author)
+  WHEN 'flaky-claw' THEN 'yinsu@pingcap.com'
+  WHEN 'ti-chi-bot' THEN 'wei.zheng@pingcap.com'
+  ELSE NULL
+END
+""".strip()
+_SUMMARY_AUTHOR_OVERRIDE_EMAIL = """
+CASE LOWER(summary.author)
+  WHEN 'flaky-claw' THEN 'yinsu@pingcap.com'
+  WHEN 'ti-chi-bot' THEN 'wei.zheng@pingcap.com'
+  ELSE NULL
+END
+""".strip()
 
 
 _INSERT_ATTRIBUTION_DAILY = text(
@@ -294,12 +310,14 @@ _INSERT_ATTRIBUTION_DAILY = text(
         raw.author AS owner,
         CASE
           WHEN COALESCE(
+            override_employee.id,
             github_employee.id,
             email_employee.id,
             normalized_employee.id
           ) IS NOT NULL THEN CONCAT(
             'employee:',
             CAST(COALESCE(
+              override_employee.id,
               github_employee.id,
               email_employee.id,
               normalized_employee.id
@@ -309,6 +327,7 @@ _INSERT_ATTRIBUTION_DAILY = text(
           ELSE 'unattributed'
         END AS attribution_key,
         CASE
+          WHEN override_employee.id IS NOT NULL THEN 'author_override'
           WHEN github_employee.id IS NOT NULL THEN 'author_github'
           WHEN email_employee.id IS NOT NULL THEN 'author_email'
           WHEN normalized_employee.id IS NOT NULL THEN 'author_normalized'
@@ -317,6 +336,7 @@ _INSERT_ATTRIBUTION_DAILY = text(
         END AS attribution_source,
         CASE
           WHEN COALESCE(
+            override_employee.id,
             github_employee.id,
             email_employee.id,
             normalized_employee.id
@@ -325,16 +345,19 @@ _INSERT_ATTRIBUTION_DAILY = text(
           ELSE 'unattributed'
         END AS attribution_status,
         COALESCE(
+          override_employee.id,
           github_employee.id,
           email_employee.id,
           normalized_employee.id
         ) AS employee_id,
         COALESCE(
+          override_employee.group_id,
           github_employee.group_id,
           email_employee.group_id,
           normalized_employee.group_id
         ) AS group_id,
         COALESCE(
+          override_employee.manager_id,
           github_employee.manager_id,
           email_employee.manager_id,
           normalized_employee.manager_id,
@@ -346,8 +369,14 @@ _INSERT_ATTRIBUTION_DAILY = text(
         raw.credit_amount,
         raw.net_cost
       FROM cost_raw_details raw
+      LEFT JOIN roster_employees override_employee
+        ON override_employee.is_active = 1
+       AND raw.author IS NOT NULL
+       AND override_employee.email IS NOT NULL
+       AND LOWER(override_employee.email) = LOWER({_RAW_AUTHOR_OVERRIDE_EMAIL})
       LEFT JOIN roster_employees github_employee
-        ON github_employee.is_active = 1
+        ON override_employee.id IS NULL
+       AND github_employee.is_active = 1
        AND raw.author IS NOT NULL
        AND github_employee.github_id IS NOT NULL
        AND LOWER(github_employee.github_id) = LOWER(raw.author)
@@ -378,6 +407,7 @@ _INSERT_ATTRIBUTION_DAILY = text(
       LEFT JOIN roster_groups matched_group
         ON matched_group.is_active = 1
        AND matched_group.id = COALESCE(
+         override_employee.group_id,
          github_employee.group_id,
          email_employee.group_id,
          normalized_employee.group_id
@@ -438,8 +468,8 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
       attributed.usage_date,
       attributed.vendor,
       attributed.account_id,
-      NULL AS service_name,
-      NULL AS sku_name,
+      attributed.service_name,
+      attributed.sku_name,
       attributed.org,
       attributed.repo,
       NULL AS resource_name,
@@ -463,8 +493,8 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
           DATE_FORMAT(attributed.usage_date, '%Y-%m-%d'),
           COALESCE(attributed.vendor, ''),
           COALESCE(attributed.account_id, ''),
-          '',
-          '',
+          COALESCE(attributed.service_name, ''),
+          COALESCE(attributed.sku_name, ''),
           COALESCE(attributed.org, ''),
           COALESCE(attributed.repo, ''),
           '',
@@ -484,18 +514,22 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
         summary.usage_date,
         summary.vendor,
         summary.account_id,
+        summary.service_name,
+        summary.sku_name,
         summary.org,
         summary.repo,
         summary.author,
         summary.author AS owner,
         CASE
           WHEN COALESCE(
+            override_employee.id,
             github_employee.id,
             email_employee.id,
             normalized_employee.id
           ) IS NOT NULL THEN CONCAT(
             'employee:',
             CAST(COALESCE(
+              override_employee.id,
               github_employee.id,
               email_employee.id,
               normalized_employee.id
@@ -505,6 +539,7 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
           ELSE 'unattributed'
         END AS attribution_key,
         CASE
+          WHEN override_employee.id IS NOT NULL THEN 'author_override'
           WHEN github_employee.id IS NOT NULL THEN 'author_github'
           WHEN email_employee.id IS NOT NULL THEN 'author_email'
           WHEN normalized_employee.id IS NOT NULL THEN 'author_normalized'
@@ -513,6 +548,7 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
         END AS attribution_source,
         CASE
           WHEN COALESCE(
+            override_employee.id,
             github_employee.id,
             email_employee.id,
             normalized_employee.id
@@ -521,16 +557,19 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
           ELSE 'unattributed'
         END AS attribution_status,
         COALESCE(
+          override_employee.id,
           github_employee.id,
           email_employee.id,
           normalized_employee.id
         ) AS employee_id,
         COALESCE(
+          override_employee.group_id,
           github_employee.group_id,
           email_employee.group_id,
           normalized_employee.group_id
         ) AS group_id,
         COALESCE(
+          override_employee.manager_id,
           github_employee.manager_id,
           email_employee.manager_id,
           normalized_employee.manager_id,
@@ -541,8 +580,14 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
         summary.credit_amount,
         summary.net_cost
       FROM cost_bq_export_summary_daily summary
+      LEFT JOIN roster_employees override_employee
+        ON override_employee.is_active = 1
+       AND summary.author IS NOT NULL
+       AND override_employee.email IS NOT NULL
+       AND LOWER(override_employee.email) = LOWER({_SUMMARY_AUTHOR_OVERRIDE_EMAIL})
       LEFT JOIN roster_employees github_employee
-        ON github_employee.is_active = 1
+        ON override_employee.id IS NULL
+       AND github_employee.is_active = 1
        AND summary.author IS NOT NULL
        AND github_employee.github_id IS NOT NULL
        AND LOWER(github_employee.github_id) = LOWER(summary.author)
@@ -573,6 +618,7 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
       LEFT JOIN roster_groups matched_group
         ON matched_group.is_active = 1
        AND matched_group.id = COALESCE(
+         override_employee.group_id,
          github_employee.group_id,
          email_employee.group_id,
          normalized_employee.group_id
@@ -585,6 +631,8 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
       attributed.usage_date,
       attributed.vendor,
       attributed.account_id,
+      attributed.service_name,
+      attributed.sku_name,
       attributed.org,
       attributed.repo,
       attributed.author,

--- a/cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py
@@ -25,6 +25,7 @@ from cost_insight.jobs.sync_gcp_billing_export import (
     _upsert_cost_source,
 )
 from cost_insight.sources.gcp_billing_export import (
+    DEFAULT_COST_OWNER_AUTHOR,
     decimal_or_none,
     fetch_gcp_billing_summary_rows,
 )
@@ -32,12 +33,15 @@ from cost_insight.sources.gcp_billing_export import (
 LOG = logging.getLogger(__name__)
 
 JOB_NAME = "sync_gcp_billing_summary"
+OWNER_OVERRIDE_DELETE_CHUNK_SIZE = 1000
 HASH_FIELDS = (
     "vendor",
     "account_id",
     "billing_account_id",
     "export_partition_date",
     "usage_date",
+    "service_name",
+    "sku_name",
     "author",
     "org",
     "repo",
@@ -194,6 +198,8 @@ def _normalize_summary_row(row: dict[str, Any]) -> dict[str, Any]:
         "billing_account_id": nullable_text(row.get("billing_account_id")),
         "export_partition_date": coerce_date(row.get("export_partition_date")),
         "usage_date": coerce_date(row.get("usage_date")),
+        "service_name": nullable_text(row.get("service_name")),
+        "sku_name": nullable_text(row.get("sku_name")),
         "author": nullable_text(row.get("author")),
         "org": nullable_text(row.get("org")),
         "repo": nullable_text(row.get("repo")),
@@ -226,6 +232,8 @@ def write_summary_rows(engine: Engine, rows: Sequence[dict[str, Any]], *, dry_ru
         LOG.info("dry-run skipped cost_bq_export_summary_daily upsert", extra={"row_count": len(rows)})
         return 0
     with engine.begin() as connection:
+        _delete_legacy_summary_rows(connection, rows)
+        _delete_superseded_owner_override_rows(connection, rows)
         connection.execute(_build_upsert_statement(connection), _bind_rows(connection, rows))
     return len(rows)
 
@@ -235,6 +243,62 @@ def _bind_rows(connection: Connection, rows: Sequence[dict[str, Any]]) -> list[d
     if connection.dialect.name != "sqlite":
         return bound_rows
     return bind_decimal_rows(bound_rows)
+
+
+def _delete_legacy_summary_rows(connection: Connection, rows: Sequence[dict[str, Any]]) -> None:
+    partitions = {
+        (
+            row["vendor"],
+            row["account_id"],
+            row["export_partition_date"],
+        )
+        for row in rows
+    }
+    if not partitions:
+        return
+    for vendor, account_id, export_partition_date in partitions:
+        connection.execute(
+            _DELETE_LEGACY_SUMMARY_ROWS,
+            {
+                "vendor": vendor,
+                "account_id": account_id,
+                "export_partition_date": export_partition_date,
+            },
+        )
+
+
+def _delete_superseded_owner_override_rows(
+    connection: Connection,
+    rows: Sequence[dict[str, Any]],
+) -> None:
+    for offset in range(0, len(rows), OWNER_OVERRIDE_DELETE_CHUNK_SIZE):
+        params = [
+            {
+                "vendor": row.get("vendor") or "",
+                "account_id": row.get("account_id") or "",
+                "billing_account_id": row.get("billing_account_id") or "",
+                "export_partition_date": row["export_partition_date"],
+                "usage_date": row["usage_date"],
+                "service_name": row.get("service_name") or "",
+                "sku_name": row.get("sku_name") or "",
+                "org": row.get("org") or "",
+                "repo": row.get("repo") or "",
+            }
+            for row in rows[offset : offset + OWNER_OVERRIDE_DELETE_CHUNK_SIZE]
+            if _is_owner_override_row(row)
+        ]
+        if params:
+            connection.execute(_DELETE_SUPERSEDED_OWNER_OVERRIDE_ROWS, params)
+
+
+def _is_owner_override_row(row: dict[str, Any]) -> bool:
+    if row.get("author") != DEFAULT_COST_OWNER_AUTHOR:
+        return False
+    return (
+        row.get("service_name") == "Cloud Logging"
+        or row.get("sku_name") == "Compute Flexible Committed Use Discounts - 3 Year"
+        or row.get("sku_name") == "Compute Flexible Committed Use Discounts - 1 Year"
+    )
 
 
 def _get_touched_usage_dates(
@@ -271,6 +335,8 @@ def _build_upsert_statement(connection: Connection):
               billing_account_id,
               export_partition_date,
               usage_date,
+              service_name,
+              sku_name,
               org,
               repo,
               author,
@@ -286,6 +352,8 @@ def _build_upsert_statement(connection: Connection):
               :billing_account_id,
               :export_partition_date,
               :usage_date,
+              :service_name,
+              :sku_name,
               :org,
               :repo,
               :author,
@@ -299,12 +367,14 @@ def _build_upsert_statement(connection: Connection):
             ON CONFLICT(vendor, account_id, export_partition_date, source_row_hash)
             DO UPDATE SET
               billing_account_id = excluded.billing_account_id,
-              list_cost = excluded.list_cost,
-              effective_cost = excluded.effective_cost,
-              credit_amount = excluded.credit_amount,
-              net_cost = excluded.net_cost,
-              source_export_time = excluded.source_export_time,
-              updated_at = CURRENT_TIMESTAMP
+          list_cost = excluded.list_cost,
+          effective_cost = excluded.effective_cost,
+          credit_amount = excluded.credit_amount,
+          net_cost = excluded.net_cost,
+          service_name = excluded.service_name,
+          sku_name = excluded.sku_name,
+          source_export_time = excluded.source_export_time,
+          updated_at = CURRENT_TIMESTAMP
             """
         )
     return text(
@@ -315,6 +385,8 @@ def _build_upsert_statement(connection: Connection):
           billing_account_id,
           export_partition_date,
           usage_date,
+          service_name,
+          sku_name,
           org,
           repo,
           author,
@@ -330,6 +402,8 @@ def _build_upsert_statement(connection: Connection):
           :billing_account_id,
           :export_partition_date,
           :usage_date,
+          :service_name,
+          :sku_name,
           :org,
           :repo,
           :author,
@@ -347,6 +421,8 @@ def _build_upsert_statement(connection: Connection):
           effective_cost = VALUES(effective_cost),
           credit_amount = VALUES(credit_amount),
           net_cost = VALUES(net_cost),
+          service_name = VALUES(service_name),
+          sku_name = VALUES(sku_name),
           source_export_time = VALUES(source_export_time),
           updated_at = CURRENT_TIMESTAMP
         """
@@ -361,5 +437,34 @@ _SELECT_TOUCHED_USAGE_DATES = text(
       AND vendor = :vendor
       AND account_id = :account_id
     ORDER BY usage_date
+    """
+)
+
+
+_DELETE_LEGACY_SUMMARY_ROWS = text(
+    """
+    DELETE FROM cost_bq_export_summary_daily
+    WHERE vendor = :vendor
+      AND account_id = :account_id
+      AND export_partition_date = :export_partition_date
+      AND service_name IS NULL
+      AND sku_name IS NULL
+    """
+)
+
+
+_DELETE_SUPERSEDED_OWNER_OVERRIDE_ROWS = text(
+    """
+    DELETE FROM cost_bq_export_summary_daily
+    WHERE vendor = :vendor
+      AND account_id = :account_id
+      AND COALESCE(billing_account_id, '') = :billing_account_id
+      AND export_partition_date = :export_partition_date
+      AND usage_date = :usage_date
+      AND COALESCE(service_name, '') = :service_name
+      AND COALESCE(sku_name, '') = :sku_name
+      AND COALESCE(org, '') = :org
+      AND COALESCE(repo, '') = :repo
+      AND author IS NULL
     """
 )

--- a/cost-insight/src/cost_insight/sources/gcp_billing_export.py
+++ b/cost-insight/src/cost_insight/sources/gcp_billing_export.py
@@ -6,6 +6,9 @@ from decimal import Decimal
 from typing import Any
 
 
+DEFAULT_COST_OWNER_AUTHOR = "wei_zheng"
+
+
 def fetch_gcp_billing_rows(
     *,
     billing_table: str,
@@ -109,6 +112,7 @@ def fetch_gcp_unmatched_resource_rows(
 
 def build_gcp_billing_query(*, billing_table: str, limit: int | None = None) -> str:
     limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
+    author_expr = _author_expr_with_overrides()
     return f"""
 WITH normalized AS (
   SELECT
@@ -119,7 +123,7 @@ WITH normalized AS (
     sku.description AS sku_name,
     location.region AS region,
     {_label_expr(("k8s-namespace", "namespace"))} AS namespace,
-    {_label_expr(("k8s-label/author", "author"))} AS author,
+    {author_expr} AS author,
     {_label_expr(("k8s-label/org", "org"))} AS org,
     {_label_expr(("k8s-label/repo", "repo"))} AS repo,
     COALESCE(
@@ -185,6 +189,7 @@ ORDER BY usage_date, service_name, sku_name, resource_name{limit_clause}
 
 def build_gcp_billing_summary_query(*, billing_table: str, limit: int | None = None) -> str:
     limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
+    author_expr = _author_expr_with_overrides()
     return f"""
 SELECT
   'gcp' AS vendor,
@@ -192,7 +197,9 @@ SELECT
   billing_account_id,
   _PARTITIONDATE AS export_partition_date,
   DATE(usage_start_time) AS usage_date,
-  {_label_expr(("k8s-label/author", "author"))} AS author,
+  service.description AS service_name,
+  sku.description AS sku_name,
+  {author_expr} AS author,
   {_label_expr(("k8s-label/org", "org"))} AS org,
   {_label_expr(("k8s-label/repo", "repo"))} AS repo,
   ROUND(SUM(cost_at_list), 2) AS list_cost,
@@ -211,17 +218,19 @@ GROUP BY
   billing_account_id,
   export_partition_date,
   usage_date,
+  service_name,
+  sku_name,
   author,
   org,
   repo
-ORDER BY export_partition_date, usage_date, author, org, repo{limit_clause}
+ORDER BY export_partition_date, usage_date, service_name, sku_name, author, org, repo{limit_clause}
 """.strip()
 
 
 def build_gcp_unmatched_resource_query(*, billing_table: str, limit: int | None = None) -> str:
     limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
     namespace_expr = _label_expr(("k8s-namespace", "namespace"))
-    author_expr = _label_expr(("k8s-label/author", "author"))
+    author_expr = _author_expr_with_overrides()
     org_expr = _label_expr(("k8s-label/org", "org"))
     repo_expr = _label_expr(("k8s-label/repo", "repo"))
     workload_expr = _label_expr(("k8s-workload-name",))
@@ -311,6 +320,23 @@ def _label_expr(keys: Iterable[str]) -> str:
       WHERE label.key IN ({key_list})
       LIMIT 1
     )[SAFE_OFFSET(0)]
+    """.strip()
+
+
+def _author_expr_with_overrides() -> str:
+    label_author = _label_expr(("k8s-label/author", "author"))
+    return f"""
+    COALESCE(
+      {label_author},
+      CASE
+        WHEN service.description = 'Cloud Logging' THEN '{DEFAULT_COST_OWNER_AUTHOR}'
+        WHEN sku.description = 'Compute Flexible Committed Use Discounts - 3 Year'
+          THEN '{DEFAULT_COST_OWNER_AUTHOR}'
+        WHEN sku.description = 'Compute Flexible Committed Use Discounts - 1 Year'
+          THEN '{DEFAULT_COST_OWNER_AUTHOR}'
+        ELSE NULL
+      END
+    )
     """.strip()
 
 

--- a/cost-insight/tests/test_backfill_cost_refine_from_raw.py
+++ b/cost-insight/tests/test_backfill_cost_refine_from_raw.py
@@ -58,6 +58,8 @@ def _sqlite_engine():
               billing_account_id TEXT,
               export_partition_date TEXT NOT NULL,
               usage_date TEXT NOT NULL,
+              service_name TEXT,
+              sku_name TEXT,
               org TEXT,
               repo TEXT,
               author TEXT,
@@ -159,7 +161,7 @@ def test_backfill_cost_refine_from_raw_writes_summary_and_unmatched_rows() -> No
             summary_cost = connection.execute(
                 text(
                     """
-                    SELECT list_cost, effective_cost, credit_amount, net_cost
+                    SELECT service_name, sku_name, list_cost, effective_cost, credit_amount, net_cost
                     FROM cost_bq_export_summary_daily
                     WHERE usage_date = '2026-05-17'
                     """
@@ -177,6 +179,8 @@ def test_backfill_cost_refine_from_raw_writes_summary_and_unmatched_rows() -> No
             job_state = state_store.get_job_state(connection, JOB_NAME)
             summary_state = state_store.get_job_state(connection, SUMMARY_JOB_NAME)
 
+        assert summary_cost["service_name"] == "Compute Engine"
+        assert summary_cost["sku_name"] == "Core running"
         assert summary_cost["list_cost"] == 15
         assert summary_cost["effective_cost"] == 12
         assert summary_cost["credit_amount"] == -1.5

--- a/cost-insight/tests/test_gcp_billing_export.py
+++ b/cost-insight/tests/test_gcp_billing_export.py
@@ -22,6 +22,10 @@ def test_build_gcp_billing_query_keeps_expected_dimensions() -> None:
     assert "cost_at_list" in query
     assert "pricing_unit NOT IN ('hour', 'minute', 'second')" in query
     assert "ROUND(SUM(amount_in_pricing_units) * 60, 2)" in query
+    assert "Cloud Logging" in query
+    assert "Compute Flexible Committed Use Discounts - 3 Year" in query
+    assert "Compute Flexible Committed Use Discounts - 1 Year" in query
+    assert "wei_zheng" in query
     assert "MAX(export_time) AS source_export_time" in query
     assert "LIMIT 10" in query
 
@@ -41,7 +45,12 @@ def test_build_gcp_billing_summary_query_uses_partition_pruning() -> None:
     assert "k8s-label/author" in query
     assert "k8s-label/repo" in query
     assert "resource_name" not in query
-    assert "service.description" not in query
+    assert "service.description AS service_name" in query
+    assert "sku.description AS sku_name" in query
+    assert "Cloud Logging" in query
+    assert "Compute Flexible Committed Use Discounts - 3 Year" in query
+    assert "Compute Flexible Committed Use Discounts - 1 Year" in query
+    assert "wei_zheng" in query
     assert "LIMIT 20" in query
 
 
@@ -54,6 +63,8 @@ def test_build_gcp_unmatched_resource_query_keeps_resource_context() -> None:
     assert "resource.global_name" in query
     assert "usage_seconds" in query
     assert "service.description AS service_name" in query
+    assert "Cloud Logging" in query
+    assert "wei_zheng" in query
 
 
 def test_decimal_or_none() -> None:

--- a/cost-insight/tests/test_refresh_attribution_daily.py
+++ b/cost-insight/tests/test_refresh_attribution_daily.py
@@ -66,6 +66,7 @@ def test_normalized_identity_sql_replaces_label_unsafe_characters() -> None:
     assert "'@'" in sql
     assert "'-'" in sql
     assert "'.'" in sql
+    assert "'_'" in sql
     assert "' '" in sql
 
 
@@ -295,6 +296,12 @@ def test_insert_sql_contains_roster_matching_and_daily_dimensions() -> None:
     sql = str(_INSERT_ATTRIBUTION_DAILY)
 
     assert "LEFT JOIN roster_employees github_employee" in sql
+    assert "LEFT JOIN roster_employees override_employee" in sql
+    assert "flaky-claw" in sql
+    assert "yinsu@pingcap.com" in sql
+    assert "ti-chi-bot" in sql
+    assert "wei.zheng@pingcap.com" in sql
+    assert "author_override" in sql
     assert "LEFT JOIN roster_employees normalized_employee" in sql
     assert "LOWER(github_employee.github_id) = LOWER(raw.author)" in sql
     assert "SUBSTRING_INDEX(email_employee.email, '@', 1)" in sql
@@ -312,12 +319,14 @@ def test_summary_insert_sql_uses_summary_source_and_nullable_resource_columns() 
     sql = str(_INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY)
 
     assert "FROM cost_bq_export_summary_daily summary" in sql
-    assert "NULL AS service_name" in sql
-    assert "NULL AS sku_name" in sql
+    assert "summary.service_name" in sql
+    assert "summary.sku_name" in sql
     assert "NULL AS resource_name" in sql
     assert "NULL AS usage_seconds" in sql
     assert "LEFT JOIN roster_employees github_employee" in sql
+    assert "LEFT JOIN roster_employees override_employee" in sql
     assert "LOWER(github_employee.github_id) = LOWER(summary.author)" in sql
+    assert "author_override" in sql
     assert "author_normalized" in sql
     assert "SHA2(" in sql
     assert "{normalized_" not in sql

--- a/cost-insight/tests/test_sync_gcp_billing_summary.py
+++ b/cost-insight/tests/test_sync_gcp_billing_summary.py
@@ -59,6 +59,8 @@ def _sqlite_engine():
                   billing_account_id TEXT,
                   export_partition_date TEXT NOT NULL,
                   usage_date TEXT NOT NULL,
+                  service_name TEXT,
+                  sku_name TEXT,
                   org TEXT,
                   repo TEXT,
                   author TEXT,
@@ -85,6 +87,8 @@ def _summary_row(day: str = "2026-05-18") -> dict[str, object]:
         "billing_account_id": "billing-1",
         "export_partition_date": day,
         "usage_date": day,
+        "service_name": "Compute Engine",
+        "sku_name": "C4 Instance Core running in Americas",
         "author": "hawkingrei",
         "org": "pingcap",
         "repo": "tidb",
@@ -122,6 +126,9 @@ def test_summary_hash_ignores_amount_changes() -> None:
     changed = {**row, "net_cost": "99.00"}
 
     assert build_summary_row_hash(row) == build_summary_row_hash(changed)
+    assert build_summary_row_hash(row) != build_summary_row_hash(
+        {**row, "service_name": "Cloud Storage"}
+    )
 
 
 def test_select_billing_account_id_handles_empty_and_multiple_values() -> None:
@@ -150,10 +157,202 @@ def test_run_sync_gcp_billing_summary_writes_rows_and_touched_dates() -> None:
             count = connection.execute(
                 text("SELECT COUNT(*) FROM cost_bq_export_summary_daily")
             ).scalar_one()
+            service_names = connection.execute(
+                text("SELECT DISTINCT service_name FROM cost_bq_export_summary_daily")
+            ).scalars().all()
             state = state_store.get_job_state(connection, JOB_NAME)
         assert count == 2
+        assert service_names == ["Compute Engine"]
         assert state is not None
         assert state.last_status == "succeeded"
+    finally:
+        engine.dispose()
+
+
+def test_run_sync_gcp_billing_summary_deletes_superseded_owner_override_rows() -> None:
+    engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account")
+    old_row = _normalize_summary_row(
+        {
+            **_summary_row(),
+            "service_name": "Cloud Logging",
+            "sku_name": "Log Storage cost",
+            "author": None,
+        }
+    )
+    old_row = {
+        **old_row,
+        "list_cost": float(old_row["list_cost"]),
+        "effective_cost": float(old_row["effective_cost"]),
+        "credit_amount": float(old_row["credit_amount"]),
+        "net_cost": float(old_row["net_cost"]),
+    }
+    new_row = {
+        **_summary_row(),
+        "service_name": "Cloud Logging",
+        "sku_name": "Log Storage cost",
+        "author": "wei_zheng",
+    }
+
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO cost_bq_export_summary_daily (
+                      vendor,
+                      account_id,
+                      billing_account_id,
+                      export_partition_date,
+                      usage_date,
+                      service_name,
+                      sku_name,
+                      org,
+                      repo,
+                      author,
+                      list_cost,
+                      effective_cost,
+                      credit_amount,
+                      net_cost,
+                      source_export_time,
+                      source_row_hash
+                    ) VALUES (
+                      :vendor,
+                      :account_id,
+                      :billing_account_id,
+                      :export_partition_date,
+                      :usage_date,
+                      :service_name,
+                      :sku_name,
+                      :org,
+                      :repo,
+                      :author,
+                      :list_cost,
+                      :effective_cost,
+                      :credit_amount,
+                      :net_cost,
+                      :source_export_time,
+                      :source_row_hash
+                    )
+                    """
+                ),
+                old_row,
+            )
+
+        run_sync_gcp_billing_summary(
+            engine,
+            settings=settings,
+            export_partition_start=date(2026, 5, 18),
+            export_partition_end=date(2026, 5, 18),
+            dry_run=False,
+            fetch_rows=lambda **_kwargs: [new_row],
+        )
+
+        with engine.begin() as connection:
+            rows = connection.execute(
+                text(
+                    """
+                    SELECT author, ROUND(SUM(list_cost), 2) AS list_cost
+                    FROM cost_bq_export_summary_daily
+                    GROUP BY author
+                    """
+                )
+            ).all()
+        assert rows == [("wei_zheng", 10.0)]
+    finally:
+        engine.dispose()
+
+
+def test_run_sync_gcp_billing_summary_deletes_one_year_cud_superseded_rows() -> None:
+    engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account")
+    old_row = _normalize_summary_row(
+        {
+            **_summary_row(),
+            "service_name": "Compute Engine",
+            "sku_name": "Compute Flexible Committed Use Discounts - 1 Year",
+            "author": None,
+        }
+    )
+    old_row = {
+        **old_row,
+        "list_cost": float(old_row["list_cost"]),
+        "effective_cost": float(old_row["effective_cost"]),
+        "credit_amount": float(old_row["credit_amount"]),
+        "net_cost": float(old_row["net_cost"]),
+    }
+    new_row = {
+        **_summary_row(),
+        "service_name": "Compute Engine",
+        "sku_name": "Compute Flexible Committed Use Discounts - 1 Year",
+        "author": "wei_zheng",
+    }
+
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO cost_bq_export_summary_daily (
+                      vendor,
+                      account_id,
+                      billing_account_id,
+                      export_partition_date,
+                      usage_date,
+                      service_name,
+                      sku_name,
+                      org,
+                      repo,
+                      author,
+                      list_cost,
+                      effective_cost,
+                      credit_amount,
+                      net_cost,
+                      source_export_time,
+                      source_row_hash
+                    ) VALUES (
+                      :vendor,
+                      :account_id,
+                      :billing_account_id,
+                      :export_partition_date,
+                      :usage_date,
+                      :service_name,
+                      :sku_name,
+                      :org,
+                      :repo,
+                      :author,
+                      :list_cost,
+                      :effective_cost,
+                      :credit_amount,
+                      :net_cost,
+                      :source_export_time,
+                      :source_row_hash
+                    )
+                    """
+                ),
+                old_row,
+            )
+
+        run_sync_gcp_billing_summary(
+            engine,
+            settings=settings,
+            export_partition_start=date(2026, 5, 18),
+            export_partition_end=date(2026, 5, 18),
+            dry_run=False,
+            fetch_rows=lambda **_kwargs: [new_row],
+        )
+
+        with engine.begin() as connection:
+            rows = connection.execute(
+                text(
+                    """
+                    SELECT author, ROUND(SUM(list_cost), 2) AS list_cost
+                    FROM cost_bq_export_summary_daily
+                    GROUP BY author
+                    """
+                )
+            ).all()
+        assert rows == [("wei_zheng", 10.0)]
     finally:
         engine.dispose()
 


### PR DESCRIPTION
## Summary
- add a previous-complete-week cost overview to the Cost tab with list/net cost cards, service share, and level-2 group share
- switch weekly service share to `cost_attribution_daily.service_name` and show services above 1% of list cost
- add labeled donut charts and proportional reallocation for Efficiency & Quality shared cost
- preserve service/sku dimensions in GCP billing summary and attribution refresh, with a migration for existing summary rows
- add owner overrides for Cloud Logging, 1-year/3-year Compute Flexible CUD, and bot authors (`flaky-claw`, `ti-chi-bot`)

## Data repair performed
- repaired production `cost_bq_export_summary_daily` service/sku data and refreshed `cost_attribution_daily`
- refreshed 2026-05-16 through 2026-05-22 after CUD/bot author attribution fixes

## Tests
- `PYTHONPATH=cost-insight/src ci-dashboard/.venv/bin/python -m pytest --override-ini addopts='' cost-insight/tests/test_sync_gcp_billing_summary.py cost-insight/tests/test_refresh_attribution_daily.py cost-insight/tests/test_gcp_billing_export.py cost-insight/tests/test_backfill_cost_refine_from_raw.py -q`
- `PYTHONPATH=ci-dashboard/src ci-dashboard/.venv/bin/python -m pytest ci-dashboard/tests/api/test_routes.py -q`
- `PYTHONPATH=roster/src ci-dashboard/.venv/bin/python -m pytest --override-ini addopts='' roster/tests/test_sync_roster.py -q`
- `PYTHONPATH=cost-insight/src ci-dashboard/.venv/bin/ruff check cost-insight/src/cost_insight/sources/gcp_billing_export.py cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py cost-insight/tests/test_gcp_billing_export.py cost-insight/tests/test_sync_gcp_billing_summary.py cost-insight/tests/test_refresh_attribution_daily.py`
- `npm run build` in `ci-dashboard/web`
