### PR TITLE
feat(roster): support multiple weekly summary recipients

### DIFF
--- a/roster/README.md
+++ b/roster/README.md
@@ -61,8 +61,13 @@ Optional Lark settings:
 ```bash
 ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID=...
 ROSTER_LARK_NOTIFY_OPEN_ID=...
+ROSTER_LARK_NOTIFY_OPEN_IDS=ou_xxx,ou_yyy
 ROSTER_LARK_ROOT_DEPARTMENT_ID=0
 ```
+
+`ROSTER_LARK_NOTIFY_OPEN_ID` stays supported for the existing single-recipient setup.
+Use `ROSTER_LARK_NOTIFY_OPEN_IDS` when the weekly summary should be sent to
+multiple users.
 
 ## Kubernetes CronJob
 

--- a/roster/src/roster/common/config.py
+++ b/roster/src/roster/common/config.py
@@ -41,11 +41,23 @@ class LarkSettings:
     app_secret: str | None = None
     github_custom_attr_id: str | None = None
     notify_open_id: str | None = None
+    notify_open_ids: tuple[str, ...] = ()
     root_department_id: str = "0"
 
     @property
     def is_configured(self) -> bool:
         return bool(self.app_id and self.app_secret)
+
+    @property
+    def all_notify_open_ids(self) -> tuple[str, ...]:
+        values = list(self.notify_open_ids)
+        if self.notify_open_id:
+            values.insert(0, self.notify_open_id)
+        return _normalize_values(values)
+
+    @property
+    def has_notify_targets(self) -> bool:
+        return bool(self.all_notify_open_ids)
 
 
 @dataclass(frozen=True)
@@ -99,6 +111,7 @@ def load_settings(
             app_secret=env.get("ROSTER_LARK_APP_SECRET") or None,
             github_custom_attr_id=env.get("ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID") or None,
             notify_open_id=env.get("ROSTER_LARK_NOTIFY_OPEN_ID") or None,
+            notify_open_ids=_read_csv(env.get("ROSTER_LARK_NOTIFY_OPEN_IDS")),
             root_department_id=env.get("ROSTER_LARK_ROOT_DEPARTMENT_ID") or "0",
         ),
         log_level=(env.get("ROSTER_LOG_LEVEL") or "INFO").upper(),
@@ -123,3 +136,21 @@ def _read_int_any(environ: Mapping[str, str], keys: tuple[str, ...], default: in
         if key in environ:
             return _read_int(environ, key, default)
     return default
+
+
+def _read_csv(raw: str | None) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    return _normalize_values(raw.split(","))
+
+
+def _normalize_values(values: list[str] | tuple[str, ...]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in values:
+        stripped = value.strip()
+        if not stripped or stripped in seen:
+            continue
+        seen.add(stripped)
+        normalized.append(stripped)
+    return tuple(normalized)

--- a/roster/src/roster/jobs/cli.py
+++ b/roster/src/roster/jobs/cli.py
@@ -14,7 +14,7 @@ from roster.jobs.validate_lark import validate_lark_roster
 from roster.jobs.weekly_summary import (
     DEFAULT_WEEKLY_SUMMARY_DAYS,
     load_weekly_roster_summary,
-    send_weekly_roster_summary_to_lark,
+    send_weekly_roster_summary_to_lark_recipients,
 )
 from roster.sources.lark import LarkApiClient, LarkRosterSource
 
@@ -36,7 +36,7 @@ def build_parser() -> argparse.ArgumentParser:
     weekly_summary.add_argument(
         "--send-lark",
         action="store_true",
-        help="Send the weekly summary to ROSTER_LARK_NOTIFY_OPEN_ID",
+        help="Send the weekly summary to configured Lark recipients",
     )
     subparsers.add_parser("validate-lark", help="Fetch Lark roster data and print field quality summary")
     validate_history = subparsers.add_parser(
@@ -82,12 +82,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "weekly-summary --send-lark requires "
                         "ROSTER_LARK_APP_ID and ROSTER_LARK_APP_SECRET"
                     )
-                if not settings.lark.notify_open_id:
-                    raise SystemExit("weekly-summary --send-lark requires ROSTER_LARK_NOTIFY_OPEN_ID")
-                send_weekly_roster_summary_to_lark(
+                if not settings.lark.has_notify_targets:
+                    raise SystemExit(
+                        "weekly-summary --send-lark requires "
+                        "ROSTER_LARK_NOTIFY_OPEN_ID or ROSTER_LARK_NOTIFY_OPEN_IDS"
+                    )
+                send_weekly_roster_summary_to_lark_recipients(
                     summary,
                     client=LarkApiClient(settings.lark.app_id, settings.lark.app_secret),
-                    open_id=settings.lark.notify_open_id,
+                    open_ids=settings.lark.all_notify_open_ids,
                 )
             else:
                 print(json.dumps(summary.to_dict(), indent=2, sort_keys=True))

--- a/roster/src/roster/jobs/weekly_summary.py
+++ b/roster/src/roster/jobs/weekly_summary.py
@@ -17,6 +17,11 @@ DEFAULT_DISPLAY_TIMEZONE = ZoneInfo("Asia/Shanghai")
 
 
 @dataclass(frozen=True)
+class LarkRecipient:
+    receive_id: str
+
+
+@dataclass(frozen=True)
 class RosterChangeItem:
     event_type: str
     employee_name: str
@@ -118,17 +123,36 @@ def send_weekly_roster_summary_to_lark(
     client: LarkApiClient,
     open_id: str,
 ) -> None:
-    token = client.tenant_access_token()
-    client.post(
-        "/im/v1/messages",
-        params={"receive_id_type": "open_id"},
-        json_body={
-            "receive_id": open_id,
-            "msg_type": "text",
-            "content": json.dumps({"text": summary.render_text()}, ensure_ascii=False),
-        },
-        token=token,
+    send_weekly_roster_summary_to_lark_recipients(
+        summary,
+        client=client,
+        open_ids=[open_id],
     )
+
+
+def send_weekly_roster_summary_to_lark_recipients(
+    summary: WeeklyRosterSummary,
+    *,
+    client: LarkApiClient,
+    open_ids: Sequence[str] = (),
+) -> None:
+    recipients = _build_lark_recipients(open_ids=open_ids)
+    if not recipients:
+        raise ValueError("at least one Lark recipient is required")
+
+    token = client.tenant_access_token()
+    content = json.dumps({"text": summary.render_text()}, ensure_ascii=False)
+    for recipient in recipients:
+        client.post(
+            "/im/v1/messages",
+            params={"receive_id_type": "open_id"},
+            json_body={
+                "receive_id": recipient.receive_id,
+                "msg_type": "text",
+                "content": content,
+            },
+            token=token,
+        )
 
 
 def _row_to_change_item(row) -> RosterChangeItem:
@@ -178,3 +202,20 @@ def _person_text(name: str | None, email: str | None) -> str:
 def _format_display_date(value: datetime) -> str:
     aware = value.replace(tzinfo=UTC)
     return aware.astimezone(DEFAULT_DISPLAY_TIMEZONE).strftime("%Y-%m-%d")
+
+
+def _build_lark_recipients(
+    *,
+    open_ids: Sequence[str],
+) -> list[LarkRecipient]:
+    recipients: list[LarkRecipient] = []
+    seen: set[str] = set()
+
+    for value in open_ids:
+        stripped = value.strip()
+        if not stripped or stripped in seen:
+            continue
+        seen.add(stripped)
+        recipients.append(LarkRecipient(receive_id=stripped))
+
+    return recipients

--- a/roster/tests/test_cli.py
+++ b/roster/tests/test_cli.py
@@ -160,6 +160,8 @@ def test_main_weekly_summary_sends_lark(monkeypatch) -> None:
         app_id="cli_xxx",
         app_secret="secret",
         notify_open_id="ou_xxx",
+        all_notify_open_ids=("ou_xxx",),
+        has_notify_targets=True,
     )
     settings = SimpleNamespace(log_level="INFO", lark=lark_settings)
     engine = SimpleNamespace(dispose=lambda: calls.setdefault("disposed", True))
@@ -176,15 +178,15 @@ def test_main_weekly_summary_sends_lark(monkeypatch) -> None:
         lambda app_id, app_secret: calls.setdefault("client", (app_id, app_secret)) and client,
     )
 
-    def fake_send(summary_arg, *, client, open_id):
-        calls["send"] = (summary_arg, client, open_id)
+    def fake_send(summary_arg, *, client, open_ids):
+        calls["send"] = (summary_arg, client, open_ids)
 
-    monkeypatch.setattr(cli, "send_weekly_roster_summary_to_lark", fake_send)
+    monkeypatch.setattr(cli, "send_weekly_roster_summary_to_lark_recipients", fake_send)
 
     assert cli.main(["weekly-summary", "--send-lark"]) == 0
     assert calls == {
         "client": ("cli_xxx", "secret"),
-        "send": (summary, client, "ou_xxx"),
+        "send": (summary, client, ("ou_xxx",)),
         "disposed": True,
     }
 

--- a/roster/tests/test_config_and_db.py
+++ b/roster/tests/test_config_and_db.py
@@ -29,6 +29,7 @@ def test_load_settings_builds_tidb_fields() -> None:
             "ROSTER_LARK_APP_SECRET": "secret",
             "ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID": "github_attr",
             "ROSTER_LARK_NOTIFY_OPEN_ID": "ou_xxx",
+            "ROSTER_LARK_NOTIFY_OPEN_IDS": "ou_xxx, ou_yyy",
             "ROSTER_LARK_ROOT_DEPARTMENT_ID": "od-root",
         }
     )
@@ -43,6 +44,9 @@ def test_load_settings_builds_tidb_fields() -> None:
     assert settings.lark.app_secret == "secret"
     assert settings.lark.github_custom_attr_id == "github_attr"
     assert settings.lark.notify_open_id == "ou_xxx"
+    assert settings.lark.notify_open_ids == ("ou_xxx", "ou_yyy")
+    assert settings.lark.all_notify_open_ids == ("ou_xxx", "ou_yyy")
+    assert settings.lark.has_notify_targets is True
     assert settings.lark.root_department_id == "od-root"
     assert settings.log_level == "DEBUG"
 

--- a/roster/tests/test_weekly_summary.py
+++ b/roster/tests/test_weekly_summary.py
@@ -9,6 +9,7 @@ from roster.jobs.sync_roster import employee_change_events_table, metadata
 from roster.jobs.weekly_summary import (
     load_weekly_roster_summary,
     send_weekly_roster_summary_to_lark,
+    send_weekly_roster_summary_to_lark_recipients,
 )
 from roster.sources.lark import LarkApiClient
 
@@ -114,6 +115,33 @@ def test_send_weekly_roster_summary_to_lark_sends_text_message() -> None:
     assert message_call["json_body"]["msg_type"] == "text"
     content = json.loads(message_call["json_body"]["content"])
     assert "本周没有入职、离职、换组记录。" in content["text"]
+
+
+def test_send_weekly_roster_summary_to_lark_recipients_supports_multiple_open_ids() -> None:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    metadata.create_all(engine)
+    now = datetime.fromisoformat("2026-05-25T01:00:00")
+    summary = load_weekly_roster_summary(engine, now=now, days=7)
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {"code": 0, "data": {"message_id": "om_open"}},
+            {"code": 0, "data": {"message_id": "om_second"}},
+        ]
+    )
+
+    send_weekly_roster_summary_to_lark_recipients(
+        summary,
+        client=LarkApiClient("app_id", "app_secret", transport=transport),
+        open_ids=["ou_xxx", "ou_yyy"],
+    )
+
+    first_call = transport.calls[1]
+    second_call = transport.calls[2]
+    assert first_call["params"] == {"receive_id_type": "open_id"}
+    assert first_call["json_body"]["receive_id"] == "ou_xxx"
+    assert second_call["params"] == {"receive_id_type": "open_id"}
+    assert second_call["json_body"]["receive_id"] == "ou_yyy"
 
 
 def _event_row(


### PR DESCRIPTION
## Summary
- allow roster weekly summary to send the same Lark message to multiple open IDs
- add `ROSTER_LARK_NOTIFY_OPEN_IDS` alongside the existing single-recipient env var
- cover config, CLI, and send-path behavior with tests and README updates

## Testing
- python -m pytest roster/tests