### PR TITLE
feat(tibuild): use tekton as default engine for TiFlash

### DIFF
--- a/tibuild/pkg/rest/service/cloud_event_client_test.go
+++ b/tibuild/pkg/rest/service/cloud_event_client_test.go
@@ -32,7 +32,7 @@ func TestNewEvent(t *testing.T) {
 	require.NoError(t, err)
 	js, err := json.Marshal(evs)
 	require.NoError(t, err)
-	expected := `[{"specversion":"1.0","id":"","paramgithubrepo":"tikv/pd","paramprofile":"community","source":"tibuild.pingcap.net/api/devbuilds/1","type":"net.pingcap.tibuild.devbuild.push","subject":"1","datacontenttype":"application/json","data":{"ref":"refs/heads/master","after":"754095a9f460dcf31f053045cfedfb00b9ad8e81", "before":"00000000000000000000000000000000000000000","repository":{"full_name":"tikv/pd", "name":"pd","owner":{"login":"tikv"},"clone_url":"https://github.com/tikv/pd.git"}},"user":"some@pingcap.com"}]`
+	expected := `[{"specversion":"1.0","id":"","paramgithubrepo":"tikv/pd","paramispushgcr":false,"paramprofile":"community","source":"tibuild.pingcap.net/api/devbuilds/1","type":"net.pingcap.tibuild.devbuild.push","subject":"1","datacontenttype":"application/json","data":{"ref":"refs/heads/master","after":"754095a9f460dcf31f053045cfedfb00b9ad8e81", "before":"00000000000000000000000000000000000000000","repository":{"full_name":"tikv/pd", "name":"pd","owner":{"login":"tikv"},"clone_url":"https://github.com/tikv/pd.git"}},"user":"some@pingcap.com"}]`
 	require.JSONEq(t, expected, string(js))
 }
 

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -369,7 +369,7 @@ func fillWithDefaults(req *DevBuild) {
 	fillForFIPS(spec)
 	if req.Spec.PipelineEngine == "" {
 		// switch to tekton engine for common dev-build for tikv components.
-		if req.Spec.Product == ProductTikv && !req.Spec.IsHotfix {
+		if (req.Spec.Product == ProductTikv || req.Spec.Product == ProductTiflash) && !req.Spec.IsHotfix {
 			req.Spec.PipelineEngine = TektonEngine
 		} else {
 			req.Spec.PipelineEngine = JenkinsEngine

--- a/tibuild/website/src/App.js
+++ b/tibuild/website/src/App.js
@@ -93,9 +93,6 @@ const PipelineTabs = ({buildTypeProp}) => {
                 build_type: buildTypeSelect
             }),
         {
-            onSuccess: (data) => {
-                console.log(data)
-            },
             keepPreviousData: true,
             staleTime: 5000,
         }
@@ -121,7 +118,7 @@ const PipelineTabs = ({buildTypeProp}) => {
             <>
                 <Tabs value={tab} onChange={handleChange} aria-label="basic tabs example">
                     {currentVersions.map((v) => (
-                        <Tab label={v.pipeline_name}></Tab>
+                        <Tab key={v.pipeline_id} label={v.pipeline_name}></Tab>
                     ))}
                 </Tabs>
                 <GridList tab={tab} currentVersions={currentVersions}></GridList>
@@ -133,7 +130,7 @@ const PipelineTabs = ({buildTypeProp}) => {
             <>
                 <Tabs value={tabNightly} onChange={handleChangeNightly} aria-label="basic tabs example">
                     {currentVersions.map((v) => (
-                        <Tab label={v.pipeline_name}></Tab>
+                        <Tab key={v.pipeline_id} label={v.pipeline_name}></Tab>
                     ))}
                 </Tabs>
                 <GridList tab={tabNightly} currentVersions={currentVersions}></GridList>
@@ -144,7 +141,7 @@ const PipelineTabs = ({buildTypeProp}) => {
             <>
                 <Tabs value={0} onChange={handleChange} aria-label="basic tabs example">
                     {currentVersions.map((v) => (
-                        <Tab label={v.pipeline_name}></Tab>
+                        <Tab key={v.pipeline_id} label={v.pipeline_name}></Tab>
                     ))}
                 </Tabs>
                 <GridList tab={0} currentVersions={currentVersions}></GridList>
@@ -167,7 +164,7 @@ const ListPage = ({props}) => {
                     {/*</Paper>*/}
                     <Accordion defaultExpanded={true}>
                         <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
-                            <td><font face="Comic Sans MS"> Build Target</font></td>
+                            <Box component="span" sx={{fontFamily: "Comic Sans MS"}}>Build Target</Box>
                         </AccordionSummary>
                         <AccordionDetails>
                             <Box sx={{width: "100%"}}>

--- a/tibuild/website/src/App.test.js
+++ b/tibuild/website/src/App.test.js
@@ -1,57 +1,43 @@
-import * as React from 'react';
-import Container from '@mui/material/Container';
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import Box from "@mui/material/Box";
-import Tabs from "@mui/material/Tabs";
-import Tab from "@mui/material/Tab";
-import Layout from './layout/Layout';
-import DataGridDemo from './layout/IssueGrid'
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import App from './App';
+import { fetchPipelines } from './request/PipelineType';
 
-const PipelineTabs = () => {
-    const [tab, setTab] = React.useState(0);
+jest.mock('./request/PipelineType', () => ({
+    fetchPipelines: jest.fn(),
+}));
 
-    const handleChange = (event, newValue) => {
-        setTab(newValue);
-    };
+jest.mock('./layout/GridColumns', () => () => (
+    <div data-testid="build-grid" />
+));
 
-    const currentVersions = ["TiDB", "TiKV", "TiFlash"];
-    return (
-        <>
-            <Tabs value={tab} onChange={handleChange} aria-label="basic tabs example">
-                {/* <Tab label="All" /> */}
-                {currentVersions.map((v) => (
-                    <Tab label={v}></Tab>
-                ))}
-            </Tabs>
-            <DataGridDemo></DataGridDemo>
-        </>
+test('renders build list page', async () => {
+    fetchPipelines.mockResolvedValue([
+        {
+            pipeline_id: 1,
+            pipeline_name: 'TiDB',
+        },
+    ]);
+
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={['/home/list/dev']}>
+                <Routes>
+                    <Route path="/home/list/:type" element={<App />} />
+                </Routes>
+            </MemoryRouter>
+        </QueryClientProvider>
     );
-};
 
-const ListPage = () => {
-    return (
-        <Layout>
-            <Container maxWidth="xxl" sx={{mt: 4, mb: 4}}>
-                {/*<Paper sx={{p: 2, display: 'flex', flexDirection: 'column'}}>*/}
-                {/*</Paper>*/}
-                <Accordion defaultExpanded={true}>
-                    <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
-                        Build Type
-                    </AccordionSummary>
-                    <AccordionDetails>
-                        <Box sx={{width: "100%"}}>
-                            <Box sx={{borderBottom: 1, borderColor: "divider"}}></Box>
-                            <PipelineTabs></PipelineTabs>
-                        </Box>
-
-                    </AccordionDetails>
-                </Accordion>
-            </Container>
-        </Layout>
-    )
-};
-
-export default ListPage;
+    expect(await screen.findByText('TiDB')).toBeInTheDocument();
+    expect(screen.getByTestId('build-grid')).toBeInTheDocument();
+});

--- a/tibuild/website/src/config.js
+++ b/tibuild/website/src/config.js
@@ -9,8 +9,6 @@ const prod_config = {
   SERVER_HOST: "/",
 };
 
-console.log(process.env);
-
 export default process.env.NODE_ENV === "development"
   ? dev_config
   : prod_config;


### PR DESCRIPTION
## Summary
- use Tekton as the default pipeline engine for TiFlash dev builds
- update CloudEvent test expectation for `paramIsPushGcr`
- replace stale frontend smoke test and clean React test warnings

## Tests
- `go test ./...`
- `CI=true npm test -- --watchAll=false`