### PR TITLE
Make flaky issues branch-agnostic and keep PRs scoped by target branch

### DIFF
--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -496,10 +496,11 @@ def get_issue_filtered_weekly_case_rates(
     filters: CommonFilters,
 ) -> dict[str, Any]:
     effective_repo = filters.repo or DEFAULT_DISTINCT_CASE_REPO
+    issue_filters = _issue_query_filters(filters)
 
     with engine.begin() as connection:
-        issue_cases = _fetch_issue_cases(connection, filters, effective_repo)
-        data_rows = _fetch_issue_weekly_rate_rows(connection, filters, effective_repo)
+        issue_cases = _fetch_issue_cases(connection, issue_filters, effective_repo)
+        data_rows = _fetch_issue_weekly_rate_rows(connection, issue_filters, effective_repo)
 
     week_columns = _week_columns(filters.start_date, filters.end_date, data_rows)
     metrics_by_case_week: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
@@ -541,7 +542,7 @@ def get_issue_filtered_weekly_case_rates(
                 "display_name": _issue_display_name(
                     case_name=case_name,
                     issue_branch=issue_branch,
-                    selected_branch=filters.branch,
+                    selected_branch=issue_filters.branch,
                 ),
                 "issue_branch": issue_branch,
                 "issue_number": int(issue["issue_number"]),
@@ -576,6 +577,7 @@ def get_issue_filtered_weekly_case_rates(
             "bucket_granularity": "week",
             "defaulted_repo": filters.repo is None,
             "issue_case_count": len(rows_payload),
+            "ignores_branch": True,
         }
     )
     return {
@@ -601,6 +603,7 @@ def get_issue_lifecycle_snapshot(
     filters: CommonFilters,
 ) -> dict[str, Any]:
     effective_repo = filters.repo or DEFAULT_DISTINCT_CASE_REPO
+    issue_filters = _issue_query_filters(filters)
     latest_full_week_start = _latest_complete_week_start(filters.end_date)
     latest_full_week_end = (
         latest_full_week_start + timedelta(days=6)
@@ -609,7 +612,7 @@ def get_issue_lifecycle_snapshot(
     )
 
     with engine.begin() as connection:
-        issue_rows = _fetch_issue_latest_rows(connection, filters, effective_repo)
+        issue_rows = _fetch_issue_latest_rows(connection, issue_filters, effective_repo)
 
     scoped_issue_rows = [
         row
@@ -672,6 +675,7 @@ def get_issue_lifecycle_snapshot(
                 latest_full_week_end.isoformat() if latest_full_week_end else None
             ),
             "ignores_issue_status": True,
+            "ignores_branch": True,
         }
     )
 
@@ -711,10 +715,10 @@ def get_issue_fix_progress_snapshot(
     effective_repo = filters.repo or DEFAULT_DISTINCT_CASE_REPO
     as_of_date = filters.end_date or date.today()
     comparison_as_of_date = as_of_date - timedelta(days=7)
-    scoped_filters = CommonFilters(repo=filters.repo, branch=filters.branch)
+    issue_filters = _issue_query_filters(filters)
 
     with engine.begin() as connection:
-        issue_rows = _fetch_issue_latest_rows(connection, scoped_filters, effective_repo)
+        issue_rows = _fetch_issue_latest_rows(connection, issue_filters, effective_repo)
 
         current_issue_rows = [
             row for row in issue_rows if _entity_exists_as_of(row.get("issue_created_at"), as_of_date)
@@ -726,10 +730,12 @@ def get_issue_fix_progress_snapshot(
         current_pull_rows = _fetch_linked_pull_rows(
             connection,
             [(str(row["repo"]), int(row["issue_number"])) for row in current_issue_rows],
+            branch=filters.branch,
         )
         previous_pull_rows = _fetch_linked_pull_rows(
             connection,
             [(str(row["repo"]), int(row["issue_number"])) for row in previous_issue_rows],
+            branch=filters.branch,
         )
 
     current_fixed_issue_count = sum(
@@ -770,6 +776,8 @@ def get_issue_fix_progress_snapshot(
             "ignores_job_name": True,
             "ignores_cloud_phase": True,
             "ignores_issue_status": True,
+            "ignores_branch_for_issues": True,
+            "applies_branch_to_prs": bool(filters.branch),
         }
     )
 
@@ -791,8 +799,9 @@ def get_issue_lifecycle_weekly(
     filters: CommonFilters,
 ) -> dict[str, Any]:
     effective_repo = filters.repo or DEFAULT_DISTINCT_CASE_REPO
+    issue_filters = _issue_query_filters(filters)
     with engine.begin() as connection:
-        issue_rows = _fetch_issue_latest_rows(connection, filters, effective_repo)
+        issue_rows = _fetch_issue_latest_rows(connection, issue_filters, effective_repo)
 
     scoped_issue_rows = [
         row
@@ -855,6 +864,7 @@ def get_issue_lifecycle_weekly(
             "defaulted_repo": filters.repo is None,
             "bucket_granularity": "week",
             "ignores_issue_status": True,
+            "ignores_branch": True,
         }
     )
     return {
@@ -1195,6 +1205,19 @@ def _fetch_issue_weekly_rate_rows(
     return [dict(row) for row in rows]
 
 
+def _issue_query_filters(filters: CommonFilters) -> CommonFilters:
+    return CommonFilters(
+        repo=filters.repo,
+        branch=None,
+        job_name=filters.job_name,
+        cloud_phase=filters.cloud_phase,
+        issue_status=filters.issue_status,
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        granularity=filters.granularity,
+    )
+
+
 def _fetch_weekly_flaky_case_presence(
     connection: Connection,
     filters: CommonFilters,
@@ -1413,6 +1436,8 @@ def _fetch_issue_latest_rows(
 def _fetch_linked_pull_rows(
     connection: Connection,
     issue_keys: list[tuple[str, int]],
+    *,
+    branch: str | None = None,
 ) -> list[dict[str, Any]]:
     if not issue_keys:
         return []
@@ -1425,6 +1450,11 @@ def _fetch_linked_pull_rows(
         )
         params[f"issue_repo_{index}"] = issue_repo
         params[f"issue_number_{index}"] = issue_number
+
+    branch_clause = ""
+    if branch:
+        branch_clause = f" AND {_pull_ticket_branch_expr(connection, 'p')} = :branch"
+        params["branch"] = branch
 
     rows = connection.execute(
         text(
@@ -1442,13 +1472,21 @@ def _fetch_linked_pull_rows(
               ON p.type = 'pull'
              AND p.repo = l.pr_repo
              AND p.number = l.pr_number
-            WHERE {' OR '.join(clauses)}
+            WHERE ({' OR '.join(clauses)})
+            {branch_clause}
             ORDER BY p.repo, p.number
             """
         ),
         params,
     ).mappings()
     return [dict(row) for row in rows]
+
+
+def _pull_ticket_branch_expr(connection: Connection, table_alias: str) -> str:
+    prefix = f"{table_alias}."
+    if connection.dialect.name == "sqlite":
+        return f"json_extract({prefix}branches, '$.base.ref')"
+    return f"JSON_UNQUOTE(JSON_EXTRACT({prefix}branches, '$.base.ref'))"
 
 
 def _latest_complete_week_start(end_date: date | None) -> date | None:

--- a/ci-dashboard/src/ci_dashboard/jobs/sync_flaky_issues.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/sync_flaky_issues.py
@@ -36,6 +36,8 @@ CASE_NAME_PATTERN = re.compile(r"^Flaky test:\s*(.+?)\s+in\s+.+$")
 BRANCH_PATTERN = re.compile(r"- Branch:\s*([^\n<\"]+)")
 GITHUB_API_BASE_URL = "https://api.github.com"
 BOT_AUTHORS = {"ti-chi-bot", "ti-chi-bot[bot]"}
+DEFAULT_ISSUE_BRANCH = "master"
+DEFAULT_BRANCH_SOURCE = "default_master"
 
 
 @dataclass(frozen=True)
@@ -267,45 +269,8 @@ def _resolve_issue_branch(
     row: dict[str, Any],
     existing: dict[str, Any] | None,
 ) -> tuple[str | None, str, bool, bool]:
-    source_comments_branch = parse_issue_branch_from_comments(row.get("comments"))
-    if source_comments_branch:
-        return source_comments_branch, "ticket_comments", False, False
-
-    ticket_body = str(row.get("body") or "")
-    body_branch = parse_issue_branch(ticket_body)
-    if body_branch:
-        return body_branch, "ticket_body", False, False
-
-    reused_branch, reused_source = _reuse_existing_issue_branch_if_fresh(row, existing)
-    if reused_branch:
-        return reused_branch, reused_source, False, False
-
-    repo = str(row["repo"])
-    issue_number = int(row["number"])
-    try:
-        github_body, github_comments = fetch_issue_details_via_github_api(
-            repo=repo,
-            issue_number=issue_number,
-        )
-        github_comments_branch = parse_issue_branch_from_comments(github_comments)
-        if github_comments_branch:
-            return github_comments_branch, "github_api_comments", True, False
-        github_body_branch = parse_issue_branch(github_body)
-        if github_body_branch:
-            return github_body_branch, "github_api_body", True, False
-        fallback_branch, fallback_source = _fallback_issue_branch(existing)
-        return fallback_branch, fallback_source, True, False
-    except Exception as exc:
-        LOG.warning(
-            "failed to fetch flaky issue details via GitHub API",
-            extra={
-                "repo": repo,
-                "issue_number": issue_number,
-                "error": str(exc),
-            },
-        )
-        fallback_branch, fallback_source = _fallback_issue_branch(existing)
-        return fallback_branch, fallback_source, True, True
+    del row, existing
+    return DEFAULT_ISSUE_BRANCH, DEFAULT_BRANCH_SOURCE, False, False
 
 
 def _fallback_issue_branch(existing: dict[str, Any] | None) -> tuple[str | None, str]:

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import date, datetime, timezone
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -318,6 +319,7 @@ def _insert_pull_ticket(
     closed_at: str | None = None,
     merged: int = 0,
     merged_at: str | None = None,
+    target_branch: str | None = "master",
 ) -> None:
     with sqlite_engine.begin() as connection:
         connection.execute(
@@ -328,7 +330,7 @@ def _insert_pull_ticket(
                   closed_at, merged, merged_at, review, review_comments, timeline, branches
                 ) VALUES (
                   'pull', :repo, :number, :title, NULL, '[]', :state, :created_at, :updated_at,
-                  :closed_at, :merged, :merged_at, '[]', '[]', '[]', NULL
+                  :closed_at, :merged, :merged_at, '[]', '[]', '[]', :branches
                 )
                 """
             ),
@@ -342,6 +344,11 @@ def _insert_pull_ticket(
                 "closed_at": closed_at,
                 "merged": merged,
                 "merged_at": merged_at,
+                "branches": (
+                    json.dumps({"base": {"ref": target_branch}})
+                    if target_branch is not None
+                    else None
+                ),
             },
         )
 
@@ -2028,7 +2035,7 @@ def test_page_routes(api_client: TestClient) -> None:
     ]
     assert flaky_body["bucketed_flaky_rate"]["meta"]["requested_granularity"] == "day"
     assert flaky_body["bucketed_flaky_rate"]["meta"]["effective_granularity"] == "week"
-    assert flaky_body["issue_case_weekly_rates"]["rows"][0]["display_name"] == "TestCaseAlpha"
+    assert flaky_body["issue_case_weekly_rates"]["rows"][0]["display_name"] == "[master] TestCaseAlpha"
     assert flaky_body["issue_case_weekly_rates"]["rows"][0]["cells"] == ["100.00% (1/1)"]
     assert flaky_body["issue_case_weekly_rates"]["rows"][1]["cells"] == ["100.00% (1/1)"]
     failure_series = {
@@ -3153,6 +3160,7 @@ def test_flaky_page_issue_lifecycle_snapshot_ignores_issue_status_filter(
     assert lifecycle["meta"]["latest_full_week_start"] == "2026-04-13"
     assert lifecycle["meta"]["latest_full_week_end"] == "2026-04-19"
     assert lifecycle["meta"]["ignores_issue_status"] is True
+    assert lifecycle["meta"]["ignores_branch"] is True
     assert lifecycle["latest_week_created_count"] == 2
     assert lifecycle["latest_week_created_open_count"] == 1
     assert lifecycle["latest_week_created_closed_count"] == 1
@@ -3274,6 +3282,8 @@ def test_flaky_page_issue_fix_progress_snapshot(
     assert progress["meta"]["ignores_job_name"] is True
     assert progress["meta"]["ignores_cloud_phase"] is True
     assert progress["meta"]["ignores_issue_status"] is True
+    assert progress["meta"]["ignores_branch_for_issues"] is True
+    assert progress["meta"]["applies_branch_to_prs"] is True
     assert progress["filed_issue_count"] == 5
     assert progress["filed_issue_delta"] == 1
     assert progress["fixed_issue_count"] == 2
@@ -3282,3 +3292,112 @@ def test_flaky_page_issue_fix_progress_snapshot(
     assert progress["in_review_pr_delta"] == 0
     assert progress["merged_pr_count"] == 1
     assert progress["merged_pr_delta"] == 1
+
+
+def test_flaky_issue_queries_ignore_branch_filter(sqlite_engine) -> None:
+    _insert_flaky_issue(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        issue_number=72001,
+        case_name="ReleaseScopedCase",
+        issue_branch="release-8.5",
+        issue_status="open",
+        issue_created_at="2026-04-10 10:00:00",
+    )
+    _insert_flaky_issue(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        issue_number=72002,
+        case_name="MasterScopedCase",
+        issue_branch="master",
+        issue_status="closed",
+        issue_created_at="2026-04-11 10:00:00",
+        issue_closed_at="2026-04-12 12:00:00",
+    )
+    _insert_flaky_issue_pr_link(
+        sqlite_engine,
+        issue_repo="pingcap/tidb",
+        issue_number=72001,
+        pr_repo="pingcap/tidb",
+        pr_number=73001,
+        linked_at="2026-04-10 11:00:00",
+    )
+    _insert_flaky_issue_pr_link(
+        sqlite_engine,
+        issue_repo="pingcap/tidb",
+        issue_number=72002,
+        pr_repo="pingcap/tidb",
+        pr_number=73002,
+        linked_at="2026-04-11 11:00:00",
+    )
+    _insert_pull_ticket(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        number=73001,
+        state="open",
+        created_at="2026-04-10 11:05:00",
+        target_branch="release-8.5",
+    )
+    _insert_pull_ticket(
+        sqlite_engine,
+        repo="pingcap/tidb",
+        number=73002,
+        state="closed",
+        created_at="2026-04-11 11:05:00",
+        closed_at="2026-04-12 12:00:00",
+        merged=1,
+        merged_at="2026-04-12 12:00:00",
+    )
+
+    app.dependency_overrides[get_engine] = lambda: sqlite_engine
+    try:
+        with TestClient(app) as client:
+            page_response = client.get(
+                "/api/v1/pages/flaky",
+                params={
+                    "repo": "pingcap/tidb",
+                    "branch": "master",
+                    "start_date": "2026-04-01",
+                    "end_date": "2026-04-20",
+                },
+            )
+            issue_rates_response = client.get(
+                "/api/v1/flaky/issue-weekly-rates",
+                params={
+                    "repo": "pingcap/tidb",
+                    "branch": "master",
+                    "start_date": "2026-04-01",
+                    "end_date": "2026-04-20",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert page_response.status_code == 200
+    assert issue_rates_response.status_code == 200
+
+    page_body = page_response.json()
+    issue_fix_progress = page_body["issue_fix_progress"]
+    assert issue_fix_progress["meta"]["ignores_branch_for_issues"] is True
+    assert issue_fix_progress["meta"]["applies_branch_to_prs"] is True
+    assert issue_fix_progress["filed_issue_count"] == 2
+    assert issue_fix_progress["fixed_issue_count"] == 1
+    assert issue_fix_progress["in_review_pr_count"] == 0
+    assert issue_fix_progress["merged_pr_count"] == 1
+
+    issue_lifecycle = page_body["issue_lifecycle"]
+    assert issue_lifecycle["meta"]["ignores_branch"] is True
+    assert issue_lifecycle["scoped_issue_count"] == 2
+
+    issue_lifecycle_weekly = page_body["issue_lifecycle_weekly"]
+    assert issue_lifecycle_weekly["meta"]["ignores_branch"] is True
+
+    issue_rates_body = issue_rates_response.json()
+    assert issue_rates_body["meta"]["ignores_branch"] is True
+    rows_by_issue = {
+        row["issue_number"]: row
+        for row in issue_rates_body["rows"]
+    }
+    assert rows_by_issue[72001]["issue_branch"] == "release-8.5"
+    assert rows_by_issue[72001]["display_name"] == "[release-8.5] ReleaseScopedCase"
+    assert rows_by_issue[72002]["display_name"] == "[master] MasterScopedCase"

--- a/ci-dashboard/tests/jobs/test_sync_flaky_issues.py
+++ b/ci-dashboard/tests/jobs/test_sync_flaky_issues.py
@@ -161,7 +161,7 @@ def test_sync_flaky_issues_end_to_end_and_idempotent_refresh(sqlite_engine, monk
     assert row["case_name"] == "TestAuditPluginRetrying"
     assert row["issue_status"] == "closed"
     assert row["issue_branch"] == "master"
-    assert row["branch_source"] == "ticket_body"
+    assert row["branch_source"] == "default_master"
     assert str(row["issue_closed_at"]).startswith("2026-04-13 09:30:00")
     assert str(row["last_reopened_at"]).startswith("2026-04-12 08:00:00")
     assert row["reopen_count"] == 1
@@ -217,7 +217,7 @@ def test_sync_flaky_issues_end_to_end_and_idempotent_refresh(sqlite_engine, monk
     assert total_rows["count"] == 1
 
 
-def test_sync_flaky_issues_uses_github_api_comments_when_ticket_body_missing(
+def test_sync_flaky_issues_defaults_branch_to_master_when_ticket_body_missing(
     sqlite_engine,
     monkeypatch,
 ) -> None:
@@ -237,20 +237,14 @@ def test_sync_flaky_issues_uses_github_api_comments_when_ticket_body_missing(
 
     monkeypatch.setattr(
         "ci_dashboard.jobs.sync_flaky_issues.fetch_issue_details_via_github_api",
-        lambda **_: (
-            "Automated flaky test report.\n- Branch: master\n",
-            [
-                {
-                    "user": {"login": "ti-chi-bot"},
-                    "body": "Automated flaky test report update.\n- Branch: release-8.5\n",
-                }
-            ],
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("GitHub API should not be called for branch metadata")
         ),
     )
 
     summary = run_sync_flaky_issues(sqlite_engine, _settings(batch_size=10))
 
-    assert summary.branch_fetch_attempted == 1
+    assert summary.branch_fetch_attempted == 0
     assert summary.branch_fetch_failed == 0
 
     with sqlite_engine.begin() as connection:
@@ -264,8 +258,8 @@ def test_sync_flaky_issues_uses_github_api_comments_when_ticket_body_missing(
             )
         ).mappings().one()
 
-    assert row["issue_branch"] == "release-8.5"
-    assert row["branch_source"] == "github_api_comments"
+    assert row["issue_branch"] == "master"
+    assert row["branch_source"] == "default_master"
 
 
 def test_sync_flaky_issues_writes_and_replaces_issue_pr_links(
@@ -634,7 +628,7 @@ def test_sync_flaky_issues_reuses_existing_branch_when_ticket_is_unchanged(
         ).mappings().one()
 
     assert row["issue_branch"] == "master"
-    assert row["branch_source"] == "github_api_body"
+    assert row["branch_source"] == "default_master"
 
 
 def test_parse_issue_branch_handles_plain_body_and_escaped_newlines() -> None:
@@ -788,12 +782,14 @@ def test_sync_flaky_issue_helpers_cover_fallbacks_and_payload_shapes(monkeypatch
 
     monkeypatch.setattr(
         "ci_dashboard.jobs.sync_flaky_issues.fetch_issue_details_via_github_api",
-        lambda **_: ("body without branch", []),
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("GitHub API should not be called for branch metadata")
+        ),
     )
     assert _resolve_issue_branch(
         {"repo": "pingcap/tidb", "number": 1, "body": None, "comments": None, "updated_at": "2026-04-16T09:00:00Z"},
         existing,
-    ) == ("release-8.5", "github_api_body", True, False)
+    ) == ("master", "default_master", False, False)
 
 
 def test_fetch_github_api_json_and_issue_details_wrap_http_failures(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- default synced flaky issues to the `master` branch without re-parsing issue metadata for branch changes
- ignore the flaky page branch filter for issue-based cards and issue weekly rates
- keep flaky fix PR progress scoped by PR target branch so the default `master` filter still only counts master PRs

## Testing
- `PYTHONPATH=src /Users/dillon/workspace/ee-apps/ci-dashboard/.venv/bin/python -m pytest tests/jobs/test_sync_flaky_issues.py`
- `PYTHONPATH=src /Users/dillon/workspace/ee-apps/ci-dashboard/.venv/bin/python -m pytest tests/api/test_routes.py`

Supersedes #467, which was opened from a fork and hit GitHub Actions setup failures when downloading a third-party action.