### PR TITLE
feat(ci-dashboard): refine runtime insight trend drilldowns

### DIFF
--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-dashboard"
-version = "0.3.5"
+version = "0.3.6"
 description = "CI dashboard jobs and API scaffold"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
+++ b/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: ci-dashboard
-Version: 0.3.5
+Version: 0.3.6
 Summary: CI dashboard jobs and API scaffold
 Requires-Python: >=3.11
 Description-Content-Type: text/markdown

--- a/ci-dashboard/src/ci_dashboard/__init__.py
+++ b/ci-dashboard/src/ci_dashboard/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"

--- a/ci-dashboard/web/package-lock.json
+++ b/ci-dashboard/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-dashboard-web",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -436,13 +436,16 @@ export function TrendChart({
                 ? Math.max(resolvedRightYMax - resolvedRightYMin, 1)
                 : leftMaxValue;
             const axisMin = item.axis === "right" ? resolvedRightYMin : 0;
+            const axisMax = item.axis === "right" ? resolvedRightYMax : leftMaxValue;
             const baseValue = stackBars
               ? stackedSeries
                   .slice(0, Math.max(axisSeriesIndex, 0))
                   .reduce((sum, candidate) => sum + (pointMaps.get(candidate.key)?.get(label) ?? 0), 0)
               : 0;
-            const normalizedValue = Math.max(value - axisMin, 0);
-            const normalizedBaseValue = Math.max(baseValue - axisMin, 0);
+            const clampedValue = Math.min(Math.max(value, axisMin), axisMax);
+            const clampedBaseValue = Math.min(Math.max(baseValue, axisMin), axisMax);
+            const normalizedValue = Math.max(clampedValue - axisMin, 0);
+            const normalizedBaseValue = Math.max(clampedBaseValue - axisMin, 0);
             const barHeight = axisRange > 0 ? (normalizedValue / axisRange) * plotHeight : 0;
             const y = stackBars
               ? padding.top + plotHeight - ((normalizedBaseValue + normalizedValue) / axisRange) * plotHeight
@@ -482,7 +485,12 @@ export function TrendChart({
             }
 
             const x = xForIndex(index);
-            const y = padding.top + plotHeight - ((value - axisMin) / axisRange) * plotHeight;
+            const clampedValue = Math.min(
+              Math.max(value, axisMin),
+              axisMin + axisRange,
+            );
+            const y =
+              padding.top + plotHeight - ((clampedValue - axisMin) / axisRange) * plotHeight;
             currentSegment.push({ label, x, y });
           });
 

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -75,6 +75,7 @@ const SERIES_COLORS = {
   DISK_FULL: "#bc6c25",
   STORAGE: "#bc6c25",
   EXTERNAL_DEP: "#8d5a97",
+  selected_share_pct: "#264653",
   COMPILE: "#bc6c25",
   TIMEOUT: "#d88b3d",
   classified_count: "#2a9d8f",

--- a/ci-dashboard/web/src/pages/RuntimeInsightsPage.jsx
+++ b/ci-dashboard/web/src/pages/RuntimeInsightsPage.jsx
@@ -23,6 +23,83 @@ const EMPTY_ITEMS = [];
 const EMPTY_DETAILS = {};
 const formatOneDecimal = (value) => Number(value || 0).toFixed(1);
 
+function buildRateAxisBounds(values) {
+  const numericValues = values.filter((value) => Number.isFinite(value));
+  if (!numericValues.length) {
+    return { min: 0, max: 10 };
+  }
+
+  const hardMin = 0;
+  const hardMax = 95;
+  const rawMin = Math.min(...numericValues);
+  const rawMax = Math.max(...numericValues);
+  const span = rawMax - rawMin;
+  const pad = span === 0 ? Math.max(4, rawMax * 0.35 || 4) : Math.max(span, 4);
+
+  let min = rawMin - pad;
+  let max = rawMax + pad;
+  const desiredRange = max - min;
+
+  if (min < hardMin) {
+    max = Math.min(hardMax, max + (hardMin - min));
+    min = hardMin;
+  }
+  if (max > hardMax) {
+    min = Math.max(hardMin, min - (max - hardMax));
+    max = hardMax;
+  }
+  if (max - min < 1) {
+    max = Math.min(hardMax, min + 1);
+  }
+  if (max - min < desiredRange && min === hardMin) {
+    max = Math.min(hardMax, hardMin + desiredRange);
+  }
+
+  return {
+    min: Number(min.toFixed(1)),
+    max: Number(max.toFixed(1)),
+  };
+}
+
+function buildSelectedTrendWithShare(selectedKey, allSeries, shareLabelSuffix) {
+  if (!selectedKey || !allSeries?.length) {
+    return { series: EMPTY_ITEMS, rightAxis: null };
+  }
+
+  const selectedSeries = allSeries.find((item) => item.key === selectedKey);
+  if (!selectedSeries) {
+    return { series: EMPTY_ITEMS, rightAxis: null };
+  }
+
+  const labels = Array.from(
+    new Set(allSeries.flatMap((item) => item.points.map((point) => point[0]))),
+  ).sort();
+  const selectedValues = new Map(
+    selectedSeries.points.map((point) => [point[0], Number(point[1] || 0)]),
+  );
+
+  const shareSeries = {
+    key: "selected_share_pct",
+    label: `${selectedSeries.label || selectedKey} ${shareLabelSuffix}`,
+    type: "line",
+    axis: "right",
+    points: labels.map((label) => {
+      const total = allSeries.reduce((sum, item) => {
+        const point = item.points.find((candidate) => candidate[0] === label);
+        return sum + Number(point?.[1] || 0);
+      }, 0);
+      const selectedValue = selectedValues.get(label) || 0;
+      const sharePct = total > 0 ? (selectedValue / total) * 100 : 0;
+      return [label, Number(sharePct.toFixed(1))];
+    }),
+  };
+
+  return {
+    series: [selectedSeries, shareSeries],
+    rightAxis: buildRateAxisBounds(shareSeries.points.map((point) => point[1])),
+  };
+}
+
 export default function RuntimeInsightsPage({ filters }) {
   const page = useApiData("/api/v1/pages/runtime-insights", filters);
   const [selectedL1, setSelectedL1] = useState("INFRA");
@@ -47,11 +124,20 @@ export default function RuntimeInsightsPage({ filters }) {
   const classificationSummary = classificationCoverage.summary || {};
   const l1Items = page.data?.error_l1_share?.items || EMPTY_ITEMS;
   const l2Details = page.data?.error_l1_share?.l2_details || EMPTY_DETAILS;
+  const selectedL1Trend = buildSelectedTrendWithShare(
+    selectedL1,
+    page.data?.error_l1_trend?.series || EMPTY_ITEMS,
+    "share",
+  );
   const selectedL2Share =
     selectedL1 === "INFRA"
       ? page.data?.infra_l2_share?.items || l2Details.INFRA || EMPTY_ITEMS
       : l2Details[selectedL1] || EMPTY_ITEMS;
-  const selectedL2Trend = page.data?.error_l2_trends?.items?.[selectedL1]?.series || EMPTY_ITEMS;
+  const selectedL2Trend = buildSelectedTrendWithShare(
+    selectedL2,
+    page.data?.error_l2_trends?.items?.[selectedL1]?.series || EMPTY_ITEMS,
+    "share",
+  );
   const topErrorJobs = useApiData("/api/v1/pages/runtime-error-top-jobs", {
     ...filters,
     error_l1_category: selectedL1 || "",
@@ -315,14 +401,16 @@ export default function RuntimeInsightsPage({ filters }) {
 
         <Panel
           title="Jenkins Error Catalog Trend"
-          subtitle="Failure-like builds by Jenkins Error Catalog over time."
+          subtitle={`Showing ${selectedL1} count by time bucket, with its share of the total bucket on the right axis.`}
           loading={page.loading}
           error={page.error}
         >
           <TrendChart
-            series={page.data?.error_l1_trend?.series}
+            series={selectedL1Trend.series}
             yFormatter={formatNumber}
-            stackBars
+            rightYFormatter={formatPercent}
+            rightYMin={selectedL1Trend.rightAxis?.min ?? 0}
+            rightYMax={selectedL1Trend.rightAxis?.max ?? 10}
           />
         </Panel>
 
@@ -344,14 +432,20 @@ export default function RuntimeInsightsPage({ filters }) {
 
         <Panel
           title={`${selectedL1} Error Details Trend`}
-          subtitle="Trend of the top error details inside the selected catalog."
+          subtitle={
+            selectedL2
+              ? `Showing ${selectedL2} count by time bucket, with its share inside ${selectedL1} on the right axis.`
+              : "Select an error detail from the chart on the left."
+          }
           loading={page.loading}
           error={page.error}
         >
           <TrendChart
-            series={selectedL2Trend}
+            series={selectedL2Trend.series}
             yFormatter={formatNumber}
-            stackBars
+            rightYFormatter={formatPercent}
+            rightYMin={selectedL2Trend.rightAxis?.min ?? 0}
+            rightYMax={selectedL2Trend.rightAxis?.max ?? 10}
           />
         </Panel>
 

--- a/ci-dashboard/web/src/pages/RuntimeInsightsPage.jsx
+++ b/ci-dashboard/web/src/pages/RuntimeInsightsPage.jsx
@@ -74,8 +74,15 @@ function buildSelectedTrendWithShare(selectedKey, allSeries, shareLabelSuffix) {
   const labels = Array.from(
     new Set(allSeries.flatMap((item) => item.points.map((point) => point[0]))),
   ).sort();
+  const totals = new Map();
+  allSeries.forEach((item) => {
+    item.points.forEach(([label, value]) => {
+      totals.set(label, (totals.get(label) || 0) + Number(value || 0));
+    });
+  });
+  const selectedPoints = selectedSeries.points || [];
   const selectedValues = new Map(
-    selectedSeries.points.map((point) => [point[0], Number(point[1] || 0)]),
+    selectedPoints.map((point) => [point[0], Number(point[1] || 0)]),
   );
 
   const shareSeries = {
@@ -84,10 +91,7 @@ function buildSelectedTrendWithShare(selectedKey, allSeries, shareLabelSuffix) {
     type: "line",
     axis: "right",
     points: labels.map((label) => {
-      const total = allSeries.reduce((sum, item) => {
-        const point = item.points.find((candidate) => candidate[0] === label);
-        return sum + Number(point?.[1] || 0);
-      }, 0);
+      const total = totals.get(label) || 0;
       const selectedValue = selectedValues.get(label) || 0;
       const sharePct = total > 0 ? (selectedValue / total) * 100 : 0;
       return [label, Number(sharePct.toFixed(1))];


### PR DESCRIPTION
## Summary
- let Runtime Insights trend panels follow the selected value from the left donut charts instead of rendering every series together
- add a right-axis share line for the selected value and make the share axis auto-scale so the line stays centered instead of pinning to 100%
- bump CI Dashboard version from `0.3.5` to `0.3.6` across Python and web package metadata

## Verification
- `cd ci-dashboard/web && npm run build`
- local Runtime Insights page verified against the local API with real data