### PR TITLE
feat(cost-insight): add multi-source billing sync

### DIFF
--- a/cost-insight/README.md
+++ b/cost-insight/README.md
@@ -3,9 +3,12 @@
 Cost Insight is an independent project for cloud cost and usage collection,
 attribution, budget comparison, and cost exploration.
 
-The first implementation target is GCP project `pingcap-testing-account`. The
-design stays vendor-neutral so AWS CUR and other vendors can land in the same
-logical model later.
+The current implementation supports multiple active sources through
+`cost_sources`, including:
+
+- GCP project `pingcap-testing-account`
+- GCP project `qa-infra-dev`
+- AWS account `946646677266` (`qa-infra-dev`)
 
 Current design:
 
@@ -37,6 +40,17 @@ Useful GCP settings:
 | `COST_INSIGHT_UNMATCHED_RESOURCE_LAG_DAYS` | `5` |
 | `COST_INSIGHT_SYNC_PAGE_SIZE` | `5000` |
 
+Useful AWS settings:
+
+| Env | Default |
+| --- | --- |
+| `COST_INSIGHT_AWS_BILLING_TABLE` | `gcp-digital-bi.stg_cloud_billing.stg_aws_billing` |
+| `COST_INSIGHT_AWS_ACCOUNT_ID` | unset |
+| `COST_INSIGHT_AWS_EARLIEST_USAGE_DATE` | `2026-01-01` |
+| `COST_INSIGHT_AWS_EXPORT_OVERLAP_MONTHS` | `1` |
+| `COST_INSIGHT_AWS_SYNC_INITIAL_LOOKBACK_MONTHS` | `2` |
+| `COST_INSIGHT_AWS_SYNC_PAGE_SIZE` | `5000` |
+
 The Python BigQuery SDK requires Application Default Credentials. For local
 validation with a user account:
 
@@ -45,13 +59,19 @@ gcloud auth application-default login
 gcloud auth application-default set-quota-project pingcap-testing-account
 ```
 
-## First GCP Backfill
+## Seed Active Sources
 
 After `sql/001_create_cost_tables.sql` is applied:
 
 ```bash
 mysql < sql/002_seed_initial_cost_sources.sql
 ```
+
+All recurring summary, unmatched-resource, and attribution jobs discover active
+sources from `cost_sources`. The env account IDs are now fallback values for
+local validation when the registry table is empty.
+
+## GCP Raw Backfill
 
 ```bash
 cost-insight sync-gcp-billing-export --start-date 2026-01-01 --end-date 2026-05-17 --split-by-day
@@ -99,6 +119,14 @@ cost-insight sync-gcp-billing-summary \
   --export-partition-end 2026-05-23
 ```
 
+AWS summary import uses the same `cost_bq_export_summary_daily` table:
+
+```bash
+cost-insight sync-aws-billing-summary \
+  --export-partition-start 2026-05-01 \
+  --export-partition-end 2026-05-01
+```
+
 After summary rows are imported, refresh attribution from the summary table:
 
 ```bash
@@ -113,6 +141,14 @@ week:
 
 ```bash
 cost-insight sync-gcp-unmatched-resources \
+  --usage-start-date 2026-05-17 \
+  --usage-end-date 2026-05-23
+```
+
+AWS unmatched resources use the same investigation table:
+
+```bash
+cost-insight sync-aws-unmatched-resources \
   --usage-start-date 2026-05-17 \
   --usage-end-date 2026-05-23
 ```

--- a/cost-insight/docs/system-design.md
+++ b/cost-insight/docs/system-design.md
@@ -441,8 +441,8 @@ Sample watermarks:
 
 | job_name | watermark_json |
 | --- | --- |
-| `sync-gcp-billing-export` | `{"account_id":"pingcap-testing-account","start_date":"2026-05-15","end_date":"2026-05-18"}` |
-| `refresh-attribution-daily` | `{"last_usage_date":"2026-05-18"}` |
+| `sync_gcp_billing_export:gcp:pingcap-testing-account` | `{"account_id":"pingcap-testing-account","start_date":"2026-05-15","end_date":"2026-05-18"}` |
+| `refresh_cost_attribution_from_summary:aws:946646677266` | `{"vendor":"aws","account_id":"946646677266","start_date":"2026-05-01","end_date":"2026-05-31"}` |
 
 ## ETL Flow
 
@@ -459,9 +459,8 @@ flowchart LR
 
 Steps:
 
-1. Ensure the configured GCP project exists in `cost_sources` and is active.
-   V1 is still one configured source per run; multi-source discovery can be
-   added when we onboard AWS or more GCP projects.
+1. Discover active sources from `cost_sources` for the current vendor and
+   ensure each source is active before import starts.
 2. Read a usage-date range. On scheduled runs, re-read the last successful
    `end_date - overlap_days` window because billing export can receive late
    corrections.

--- a/cost-insight/sql/002_seed_initial_cost_sources.sql
+++ b/cost-insight/sql/002_seed_initial_cost_sources.sql
@@ -4,11 +4,26 @@ INSERT INTO cost_sources (
   billing_account_id,
   display_name,
   is_active
-) VALUES (
+) VALUES
+(
   'gcp',
   'pingcap-testing-account',
   '01D088-8F9CF2-8AF1C6',
   'pingcap-testing-account',
+  1
+),
+(
+  'gcp',
+  'qa-infra-dev',
+  '01D088-8F9CF2-8AF1C6',
+  'qa-infra-dev',
+  1
+),
+(
+  'aws',
+  '946646677266',
+  '946646677266',
+  'qa-infra-dev',
   1
 )
 ON DUPLICATE KEY UPDATE

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -11,6 +11,7 @@ DEFAULT_GCP_BILLING_TABLE = (
     "gcp_billing_export_resource_v1_01D088_8F9CF2_8AF1C6"
 )
 DEFAULT_GCP_ACCOUNT_ID = "pingcap-testing-account"
+DEFAULT_AWS_BILLING_TABLE = "gcp-digital-bi.stg_cloud_billing.stg_aws_billing"
 DEFAULT_EARLIEST_USAGE_DATE = date(2026, 1, 1)
 
 
@@ -39,9 +40,20 @@ class GcpBillingSettings:
 
 
 @dataclass(frozen=True)
+class AwsBillingSettings:
+    billing_table: str = DEFAULT_AWS_BILLING_TABLE
+    account_id: str | None = None
+    earliest_usage_date: date = DEFAULT_EARLIEST_USAGE_DATE
+    export_overlap_months: int = 1
+    sync_initial_lookback_months: int | None = 2
+    page_size: int = 5000
+
+
+@dataclass(frozen=True)
 class Settings:
     database: DatabaseSettings
     gcp_billing: GcpBillingSettings = GcpBillingSettings()
+    aws_billing: AwsBillingSettings = AwsBillingSettings()
     log_level: str = "INFO"
 
 
@@ -105,6 +117,44 @@ def load_settings(
             page_size=_read_int_any(
                 env,
                 ("COST_INSIGHT_SYNC_PAGE_SIZE", "COST_SYNC_PAGE_SIZE"),
+                5000,
+            ),
+        ),
+        aws_billing=AwsBillingSettings(
+            billing_table=_read_any(
+                env,
+                DEFAULT_AWS_BILLING_TABLE,
+                "COST_INSIGHT_AWS_BILLING_TABLE",
+                "COST_AWS_BILLING_TABLE",
+            ),
+            account_id=_read_optional_any(
+                env,
+                "COST_INSIGHT_AWS_ACCOUNT_ID",
+                "COST_AWS_ACCOUNT_ID",
+            ),
+            earliest_usage_date=_read_date_any(
+                env,
+                ("COST_INSIGHT_AWS_EARLIEST_USAGE_DATE", "COST_AWS_EARLIEST_USAGE_DATE"),
+                DEFAULT_EARLIEST_USAGE_DATE,
+            ),
+            export_overlap_months=_read_non_negative_int_any(
+                env,
+                (
+                    "COST_INSIGHT_AWS_EXPORT_OVERLAP_MONTHS",
+                    "COST_AWS_EXPORT_OVERLAP_MONTHS",
+                ),
+                1,
+            ),
+            sync_initial_lookback_months=_read_optional_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_AWS_SYNC_INITIAL_LOOKBACK_MONTHS",
+                    "COST_AWS_SYNC_INITIAL_LOOKBACK_MONTHS",
+                ),
+            ),
+            page_size=_read_int_any(
+                env,
+                ("COST_INSIGHT_AWS_SYNC_PAGE_SIZE", "COST_AWS_SYNC_PAGE_SIZE"),
                 5000,
             ),
         ),
@@ -182,6 +232,14 @@ def _read_required_any(environ: Mapping[str, str], *keys: str) -> str:
         if value is not None and value.strip() != "":
             return value
     raise ValueError(f"Missing required environment variable: {' or '.join(keys)}")
+
+
+def _read_optional_any(environ: Mapping[str, str], *keys: str) -> str | None:
+    for key in keys:
+        value = environ.get(key)
+        if value is not None and value.strip() != "":
+            return value
+    return None
 
 
 def _read_int(environ: Mapping[str, str], key: str, default: int) -> int:

--- a/cost-insight/src/cost_insight/jobs/backfill_cost_refine_from_raw.py
+++ b/cost-insight/src/cost_insight/jobs/backfill_cost_refine_from_raw.py
@@ -10,6 +10,7 @@ from sqlalchemy.engine import Engine
 from cost_insight.common.config import GcpBillingSettings
 from cost_insight.common.row_utils import coerce_date
 from cost_insight.jobs import state_store
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.jobs.sync_gcp_billing_summary import (
     JOB_NAME as SUMMARY_JOB_NAME,
 )
@@ -56,6 +57,7 @@ def run_backfill_cost_refine_from_raw(
     if start_date > end_date:
         raise ValueError("start_date must be before or equal to end_date")
 
+    job_name = source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id)
     params = {
         "vendor": "gcp",
         "account_id": settings.account_id,
@@ -70,7 +72,7 @@ def run_backfill_cost_refine_from_raw(
 
     if not dry_run:
         with engine.begin() as connection:
-            state_store.mark_job_started(connection, JOB_NAME, watermark)
+            state_store.mark_job_started(connection, job_name, watermark)
 
     try:
         summary_rows_seen = 0
@@ -127,7 +129,11 @@ def run_backfill_cost_refine_from_raw(
             with engine.begin() as connection:
                 state_store.mark_job_succeeded(
                     connection,
-                    SUMMARY_JOB_NAME,
+                    source_job_name(
+                        SUMMARY_JOB_NAME,
+                        vendor="gcp",
+                        account_id=settings.account_id,
+                    ),
                     summary_watermark(
                         account_id=settings.account_id,
                         export_partition_start=export_partition_start,
@@ -138,7 +144,7 @@ def run_backfill_cost_refine_from_raw(
 
         if not dry_run:
             with engine.begin() as connection:
-                state_store.mark_job_succeeded(connection, JOB_NAME, watermark)
+                state_store.mark_job_succeeded(connection, job_name, watermark)
 
         return BackfillCostRefineFromRawSummary(
             account_id=settings.account_id,
@@ -157,7 +163,7 @@ def run_backfill_cost_refine_from_raw(
         LOG.exception("backfill_cost_refine_from_raw failed")
         if not dry_run:
             with engine.begin() as connection:
-                state_store.mark_job_failed(connection, JOB_NAME, watermark, repr(exc))
+                state_store.mark_job_failed(connection, job_name, watermark, repr(exc))
         raise
 
 

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -4,16 +4,21 @@ import argparse
 import json
 import logging
 from collections.abc import Sequence
+from dataclasses import replace
 from datetime import date, timedelta
 
-from cost_insight.common.config import get_settings
+from cost_insight.common.config import AwsBillingSettings, GcpBillingSettings, get_settings
 from cost_insight.common.db import build_engine
 from cost_insight.common.logging import configure_logging
 from cost_insight.jobs.backfill_cost_refine_from_raw import run_backfill_cost_refine_from_raw
+from cost_insight.jobs.cost_sources import list_active_cost_sources
 from cost_insight.jobs.refresh_attribution_daily import (
+    CostAttributionSource,
     run_refresh_cost_attribution_daily,
     run_refresh_cost_attribution_from_summary,
 )
+from cost_insight.jobs.sync_aws_billing_summary import run_sync_aws_billing_summary
+from cost_insight.jobs.sync_aws_unmatched_resources import run_sync_aws_unmatched_resources
 from cost_insight.jobs.sync_gcp_billing_summary import run_sync_gcp_billing_summary
 from cost_insight.jobs.sync_gcp_billing_export import run_sync_gcp_billing_export
 from cost_insight.jobs.sync_gcp_unmatched_resources import run_sync_gcp_unmatched_resources
@@ -47,6 +52,16 @@ def build_parser() -> argparse.ArgumentParser:
     sync_summary.add_argument("--dry-run", action="store_true")
     sync_summary.add_argument("--limit", type=int, default=None)
 
+    sync_aws_summary = subparsers.add_parser(
+        "sync-aws-billing-summary",
+        help="Sync AWS billing export partitions into cost_bq_export_summary_daily",
+    )
+    sync_aws_summary.add_argument("--export-partition-start", type=_parse_date, default=None)
+    sync_aws_summary.add_argument("--export-partition-end", type=_parse_date, default=None)
+    sync_aws_summary.add_argument("--earliest-usage-date", type=_parse_date, default=None)
+    sync_aws_summary.add_argument("--dry-run", action="store_true")
+    sync_aws_summary.add_argument("--limit", type=int, default=None)
+
     sync_unmatched = subparsers.add_parser(
         "sync-gcp-unmatched-resources",
         help="Sync weekly GCP resource-level rows for unmatched resource investigation",
@@ -57,6 +72,17 @@ def build_parser() -> argparse.ArgumentParser:
     sync_unmatched.add_argument("--export-partition-end", type=_parse_date, default=None)
     sync_unmatched.add_argument("--dry-run", action="store_true")
     sync_unmatched.add_argument("--limit", type=int, default=None)
+
+    sync_aws_unmatched = subparsers.add_parser(
+        "sync-aws-unmatched-resources",
+        help="Sync weekly AWS resource-level rows for unmatched resource investigation",
+    )
+    sync_aws_unmatched.add_argument("--usage-start-date", type=_parse_date, required=True)
+    sync_aws_unmatched.add_argument("--usage-end-date", type=_parse_date, required=True)
+    sync_aws_unmatched.add_argument("--export-partition-start", type=_parse_date, default=None)
+    sync_aws_unmatched.add_argument("--export-partition-end", type=_parse_date, default=None)
+    sync_aws_unmatched.add_argument("--dry-run", action="store_true")
+    sync_aws_unmatched.add_argument("--limit", type=int, default=None)
 
     backfill_refine = subparsers.add_parser(
         "backfill-gcp-cost-refine-from-raw",
@@ -113,13 +139,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "sync-gcp-billing-export":
         engine = build_engine(settings)
         try:
-            summaries = _run_sync_gcp_command(engine, settings=settings.gcp_billing, args=args)
-            payload = (
-                [_summary_to_json(summary) for summary in summaries]
-                if args.split_by_day
-                else _summary_to_json(summaries[0])
-            )
-            print(json.dumps(payload, indent=2, sort_keys=True))
+            summaries = []
+            for gcp_settings in _resolve_gcp_sources(engine, settings=settings.gcp_billing):
+                summaries.extend(_run_sync_gcp_command(engine, settings=gcp_settings, args=args))
+            print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
             return 0
         finally:
             engine.dispose()
@@ -127,16 +150,42 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "sync-gcp-billing-summary":
         engine = build_engine(settings)
         try:
-            summary = run_sync_gcp_billing_summary(
-                engine,
-                settings=settings.gcp_billing,
-                export_partition_start=args.export_partition_start,
-                export_partition_end=args.export_partition_end,
-                earliest_usage_date=args.earliest_usage_date,
-                dry_run=args.dry_run,
-                limit=args.limit,
-            )
-            print(json.dumps(_summary_to_json(summary), indent=2, sort_keys=True))
+            summaries = []
+            for gcp_settings in _resolve_gcp_sources(engine, settings=settings.gcp_billing):
+                summaries.append(
+                    run_sync_gcp_billing_summary(
+                        engine,
+                        settings=gcp_settings,
+                        export_partition_start=args.export_partition_start,
+                        export_partition_end=args.export_partition_end,
+                        earliest_usage_date=args.earliest_usage_date,
+                        dry_run=args.dry_run,
+                        limit=args.limit,
+                    )
+                )
+            print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
+            return 0
+        finally:
+            engine.dispose()
+
+    if args.command == "sync-aws-billing-summary":
+        engine = build_engine(settings)
+        try:
+            summaries = []
+            for account_id in _resolve_aws_sources(engine, settings=settings.aws_billing):
+                summaries.append(
+                    run_sync_aws_billing_summary(
+                        engine,
+                        settings=settings.aws_billing,
+                        account_id=account_id,
+                        export_partition_start=args.export_partition_start,
+                        export_partition_end=args.export_partition_end,
+                        earliest_usage_date=args.earliest_usage_date,
+                        dry_run=args.dry_run,
+                        limit=args.limit,
+                    )
+                )
+            print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
             return 0
         finally:
             engine.dispose()
@@ -144,17 +193,44 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "sync-gcp-unmatched-resources":
         engine = build_engine(settings)
         try:
-            summary = run_sync_gcp_unmatched_resources(
-                engine,
-                settings=settings.gcp_billing,
-                usage_start_date=args.usage_start_date,
-                usage_end_date=args.usage_end_date,
-                export_partition_start=args.export_partition_start,
-                export_partition_end=args.export_partition_end,
-                dry_run=args.dry_run,
-                limit=args.limit,
-            )
-            print(json.dumps(_summary_to_json(summary), indent=2, sort_keys=True))
+            summaries = []
+            for gcp_settings in _resolve_gcp_sources(engine, settings=settings.gcp_billing):
+                summaries.append(
+                    run_sync_gcp_unmatched_resources(
+                        engine,
+                        settings=gcp_settings,
+                        usage_start_date=args.usage_start_date,
+                        usage_end_date=args.usage_end_date,
+                        export_partition_start=args.export_partition_start,
+                        export_partition_end=args.export_partition_end,
+                        dry_run=args.dry_run,
+                        limit=args.limit,
+                    )
+                )
+            print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
+            return 0
+        finally:
+            engine.dispose()
+
+    if args.command == "sync-aws-unmatched-resources":
+        engine = build_engine(settings)
+        try:
+            summaries = []
+            for account_id in _resolve_aws_sources(engine, settings=settings.aws_billing):
+                summaries.append(
+                    run_sync_aws_unmatched_resources(
+                        engine,
+                        settings=settings.aws_billing,
+                        account_id=account_id,
+                        usage_start_date=args.usage_start_date,
+                        usage_end_date=args.usage_end_date,
+                        export_partition_start=args.export_partition_start,
+                        export_partition_end=args.export_partition_end,
+                        dry_run=args.dry_run,
+                        limit=args.limit,
+                    )
+                )
+            print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
             return 0
         finally:
             engine.dispose()
@@ -162,16 +238,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "backfill-gcp-cost-refine-from-raw":
         engine = build_engine(settings)
         try:
-            summary = run_backfill_cost_refine_from_raw(
-                engine,
-                settings=settings.gcp_billing,
-                start_date=args.start_date,
-                end_date=args.end_date,
-                include_unmatched_resources=not args.skip_unmatched_resources,
-                mark_summary_watermark=args.mark_summary_watermark,
-                dry_run=args.dry_run,
-            )
-            print(json.dumps(_summary_to_json(summary), indent=2, sort_keys=True))
+            summaries = []
+            for gcp_settings in _resolve_gcp_sources(engine, settings=settings.gcp_billing):
+                summaries.append(
+                    run_backfill_cost_refine_from_raw(
+                        engine,
+                        settings=gcp_settings,
+                        start_date=args.start_date,
+                        end_date=args.end_date,
+                        include_unmatched_resources=not args.skip_unmatched_resources,
+                        mark_summary_watermark=args.mark_summary_watermark,
+                        dry_run=args.dry_run,
+                    )
+                )
+            print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
             return 0
         finally:
             engine.dispose()
@@ -179,17 +259,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "refresh-cost-attribution-daily":
         engine = build_engine(settings)
         try:
-            summaries = _run_refresh_attribution_command(
+            summaries = []
+            for source in _resolve_attribution_sources(
                 engine,
-                settings=settings.gcp_billing,
-                args=args,
-            )
-            payload = (
-                [_summary_to_json(summary) for summary in summaries]
-                if args.split_by_day
-                else _summary_to_json(summaries[0])
-            )
-            print(json.dumps(payload, indent=2, sort_keys=True))
+                gcp_settings=settings.gcp_billing,
+                aws_settings=settings.aws_billing,
+            ):
+                summaries.extend(_run_refresh_attribution_command(engine, source=source, args=args))
+            print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
             return 0
         finally:
             engine.dispose()
@@ -197,17 +274,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "refresh-cost-attribution-from-summary":
         engine = build_engine(settings)
         try:
-            summaries = _run_refresh_attribution_from_summary_command(
+            summaries = []
+            for source in _resolve_attribution_sources(
                 engine,
-                settings=settings.gcp_billing,
-                args=args,
-            )
-            payload = (
-                [_summary_to_json(summary) for summary in summaries]
-                if args.split_by_day
-                else _summary_to_json(summaries[0])
-            )
-            print(json.dumps(payload, indent=2, sort_keys=True))
+                gcp_settings=settings.gcp_billing,
+                aws_settings=settings.aws_billing,
+            ):
+                summaries.extend(
+                    _run_refresh_attribution_from_summary_command(engine, source=source, args=args)
+                )
+            print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
             return 0
         finally:
             engine.dispose()
@@ -257,18 +333,18 @@ def _run_sync_gcp_command(engine, *, settings, args):
     return [summary]
 
 
-def _run_refresh_attribution_command(engine, *, settings, args):
+def _run_refresh_attribution_command(engine, *, source: CostAttributionSource, args):
     logger = logging.getLogger(__name__)
     if args.split_by_day:
         summaries = []
         for usage_date in _date_range(args.start_date, args.end_date):
             logger.info(
                 "refresh-cost-attribution-daily day started",
-                extra={"usage_date": usage_date},
+                extra={"vendor": source.vendor, "account_id": source.account_id, "usage_date": usage_date},
             )
             summary = run_refresh_cost_attribution_daily(
                 engine,
-                settings=settings,
+                source=source,
                 start_date=usage_date,
                 end_date=usage_date,
                 dry_run=args.dry_run,
@@ -282,7 +358,7 @@ def _run_refresh_attribution_command(engine, *, settings, args):
 
     summary = run_refresh_cost_attribution_daily(
         engine,
-        settings=settings,
+        source=source,
         start_date=args.start_date,
         end_date=args.end_date,
         dry_run=args.dry_run,
@@ -294,18 +370,18 @@ def _run_refresh_attribution_command(engine, *, settings, args):
     return [summary]
 
 
-def _run_refresh_attribution_from_summary_command(engine, *, settings, args):
+def _run_refresh_attribution_from_summary_command(engine, *, source: CostAttributionSource, args):
     logger = logging.getLogger(__name__)
     if args.split_by_day:
         summaries = []
         for usage_date in _date_range(args.start_date, args.end_date):
             logger.info(
                 "refresh-cost-attribution-from-summary day started",
-                extra={"usage_date": usage_date},
+                extra={"vendor": source.vendor, "account_id": source.account_id, "usage_date": usage_date},
             )
             summary = run_refresh_cost_attribution_from_summary(
                 engine,
-                settings=settings,
+                source=source,
                 start_date=usage_date,
                 end_date=usage_date,
                 dry_run=args.dry_run,
@@ -319,7 +395,7 @@ def _run_refresh_attribution_from_summary_command(engine, *, settings, args):
 
     summary = run_refresh_cost_attribution_from_summary(
         engine,
-        settings=settings,
+        source=source,
         start_date=args.start_date,
         end_date=args.end_date,
         dry_run=args.dry_run,
@@ -340,11 +416,64 @@ def _date_range(start_date: date, end_date: date):
         current += timedelta(days=1)
 
 
+def _resolve_gcp_sources(engine, *, settings: GcpBillingSettings) -> tuple[GcpBillingSettings, ...]:
+    sources = _list_sources(engine, vendor="gcp")
+    if not sources:
+        return (settings,)
+    return tuple(replace(settings, account_id=source.account_id) for source in sources)
+
+
+def _resolve_aws_sources(engine, *, settings: AwsBillingSettings) -> tuple[str, ...]:
+    sources = _list_sources(engine, vendor="aws")
+    if sources:
+        return tuple(source.account_id for source in sources)
+    if settings.account_id:
+        return (settings.account_id,)
+    logging.getLogger(__name__).warning(
+        "No active AWS cost sources found in cost_sources and COST_INSIGHT_AWS_ACCOUNT_ID is not set."
+    )
+    return ()
+
+
+def _resolve_attribution_sources(
+    engine,
+    *,
+    gcp_settings: GcpBillingSettings,
+    aws_settings: AwsBillingSettings,
+) -> tuple[CostAttributionSource, ...]:
+    sources = _list_sources(engine, vendor=None)
+    if sources:
+        return tuple(
+            CostAttributionSource(vendor=source.vendor, account_id=source.account_id)
+            for source in sources
+        )
+    fallback_sources = [CostAttributionSource(vendor="gcp", account_id=gcp_settings.account_id)]
+    if aws_settings.account_id:
+        fallback_sources.append(
+            CostAttributionSource(vendor="aws", account_id=aws_settings.account_id)
+        )
+    return tuple(fallback_sources)
+
+
+def _list_sources(engine, *, vendor: str | None):
+    if not hasattr(engine, "begin"):
+        return ()
+    with engine.begin() as connection:
+        return list_active_cost_sources(connection, vendor=vendor)
+
+
+def _summaries_to_json(summaries: Sequence[object]) -> object:
+    payload = [_summary_to_json(summary) for summary in summaries]
+    return payload[0] if len(payload) == 1 else payload
+
+
 def _summary_to_json(summary) -> dict[str, object]:
     payload = {
         "account_id": summary.account_id,
         "dry_run": summary.dry_run,
     }
+    if hasattr(summary, "vendor") and getattr(summary, "vendor") is not None:
+        payload["vendor"] = getattr(summary, "vendor")
     for field in (
         "start_date",
         "end_date",

--- a/cost-insight/src/cost_insight/jobs/cost_sources.py
+++ b/cost-insight/src/cost_insight/jobs/cost_sources.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+
+@dataclass(frozen=True)
+class CostSource:
+    vendor: str
+    account_id: str
+    billing_account_id: str | None
+    display_name: str | None
+    is_active: bool
+
+
+_SELECT_COST_SOURCE = text(
+    """
+    SELECT vendor, account_id, billing_account_id, display_name, is_active
+    FROM cost_sources
+    WHERE vendor = :vendor AND account_id = :account_id
+    """
+)
+
+_SELECT_ACTIVE_COST_SOURCES = text(
+    """
+    SELECT vendor, account_id, billing_account_id, display_name, is_active
+    FROM cost_sources
+    WHERE is_active = 1
+      AND (:vendor IS NULL OR vendor = :vendor)
+    ORDER BY vendor, account_id
+    """
+)
+
+
+def get_cost_source(
+    connection: Connection,
+    *,
+    vendor: str,
+    account_id: str,
+) -> CostSource | None:
+    row = (
+        connection.execute(
+            _SELECT_COST_SOURCE,
+            {"vendor": vendor, "account_id": account_id},
+        )
+        .mappings()
+        .first()
+    )
+    return _coerce_cost_source(row) if row is not None else None
+
+
+def list_active_cost_sources(
+    connection: Connection,
+    *,
+    vendor: str | None = None,
+) -> tuple[CostSource, ...]:
+    rows = connection.execute(_SELECT_ACTIVE_COST_SOURCES, {"vendor": vendor}).mappings()
+    return tuple(_coerce_cost_source(row) for row in rows)
+
+
+def ensure_cost_source_enabled(
+    connection: Connection,
+    *,
+    vendor: str,
+    account_id: str,
+    dry_run: bool,
+    display_name: str | None = None,
+) -> None:
+    source = get_cost_source(connection, vendor=vendor, account_id=account_id)
+    if source is not None:
+        if not source.is_active:
+            raise ValueError(f"Cost source {vendor}/{account_id} is inactive")
+        return
+    if not dry_run:
+        upsert_cost_source(
+            connection,
+            vendor=vendor,
+            account_id=account_id,
+            display_name=display_name or account_id,
+        )
+
+
+def upsert_cost_source(
+    connection: Connection,
+    *,
+    vendor: str,
+    account_id: str,
+    billing_account_id: str | None = None,
+    display_name: str | None = None,
+) -> None:
+    connection.execute(
+        _build_upsert_cost_source_statement(connection),
+        {
+            "vendor": vendor,
+            "account_id": account_id,
+            "billing_account_id": billing_account_id,
+            "display_name": display_name or account_id,
+        },
+    )
+
+
+def _coerce_cost_source(row: Any) -> CostSource:
+    return CostSource(
+        vendor=str(row["vendor"]),
+        account_id=str(row["account_id"]),
+        billing_account_id=row["billing_account_id"],
+        display_name=row["display_name"],
+        is_active=bool(int(row["is_active"])),
+    )
+
+
+def _build_upsert_cost_source_statement(connection: Connection):
+    if connection.dialect.name == "sqlite":
+        return text(
+            """
+            INSERT INTO cost_sources (
+              vendor,
+              account_id,
+              billing_account_id,
+              display_name,
+              is_active,
+              updated_at
+            ) VALUES (
+              :vendor,
+              :account_id,
+              :billing_account_id,
+              :display_name,
+              1,
+              CURRENT_TIMESTAMP
+            )
+            ON CONFLICT(vendor, account_id) DO UPDATE SET
+              billing_account_id = COALESCE(
+                excluded.billing_account_id,
+                cost_sources.billing_account_id
+              ),
+              display_name = COALESCE(cost_sources.display_name, excluded.display_name),
+              updated_at = CURRENT_TIMESTAMP
+            """
+        )
+    return text(
+        """
+        INSERT INTO cost_sources (
+          vendor,
+          account_id,
+          billing_account_id,
+          display_name,
+          is_active
+        ) VALUES (
+          :vendor,
+          :account_id,
+          :billing_account_id,
+          :display_name,
+          1
+        )
+        ON DUPLICATE KEY UPDATE
+          billing_account_id = COALESCE(VALUES(billing_account_id), billing_account_id),
+          display_name = COALESCE(display_name, VALUES(display_name)),
+          updated_at = CURRENT_TIMESTAMP
+        """
+    )

--- a/cost-insight/src/cost_insight/jobs/job_keys.py
+++ b/cost-insight/src/cost_insight/jobs/job_keys.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def source_job_name(base_job_name: str, *, vendor: str, account_id: str) -> str:
+    return f"{base_job_name}:{vendor}:{account_id}"

--- a/cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py
+++ b/cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py
@@ -8,18 +8,24 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
-from cost_insight.common.config import GcpBillingSettings
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.jobs import state_store
 
 LOG = logging.getLogger(__name__)
 
 JOB_NAME = "refresh_cost_attribution_daily"
 SUMMARY_JOB_NAME = "refresh_cost_attribution_from_summary"
-VENDOR = "gcp"
+
+
+@dataclass(frozen=True)
+class CostAttributionSource:
+    vendor: str
+    account_id: str
 
 
 @dataclass(frozen=True)
 class RefreshAttributionSummary:
+    vendor: str
     account_id: str
     start_date: date
     end_date: date
@@ -33,7 +39,7 @@ class RefreshAttributionSummary:
 def run_refresh_cost_attribution_daily(
     engine: Engine,
     *,
-    settings: GcpBillingSettings,
+    source: CostAttributionSource,
     start_date: date,
     end_date: date,
     dry_run: bool = False,
@@ -42,18 +48,20 @@ def run_refresh_cost_attribution_daily(
         raise ValueError("start_date must be before or equal to end_date")
 
     params = {
-        "vendor": VENDOR,
-        "account_id": settings.account_id,
+        "vendor": source.vendor,
+        "account_id": source.account_id,
         "start_date": start_date,
         "end_date": end_date,
     }
-    watermark = _watermark(account_id=settings.account_id, start_date=start_date, end_date=end_date)
+    watermark = _watermark(vendor=source.vendor, account_id=source.account_id, start_date=start_date, end_date=end_date)
+    job_name = source_job_name(JOB_NAME, vendor=source.vendor, account_id=source.account_id)
 
     if dry_run:
         with engine.begin() as connection:
             raw_rows = connection.execute(_COUNT_RAW_DETAILS, params).scalar_one()
         return RefreshAttributionSummary(
-            account_id=settings.account_id,
+            vendor=source.vendor,
+            account_id=source.account_id,
             start_date=start_date,
             end_date=end_date,
             rows_deleted=0,
@@ -64,15 +72,16 @@ def run_refresh_cost_attribution_daily(
 
     try:
         with engine.begin() as connection:
-            state_store.mark_job_started(connection, JOB_NAME, watermark)
+            state_store.mark_job_started(connection, job_name, watermark)
 
         with engine.begin() as connection:
             delete_result = connection.execute(_DELETE_ATTRIBUTION_DAILY, params)
             insert_result = connection.execute(_INSERT_ATTRIBUTION_DAILY, params)
-            state_store.mark_job_succeeded(connection, JOB_NAME, watermark)
+            state_store.mark_job_succeeded(connection, job_name, watermark)
 
         return RefreshAttributionSummary(
-            account_id=settings.account_id,
+            vendor=source.vendor,
+            account_id=source.account_id,
             start_date=start_date,
             end_date=end_date,
             rows_deleted=_positive_rowcount(delete_result.rowcount),
@@ -82,14 +91,14 @@ def run_refresh_cost_attribution_daily(
     except Exception as exc:
         LOG.exception("refresh_cost_attribution_daily failed")
         with engine.begin() as connection:
-            state_store.mark_job_failed(connection, JOB_NAME, watermark, repr(exc))
+            state_store.mark_job_failed(connection, job_name, watermark, repr(exc))
         raise
 
 
 def run_refresh_cost_attribution_from_summary(
     engine: Engine,
     *,
-    settings: GcpBillingSettings,
+    source: CostAttributionSource,
     start_date: date,
     end_date: date,
     dry_run: bool = False,
@@ -98,18 +107,20 @@ def run_refresh_cost_attribution_from_summary(
         raise ValueError("start_date must be before or equal to end_date")
 
     params = {
-        "vendor": VENDOR,
-        "account_id": settings.account_id,
+        "vendor": source.vendor,
+        "account_id": source.account_id,
         "start_date": start_date,
         "end_date": end_date,
     }
-    watermark = _watermark(account_id=settings.account_id, start_date=start_date, end_date=end_date)
+    watermark = _watermark(vendor=source.vendor, account_id=source.account_id, start_date=start_date, end_date=end_date)
+    job_name = source_job_name(SUMMARY_JOB_NAME, vendor=source.vendor, account_id=source.account_id)
 
     if dry_run:
         with engine.begin() as connection:
             summary_rows = connection.execute(_COUNT_SUMMARY_DETAILS, params).scalar_one()
         return RefreshAttributionSummary(
-            account_id=settings.account_id,
+            vendor=source.vendor,
+            account_id=source.account_id,
             start_date=start_date,
             end_date=end_date,
             rows_deleted=0,
@@ -120,15 +131,16 @@ def run_refresh_cost_attribution_from_summary(
 
     try:
         with engine.begin() as connection:
-            state_store.mark_job_started(connection, SUMMARY_JOB_NAME, watermark)
+            state_store.mark_job_started(connection, job_name, watermark)
 
         with engine.begin() as connection:
             delete_result = connection.execute(_DELETE_ATTRIBUTION_DAILY, params)
             insert_result = connection.execute(_INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY, params)
-            state_store.mark_job_succeeded(connection, SUMMARY_JOB_NAME, watermark)
+            state_store.mark_job_succeeded(connection, job_name, watermark)
 
         return RefreshAttributionSummary(
-            account_id=settings.account_id,
+            vendor=source.vendor,
+            account_id=source.account_id,
             start_date=start_date,
             end_date=end_date,
             rows_deleted=_positive_rowcount(delete_result.rowcount),
@@ -138,12 +150,13 @@ def run_refresh_cost_attribution_from_summary(
     except Exception as exc:
         LOG.exception("refresh_cost_attribution_from_summary failed")
         with engine.begin() as connection:
-            state_store.mark_job_failed(connection, SUMMARY_JOB_NAME, watermark, repr(exc))
+            state_store.mark_job_failed(connection, job_name, watermark, repr(exc))
         raise
 
 
-def _watermark(*, account_id: str, start_date: date, end_date: date) -> dict[str, Any]:
+def _watermark(*, vendor: str, account_id: str, start_date: date, end_date: date) -> dict[str, Any]:
     return {
+        "vendor": vendor,
         "account_id": account_id,
         "start_date": start_date.isoformat(),
         "end_date": end_date.isoformat(),

--- a/cost-insight/src/cost_insight/jobs/sync_aws_billing_summary.py
+++ b/cost-insight/src/cost_insight/jobs/sync_aws_billing_summary.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any
+
+from sqlalchemy.engine import Engine
+
+from cost_insight.common.config import AwsBillingSettings
+from cost_insight.jobs import state_store
+from cost_insight.jobs.cost_sources import ensure_cost_source_enabled, upsert_cost_source
+from cost_insight.jobs.job_keys import source_job_name
+from cost_insight.jobs.sync_gcp_billing_summary import (
+    SyncGcpBillingSummaryResult,
+    _normalize_summary_row,
+    _select_billing_account_id,
+    _watermark as gcp_watermark,
+    write_summary_rows,
+)
+from cost_insight.sources.aws_billing_export import fetch_aws_billing_summary_rows
+
+LOG = logging.getLogger(__name__)
+
+JOB_NAME = "sync_aws_billing_summary"
+RowFetcher = Callable[..., Iterable[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class SyncAwsBillingSummaryResult(SyncGcpBillingSummaryResult):
+    pass
+
+
+def run_sync_aws_billing_summary(
+    engine: Engine,
+    *,
+    settings: AwsBillingSettings,
+    account_id: str,
+    export_partition_start: date | None = None,
+    export_partition_end: date | None = None,
+    earliest_usage_date: date | None = None,
+    dry_run: bool = False,
+    limit: int | None = None,
+    fetch_rows: RowFetcher = fetch_aws_billing_summary_rows,
+) -> SyncAwsBillingSummaryResult:
+    resolved_end = export_partition_end or _month_floor(datetime.now(timezone.utc).date())
+    job_name = source_job_name(JOB_NAME, vendor="aws", account_id=account_id)
+    with engine.begin() as connection:
+        ensure_cost_source_enabled(
+            connection,
+            vendor="aws",
+            account_id=account_id,
+            dry_run=dry_run,
+            display_name=account_id,
+        )
+        state = state_store.get_job_state(connection, job_name)
+        resolved_start = export_partition_start or _start_partition_from_state(
+            state.watermark if state else {},
+            end_date=resolved_end,
+            overlap_months=settings.export_overlap_months,
+            initial_lookback_months=settings.sync_initial_lookback_months,
+        )
+        watermark = _watermark(
+            account_id=account_id,
+            export_partition_start=resolved_start,
+            export_partition_end=resolved_end,
+        )
+        if not dry_run:
+            state_store.mark_job_started(connection, job_name, watermark)
+
+    try:
+        rows_seen = 0
+        rows_written = 0
+        source_billing_account_ids: set[str] = set()
+        batch: list[dict[str, Any]] = []
+        for source_row in fetch_rows(
+            billing_table=settings.billing_table,
+            account_id=account_id,
+            export_partition_start=resolved_start,
+            export_partition_end=resolved_end,
+            earliest_usage_date=earliest_usage_date or settings.earliest_usage_date,
+            page_size=settings.page_size,
+            limit=limit,
+        ):
+            rows_seen += 1
+            normalized = _normalize_summary_row(source_row)
+            if normalized["billing_account_id"]:
+                source_billing_account_ids.add(str(normalized["billing_account_id"]))
+            batch.append(normalized)
+            if len(batch) >= settings.page_size:
+                rows_written += write_summary_rows(engine, batch, dry_run=dry_run)
+                batch.clear()
+        rows_written += write_summary_rows(engine, batch, dry_run=dry_run)
+
+        touched_usage_dates: tuple[date, ...] = ()
+        if not dry_run:
+            with engine.begin() as connection:
+                source_billing_account_id = _select_billing_account_id(source_billing_account_ids)
+                if source_billing_account_id:
+                    upsert_cost_source(
+                        connection,
+                        vendor="aws",
+                        account_id=account_id,
+                        billing_account_id=source_billing_account_id,
+                        display_name=account_id,
+                    )
+                touched_usage_dates = _get_touched_usage_dates(
+                    engine,
+                    account_id=account_id,
+                    export_partition_start=resolved_start,
+                    export_partition_end=resolved_end,
+                )
+                state_store.mark_job_succeeded(connection, job_name, watermark)
+
+        return SyncAwsBillingSummaryResult(
+            account_id=account_id,
+            export_partition_start=resolved_start,
+            export_partition_end=resolved_end,
+            rows_seen=rows_seen,
+            rows_written=rows_written,
+            dry_run=dry_run,
+            touched_usage_dates=touched_usage_dates,
+        )
+    except Exception as exc:
+        LOG.exception("sync_aws_billing_summary failed")
+        if not dry_run:
+            with engine.begin() as connection:
+                state_store.mark_job_failed(connection, job_name, watermark, repr(exc))
+        raise
+
+
+def _watermark(
+    *,
+    account_id: str,
+    export_partition_start: date,
+    export_partition_end: date,
+) -> dict[str, Any]:
+    payload = gcp_watermark(
+        account_id=account_id,
+        export_partition_start=export_partition_start,
+        export_partition_end=export_partition_end,
+    )
+    payload["vendor"] = "aws"
+    return payload
+
+
+def _start_partition_from_state(
+    watermark: dict[str, Any],
+    *,
+    end_date: date,
+    overlap_months: int,
+    initial_lookback_months: int | None,
+) -> date:
+    last_end_date = watermark.get("export_partition_end")
+    if last_end_date:
+        parsed = _month_floor(date.fromisoformat(str(last_end_date)))
+        return min(_add_months(parsed, 1 - overlap_months), end_date)
+    if initial_lookback_months is not None:
+        return _add_months(end_date, 1 - initial_lookback_months)
+    return end_date
+
+
+def _month_floor(value: date) -> date:
+    return value.replace(day=1)
+
+
+def _add_months(value: date, months: int) -> date:
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    return date(year, month, 1)
+
+
+def _get_touched_usage_dates(
+    engine: Engine,
+    *,
+    account_id: str,
+    export_partition_start: date,
+    export_partition_end: date,
+) -> tuple[date, ...]:
+    from sqlalchemy import text
+
+    query = text(
+        """
+        SELECT DISTINCT usage_date
+        FROM cost_bq_export_summary_daily
+        WHERE vendor = 'aws'
+          AND account_id = :account_id
+          AND export_partition_date BETWEEN :export_partition_start AND :export_partition_end
+        ORDER BY usage_date
+        """
+    )
+    with engine.begin() as connection:
+        rows = connection.execute(
+            query,
+            {
+                "account_id": account_id,
+                "export_partition_start": export_partition_start,
+                "export_partition_end": export_partition_end,
+            },
+        ).scalars()
+        return tuple(date.fromisoformat(str(value)) if isinstance(value, str) else value for value in rows)

--- a/cost-insight/src/cost_insight/jobs/sync_aws_unmatched_resources.py
+++ b/cost-insight/src/cost_insight/jobs/sync_aws_unmatched_resources.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from sqlalchemy.engine import Engine
+
+from cost_insight.common.config import AwsBillingSettings
+from cost_insight.jobs import state_store
+from cost_insight.jobs.cost_sources import ensure_cost_source_enabled, upsert_cost_source
+from cost_insight.jobs.job_keys import source_job_name
+from cost_insight.jobs.sync_gcp_unmatched_resources import (
+    SyncGcpUnmatchedResourcesSummary,
+    _normalize_resource_row,
+    _watermark as gcp_watermark,
+    write_unmatched_resource_rows,
+)
+from cost_insight.sources.aws_billing_export import fetch_aws_unmatched_resource_rows
+
+LOG = logging.getLogger(__name__)
+
+JOB_NAME = "sync_aws_unmatched_resources"
+RowFetcher = Callable[..., Iterable[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class SyncAwsUnmatchedResourcesSummary(SyncGcpUnmatchedResourcesSummary):
+    pass
+
+
+def run_sync_aws_unmatched_resources(
+    engine: Engine,
+    *,
+    settings: AwsBillingSettings,
+    account_id: str,
+    usage_start_date: date,
+    usage_end_date: date,
+    export_partition_start: date | None = None,
+    export_partition_end: date | None = None,
+    dry_run: bool = False,
+    limit: int | None = None,
+    fetch_rows: RowFetcher = fetch_aws_unmatched_resource_rows,
+) -> SyncAwsUnmatchedResourcesSummary:
+    if usage_start_date > usage_end_date:
+        raise ValueError("usage_start_date must be before or equal to usage_end_date")
+    job_name = source_job_name(JOB_NAME, vendor="aws", account_id=account_id)
+    # AWS staging data is partitioned by billing month, so the default partition
+    # window must expand a mid-month usage request to the first day of that month.
+    resolved_export_start = export_partition_start or usage_start_date.replace(day=1)
+    resolved_export_end = export_partition_end or usage_end_date.replace(day=1)
+    watermark = _watermark(
+        account_id=account_id,
+        usage_start_date=usage_start_date,
+        usage_end_date=usage_end_date,
+        export_partition_start=resolved_export_start,
+        export_partition_end=resolved_export_end,
+    )
+    with engine.begin() as connection:
+        ensure_cost_source_enabled(
+            connection,
+            vendor="aws",
+            account_id=account_id,
+            dry_run=dry_run,
+            display_name=account_id,
+        )
+        if not dry_run:
+            state_store.mark_job_started(connection, job_name, watermark)
+
+    try:
+        rows_seen = 0
+        rows_written = 0
+        source_billing_account_id: str | None = None
+        batch: list[dict[str, Any]] = []
+        for source_row in fetch_rows(
+            billing_table=settings.billing_table,
+            account_id=account_id,
+            export_partition_start=resolved_export_start,
+            export_partition_end=resolved_export_end,
+            usage_start_date=usage_start_date,
+            usage_end_date=usage_end_date,
+            page_size=settings.page_size,
+            limit=limit,
+        ):
+            rows_seen += 1
+            normalized = _normalize_resource_row(source_row)
+            source_billing_account_id = source_billing_account_id or normalized["billing_account_id"]
+            batch.append(normalized)
+            if len(batch) >= settings.page_size:
+                rows_written += write_unmatched_resource_rows(engine, batch, dry_run=dry_run)
+                batch.clear()
+        rows_written += write_unmatched_resource_rows(engine, batch, dry_run=dry_run)
+
+        if not dry_run:
+            with engine.begin() as connection:
+                if source_billing_account_id:
+                    upsert_cost_source(
+                        connection,
+                        vendor="aws",
+                        account_id=account_id,
+                        billing_account_id=str(source_billing_account_id),
+                        display_name=account_id,
+                    )
+                state_store.mark_job_succeeded(connection, job_name, watermark)
+
+        return SyncAwsUnmatchedResourcesSummary(
+            account_id=account_id,
+            usage_start_date=usage_start_date,
+            usage_end_date=usage_end_date,
+            export_partition_start=resolved_export_start,
+            export_partition_end=resolved_export_end,
+            rows_seen=rows_seen,
+            rows_written=rows_written,
+            dry_run=dry_run,
+        )
+    except Exception as exc:
+        LOG.exception("sync_aws_unmatched_resources failed")
+        if not dry_run:
+            with engine.begin() as connection:
+                state_store.mark_job_failed(connection, job_name, watermark, repr(exc))
+        raise
+
+
+def _watermark(
+    *,
+    account_id: str,
+    usage_start_date: date,
+    usage_end_date: date,
+    export_partition_start: date,
+    export_partition_end: date,
+) -> dict[str, Any]:
+    payload = gcp_watermark(
+        account_id=account_id,
+        usage_start_date=usage_start_date,
+        usage_end_date=usage_end_date,
+        export_partition_start=export_partition_start,
+        export_partition_end=export_partition_end,
+    )
+    payload["vendor"] = "aws"
+    return payload

--- a/cost-insight/src/cost_insight/jobs/sync_gcp_billing_export.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcp_billing_export.py
@@ -9,10 +9,12 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from sqlalchemy import text
-from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.engine import Engine
 
 from cost_insight.common.config import GcpBillingSettings
 from cost_insight.common.row_utils import coerce_date, coerce_datetime, hash_value, nullable_text
+from cost_insight.jobs.cost_sources import ensure_cost_source_enabled, upsert_cost_source
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.jobs import state_store
 from cost_insight.sources.gcp_billing_export import decimal_or_none, fetch_gcp_billing_rows
 
@@ -58,9 +60,16 @@ def run_sync_gcp_billing_export(
     fetch_rows: RowFetcher = fetch_gcp_billing_rows,
 ) -> SyncGcpBillingSummary:
     resolved_end_date = end_date or (datetime.now(timezone.utc).date() - timedelta(days=1))
+    job_name = source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id)
     with engine.begin() as connection:
-        _ensure_cost_source_enabled(connection, settings, dry_run=dry_run)
-        state = state_store.get_job_state(connection, JOB_NAME)
+        ensure_cost_source_enabled(
+            connection,
+            vendor="gcp",
+            account_id=settings.account_id,
+            dry_run=dry_run,
+            display_name=settings.account_id,
+        )
+        state = state_store.get_job_state(connection, job_name)
         resolved_start_date = start_date or _start_date_from_state(
             state.watermark if state else {},
             end_date=resolved_end_date,
@@ -72,7 +81,7 @@ def run_sync_gcp_billing_export(
             end_date=resolved_end_date,
         )
         if not dry_run:
-            state_store.mark_job_started(connection, JOB_NAME, watermark)
+            state_store.mark_job_started(connection, job_name, watermark)
 
     try:
         rows_seen = 0
@@ -99,12 +108,14 @@ def run_sync_gcp_billing_export(
         if not dry_run:
             with engine.begin() as connection:
                 if source_billing_account_id:
-                    _upsert_cost_source(
+                    upsert_cost_source(
                         connection,
+                        vendor="gcp",
                         account_id=settings.account_id,
                         billing_account_id=source_billing_account_id,
+                        display_name=settings.account_id,
                     )
-                state_store.mark_job_succeeded(connection, JOB_NAME, watermark)
+                state_store.mark_job_succeeded(connection, job_name, watermark)
         return SyncGcpBillingSummary(
             account_id=settings.account_id,
             start_date=resolved_start_date,
@@ -117,7 +128,7 @@ def run_sync_gcp_billing_export(
         LOG.exception("sync_gcp_billing_export failed")
         if not dry_run:
             with engine.begin() as connection:
-                state_store.mark_job_failed(connection, JOB_NAME, watermark, repr(exc))
+                state_store.mark_job_failed(connection, job_name, watermark, repr(exc))
         raise
 
 
@@ -140,50 +151,6 @@ def _watermark(*, account_id: str, start_date: date, end_date: date) -> dict[str
         "start_date": start_date.isoformat(),
         "end_date": end_date.isoformat(),
     }
-
-
-def _ensure_cost_source_enabled(
-    connection: Connection,
-    settings: GcpBillingSettings,
-    *,
-    dry_run: bool,
-) -> None:
-    source = _get_cost_source(connection, account_id=settings.account_id)
-    if source is not None:
-        if int(source["is_active"]) != 1:
-            raise ValueError(f"Cost source gcp/{settings.account_id} is inactive")
-        return
-    if not dry_run:
-        _upsert_cost_source(connection, account_id=settings.account_id)
-
-
-def _get_cost_source(connection: Connection, *, account_id: str) -> dict[str, Any] | None:
-    row = (
-        connection.execute(
-            _SELECT_COST_SOURCE,
-            {"vendor": "gcp", "account_id": account_id},
-        )
-        .mappings()
-        .first()
-    )
-    return dict(row) if row is not None else None
-
-
-def _upsert_cost_source(
-    connection: Connection,
-    *,
-    account_id: str,
-    billing_account_id: str | None = None,
-) -> None:
-    connection.execute(
-        _build_upsert_cost_source_statement(connection),
-        {
-            "vendor": "gcp",
-            "account_id": account_id,
-            "billing_account_id": billing_account_id,
-            "display_name": account_id,
-        },
-    )
 
 
 def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
@@ -230,67 +197,6 @@ def _write_batch(engine: Engine, rows: Sequence[dict[str, Any]], *, dry_run: boo
     with engine.begin() as connection:
         connection.execute(_UPSERT_COST_RAW_DETAILS, list(rows))
     return len(rows)
-
-
-_SELECT_COST_SOURCE = text(
-    """
-    SELECT vendor, account_id, billing_account_id, display_name, is_active
-    FROM cost_sources
-    WHERE vendor = :vendor AND account_id = :account_id
-    """
-)
-
-
-def _build_upsert_cost_source_statement(connection: Connection):
-    if connection.dialect.name == "sqlite":
-        return text(
-            """
-            INSERT INTO cost_sources (
-              vendor,
-              account_id,
-              billing_account_id,
-              display_name,
-              is_active,
-              updated_at
-            ) VALUES (
-              :vendor,
-              :account_id,
-              :billing_account_id,
-              :display_name,
-              1,
-              CURRENT_TIMESTAMP
-            )
-            ON CONFLICT(vendor, account_id) DO UPDATE SET
-              billing_account_id = COALESCE(
-                excluded.billing_account_id,
-                cost_sources.billing_account_id
-              ),
-              display_name = COALESCE(cost_sources.display_name, excluded.display_name),
-              updated_at = CURRENT_TIMESTAMP
-            """
-        )
-    return text(
-        """
-        INSERT INTO cost_sources (
-          vendor,
-          account_id,
-          billing_account_id,
-          display_name,
-          is_active
-        ) VALUES (
-          :vendor,
-          :account_id,
-          :billing_account_id,
-          :display_name,
-          1
-        )
-        ON DUPLICATE KEY UPDATE
-          billing_account_id = COALESCE(VALUES(billing_account_id), billing_account_id),
-          display_name = COALESCE(display_name, VALUES(display_name)),
-          updated_at = CURRENT_TIMESTAMP
-        """
-    )
-
 
 _UPSERT_COST_RAW_DETAILS = text(
     """

--- a/cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcp_billing_summary.py
@@ -20,10 +20,8 @@ from cost_insight.common.row_utils import (
     nullable_text,
 )
 from cost_insight.jobs import state_store
-from cost_insight.jobs.sync_gcp_billing_export import (
-    _ensure_cost_source_enabled,
-    _upsert_cost_source,
-)
+from cost_insight.jobs.cost_sources import ensure_cost_source_enabled, upsert_cost_source
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.sources.gcp_billing_export import (
     DEFAULT_COST_OWNER_AUTHOR,
     decimal_or_none,
@@ -75,9 +73,16 @@ def run_sync_gcp_billing_summary(
     resolved_end = export_partition_end or (
         datetime.now(timezone.utc).date() - timedelta(days=settings.sync_lag_days)
     )
+    job_name = source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id)
     with engine.begin() as connection:
-        _ensure_cost_source_enabled(connection, settings, dry_run=dry_run)
-        state = state_store.get_job_state(connection, JOB_NAME)
+        ensure_cost_source_enabled(
+            connection,
+            vendor="gcp",
+            account_id=settings.account_id,
+            dry_run=dry_run,
+            display_name=settings.account_id,
+        )
+        state = state_store.get_job_state(connection, job_name)
         resolved_start = export_partition_start or _start_partition_from_state(
             state.watermark if state else {},
             end_date=resolved_end,
@@ -90,7 +95,7 @@ def run_sync_gcp_billing_summary(
             export_partition_end=resolved_end,
         )
         if not dry_run:
-            state_store.mark_job_started(connection, JOB_NAME, watermark)
+            state_store.mark_job_started(connection, job_name, watermark)
 
     try:
         rows_seen = 0
@@ -121,10 +126,12 @@ def run_sync_gcp_billing_summary(
             with engine.begin() as connection:
                 source_billing_account_id = _select_billing_account_id(source_billing_account_ids)
                 if source_billing_account_id:
-                    _upsert_cost_source(
+                    upsert_cost_source(
                         connection,
+                        vendor="gcp",
                         account_id=settings.account_id,
                         billing_account_id=source_billing_account_id,
+                        display_name=settings.account_id,
                     )
                 touched_usage_dates = _get_touched_usage_dates(
                     connection,
@@ -132,7 +139,7 @@ def run_sync_gcp_billing_summary(
                     export_partition_start=resolved_start,
                     export_partition_end=resolved_end,
                 )
-                state_store.mark_job_succeeded(connection, JOB_NAME, watermark)
+                state_store.mark_job_succeeded(connection, job_name, watermark)
 
         return SyncGcpBillingSummaryResult(
             account_id=settings.account_id,
@@ -147,7 +154,7 @@ def run_sync_gcp_billing_summary(
         LOG.exception("sync_gcp_billing_summary failed")
         if not dry_run:
             with engine.begin() as connection:
-                state_store.mark_job_failed(connection, JOB_NAME, watermark, repr(exc))
+                state_store.mark_job_failed(connection, job_name, watermark, repr(exc))
         raise
 
 

--- a/cost-insight/src/cost_insight/jobs/sync_gcp_unmatched_resources.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcp_unmatched_resources.py
@@ -20,10 +20,8 @@ from cost_insight.common.row_utils import (
     nullable_text,
 )
 from cost_insight.jobs import state_store
-from cost_insight.jobs.sync_gcp_billing_export import (
-    _ensure_cost_source_enabled,
-    _upsert_cost_source,
-)
+from cost_insight.jobs.cost_sources import ensure_cost_source_enabled, upsert_cost_source
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.sources.gcp_billing_export import (
     decimal_or_none,
     fetch_gcp_unmatched_resource_rows,
@@ -76,6 +74,7 @@ def run_sync_gcp_unmatched_resources(
 ) -> SyncGcpUnmatchedResourcesSummary:
     if usage_start_date > usage_end_date:
         raise ValueError("usage_start_date must be before or equal to usage_end_date")
+    job_name = source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id)
     resolved_export_start = export_partition_start or usage_start_date
     resolved_export_end = export_partition_end or (
         usage_end_date + timedelta(days=settings.unmatched_resource_lag_days)
@@ -98,9 +97,15 @@ def run_sync_gcp_unmatched_resources(
     )
 
     with engine.begin() as connection:
-        _ensure_cost_source_enabled(connection, settings, dry_run=dry_run)
+        ensure_cost_source_enabled(
+            connection,
+            vendor="gcp",
+            account_id=settings.account_id,
+            dry_run=dry_run,
+            display_name=settings.account_id,
+        )
         if not dry_run:
-            state_store.mark_job_started(connection, JOB_NAME, watermark)
+            state_store.mark_job_started(connection, job_name, watermark)
 
     try:
         rows_seen = 0
@@ -131,12 +136,14 @@ def run_sync_gcp_unmatched_resources(
         if not dry_run:
             with engine.begin() as connection:
                 if source_billing_account_id:
-                    _upsert_cost_source(
+                    upsert_cost_source(
                         connection,
+                        vendor="gcp",
                         account_id=settings.account_id,
                         billing_account_id=source_billing_account_id,
+                        display_name=settings.account_id,
                     )
-                state_store.mark_job_succeeded(connection, JOB_NAME, watermark)
+                state_store.mark_job_succeeded(connection, job_name, watermark)
 
         return SyncGcpUnmatchedResourcesSummary(
             account_id=settings.account_id,
@@ -152,7 +159,7 @@ def run_sync_gcp_unmatched_resources(
         LOG.exception("sync_gcp_unmatched_resources failed")
         if not dry_run:
             with engine.begin() as connection:
-                state_store.mark_job_failed(connection, JOB_NAME, watermark, repr(exc))
+                state_store.mark_job_failed(connection, job_name, watermark, repr(exc))
         raise
 
 

--- a/cost-insight/src/cost_insight/sources/aws_billing_export.py
+++ b/cost-insight/src/cost_insight/sources/aws_billing_export.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date
+from typing import Any
+
+
+def fetch_aws_billing_summary_rows(
+    *,
+    billing_table: str,
+    account_id: str,
+    export_partition_start: date,
+    export_partition_end: date,
+    earliest_usage_date: date,
+    page_size: int,
+    limit: int | None = None,
+) -> Iterator[dict[str, Any]]:
+    from google.cloud import bigquery
+
+    client = bigquery.Client()
+    query = build_aws_billing_summary_query(billing_table=billing_table, limit=limit)
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("account_id", "STRING", account_id),
+            bigquery.ScalarQueryParameter(
+                "export_partition_start",
+                "DATE",
+                export_partition_start.isoformat(),
+            ),
+            bigquery.ScalarQueryParameter(
+                "export_partition_end",
+                "DATE",
+                export_partition_end.isoformat(),
+            ),
+            bigquery.ScalarQueryParameter(
+                "earliest_usage_date",
+                "DATE",
+                earliest_usage_date.isoformat(),
+            ),
+        ]
+    )
+    rows = client.query(query, job_config=job_config).result(page_size=page_size)
+    for row in rows:
+        yield dict(row.items())
+
+
+def fetch_aws_unmatched_resource_rows(
+    *,
+    billing_table: str,
+    account_id: str,
+    export_partition_start: date,
+    export_partition_end: date,
+    usage_start_date: date,
+    usage_end_date: date,
+    page_size: int,
+    limit: int | None = None,
+) -> Iterator[dict[str, Any]]:
+    from google.cloud import bigquery
+
+    client = bigquery.Client()
+    query = build_aws_unmatched_resource_query(billing_table=billing_table, limit=limit)
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("account_id", "STRING", account_id),
+            bigquery.ScalarQueryParameter(
+                "export_partition_start",
+                "DATE",
+                export_partition_start.isoformat(),
+            ),
+            bigquery.ScalarQueryParameter(
+                "export_partition_end",
+                "DATE",
+                export_partition_end.isoformat(),
+            ),
+            bigquery.ScalarQueryParameter("usage_start_date", "DATE", usage_start_date.isoformat()),
+            bigquery.ScalarQueryParameter("usage_end_date", "DATE", usage_end_date.isoformat()),
+        ]
+    )
+    rows = client.query(query, job_config=job_config).result(page_size=page_size)
+    for row in rows:
+        yield dict(row.items())
+
+
+def build_aws_billing_summary_query(*, billing_table: str, limit: int | None = None) -> str:
+    limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
+    return f"""
+WITH normalized AS (
+  SELECT
+    line_item_usage_account_id AS account_id,
+    NULLIF(bill_payer_account_id, '') AS billing_account_id,
+    PARSE_DATE('%Y%m%d', billing_month) AS export_partition_date,
+    DATE(line_item_usage_start_date) AS usage_date,
+    COALESCE(NULLIF(product_servicecode, ''), NULLIF(line_item_product_code, '')) AS service_name,
+    COALESCE(
+      NULLIF(product_sku, ''),
+      NULLIF(line_item_usage_type, ''),
+      NULLIF(line_item_line_item_description, '')
+    ) AS sku_name,
+    NULLIF(tag_used_by, '') AS author,
+    NULLIF(tag_tenant, '') AS org,
+    NULLIF(tag_project, '') AS repo,
+    pricing_unit,
+    line_item_usage_amount,
+    COALESCE(pricing_public_on_demand_cost, 0) AS list_cost,
+    COALESCE(line_item_unblended_cost, line_item_blended_cost, 0) AS effective_cost,
+    COALESCE(
+      line_item_net_unblended_cost,
+      line_item_unblended_cost,
+      line_item_blended_cost,
+      0
+    ) AS net_cost,
+    line_item_usage_end_date AS source_export_time
+  FROM `{billing_table}`
+  WHERE line_item_usage_account_id = @account_id
+    AND PARSE_DATE('%Y%m%d', billing_month) BETWEEN @export_partition_start AND @export_partition_end
+    AND DATE(line_item_usage_start_date) >= @earliest_usage_date
+)
+SELECT
+  'aws' AS vendor,
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  service_name,
+  sku_name,
+  author,
+  org,
+  repo,
+  ROUND(SUM(list_cost), 2) AS list_cost,
+  ROUND(SUM(effective_cost), 2) AS effective_cost,
+  ROUND(SUM(net_cost - effective_cost), 2) AS credit_amount,
+  ROUND(SUM(net_cost), 2) AS net_cost,
+  MAX(source_export_time) AS source_export_time
+FROM normalized
+GROUP BY
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  service_name,
+  sku_name,
+  author,
+  org,
+  repo
+ORDER BY export_partition_date, usage_date, service_name, sku_name, author, org, repo{limit_clause}
+""".strip()
+
+
+def build_aws_unmatched_resource_query(*, billing_table: str, limit: int | None = None) -> str:
+    limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
+    return f"""
+WITH normalized AS (
+  SELECT
+    line_item_usage_account_id AS account_id,
+    NULLIF(bill_payer_account_id, '') AS billing_account_id,
+    PARSE_DATE('%Y%m%d', billing_month) AS export_partition_date,
+    DATE(line_item_usage_start_date) AS usage_date,
+    COALESCE(NULLIF(product_servicecode, ''), NULLIF(line_item_product_code, '')) AS service_name,
+    COALESCE(
+      NULLIF(product_sku, ''),
+      NULLIF(line_item_usage_type, ''),
+      NULLIF(line_item_line_item_description, '')
+    ) AS sku_name,
+    NULL AS namespace,
+    NULLIF(tag_used_by, '') AS author,
+    NULLIF(tag_tenant, '') AS org,
+    NULLIF(tag_project, '') AS repo,
+    COALESCE(
+      NULLIF(line_item_resource_id, ''),
+      NULLIF(split_line_item_parent_resource_id, ''),
+      NULLIF(line_item_line_item_description, '')
+    ) AS resource_name,
+    LOWER(pricing_unit) AS pricing_unit,
+    line_item_usage_amount,
+    COALESCE(pricing_public_on_demand_cost, 0) AS list_cost,
+    COALESCE(line_item_unblended_cost, line_item_blended_cost, 0) AS effective_cost,
+    COALESCE(
+      line_item_net_unblended_cost,
+      line_item_unblended_cost,
+      line_item_blended_cost,
+      0
+    ) AS net_cost,
+    line_item_usage_end_date AS source_export_time
+  FROM `{billing_table}`
+  WHERE line_item_usage_account_id = @account_id
+    AND PARSE_DATE('%Y%m%d', billing_month) BETWEEN @export_partition_start AND @export_partition_end
+    AND DATE(line_item_usage_start_date) BETWEEN @usage_start_date AND @usage_end_date
+)
+SELECT
+  'aws' AS vendor,
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  service_name,
+  sku_name,
+  namespace,
+  author,
+  org,
+  repo,
+  resource_name,
+  CASE
+    WHEN COUNTIF(pricing_unit IS NULL OR pricing_unit NOT IN ('hour', 'minute', 'second')) > 0
+      THEN NULL
+    WHEN COUNTIF(pricing_unit = 'hour') = COUNT(*)
+      THEN ROUND(SUM(line_item_usage_amount) * 3600, 2)
+    WHEN COUNTIF(pricing_unit = 'minute') = COUNT(*)
+      THEN ROUND(SUM(line_item_usage_amount) * 60, 2)
+    WHEN COUNTIF(pricing_unit = 'second') = COUNT(*)
+      THEN ROUND(SUM(line_item_usage_amount), 2)
+    ELSE NULL
+  END AS usage_seconds,
+  ROUND(SUM(list_cost), 2) AS list_cost,
+  ROUND(SUM(effective_cost), 2) AS effective_cost,
+  ROUND(SUM(net_cost - effective_cost), 2) AS credit_amount,
+  ROUND(SUM(net_cost), 2) AS net_cost,
+  MAX(source_export_time) AS source_export_time
+FROM normalized
+WHERE resource_name IS NOT NULL
+  AND resource_name <> ''
+GROUP BY
+  account_id,
+  billing_account_id,
+  export_partition_date,
+  usage_date,
+  service_name,
+  sku_name,
+  namespace,
+  author,
+  org,
+  repo,
+  resource_name
+ORDER BY usage_date, service_name, sku_name, resource_name{limit_clause}
+""".strip()

--- a/cost-insight/tests/test_aws_billing_export.py
+++ b/cost-insight/tests/test_aws_billing_export.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import google.cloud
+
+from cost_insight.sources.aws_billing_export import (
+    build_aws_billing_summary_query,
+    build_aws_unmatched_resource_query,
+    fetch_aws_billing_summary_rows,
+    fetch_aws_unmatched_resource_rows,
+)
+
+
+class _FakeScalarQueryParameter:
+    def __init__(self, name, type_, value):
+        self.name = name
+        self.type_ = type_
+        self.value = value
+
+
+class _FakeQueryJobConfig:
+    def __init__(self, query_parameters):
+        self.query_parameters = query_parameters
+
+
+class _FakeQueryResult:
+    def __init__(self, rows, client):
+        self._rows = rows
+        self._client = client
+
+    def result(self, *, page_size):
+        self._client.page_size = page_size
+        return self._rows
+
+
+class _FakeBigQueryClient:
+    def __init__(self, rows):
+        self._rows = rows
+        self.query_text = None
+        self.job_config = None
+        self.page_size = None
+
+    def query(self, query, job_config):
+        self.query_text = query
+        self.job_config = job_config
+        return _FakeQueryResult(self._rows, self)
+
+
+def test_build_aws_billing_summary_query_contains_expected_filters() -> None:
+    query = build_aws_billing_summary_query(
+        billing_table="gcp-digital-bi.stg_cloud_billing.stg_aws_billing",
+        limit=20,
+    )
+
+    assert "line_item_usage_account_id = @account_id" in query
+    assert "PARSE_DATE('%Y%m%d', billing_month) BETWEEN @export_partition_start AND @export_partition_end" in query
+    assert "ROUND(SUM(net_cost - effective_cost), 2) AS credit_amount" in query
+    assert "LIMIT 20" in query
+
+
+def test_build_aws_unmatched_resource_query_contains_usage_seconds_logic() -> None:
+    query = build_aws_unmatched_resource_query(
+        billing_table="gcp-digital-bi.stg_cloud_billing.stg_aws_billing",
+        limit=10,
+    )
+
+    assert "WHEN COUNTIF(pricing_unit = 'hour') = COUNT(*)" in query
+    assert "resource_name IS NOT NULL" in query
+    assert "ROUND(SUM(net_cost), 2) AS net_cost" in query
+    assert "LIMIT 10" in query
+
+
+def test_fetch_aws_billing_rows_use_bigquery_client(monkeypatch) -> None:
+    summary_client = _FakeBigQueryClient(
+        [{"account_id": "946646677266", "usage_date": "2026-05-01"}]
+    )
+    unmatched_client = _FakeBigQueryClient(
+        [{"account_id": "946646677266", "resource_name": "i-123"}]
+    )
+    clients = [summary_client, unmatched_client]
+
+    fake_bigquery = SimpleNamespace(
+        Client=lambda: clients.pop(0),
+        QueryJobConfig=_FakeQueryJobConfig,
+        ScalarQueryParameter=_FakeScalarQueryParameter,
+    )
+    monkeypatch.setattr(google.cloud, "bigquery", fake_bigquery, raising=False)
+
+    summary_rows = list(
+        fetch_aws_billing_summary_rows(
+            billing_table="billing.table",
+            account_id="946646677266",
+            export_partition_start=date(2026, 5, 1),
+            export_partition_end=date(2026, 5, 1),
+            earliest_usage_date=date(2026, 1, 1),
+            page_size=50,
+        )
+    )
+    unmatched_rows = list(
+        fetch_aws_unmatched_resource_rows(
+            billing_table="billing.table",
+            account_id="946646677266",
+            export_partition_start=date(2026, 5, 1),
+            export_partition_end=date(2026, 5, 1),
+            usage_start_date=date(2026, 5, 1),
+            usage_end_date=date(2026, 5, 2),
+            page_size=25,
+        )
+    )
+
+    assert summary_rows == [{"account_id": "946646677266", "usage_date": "2026-05-01"}]
+    assert unmatched_rows == [{"account_id": "946646677266", "resource_name": "i-123"}]
+    assert "line_item_usage_account_id = @account_id" in summary_client.query_text
+    assert summary_client.page_size == 50
+    assert [param.name for param in summary_client.job_config.query_parameters] == [
+        "account_id",
+        "export_partition_start",
+        "export_partition_end",
+        "earliest_usage_date",
+    ]
+    assert "DATE(line_item_usage_start_date) BETWEEN @usage_start_date AND @usage_end_date" in unmatched_client.query_text
+    assert unmatched_client.page_size == 25
+    assert [param.name for param in unmatched_client.job_config.query_parameters] == [
+        "account_id",
+        "export_partition_start",
+        "export_partition_end",
+        "usage_start_date",
+        "usage_end_date",
+    ]

--- a/cost-insight/tests/test_backfill_cost_refine_from_raw.py
+++ b/cost-insight/tests/test_backfill_cost_refine_from_raw.py
@@ -4,6 +4,7 @@ from sqlalchemy import create_engine, text
 
 from cost_insight.common.config import GcpBillingSettings
 from cost_insight.jobs import state_store
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.jobs.backfill_cost_refine_from_raw import (
     JOB_NAME,
     run_backfill_cost_refine_from_raw,
@@ -176,8 +177,14 @@ def test_backfill_cost_refine_from_raw_writes_summary_and_unmatched_rows() -> No
                     """
                 )
             ).mappings().one()
-            job_state = state_store.get_job_state(connection, JOB_NAME)
-            summary_state = state_store.get_job_state(connection, SUMMARY_JOB_NAME)
+            job_state = state_store.get_job_state(
+                connection,
+                source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id),
+            )
+            summary_state = state_store.get_job_state(
+                connection,
+                source_job_name(SUMMARY_JOB_NAME, vendor="gcp", account_id=settings.account_id),
+            )
 
         assert summary_cost["service_name"] == "Compute Engine"
         assert summary_cost["sku_name"] == "Core running"
@@ -219,7 +226,13 @@ def test_backfill_cost_refine_from_raw_dry_run_writes_nothing() -> None:
             resource_count = connection.execute(
                 text("SELECT COUNT(*) FROM cost_unmatched_resource_daily")
             ).scalar_one()
-            assert state_store.get_job_state(connection, JOB_NAME) is None
+            assert (
+                state_store.get_job_state(
+                    connection,
+                    source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id),
+                )
+                is None
+            )
         assert summary_count == 0
         assert resource_count == 0
     finally:

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -2,7 +2,12 @@ import pytest
 
 from datetime import date
 
-from cost_insight.common.config import DEFAULT_GCP_ACCOUNT_ID, DEFAULT_GCP_BILLING_TABLE, load_settings
+from cost_insight.common.config import (
+    DEFAULT_AWS_BILLING_TABLE,
+    DEFAULT_GCP_ACCOUNT_ID,
+    DEFAULT_GCP_BILLING_TABLE,
+    load_settings,
+)
 
 
 def test_load_settings_uses_cost_database_url() -> None:
@@ -35,6 +40,8 @@ def test_load_settings_can_skip_database_for_validation() -> None:
     assert settings.database.url is None
     assert settings.gcp_billing.account_id == DEFAULT_GCP_ACCOUNT_ID
     assert settings.gcp_billing.billing_table == DEFAULT_GCP_BILLING_TABLE
+    assert settings.aws_billing.billing_table == DEFAULT_AWS_BILLING_TABLE
+    assert settings.aws_billing.account_id is None
 
 
 def test_load_settings_falls_back_to_tidb_parts() -> None:
@@ -58,6 +65,27 @@ def test_load_settings_falls_back_to_tidb_parts() -> None:
     assert settings.gcp_billing.billing_table == "billing.table"
     assert settings.gcp_billing.page_size == 2000
     assert settings.log_level == "DEBUG"
+
+
+def test_load_settings_reads_aws_billing_settings() -> None:
+    settings = load_settings(
+        {
+            "COST_INSIGHT_DB_URL": "mysql+pymysql://user:pass@127.0.0.1:4000/cost_insight",
+            "COST_INSIGHT_AWS_ACCOUNT_ID": "946646677266",
+            "COST_INSIGHT_AWS_BILLING_TABLE": "aws.billing.table",
+            "COST_INSIGHT_AWS_EARLIEST_USAGE_DATE": "2026-01-01",
+            "COST_INSIGHT_AWS_EXPORT_OVERLAP_MONTHS": "2",
+            "COST_INSIGHT_AWS_SYNC_INITIAL_LOOKBACK_MONTHS": "6",
+            "COST_INSIGHT_AWS_SYNC_PAGE_SIZE": "1000",
+        }
+    )
+
+    assert settings.aws_billing.account_id == "946646677266"
+    assert settings.aws_billing.billing_table == "aws.billing.table"
+    assert settings.aws_billing.earliest_usage_date == date(2026, 1, 1)
+    assert settings.aws_billing.export_overlap_months == 2
+    assert settings.aws_billing.sync_initial_lookback_months == 6
+    assert settings.aws_billing.page_size == 1000
 
 
 def test_load_settings_requires_database_when_not_skipped() -> None:

--- a/cost-insight/tests/test_cost_sources.py
+++ b/cost-insight/tests/test_cost_sources.py
@@ -1,0 +1,134 @@
+from types import SimpleNamespace
+
+from sqlalchemy import create_engine, text
+
+from cost_insight.jobs.cost_sources import (
+    _build_upsert_cost_source_statement,
+    ensure_cost_source_enabled,
+    get_cost_source,
+    list_active_cost_sources,
+    upsert_cost_source,
+)
+
+
+def _sqlite_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cost_sources (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  vendor TEXT NOT NULL,
+                  account_id TEXT NOT NULL,
+                  billing_account_id TEXT,
+                  display_name TEXT,
+                  is_active INTEGER NOT NULL DEFAULT 1,
+                  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  UNIQUE(vendor, account_id)
+                )
+                """
+            )
+        )
+    return engine
+
+
+def test_upsert_and_list_active_cost_sources() -> None:
+    engine = _sqlite_engine()
+    try:
+        with engine.begin() as connection:
+            upsert_cost_source(
+                connection,
+                vendor="gcp",
+                account_id="qa-infra-dev",
+                billing_account_id="01D088-8F9CF2-8AF1C6",
+                display_name="QA Infra Dev",
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO cost_sources (vendor, account_id, display_name, is_active)
+                    VALUES ('aws', 'inactive-account', 'Inactive', 0)
+                    """
+                )
+            )
+
+            source = get_cost_source(connection, vendor="gcp", account_id="qa-infra-dev")
+            active_sources = list_active_cost_sources(connection)
+            active_gcp_sources = list_active_cost_sources(connection, vendor="gcp")
+
+        assert source is not None
+        assert source.billing_account_id == "01D088-8F9CF2-8AF1C6"
+        assert [(item.vendor, item.account_id) for item in active_sources] == [
+            ("gcp", "qa-infra-dev"),
+        ]
+        assert [(item.vendor, item.account_id) for item in active_gcp_sources] == [
+            ("gcp", "qa-infra-dev"),
+        ]
+    finally:
+        engine.dispose()
+
+
+def test_ensure_cost_source_enabled_inserts_only_when_not_dry_run() -> None:
+    engine = _sqlite_engine()
+    try:
+        with engine.begin() as connection:
+            ensure_cost_source_enabled(
+                connection,
+                vendor="aws",
+                account_id="946646677266",
+                dry_run=True,
+                display_name="AWS Dry Run",
+            )
+            assert get_cost_source(connection, vendor="aws", account_id="946646677266") is None
+
+        with engine.begin() as connection:
+            ensure_cost_source_enabled(
+                connection,
+                vendor="aws",
+                account_id="946646677266",
+                dry_run=False,
+                display_name="AWS Active",
+            )
+            source = get_cost_source(connection, vendor="aws", account_id="946646677266")
+
+        assert source is not None
+        assert source.display_name == "AWS Active"
+    finally:
+        engine.dispose()
+
+
+def test_ensure_cost_source_enabled_rejects_inactive_source() -> None:
+    engine = _sqlite_engine()
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO cost_sources (vendor, account_id, display_name, is_active)
+                    VALUES ('aws', '946646677266', 'AWS Inactive', 0)
+                    """
+                )
+            )
+            try:
+                ensure_cost_source_enabled(
+                    connection,
+                    vendor="aws",
+                    account_id="946646677266",
+                    dry_run=False,
+                )
+            except ValueError as exc:
+                assert "inactive" in str(exc)
+            else:  # pragma: no cover
+                raise AssertionError("expected ValueError")
+    finally:
+        engine.dispose()
+
+
+def test_build_upsert_cost_source_statement_supports_mysql() -> None:
+    connection = SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
+
+    statement = _build_upsert_cost_source_statement(connection)
+
+    assert "ON DUPLICATE KEY UPDATE" in str(statement)

--- a/cost-insight/tests/test_db_and_cli.py
+++ b/cost-insight/tests/test_db_and_cli.py
@@ -1,15 +1,51 @@
 from datetime import date
 from types import SimpleNamespace
 
+from sqlalchemy import create_engine, text
+
 from cost_insight.common import db
-from cost_insight.common.config import DatabaseSettings, GcpBillingSettings, Settings
+from cost_insight.common.config import AwsBillingSettings, DatabaseSettings, GcpBillingSettings, Settings
 from cost_insight.common.logging import configure_logging
 from cost_insight.jobs import cli
 from cost_insight.jobs.backfill_cost_refine_from_raw import BackfillCostRefineFromRawSummary
-from cost_insight.jobs.refresh_attribution_daily import RefreshAttributionSummary
+from cost_insight.jobs.refresh_attribution_daily import CostAttributionSource, RefreshAttributionSummary
 from cost_insight.jobs.sync_gcp_billing_summary import SyncGcpBillingSummaryResult
 from cost_insight.jobs.sync_gcp_billing_export import SyncGcpBillingSummary
 from cost_insight.jobs.sync_gcp_unmatched_resources import SyncGcpUnmatchedResourcesSummary
+
+
+def _sqlite_source_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cost_sources (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  vendor TEXT NOT NULL,
+                  account_id TEXT NOT NULL,
+                  billing_account_id TEXT,
+                  display_name TEXT,
+                  is_active INTEGER NOT NULL DEFAULT 1,
+                  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                  UNIQUE(vendor, account_id)
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO cost_sources (vendor, account_id, display_name, is_active)
+                VALUES
+                  ('gcp', 'pingcap-testing-account', 'PingCAP Testing', 1),
+                  ('gcp', 'qa-infra-dev', 'QA Infra Dev', 1),
+                  ('aws', '946646677266', 'QA Infra Dev AWS', 1)
+                """
+            )
+        )
+    return engine
 
 
 def test_build_engine_uses_database_url(monkeypatch) -> None:
@@ -77,6 +113,7 @@ def test_cli_runs_sync_command(monkeypatch, capsys) -> None:
 
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
         log_level="INFO",
     )
 
@@ -133,6 +170,7 @@ def test_cli_split_by_day_runs_each_date(monkeypatch, capsys) -> None:
 
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
         log_level="INFO",
     )
 
@@ -184,17 +222,19 @@ def test_cli_runs_refresh_attribution_command(monkeypatch, capsys) -> None:
 
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
         log_level="INFO",
     )
 
-    def fake_refresh(engine, *, settings, start_date, end_date, dry_run):
+    def fake_refresh(engine, *, source, start_date, end_date, dry_run):
         captured["engine"] = engine
-        captured["settings"] = settings
+        captured["source"] = source
         captured["start_date"] = start_date
         captured["end_date"] = end_date
         captured["dry_run"] = dry_run
         return RefreshAttributionSummary(
-            account_id=settings.account_id,
+            vendor=source.vendor,
+            account_id=source.account_id,
             start_date=start_date,
             end_date=end_date,
             rows_deleted=2,
@@ -225,6 +265,10 @@ def test_cli_runs_refresh_attribution_command(monkeypatch, capsys) -> None:
     assert captured["start_date"] == date(2026, 5, 9)
     assert captured["end_date"] == date(2026, 5, 17)
     assert captured["dry_run"] is True
+    assert captured["source"] == CostAttributionSource(
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+    )
     assert '"rows_inserted": 3' in output
     assert '"raw_rows": 10' in output
 
@@ -239,6 +283,7 @@ def test_cli_runs_sync_billing_summary_command(monkeypatch, capsys) -> None:
 
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
         log_level="INFO",
     )
 
@@ -294,6 +339,7 @@ def test_cli_runs_sync_unmatched_resources_command(monkeypatch, capsys) -> None:
 
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
         log_level="INFO",
     )
 
@@ -344,6 +390,7 @@ def test_cli_runs_backfill_cost_refine_from_raw_command(monkeypatch, capsys) -> 
 
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
         log_level="INFO",
     )
 
@@ -402,17 +449,19 @@ def test_cli_runs_refresh_attribution_from_summary_command(monkeypatch, capsys) 
 
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
         log_level="INFO",
     )
 
-    def fake_refresh(engine, *, settings, start_date, end_date, dry_run):
+    def fake_refresh(engine, *, source, start_date, end_date, dry_run):
         captured["engine"] = engine
-        captured["settings"] = settings
+        captured["source"] = source
         captured["start_date"] = start_date
         captured["end_date"] = end_date
         captured["dry_run"] = dry_run
         return RefreshAttributionSummary(
-            account_id=settings.account_id,
+            vendor=source.vendor,
+            account_id=source.account_id,
             start_date=start_date,
             end_date=end_date,
             rows_deleted=2,
@@ -442,6 +491,10 @@ def test_cli_runs_refresh_attribution_from_summary_command(monkeypatch, capsys) 
     assert disposed == [True]
     assert captured["start_date"] == date(2026, 5, 9)
     assert captured["end_date"] == date(2026, 5, 17)
+    assert captured["source"] == CostAttributionSource(
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+    )
     assert '"summary_rows": 10' in output
 
 
@@ -454,13 +507,15 @@ def test_cli_refresh_attribution_split_by_day_runs_each_date(monkeypatch, capsys
 
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
         log_level="INFO",
     )
 
-    def fake_refresh(_engine, *, settings, start_date, end_date, dry_run):
+    def fake_refresh(_engine, *, source, start_date, end_date, dry_run):
         calls.append((start_date, end_date, dry_run))
         return RefreshAttributionSummary(
-            account_id=settings.account_id,
+            vendor=source.vendor,
+            account_id=source.account_id,
             start_date=start_date,
             end_date=end_date,
             rows_deleted=0,
@@ -502,3 +557,232 @@ def test_date_range_rejects_invalid_range() -> None:
         assert "--start-date" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("expected ValueError")
+
+
+def test_run_sync_gcp_command_split_by_day_requires_dates() -> None:
+    args = SimpleNamespace(
+        split_by_day=True,
+        start_date=None,
+        end_date=None,
+        dry_run=False,
+        limit=None,
+    )
+
+    try:
+        cli._run_sync_gcp_command(object(), settings=GcpBillingSettings(), args=args)
+    except ValueError as exc:
+        assert "--split-by-day" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_cli_runs_sync_aws_billing_summary_command(monkeypatch, capsys) -> None:
+    disposed = []
+    captured = {}
+
+    class Engine:
+        def dispose(self):
+            disposed.append(True)
+
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(account_id="946646677266"),
+        log_level="INFO",
+    )
+
+    def fake_run(engine, **kwargs):
+        captured.update(kwargs)
+        return SyncGcpBillingSummaryResult(
+            account_id=kwargs["account_id"],
+            export_partition_start=kwargs["export_partition_start"],
+            export_partition_end=kwargs["export_partition_end"],
+            rows_seen=4,
+            rows_written=4,
+            dry_run=kwargs["dry_run"],
+            touched_usage_dates=(date(2026, 5, 17),),
+        )
+
+    monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda _settings: Engine())
+    monkeypatch.setattr(cli, "run_sync_aws_billing_summary", fake_run)
+
+    exit_code = cli.main(
+        [
+            "sync-aws-billing-summary",
+            "--export-partition-start",
+            "2026-05-01",
+            "--export-partition-end",
+            "2026-05-01",
+            "--dry-run",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert disposed == [True]
+    assert captured["account_id"] == "946646677266"
+    assert '"account_id": "946646677266"' in output
+    assert '"rows_written": 4' in output
+
+
+def test_cli_runs_sync_aws_unmatched_resources_command(monkeypatch, capsys) -> None:
+    disposed = []
+    captured = {}
+
+    class Engine:
+        def dispose(self):
+            disposed.append(True)
+
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(account_id="946646677266"),
+        log_level="INFO",
+    )
+
+    def fake_run(engine, **kwargs):
+        captured.update(kwargs)
+        return SyncGcpUnmatchedResourcesSummary(
+            account_id=kwargs["account_id"],
+            usage_start_date=kwargs["usage_start_date"],
+            usage_end_date=kwargs["usage_end_date"],
+            export_partition_start=date(2026, 5, 1),
+            export_partition_end=date(2026, 5, 1),
+            rows_seen=5,
+            rows_written=5,
+            dry_run=kwargs["dry_run"],
+        )
+
+    monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda _settings: Engine())
+    monkeypatch.setattr(cli, "run_sync_aws_unmatched_resources", fake_run)
+
+    exit_code = cli.main(
+        [
+            "sync-aws-unmatched-resources",
+            "--usage-start-date",
+            "2026-05-17",
+            "--usage-end-date",
+            "2026-05-18",
+            "--dry-run",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert disposed == [True]
+    assert captured["account_id"] == "946646677266"
+    assert captured["usage_start_date"] == date(2026, 5, 17)
+    assert '"rows_seen": 5' in output
+
+
+def test_cli_refresh_attribution_from_summary_split_by_day_runs_each_date(monkeypatch, capsys) -> None:
+    calls = []
+
+    class Engine:
+        def dispose(self):
+            pass
+
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
+        log_level="INFO",
+    )
+
+    def fake_refresh(_engine, *, source, start_date, end_date, dry_run):
+        calls.append((source.account_id, start_date, end_date, dry_run))
+        return RefreshAttributionSummary(
+            vendor=source.vendor,
+            account_id=source.account_id,
+            start_date=start_date,
+            end_date=end_date,
+            rows_deleted=0,
+            rows_inserted=1,
+            dry_run=dry_run,
+        )
+
+    monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(cli, "build_engine", lambda _settings: Engine())
+    monkeypatch.setattr(cli, "run_refresh_cost_attribution_from_summary", fake_refresh)
+
+    assert (
+        cli.main(
+            [
+                "refresh-cost-attribution-from-summary",
+                "--start-date",
+                "2026-05-09",
+                "--end-date",
+                "2026-05-10",
+                "--split-by-day",
+            ]
+        )
+        == 0
+    )
+
+    assert calls == [
+        ("pingcap-testing-account", date(2026, 5, 9), date(2026, 5, 9), False),
+        ("pingcap-testing-account", date(2026, 5, 10), date(2026, 5, 10), False),
+    ]
+    assert '"start_date": "2026-05-09"' in capsys.readouterr().out
+
+
+def test_cli_source_resolution_prefers_active_registry() -> None:
+    engine = _sqlite_source_engine()
+    try:
+        gcp_sources = cli._resolve_gcp_sources(
+            engine,
+            settings=GcpBillingSettings(account_id="fallback-project"),
+        )
+        aws_sources = cli._resolve_aws_sources(
+            engine,
+            settings=AwsBillingSettings(account_id="000000000000"),
+        )
+        attribution_sources = cli._resolve_attribution_sources(
+            engine,
+            gcp_settings=GcpBillingSettings(account_id="fallback-project"),
+            aws_settings=AwsBillingSettings(account_id="000000000000"),
+        )
+
+        assert [settings.account_id for settings in gcp_sources] == [
+            "pingcap-testing-account",
+            "qa-infra-dev",
+        ]
+        assert aws_sources == ("946646677266",)
+        assert [(source.vendor, source.account_id) for source in attribution_sources] == [
+            ("aws", "946646677266"),
+            ("gcp", "pingcap-testing-account"),
+            ("gcp", "qa-infra-dev"),
+        ]
+    finally:
+        engine.dispose()
+
+
+def test_cli_source_resolution_falls_back_when_registry_missing() -> None:
+    gcp_sources = cli._resolve_gcp_sources(
+        object(),
+        settings=GcpBillingSettings(account_id="fallback-project"),
+    )
+    aws_sources = cli._resolve_aws_sources(
+        object(),
+        settings=AwsBillingSettings(account_id="946646677266"),
+    )
+    attribution_sources = cli._resolve_attribution_sources(
+        object(),
+        gcp_settings=GcpBillingSettings(account_id="fallback-project"),
+        aws_settings=AwsBillingSettings(account_id="946646677266"),
+    )
+
+    assert [settings.account_id for settings in gcp_sources] == ["fallback-project"]
+    assert aws_sources == ("946646677266",)
+    assert [(source.vendor, source.account_id) for source in attribution_sources] == [
+        ("gcp", "fallback-project"),
+        ("aws", "946646677266"),
+    ]
+
+
+def test_cli_aws_source_resolution_returns_empty_without_registry_or_fallback(caplog) -> None:
+    with caplog.at_level("WARNING"):
+        assert cli._resolve_aws_sources(object(), settings=AwsBillingSettings()) == ()
+    assert "No active AWS cost sources found" in caplog.text

--- a/cost-insight/tests/test_refresh_attribution_daily.py
+++ b/cost-insight/tests/test_refresh_attribution_daily.py
@@ -4,9 +4,10 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Connection
 
-from cost_insight.common.config import GcpBillingSettings
 from cost_insight.jobs import state_store
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.jobs.refresh_attribution_daily import (
+    CostAttributionSource,
     JOB_NAME,
     SUMMARY_JOB_NAME,
     _INSERT_ATTRIBUTION_DAILY,
@@ -17,6 +18,8 @@ from cost_insight.jobs.refresh_attribution_daily import (
     run_refresh_cost_attribution_daily,
     run_refresh_cost_attribution_from_summary,
 )
+
+SOURCE = CostAttributionSource(vendor="gcp", account_id="pingcap-testing-account")
 
 
 def _sqlite_engine():
@@ -42,10 +45,12 @@ def _sqlite_engine():
 
 def test_watermark_formats_dates() -> None:
     assert _watermark(
+        vendor="gcp",
         account_id="pingcap-testing-account",
         start_date=date(2026, 5, 9),
         end_date=date(2026, 5, 17),
     ) == {
+        "vendor": "gcp",
         "account_id": "pingcap-testing-account",
         "start_date": "2026-05-09",
         "end_date": "2026-05-17",
@@ -99,7 +104,7 @@ def test_run_refresh_attribution_dry_run_counts_raw_rows() -> None:
 
         summary = run_refresh_cost_attribution_daily(
             engine,
-            settings=GcpBillingSettings(account_id="pingcap-testing-account"),
+            source=SOURCE,
             start_date=date(2026, 5, 9),
             end_date=date(2026, 5, 10),
             dry_run=True,
@@ -110,7 +115,13 @@ def test_run_refresh_attribution_dry_run_counts_raw_rows() -> None:
         assert summary.rows_inserted == 0
         assert summary.dry_run is True
         with engine.begin() as connection:
-            assert state_store.get_job_state(connection, JOB_NAME) is None
+            assert (
+                state_store.get_job_state(
+                    connection,
+                    source_job_name(JOB_NAME, vendor=SOURCE.vendor, account_id=SOURCE.account_id),
+                )
+                is None
+            )
     finally:
         engine.dispose()
 
@@ -144,7 +155,7 @@ def test_run_refresh_attribution_from_summary_dry_run_counts_summary_rows() -> N
 
         summary = run_refresh_cost_attribution_from_summary(
             engine,
-            settings=GcpBillingSettings(account_id="pingcap-testing-account"),
+            source=SOURCE,
             start_date=date(2026, 5, 9),
             end_date=date(2026, 5, 10),
             dry_run=True,
@@ -155,7 +166,17 @@ def test_run_refresh_attribution_from_summary_dry_run_counts_summary_rows() -> N
         assert summary.rows_inserted == 0
         assert summary.dry_run is True
         with engine.begin() as connection:
-            assert state_store.get_job_state(connection, SUMMARY_JOB_NAME) is None
+            assert (
+                state_store.get_job_state(
+                    connection,
+                    source_job_name(
+                        SUMMARY_JOB_NAME,
+                        vendor=SOURCE.vendor,
+                        account_id=SOURCE.account_id,
+                    ),
+                )
+                is None
+            )
     finally:
         engine.dispose()
 
@@ -188,7 +209,7 @@ def test_run_refresh_attribution_marks_success(monkeypatch) -> None:
     try:
         summary = run_refresh_cost_attribution_daily(
             engine,
-            settings=GcpBillingSettings(account_id="pingcap-testing-account"),
+            source=SOURCE,
             start_date=date(2026, 5, 9),
             end_date=date(2026, 5, 10),
         )
@@ -198,7 +219,10 @@ def test_run_refresh_attribution_marks_success(monkeypatch) -> None:
         assert [kind for kind, _params in executed] == ["delete", "insert"]
         assert executed[0][1]["account_id"] == "pingcap-testing-account"
         with engine.begin() as connection:
-            state = state_store.get_job_state(connection, JOB_NAME)
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(JOB_NAME, vendor=SOURCE.vendor, account_id=SOURCE.account_id),
+            )
         assert state is not None
         assert state.last_status == "succeeded"
     finally:
@@ -233,7 +257,7 @@ def test_run_refresh_attribution_from_summary_marks_success(monkeypatch) -> None
     try:
         summary = run_refresh_cost_attribution_from_summary(
             engine,
-            settings=GcpBillingSettings(account_id="pingcap-testing-account"),
+            source=SOURCE,
             start_date=date(2026, 5, 9),
             end_date=date(2026, 5, 10),
         )
@@ -242,7 +266,14 @@ def test_run_refresh_attribution_from_summary_marks_success(monkeypatch) -> None
         assert summary.rows_inserted == 5
         assert [kind for kind, _params in executed] == ["delete", "insert-summary"]
         with engine.begin() as connection:
-            state = state_store.get_job_state(connection, SUMMARY_JOB_NAME)
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(
+                    SUMMARY_JOB_NAME,
+                    vendor=SOURCE.vendor,
+                    account_id=SOURCE.account_id,
+                ),
+            )
         assert state is not None
         assert state.last_status == "succeeded"
     finally:
@@ -264,13 +295,16 @@ def test_run_refresh_attribution_marks_failure(monkeypatch) -> None:
         with pytest.raises(RuntimeError, match="delete failed"):
             run_refresh_cost_attribution_daily(
                 engine,
-                settings=GcpBillingSettings(account_id="pingcap-testing-account"),
+                source=SOURCE,
                 start_date=date(2026, 5, 9),
                 end_date=date(2026, 5, 10),
             )
 
         with engine.begin() as connection:
-            state = state_store.get_job_state(connection, JOB_NAME)
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(JOB_NAME, vendor=SOURCE.vendor, account_id=SOURCE.account_id),
+            )
         assert state is not None
         assert state.last_status == "failed"
         assert "RuntimeError" in (state.last_error or "")
@@ -284,7 +318,7 @@ def test_run_refresh_attribution_rejects_invalid_range() -> None:
         with pytest.raises(ValueError, match="start_date"):
             run_refresh_cost_attribution_daily(
                 engine,
-                settings=GcpBillingSettings(account_id="pingcap-testing-account"),
+                source=SOURCE,
                 start_date=date(2026, 5, 10),
                 end_date=date(2026, 5, 9),
             )

--- a/cost-insight/tests/test_sync_aws_jobs.py
+++ b/cost-insight/tests/test_sync_aws_jobs.py
@@ -1,0 +1,352 @@
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from cost_insight.common.config import AwsBillingSettings
+from cost_insight.jobs import state_store
+from cost_insight.jobs.job_keys import source_job_name
+from cost_insight.jobs.sync_aws_billing_summary import (
+    JOB_NAME as SUMMARY_JOB_NAME,
+    _add_months,
+    _month_floor,
+    _start_partition_from_state,
+    _watermark as summary_watermark,
+    run_sync_aws_billing_summary,
+)
+from cost_insight.jobs.sync_aws_unmatched_resources import (
+    JOB_NAME as UNMATCHED_JOB_NAME,
+    _watermark as unmatched_watermark,
+    run_sync_aws_unmatched_resources,
+)
+
+
+def _sqlite_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    with engine.begin() as connection:
+        for statement in (
+            """
+            CREATE TABLE cost_sources (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              vendor TEXT NOT NULL,
+              account_id TEXT NOT NULL,
+              billing_account_id TEXT,
+              display_name TEXT,
+              is_active INTEGER NOT NULL DEFAULT 1,
+              created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              UNIQUE(vendor, account_id)
+            )
+            """,
+            """
+            CREATE TABLE cost_job_state (
+              job_name TEXT PRIMARY KEY,
+              watermark_json TEXT,
+              last_started_at TEXT,
+              last_succeeded_at TEXT,
+              last_status TEXT,
+              last_error TEXT,
+              updated_at TEXT
+            )
+            """,
+            """
+            CREATE TABLE cost_bq_export_summary_daily (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              vendor TEXT NOT NULL,
+              account_id TEXT NOT NULL,
+              billing_account_id TEXT,
+              export_partition_date TEXT NOT NULL,
+              usage_date TEXT NOT NULL,
+              service_name TEXT,
+              sku_name TEXT,
+              org TEXT,
+              repo TEXT,
+              author TEXT,
+              list_cost REAL,
+              effective_cost REAL,
+              credit_amount REAL,
+              net_cost REAL,
+              source_export_time TEXT,
+              source_row_hash TEXT NOT NULL,
+              created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              UNIQUE(vendor, account_id, export_partition_date, source_row_hash)
+            )
+            """,
+            """
+            CREATE TABLE cost_unmatched_resource_daily (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              vendor TEXT NOT NULL,
+              account_id TEXT NOT NULL,
+              billing_account_id TEXT,
+              export_partition_date TEXT NOT NULL,
+              usage_date TEXT NOT NULL,
+              service_name TEXT,
+              sku_name TEXT,
+              namespace TEXT,
+              org TEXT,
+              repo TEXT,
+              author TEXT,
+              resource_name TEXT NOT NULL,
+              usage_seconds REAL,
+              list_cost REAL,
+              effective_cost REAL,
+              credit_amount REAL,
+              net_cost REAL,
+              source_export_time TEXT,
+              source_row_hash TEXT NOT NULL,
+              created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              UNIQUE(vendor, account_id, export_partition_date, source_row_hash)
+            )
+            """,
+        ):
+            connection.execute(text(statement))
+    return engine
+
+
+def _summary_row(day: str = "2026-05-01") -> dict[str, object]:
+    return {
+        "vendor": "aws",
+        "account_id": "946646677266",
+        "billing_account_id": "payer-1",
+        "export_partition_date": "2026-05-01",
+        "usage_date": day,
+        "service_name": "Amazon Elastic Compute Cloud",
+        "sku_name": "EBS:VolumeUsage.gp3",
+        "author": "test-infra",
+        "org": "qe",
+        "repo": "test-infra",
+        "list_cost": "10.00",
+        "effective_cost": "8.00",
+        "credit_amount": "-1.00",
+        "net_cost": "7.00",
+        "source_export_time": "2026-05-02T01:02:03Z",
+    }
+
+
+def _resource_row() -> dict[str, object]:
+    return {
+        "vendor": "aws",
+        "account_id": "946646677266",
+        "billing_account_id": "payer-1",
+        "export_partition_date": "2026-05-01",
+        "usage_date": "2026-05-01",
+        "service_name": "Amazon Elastic Compute Cloud",
+        "sku_name": "BoxUsage:c7g.2xlarge",
+        "namespace": None,
+        "author": "test-infra",
+        "org": "qe",
+        "repo": "test-infra",
+        "resource_name": "i-0123456789abcdef0",
+        "usage_seconds": "3600.00",
+        "list_cost": "12.00",
+        "effective_cost": "9.00",
+        "credit_amount": "-1.00",
+        "net_cost": "8.00",
+        "source_export_time": "2026-05-02T01:02:03Z",
+    }
+
+
+def test_aws_summary_partition_helpers() -> None:
+    assert _month_floor(date(2026, 5, 17)) == date(2026, 5, 1)
+    assert _add_months(date(2026, 1, 1), 2) == date(2026, 3, 1)
+    assert _start_partition_from_state(
+        {"export_partition_end": "2026-05-01"},
+        end_date=date(2026, 6, 1),
+        overlap_months=1,
+        initial_lookback_months=2,
+    ) == date(2026, 5, 1)
+    assert _start_partition_from_state(
+        {},
+        end_date=date(2026, 6, 1),
+        overlap_months=1,
+        initial_lookback_months=2,
+    ) == date(2026, 5, 1)
+    assert _start_partition_from_state(
+        {},
+        end_date=date(2026, 6, 1),
+        overlap_months=1,
+        initial_lookback_months=None,
+    ) == date(2026, 6, 1)
+    assert summary_watermark(
+        account_id="946646677266",
+        export_partition_start=date(2026, 5, 1),
+        export_partition_end=date(2026, 5, 1),
+    ) == {
+        "vendor": "aws",
+        "account_id": "946646677266",
+        "export_partition_start": "2026-05-01",
+        "export_partition_end": "2026-05-01",
+    }
+    assert unmatched_watermark(
+        account_id="946646677266",
+        usage_start_date=date(2026, 5, 1),
+        usage_end_date=date(2026, 5, 2),
+        export_partition_start=date(2026, 5, 1),
+        export_partition_end=date(2026, 5, 1),
+    ) == {
+        "vendor": "aws",
+        "account_id": "946646677266",
+        "usage_start_date": "2026-05-01",
+        "usage_end_date": "2026-05-02",
+        "export_partition_start": "2026-05-01",
+        "export_partition_end": "2026-05-01",
+    }
+
+
+def test_run_sync_aws_billing_summary_writes_rows_and_touched_dates() -> None:
+    engine = _sqlite_engine()
+    settings = AwsBillingSettings(account_id="946646677266", page_size=2)
+
+    try:
+        summary = run_sync_aws_billing_summary(
+            engine,
+            settings=settings,
+            account_id="946646677266",
+            export_partition_start=date(2026, 5, 1),
+            export_partition_end=date(2026, 5, 1),
+            dry_run=False,
+            fetch_rows=lambda **_kwargs: [_summary_row("2026-05-01"), _summary_row("2026-05-02")],
+        )
+
+        assert summary.rows_seen == 2
+        assert summary.rows_written == 2
+        assert summary.touched_usage_dates == (date(2026, 5, 1), date(2026, 5, 2))
+        with engine.begin() as connection:
+            count = connection.execute(text("SELECT COUNT(*) FROM cost_bq_export_summary_daily")).scalar_one()
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(SUMMARY_JOB_NAME, vendor="aws", account_id="946646677266"),
+            )
+            source = connection.execute(
+                text(
+                    """
+                    SELECT billing_account_id
+                    FROM cost_sources
+                    WHERE vendor = 'aws' AND account_id = '946646677266'
+                    """
+                )
+            ).scalar_one()
+        assert count == 2
+        assert state is not None
+        assert state.last_status == "succeeded"
+        assert source == "payer-1"
+    finally:
+        engine.dispose()
+
+
+def test_run_sync_aws_billing_summary_dry_run_and_failure() -> None:
+    engine = _sqlite_engine()
+    settings = AwsBillingSettings(account_id="946646677266")
+
+    def raise_fetch(**_kwargs):
+        raise RuntimeError("boom")
+        yield
+
+    try:
+        summary = run_sync_aws_billing_summary(
+            engine,
+            settings=settings,
+            account_id="946646677266",
+            export_partition_start=date(2026, 5, 1),
+            export_partition_end=date(2026, 5, 1),
+            dry_run=True,
+            fetch_rows=lambda **_kwargs: [_summary_row()],
+        )
+        assert summary.rows_seen == 1
+        assert summary.rows_written == 0
+
+        with pytest.raises(RuntimeError, match="boom"):
+            run_sync_aws_billing_summary(
+                engine,
+                settings=settings,
+                account_id="946646677266",
+                export_partition_start=date(2026, 5, 1),
+                export_partition_end=date(2026, 5, 1),
+                fetch_rows=raise_fetch,
+            )
+
+        with engine.begin() as connection:
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(SUMMARY_JOB_NAME, vendor="aws", account_id="946646677266"),
+            )
+        assert state is not None
+        assert state.last_status == "failed"
+    finally:
+        engine.dispose()
+
+
+def test_run_sync_aws_unmatched_resources_writes_rows() -> None:
+    engine = _sqlite_engine()
+    settings = AwsBillingSettings(account_id="946646677266", page_size=1)
+
+    try:
+        summary = run_sync_aws_unmatched_resources(
+            engine,
+            settings=settings,
+            account_id="946646677266",
+            usage_start_date=date(2026, 5, 1),
+            usage_end_date=date(2026, 5, 2),
+            dry_run=False,
+            fetch_rows=lambda **_kwargs: [_resource_row()],
+        )
+
+        assert summary.rows_seen == 1
+        assert summary.rows_written == 1
+        assert summary.export_partition_start == date(2026, 5, 1)
+        assert summary.export_partition_end == date(2026, 5, 1)
+        with engine.begin() as connection:
+            count = connection.execute(
+                text("SELECT COUNT(*) FROM cost_unmatched_resource_daily")
+            ).scalar_one()
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(UNMATCHED_JOB_NAME, vendor="aws", account_id="946646677266"),
+            )
+        assert count == 1
+        assert state is not None
+        assert state.last_status == "succeeded"
+    finally:
+        engine.dispose()
+
+
+def test_run_sync_aws_unmatched_resources_rejects_invalid_range_and_marks_failure() -> None:
+    engine = _sqlite_engine()
+    settings = AwsBillingSettings(account_id="946646677266")
+
+    def raise_fetch(**_kwargs):
+        raise RuntimeError("fetch failed")
+        yield
+
+    try:
+        with pytest.raises(ValueError, match="usage_start_date"):
+            run_sync_aws_unmatched_resources(
+                engine,
+                settings=settings,
+                account_id="946646677266",
+                usage_start_date=date(2026, 5, 2),
+                usage_end_date=date(2026, 5, 1),
+                fetch_rows=lambda **_kwargs: [],
+            )
+
+        with pytest.raises(RuntimeError, match="fetch failed"):
+            run_sync_aws_unmatched_resources(
+                engine,
+                settings=settings,
+                account_id="946646677266",
+                usage_start_date=date(2026, 5, 1),
+                usage_end_date=date(2026, 5, 1),
+                fetch_rows=raise_fetch,
+            )
+
+        with engine.begin() as connection:
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(UNMATCHED_JOB_NAME, vendor="aws", account_id="946646677266"),
+            )
+        assert state is not None
+        assert state.last_status == "failed"
+    finally:
+        engine.dispose()

--- a/cost-insight/tests/test_sync_gcp_billing_export.py
+++ b/cost-insight/tests/test_sync_gcp_billing_export.py
@@ -7,9 +7,10 @@ from sqlalchemy import create_engine, text
 from cost_insight.common.config import GcpBillingSettings
 from cost_insight.common.row_utils import coerce_date, coerce_datetime, hash_value, nullable_text
 from cost_insight.jobs import state_store
+from cost_insight.jobs.cost_sources import ensure_cost_source_enabled
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.jobs.sync_gcp_billing_export import (
     JOB_NAME,
-    _ensure_cost_source_enabled,
     _normalize_row,
     _start_date_from_state,
     _watermark,
@@ -206,7 +207,13 @@ def test_run_sync_gcp_billing_export_dry_run_does_not_update_state() -> None:
         assert summary.rows_written == 0
         assert summary.dry_run is True
         with engine.begin() as connection:
-            assert state_store.get_job_state(connection, JOB_NAME) is None
+            assert (
+                state_store.get_job_state(
+                    connection,
+                    source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id),
+                )
+                is None
+            )
             source = connection.execute(text("SELECT * FROM cost_sources")).mappings().first()
         assert source is None
     finally:
@@ -240,7 +247,10 @@ def test_run_sync_gcp_billing_export_marks_success(monkeypatch) -> None:
         assert summary.rows_written == 2
         assert [len(rows) for rows, _dry_run in writes] == [1, 1, 0]
         with engine.begin() as connection:
-            state = state_store.get_job_state(connection, JOB_NAME)
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id),
+            )
             source = (
                 connection.execute(
                     text(
@@ -285,7 +295,10 @@ def test_run_sync_gcp_billing_export_marks_failure(monkeypatch) -> None:
             )
 
         with engine.begin() as connection:
-            state = state_store.get_job_state(connection, JOB_NAME)
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id),
+            )
         assert state is not None
         assert state.last_status == "failed"
         assert "RuntimeError" in (state.last_error or "")
@@ -329,6 +342,7 @@ def test_write_batch_executes_upsert_for_non_dry_run() -> None:
 
 def test_ensure_cost_source_enabled_rejects_inactive_source() -> None:
     engine = _sqlite_engine()
+    settings = GcpBillingSettings(account_id="pingcap-testing-account")
     try:
         with engine.begin() as connection:
             connection.execute(
@@ -340,9 +354,10 @@ def test_ensure_cost_source_enabled_rejects_inactive_source() -> None:
                 )
             )
             with pytest.raises(ValueError, match="inactive"):
-                _ensure_cost_source_enabled(
+                ensure_cost_source_enabled(
                     connection,
-                    GcpBillingSettings(account_id="pingcap-testing-account"),
+                    vendor="gcp",
+                    account_id=settings.account_id,
                     dry_run=False,
                 )
     finally:

--- a/cost-insight/tests/test_sync_gcp_billing_summary.py
+++ b/cost-insight/tests/test_sync_gcp_billing_summary.py
@@ -4,6 +4,7 @@ from sqlalchemy import create_engine, text
 
 from cost_insight.common.config import GcpBillingSettings
 from cost_insight.jobs import state_store
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.jobs.sync_gcp_billing_summary import (
     JOB_NAME,
     _normalize_summary_row,
@@ -160,7 +161,10 @@ def test_run_sync_gcp_billing_summary_writes_rows_and_touched_dates() -> None:
             service_names = connection.execute(
                 text("SELECT DISTINCT service_name FROM cost_bq_export_summary_daily")
             ).scalars().all()
-            state = state_store.get_job_state(connection, JOB_NAME)
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id),
+            )
         assert count == 2
         assert service_names == ["Compute Engine"]
         assert state is not None
@@ -374,6 +378,12 @@ def test_run_sync_gcp_billing_summary_dry_run_skips_state() -> None:
         assert summary.rows_seen == 1
         assert summary.rows_written == 0
         with engine.begin() as connection:
-            assert state_store.get_job_state(connection, JOB_NAME) is None
+            assert (
+                state_store.get_job_state(
+                    connection,
+                    source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id),
+                )
+                is None
+            )
     finally:
         engine.dispose()

--- a/cost-insight/tests/test_sync_gcp_unmatched_resources.py
+++ b/cost-insight/tests/test_sync_gcp_unmatched_resources.py
@@ -5,6 +5,7 @@ from sqlalchemy import create_engine, text
 
 from cost_insight.common.config import GcpBillingSettings
 from cost_insight.jobs import state_store
+from cost_insight.jobs.job_keys import source_job_name
 from cost_insight.jobs.sync_gcp_unmatched_resources import (
     JOB_NAME,
     _normalize_resource_row,
@@ -141,7 +142,10 @@ def test_run_sync_gcp_unmatched_resources_writes_rows() -> None:
             count = connection.execute(
                 text("SELECT COUNT(*) FROM cost_unmatched_resource_daily")
             ).scalar_one()
-            state = state_store.get_job_state(connection, JOB_NAME)
+            state = state_store.get_job_state(
+                connection,
+                source_job_name(JOB_NAME, vendor="gcp", account_id=settings.account_id),
+            )
         assert count == 1
         assert state is not None
         assert state.last_status == "succeeded"


### PR DESCRIPTION
## Summary
- add a `cost_sources` registry so cost sync jobs can discover active vendor/account sources from DB
- add AWS billing summary and unmatched resource sync, and teach refresh/CLI/job keys to work per `(vendor, account_id)` source
- seed initial GCP and AWS cost sources and document the multi-source design and operational flow

## Details
- preserve manually maintained source metadata such as display names / disabled state during source upserts
- warn when AWS sync commands have no active source configured and no env fallback
- keep attribution refresh on the summary-based path without depending on raw cost tables

## Validation
- `pytest -q cost-insight/tests`
- `ruff check cost-insight/src cost-insight/tests`
- coverage: `95.51%`

## Notes
- the one-off backfill for `gcp/qa-infra-dev` and `aws/946646677266` was executed separately in temporary GKE jobs and is not part of this PR
