### PR TITLE
fix(ci-dashboard): refine runtime insights and filter URLs

### DIFF
--- a/ci-dashboard/docs/runtime-insights-design.md
+++ b/ci-dashboard/docs/runtime-insights-design.md
@@ -223,11 +223,12 @@ Design implication:
 - implementation note: the first dashboard version uses
   `last_failed_scheduling_at -> scheduled_at` from `ci_l1_pod_lifecycle` for the
   displayed successful-retry duration. A final scheduling failure is currently
-  defined as `failed_scheduling_count > 0`, `scheduled_at IS NULL`, and
-  `last_event_at` older than a 30-minute grace window. The event-table version
-  `first FailedScheduling -> Scheduled` is semantically richer, but it needs a
-  materialized lifecycle field or a faster event rollup before it is safe for the
-  page-level endpoint on production data.
+  defined as `failed_scheduling_count > 0`, `scheduled_at IS NULL`, and an
+  observed unscheduled window of at least 30 minutes. For in-flight builds,
+  `pod_created_at` older than the 30-minute grace window is also treated as
+  stale. The event-table version `first FailedScheduling -> Scheduled` is
+  semantically richer, but it needs a materialized lifecycle field or a faster
+  event rollup before it is safe for the page-level endpoint on production data.
 
 ## 5. Metric Definitions
 

--- a/ci-dashboard/src/ci_dashboard/api/queries/runtime.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/runtime.py
@@ -1581,11 +1581,13 @@ def _build_pod_build_rows_cte(
 ) -> tuple[str, dict[str, Any], dict[str, bool]]:
     where_clause, params = build_common_where(filters, table_alias="b")
     params["final_scheduling_failure_cutoff_at"] = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=30)
+    params["final_scheduling_failure_grace_seconds"] = 30 * 60
     failure_like_states = ", ".join(f"'{state}'" for state in FAILURE_LIKE_STATES)
     builds_table = builds_table_expr(connection, filters, alias="b")
     pod_created_column = _pod_created_column(connection)
     pod_created_select = f"p.{pod_created_column}" if pod_created_column else "NULL"
     scheduling_wait_s = timediff_seconds_expr(connection, "pc.pod_created_at", "pc.scheduled_at")
+    final_scheduling_observed_s = timediff_seconds_expr(connection, "pc.pod_created_at", "pc.last_event_at")
     pull_image_s = timediff_seconds_expr(connection, "pc.first_pulling_at", "pc.first_pulled_at")
     resolved_job_name = "COALESCE(NULLIF(pc.build_job_name, ''), NULLIF(pc.pod_job_name, ''))"
     canonical_job_name = _canonical_job_name_expr(
@@ -1712,8 +1714,27 @@ def _build_pod_build_rows_cte(
             CASE
               WHEN pc.failed_scheduling_count > 0
                AND pc.scheduled_at IS NULL
+               AND LOWER(COALESCE(pc.build_state, '')) IN ({failure_like_states})
                AND pc.last_event_at IS NOT NULL
-               AND pc.last_event_at < :final_scheduling_failure_cutoff_at
+               AND (
+                 (
+                   pc.pod_created_at IS NOT NULL
+                   AND (
+                     (
+                       pc.completion_time IS NULL
+                       AND pc.pod_created_at < :final_scheduling_failure_cutoff_at
+                     )
+                     OR (
+                       pc.last_event_at >= pc.pod_created_at
+                       AND {final_scheduling_observed_s} >= :final_scheduling_failure_grace_seconds
+                     )
+                   )
+                 )
+                 OR (
+                   pc.pod_created_at IS NULL
+                   AND pc.last_event_at < :final_scheduling_failure_cutoff_at
+                 )
+               )
               THEN 1 ELSE 0
             END AS final_scheduling_failure_hit,
             CASE WHEN pc.first_pulling_at IS NOT NULL THEN 1 ELSE 0 END AS pull_attempted,

--- a/ci-dashboard/tests/api/test_runtime_insights.py
+++ b/ci-dashboard/tests/api/test_runtime_insights.py
@@ -662,6 +662,153 @@ def test_runtime_insights_rolls_pods_to_builds_and_uses_effective_categories(sql
     }
 
 
+def test_runtime_ignores_unscheduled_pods_on_successful_builds(sqlite_engine) -> None:
+    build_url = "https://prow.tidb.net/jenkins/job/runtime-success-with-orphan-pod/1/"
+    _insert_build(
+        sqlite_engine,
+        build_id=701,
+        source_prow_job_id="runtime-success-orphan",
+        job_name="job-orphan",
+        state="success",
+        start_time="2026-04-20 10:00:00",
+        normalized_build_url=build_url,
+        completion_time="2026-04-20 10:30:00",
+    )
+    _insert_pod_lifecycle(
+        sqlite_engine,
+        pod_name="pod-orphan-unscheduled",
+        pod_uid="pod-orphan-unscheduled-uid",
+        normalized_build_url=build_url,
+        source_prow_job_id="runtime-success-orphan",
+        job_name="job-orphan",
+        pod_created_at="2026-04-20 10:05:00",
+        scheduled_at=None,
+        first_pulling_at=None,
+        first_pulled_at=None,
+        last_failed_scheduling_at="2026-04-20 10:20:00",
+        failed_scheduling_count=42,
+        last_event_at="2026-04-20 10:20:00",
+    )
+    _insert_pod_lifecycle(
+        sqlite_engine,
+        pod_name="pod-orphan-success",
+        pod_uid="pod-orphan-success-uid",
+        normalized_build_url=build_url,
+        source_prow_job_id="runtime-success-orphan",
+        job_name="job-orphan",
+        pod_created_at="2026-04-20 10:06:00",
+        scheduled_at="2026-04-20 10:07:00",
+        first_pulling_at="2026-04-20 10:08:00",
+        first_pulled_at="2026-04-20 10:08:10",
+    )
+
+    app.dependency_overrides[get_engine] = lambda: sqlite_engine
+    try:
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/v1/pages/runtime-insights",
+                params={
+                    "repo": "pingcap/tidb",
+                    "branch": "master",
+                    "start_date": "2026-04-20",
+                    "end_date": "2026-04-20",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["runtime_summary"]["final_scheduling_failure_count"] == 0
+    scheduling_series = {
+        item["key"]: item
+        for item in body["scheduling_trend"]["series"]
+    }
+    assert scheduling_series["final_scheduling_failure_count"]["points"] == [["2026-04-20", 0]]
+    assert body["scheduling_failure_jobs"]["items"] == []
+    assert body["scheduling_failure_jobs"]["meta"]["total_failure_job_count"] == 0
+
+
+def test_runtime_requires_observed_grace_window_for_completed_scheduling_failures(sqlite_engine) -> None:
+    short_url = "https://prow.tidb.net/jenkins/job/runtime-short-unscheduled/1/"
+    long_url = "https://prow.tidb.net/jenkins/job/runtime-long-unscheduled/1/"
+    _insert_build(
+        sqlite_engine,
+        build_id=711,
+        source_prow_job_id="runtime-short-unscheduled",
+        job_name="job-unscheduled",
+        state="failure",
+        start_time="2026-04-20 10:00:00",
+        normalized_build_url=short_url,
+        completion_time="2026-04-20 10:20:00",
+    )
+    _insert_pod_lifecycle(
+        sqlite_engine,
+        pod_name="pod-short-unscheduled",
+        pod_uid="pod-short-unscheduled-uid",
+        normalized_build_url=short_url,
+        source_prow_job_id="runtime-short-unscheduled",
+        job_name="job-unscheduled",
+        pod_created_at="2026-04-20 10:05:00",
+        scheduled_at=None,
+        first_pulling_at=None,
+        first_pulled_at=None,
+        last_failed_scheduling_at="2026-04-20 10:20:00",
+        failed_scheduling_count=12,
+        last_event_at="2026-04-20 10:20:00",
+    )
+    _insert_build(
+        sqlite_engine,
+        build_id=712,
+        source_prow_job_id="runtime-long-unscheduled",
+        job_name="job-unscheduled",
+        state="failure",
+        start_time="2026-04-20 11:00:00",
+        normalized_build_url=long_url,
+        completion_time="2026-04-20 11:45:00",
+    )
+    _insert_pod_lifecycle(
+        sqlite_engine,
+        pod_name="pod-long-unscheduled",
+        pod_uid="pod-long-unscheduled-uid",
+        normalized_build_url=long_url,
+        source_prow_job_id="runtime-long-unscheduled",
+        job_name="job-unscheduled",
+        pod_created_at="2026-04-20 11:05:00",
+        scheduled_at=None,
+        first_pulling_at=None,
+        first_pulled_at=None,
+        last_failed_scheduling_at="2026-04-20 11:40:00",
+        failed_scheduling_count=90,
+        last_event_at="2026-04-20 11:40:00",
+    )
+
+    app.dependency_overrides[get_engine] = lambda: sqlite_engine
+    try:
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/v1/pages/runtime-insights",
+                params={
+                    "repo": "pingcap/tidb",
+                    "branch": "master",
+                    "start_date": "2026-04-20",
+                    "end_date": "2026-04-20",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["runtime_summary"]["final_scheduling_failure_count"] == 1
+    scheduling_series = {
+        item["key"]: item
+        for item in body["scheduling_trend"]["series"]
+    }
+    assert scheduling_series["final_scheduling_failure_count"]["points"] == [["2026-04-20", 1]]
+    assert body["scheduling_failure_jobs"]["meta"]["total_failure_job_count"] == 1
+
+
 def test_scheduling_failure_jobs_include_latest_ten_failure_build_links(sqlite_engine) -> None:
     for index in range(12):
         build_number = 3000 + index

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --test src/**/*.test.js",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -9,6 +9,18 @@ import FlakyPage from "./pages/FlakyPage";
 import RuntimeInsightsPage from "./pages/RuntimeInsightsPage";
 import CostPage from "./pages/CostPage";
 import { buildScopeLabel, getDefaultDateRange, useApiData } from "./lib/api";
+import {
+  buildDefaultFilters,
+  buildFilterSearch,
+  CI_STATUS_PATH,
+  COST_PATH,
+  MIGRATE_STATUS_PATH,
+  NAV_PATHS,
+  readFiltersFromSearch,
+  RUNTIME_INSIGHTS_PATH,
+  sameFilters,
+  WEEK_GRANULARITY_PATHS,
+} from "./lib/filterUrl";
 
 const REPO_OPTIONS = [{ value: "pingcap/tidb", label: "pingcap/tidb" }];
 const BRANCH_OPTIONS = [
@@ -16,107 +28,6 @@ const BRANCH_OPTIONS = [
   { value: "master", label: "master" },
   { value: "release-8.5", label: "release-8.5" },
 ];
-const CI_STATUS_PATH = "/ci-status";
-const MIGRATE_STATUS_PATH = "/migrate-status";
-const RUNTIME_INSIGHTS_PATH = "/runtime-insights";
-const COST_PATH = "/cost";
-const FILTER_QUERY_KEYS = [
-  "start_date",
-  "end_date",
-  "repo",
-  "branch",
-  "job_name",
-  "cloud_phase",
-  "issue_status",
-  "granularity",
-];
-const WEEK_GRANULARITY_PATHS = new Set([
-  CI_STATUS_PATH,
-  MIGRATE_STATUS_PATH,
-  RUNTIME_INSIGHTS_PATH,
-  COST_PATH,
-]);
-const NAV_PATHS = [
-  "/",
-  CI_STATUS_PATH,
-  "/flaky",
-  MIGRATE_STATUS_PATH,
-  COST_PATH,
-  RUNTIME_INSIGHTS_PATH,
-];
-
-function buildDefaultFilters(defaultRange, pathname) {
-  const costRange =
-    pathname === COST_PATH
-      ? {
-          start_date: defaultRange.end_date.slice(0, 8) + "01",
-          end_date: defaultRange.end_date,
-        }
-      : defaultRange;
-  const baseFilters = {
-    repo: "",
-    branch: "",
-    job_name: "",
-    cloud_phase: "",
-    issue_status: "",
-    granularity: WEEK_GRANULARITY_PATHS.has(pathname) ? "week" : "day",
-    start_date: costRange.start_date,
-    end_date: costRange.end_date,
-  };
-
-  if (pathname === "/flaky") {
-    return {
-      ...baseFilters,
-      repo: "pingcap/tidb",
-      branch: "master",
-      issue_status: "closed",
-    };
-  }
-
-  return baseFilters;
-}
-
-function normalizeFiltersForPath(pathname, filters) {
-  const next = { ...filters };
-  const allowedGranularities = pathname === COST_PATH
-    ? new Set(["week", "month"])
-    : new Set(["day", "week", "month"]);
-  if (!allowedGranularities.has(next.granularity)) {
-    next.granularity = WEEK_GRANULARITY_PATHS.has(pathname) ? "week" : "day";
-  }
-  if (WEEK_GRANULARITY_PATHS.has(pathname) && pathname !== COST_PATH) {
-    next.granularity = "week";
-  }
-  return next;
-}
-
-function readFiltersFromSearch(defaultRange, pathname, search) {
-  const params = new URLSearchParams(search);
-  const next = buildDefaultFilters(defaultRange, pathname);
-  FILTER_QUERY_KEYS.forEach((key) => {
-    if (params.has(key)) {
-      next[key] = params.get(key) || "";
-    }
-  });
-  return normalizeFiltersForPath(pathname, next);
-}
-
-function buildFilterSearch(filters, pathname) {
-  const normalized = normalizeFiltersForPath(pathname, filters);
-  const params = new URLSearchParams();
-  FILTER_QUERY_KEYS.forEach((key) => {
-    const value = normalized[key];
-    if (value !== undefined && value !== null && value !== "") {
-      params.set(key, String(value));
-    }
-  });
-  const query = params.toString();
-  return query ? `?${query}` : "";
-}
-
-function sameFilters(left, right) {
-  return FILTER_QUERY_KEYS.every((key) => (left?.[key] || "") === (right?.[key] || ""));
-}
 
 export default function App() {
   const [defaultRange] = useState(() => getDefaultDateRange());

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -12,10 +12,10 @@ import { buildScopeLabel, getDefaultDateRange, useApiData } from "./lib/api";
 import {
   buildDefaultFilters,
   buildFilterSearch,
+  buildNavSearchByPath,
   CI_STATUS_PATH,
   COST_PATH,
   MIGRATE_STATUS_PATH,
-  NAV_PATHS,
   readFiltersFromSearch,
   RUNTIME_INSIGHTS_PATH,
   sameFilters,
@@ -187,13 +187,7 @@ export default function App() {
     });
   }
 
-  const navSearchByPath = NAV_PATHS.reduce((accumulator, pathname) => {
-    const routeFilters = filtersByPath[pathname] || buildDefaultFilters(defaultRange, pathname);
-    return {
-      ...accumulator,
-      [pathname]: buildFilterSearch(routeFilters, pathname),
-    };
-  }, {});
+  const navSearchByPath = buildNavSearchByPath(filtersByPath, defaultRange, filters);
 
   const filterOptions = {
     repos: REPO_OPTIONS,

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 
 import { DashboardLayout } from "./components/layout";
 import OverviewPage from "./pages/OverviewPage";
@@ -20,12 +20,30 @@ const CI_STATUS_PATH = "/ci-status";
 const MIGRATE_STATUS_PATH = "/migrate-status";
 const RUNTIME_INSIGHTS_PATH = "/runtime-insights";
 const COST_PATH = "/cost";
+const FILTER_QUERY_KEYS = [
+  "start_date",
+  "end_date",
+  "repo",
+  "branch",
+  "job_name",
+  "cloud_phase",
+  "issue_status",
+  "granularity",
+];
 const WEEK_GRANULARITY_PATHS = new Set([
   CI_STATUS_PATH,
   MIGRATE_STATUS_PATH,
   RUNTIME_INSIGHTS_PATH,
   COST_PATH,
 ]);
+const NAV_PATHS = [
+  "/",
+  CI_STATUS_PATH,
+  "/flaky",
+  MIGRATE_STATUS_PATH,
+  COST_PATH,
+  RUNTIME_INSIGHTS_PATH,
+];
 
 function buildDefaultFilters(defaultRange, pathname) {
   const costRange =
@@ -58,13 +76,57 @@ function buildDefaultFilters(defaultRange, pathname) {
   return baseFilters;
 }
 
+function normalizeFiltersForPath(pathname, filters) {
+  const next = { ...filters };
+  const allowedGranularities = pathname === COST_PATH
+    ? new Set(["week", "month"])
+    : new Set(["day", "week", "month"]);
+  if (!allowedGranularities.has(next.granularity)) {
+    next.granularity = WEEK_GRANULARITY_PATHS.has(pathname) ? "week" : "day";
+  }
+  if (WEEK_GRANULARITY_PATHS.has(pathname) && pathname !== COST_PATH) {
+    next.granularity = "week";
+  }
+  return next;
+}
+
+function readFiltersFromSearch(defaultRange, pathname, search) {
+  const params = new URLSearchParams(search);
+  const next = buildDefaultFilters(defaultRange, pathname);
+  FILTER_QUERY_KEYS.forEach((key) => {
+    if (params.has(key)) {
+      next[key] = params.get(key) || "";
+    }
+  });
+  return normalizeFiltersForPath(pathname, next);
+}
+
+function buildFilterSearch(filters, pathname) {
+  const normalized = normalizeFiltersForPath(pathname, filters);
+  const params = new URLSearchParams();
+  FILTER_QUERY_KEYS.forEach((key) => {
+    const value = normalized[key];
+    if (value !== undefined && value !== null && value !== "") {
+      params.set(key, String(value));
+    }
+  });
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+function sameFilters(left, right) {
+  return FILTER_QUERY_KEYS.every((key) => (left?.[key] || "") === (right?.[key] || ""));
+}
+
 export default function App() {
   const [defaultRange] = useState(() => getDefaultDateRange());
   const location = useLocation();
+  const navigate = useNavigate();
   const [filtersByPath, setFiltersByPath] = useState(() => ({
-    [location.pathname]: buildDefaultFilters(defaultRange, location.pathname),
+    [location.pathname]: readFiltersFromSearch(defaultRange, location.pathname, location.search),
   }));
-  const filters = filtersByPath[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
+  const filters = filtersByPath[location.pathname]
+    || readFiltersFromSearch(defaultRange, location.pathname, location.search);
   const navigation = useApiData("/api/v1/pages/navigation");
   const runtimeInsightsEnabled = navigation.data?.features?.runtime_insights_enabled === true;
   const costDashboardEnabled = navigation.data?.features?.cost_dashboard_enabled === true;
@@ -86,17 +148,32 @@ export default function App() {
   );
 
   useEffect(() => {
+    const urlFilters = readFiltersFromSearch(defaultRange, location.pathname, location.search);
     setFiltersByPath((current) => {
-      if (current[location.pathname]) {
+      if (sameFilters(current[location.pathname], urlFilters)) {
         return current;
       }
 
       return {
         ...current,
-        [location.pathname]: buildDefaultFilters(defaultRange, location.pathname),
+        [location.pathname]: urlFilters,
       };
     });
-  }, [defaultRange, location.pathname]);
+  }, [defaultRange, location.pathname, location.search]);
+
+  useEffect(() => {
+    const nextSearch = buildFilterSearch(filters, location.pathname);
+    if (nextSearch === location.search) {
+      return;
+    }
+    navigate(
+      {
+        pathname: location.pathname,
+        search: nextSearch,
+      },
+      { replace: true },
+    );
+  }, [filters, location.pathname, location.search, navigate]);
 
   useEffect(() => {
     if (location.pathname !== "/flaky") {
@@ -104,7 +181,8 @@ export default function App() {
     }
 
     setFiltersByPath((current) => {
-      const routeFilters = current[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
+      const routeFilters = current[location.pathname]
+        || readFiltersFromSearch(defaultRange, location.pathname, location.search);
       if (routeFilters.repo || routeFilters.branch || routeFilters.issue_status) {
         return current;
       }
@@ -119,7 +197,7 @@ export default function App() {
         },
       };
     });
-  }, [defaultRange, location.pathname]);
+  }, [defaultRange, location.pathname, location.search]);
 
   useEffect(() => {
     if (!WEEK_GRANULARITY_PATHS.has(location.pathname)) {
@@ -127,7 +205,8 @@ export default function App() {
     }
 
     setFiltersByPath((current) => {
-      const routeFilters = current[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
+      const routeFilters = current[location.pathname]
+        || readFiltersFromSearch(defaultRange, location.pathname, location.search);
       const hasValidGranularity = location.pathname === COST_PATH
         ? routeFilters.granularity === "week" || routeFilters.granularity === "month"
         : routeFilters.granularity === "week";
@@ -143,7 +222,7 @@ export default function App() {
         },
       };
     });
-  }, [defaultRange, location.pathname]);
+  }, [defaultRange, location.pathname, location.search]);
 
   const jobs = useApiData(
     "/api/v1/filters/jobs",
@@ -164,7 +243,8 @@ export default function App() {
 
   function handleFilterChange(key, value) {
     setFiltersByPath((current) => {
-      const routeFilters = current[location.pathname] || buildDefaultFilters(defaultRange, location.pathname);
+      const routeFilters = current[location.pathname]
+        || readFiltersFromSearch(defaultRange, location.pathname, location.search);
       if (key === "repo") {
         return {
           ...current,
@@ -196,6 +276,14 @@ export default function App() {
     });
   }
 
+  const navSearchByPath = NAV_PATHS.reduce((accumulator, pathname) => {
+    const routeFilters = filtersByPath[pathname] || buildDefaultFilters(defaultRange, pathname);
+    return {
+      ...accumulator,
+      [pathname]: buildFilterSearch(routeFilters, pathname),
+    };
+  }, {});
+
   const filterOptions = {
     repos: REPO_OPTIONS,
     branches: BRANCH_OPTIONS,
@@ -210,6 +298,7 @@ export default function App() {
       onFilterChange={handleFilterChange}
       filterOptions={filterOptions}
       features={{ runtimeInsightsEnabled, costDashboardEnabled }}
+      navSearchByPath={navSearchByPath}
     >
       <Routes>
         <Route path="/" element={<OverviewPage filters={filters} />} />

--- a/ci-dashboard/web/src/components/layout.jsx
+++ b/ci-dashboard/web/src/components/layout.jsx
@@ -7,6 +7,7 @@ export function DashboardLayout({
   onFilterChange,
   filterOptions,
   features = {},
+  navSearchByPath = {},
   children,
 }) {
   const currentVersion = packageInfo.version;
@@ -22,16 +23,37 @@ export function DashboardLayout({
         </div>
 
         <nav className="sidebar-nav" aria-label="Primary">
-          <NavItem to="/" label="Overview" caption="Signal at a glance" />
-          <NavItem to="/ci-status" label="CI Status" caption="Volume and duration" />
-          <NavItem to="/flaky" label="Flaky" caption="Noisy failures and blind-retry-loop patterns" />
-          <NavItem to="/migrate-status" label="GCP Migration" caption="GCP rollout and runtime drift" />
+          <NavItem to="/" search={navSearchByPath["/"]} label="Overview" caption="Signal at a glance" />
+          <NavItem
+            to="/ci-status"
+            search={navSearchByPath["/ci-status"]}
+            label="CI Status"
+            caption="Volume and duration"
+          />
+          <NavItem
+            to="/flaky"
+            search={navSearchByPath["/flaky"]}
+            label="Flaky"
+            caption="Noisy failures and blind-retry-loop patterns"
+          />
+          <NavItem
+            to="/migrate-status"
+            search={navSearchByPath["/migrate-status"]}
+            label="GCP Migration"
+            caption="GCP rollout and runtime drift"
+          />
           {showCostDashboard && (
-            <NavItem to="/cost" label="Cost" caption="Spend by repo and engineering ownership" />
+            <NavItem
+              to="/cost"
+              search={navSearchByPath["/cost"]}
+              label="Cost"
+              caption="Spend by repo and engineering ownership"
+            />
           )}
           {showRuntimeInsights && (
             <NavItem
               to="/runtime-insights"
+              search={navSearchByPath["/runtime-insights"]}
               label="CI details insight"
               caption="Pod and Jenkins diagnosis"
             />
@@ -59,10 +81,10 @@ export function DashboardLayout({
   );
 }
 
-function NavItem({ to, label, caption }) {
+function NavItem({ to, search = "", label, caption }) {
   return (
     <NavLink
-      to={to}
+      to={`${to}${search || ""}`}
       end={to === "/"}
       className={({ isActive }) =>
         isActive ? "sidebar-link sidebar-link--active" : "sidebar-link"

--- a/ci-dashboard/web/src/lib/filterUrl.js
+++ b/ci-dashboard/web/src/lib/filterUrl.js
@@ -1,0 +1,101 @@
+export const CI_STATUS_PATH = "/ci-status";
+export const MIGRATE_STATUS_PATH = "/migrate-status";
+export const RUNTIME_INSIGHTS_PATH = "/runtime-insights";
+export const COST_PATH = "/cost";
+export const FILTER_QUERY_KEYS = [
+  "start_date",
+  "end_date",
+  "repo",
+  "branch",
+  "job_name",
+  "cloud_phase",
+  "issue_status",
+  "granularity",
+];
+export const WEEK_GRANULARITY_PATHS = new Set([
+  CI_STATUS_PATH,
+  MIGRATE_STATUS_PATH,
+  RUNTIME_INSIGHTS_PATH,
+  COST_PATH,
+]);
+export const NAV_PATHS = [
+  "/",
+  CI_STATUS_PATH,
+  "/flaky",
+  MIGRATE_STATUS_PATH,
+  COST_PATH,
+  RUNTIME_INSIGHTS_PATH,
+];
+
+export function buildDefaultFilters(defaultRange, pathname) {
+  const costRange =
+    pathname === COST_PATH
+      ? {
+          start_date: defaultRange.end_date.slice(0, 8) + "01",
+          end_date: defaultRange.end_date,
+        }
+      : defaultRange;
+  const baseFilters = {
+    repo: "",
+    branch: "",
+    job_name: "",
+    cloud_phase: "",
+    issue_status: "",
+    granularity: WEEK_GRANULARITY_PATHS.has(pathname) ? "week" : "day",
+    start_date: costRange.start_date,
+    end_date: costRange.end_date,
+  };
+
+  if (pathname === "/flaky") {
+    return {
+      ...baseFilters,
+      repo: "pingcap/tidb",
+      branch: "master",
+      issue_status: "closed",
+    };
+  }
+
+  return baseFilters;
+}
+
+export function normalizeFiltersForPath(pathname, filters) {
+  const next = { ...filters };
+  const allowedGranularities = pathname === COST_PATH
+    ? new Set(["week", "month"])
+    : new Set(["day", "week", "month"]);
+  if (!allowedGranularities.has(next.granularity)) {
+    next.granularity = WEEK_GRANULARITY_PATHS.has(pathname) ? "week" : "day";
+  }
+  if (WEEK_GRANULARITY_PATHS.has(pathname) && pathname !== COST_PATH) {
+    next.granularity = "week";
+  }
+  return next;
+}
+
+export function readFiltersFromSearch(defaultRange, pathname, search) {
+  const params = new URLSearchParams(search);
+  const next = buildDefaultFilters(defaultRange, pathname);
+  FILTER_QUERY_KEYS.forEach((key) => {
+    if (params.has(key)) {
+      next[key] = params.get(key) || "";
+    }
+  });
+  return normalizeFiltersForPath(pathname, next);
+}
+
+export function buildFilterSearch(filters, pathname) {
+  const normalized = normalizeFiltersForPath(pathname, filters);
+  const params = new URLSearchParams();
+  FILTER_QUERY_KEYS.forEach((key) => {
+    const value = normalized[key];
+    if (value !== undefined && value !== null && value !== "") {
+      params.set(key, String(value));
+    }
+  });
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+export function sameFilters(left, right) {
+  return FILTER_QUERY_KEYS.every((key) => (left?.[key] || "") === (right?.[key] || ""));
+}

--- a/ci-dashboard/web/src/lib/filterUrl.js
+++ b/ci-dashboard/web/src/lib/filterUrl.js
@@ -99,3 +99,20 @@ export function buildFilterSearch(filters, pathname) {
 export function sameFilters(left, right) {
   return FILTER_QUERY_KEYS.every((key) => (left?.[key] || "") === (right?.[key] || ""));
 }
+
+export function buildNavSearchByPath(filtersByPath, defaultRange, currentFilters) {
+  return NAV_PATHS.reduce((accumulator, pathname) => {
+    const routeFilters = filtersByPath[pathname] || buildDefaultFilters(defaultRange, pathname);
+    return {
+      ...accumulator,
+      [pathname]: buildFilterSearch(
+        {
+          ...routeFilters,
+          start_date: currentFilters.start_date,
+          end_date: currentFilters.end_date,
+        },
+        pathname,
+      ),
+    };
+  }, {});
+}

--- a/ci-dashboard/web/src/lib/filterUrl.test.js
+++ b/ci-dashboard/web/src/lib/filterUrl.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildDefaultFilters,
   buildFilterSearch,
+  buildNavSearchByPath,
   readFiltersFromSearch,
   sameFilters,
 } from "./filterUrl.js";
@@ -74,4 +75,34 @@ test("compares filter values without being sensitive to object identity", () => 
     ),
     false,
   );
+});
+
+test("keeps the active date range when building links to other tabs", () => {
+  const navSearchByPath = buildNavSearchByPath(
+    {
+      "/flaky": {
+        ...buildDefaultFilters(defaultRange, "/flaky"),
+        start_date: "2026-04-01",
+        end_date: "2026-04-30",
+      },
+    },
+    defaultRange,
+    {
+      ...buildDefaultFilters(defaultRange, "/ci-status"),
+      start_date: "2026-05-25",
+      end_date: "2026-06-01",
+      repo: "pingcap/tidb",
+      branch: "master",
+    },
+  );
+
+  const flakyParams = new URLSearchParams(navSearchByPath["/flaky"]);
+  const migrateParams = new URLSearchParams(navSearchByPath["/migrate-status"]);
+  assert.equal(flakyParams.get("start_date"), "2026-05-25");
+  assert.equal(flakyParams.get("end_date"), "2026-06-01");
+  assert.equal(flakyParams.get("repo"), "pingcap/tidb");
+  assert.equal(flakyParams.get("issue_status"), "closed");
+  assert.equal(migrateParams.get("start_date"), "2026-05-25");
+  assert.equal(migrateParams.get("end_date"), "2026-06-01");
+  assert.equal(migrateParams.get("granularity"), "week");
 });

--- a/ci-dashboard/web/src/lib/filterUrl.test.js
+++ b/ci-dashboard/web/src/lib/filterUrl.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildDefaultFilters,
+  buildFilterSearch,
+  readFiltersFromSearch,
+  sameFilters,
+} from "./filterUrl.js";
+
+const defaultRange = {
+  start_date: "2026-05-01",
+  end_date: "2026-06-01",
+};
+
+test("reads shareable filters from the current URL search", () => {
+  const filters = readFiltersFromSearch(
+    defaultRange,
+    "/ci-status",
+    "?repo=pingcap%2Ftidb&branch=master&job_name=pingcap%2Ftidb%2Fghpr_unit_test&cloud_phase=GCP&issue_status=closed&granularity=month&start_date=2026-05-25&end_date=2026-06-01",
+  );
+
+  assert.equal(filters.repo, "pingcap/tidb");
+  assert.equal(filters.branch, "master");
+  assert.equal(filters.job_name, "pingcap/tidb/ghpr_unit_test");
+  assert.equal(filters.cloud_phase, "GCP");
+  assert.equal(filters.issue_status, "closed");
+  assert.equal(filters.start_date, "2026-05-25");
+  assert.equal(filters.end_date, "2026-06-01");
+  assert.equal(filters.granularity, "week");
+});
+
+test("serializes non-empty filters into request-compatible URL parameters", () => {
+  const filters = {
+    ...buildDefaultFilters(defaultRange, "/flaky"),
+    job_name: "pingcap/tidb/ghpr_unit_test",
+    cloud_phase: "GCP",
+  };
+
+  const search = buildFilterSearch(filters, "/flaky");
+  const params = new URLSearchParams(search);
+
+  assert.equal(params.get("repo"), "pingcap/tidb");
+  assert.equal(params.get("branch"), "master");
+  assert.equal(params.get("job_name"), "pingcap/tidb/ghpr_unit_test");
+  assert.equal(params.get("cloud_phase"), "GCP");
+  assert.equal(params.get("issue_status"), "closed");
+  assert.equal(params.get("granularity"), "day");
+});
+
+test("keeps cost dashboard month buckets but normalizes invalid values", () => {
+  assert.equal(
+    readFiltersFromSearch(defaultRange, "/cost", "?granularity=month").granularity,
+    "month",
+  );
+  assert.equal(
+    readFiltersFromSearch(defaultRange, "/cost", "?granularity=day").granularity,
+    "week",
+  );
+});
+
+test("compares filter values without being sensitive to object identity", () => {
+  assert.equal(
+    sameFilters(
+      { repo: "pingcap/tidb", branch: "master", start_date: "2026-05-25" },
+      { repo: "pingcap/tidb", branch: "master", start_date: "2026-05-25" },
+    ),
+    true,
+  );
+  assert.equal(
+    sameFilters(
+      { repo: "pingcap/tidb", branch: "master" },
+      { repo: "pingcap/tidb", branch: "release-8.5" },
+    ),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- require final scheduling failures to come from failure-like builds
- require completed builds to have an observed unscheduled pod window of at least 30 minutes before counting final scheduling failure
- sync dashboard filters with page URL query parameters so shared links and refreshes preserve selected scope
- keep per-tab filter URLs on sidebar navigation
- add frontend unit coverage for filter URL parsing/serialization helpers

## Validation
- npm test
- npm run build
- PYTHONPATH=src python -m pytest tests/api/test_runtime_insights.py -q
- PYTHONPATH=src python -m pytest --cov=ci_dashboard --cov-report=term --cov-fail-under=0