### PR TITLE
fix(mac-builder-operator): pin artifacts script source

### DIFF
--- a/mac-builder-operator/README.md
+++ b/mac-builder-operator/README.md
@@ -13,6 +13,8 @@ This project aims to bring macOS platform build tasks into the Kubernetes declar
 
 `--build-timeout` bounds how long a job may remain in `Building` before it is marked `Failed`, and
 `--build-poll-interval` controls how often agents recheck jobs owned by another worker.
+The agent also pins the external `artifacts.git` build-script source to an immutable revision via
+`--artifacts-repo-revision` plus `--artifacts-repo-commit`; branch refs such as `main` are rejected.
 
 ### Prerequisites
 - go version v1.25.0+

--- a/mac-builder-operator/cmd/main.go
+++ b/mac-builder-operator/cmd/main.go
@@ -65,6 +65,7 @@ func main() {
 	var tlsOpts []func(*tls.Config)
 	var enableAgent, enableGC bool
 	var buildTimeout, buildPollInterval time.Duration
+	var artifactsRepoURL, artifactsRepoRevision, artifactsRepoCommit string
 
 	// Controller-specific flags
 	flag.BoolVar(&enableAgent, "enable-agent", false, "Enable the MacBuild agent reconciler. Runs on the Mac worker.")
@@ -73,6 +74,12 @@ func main() {
 		"Maximum time a MacBuild may stay in Building before the agent marks it failed.")
 	flag.DurationVar(&buildPollInterval, "build-poll-interval", 5*time.Minute,
 		"How often the agent rechecks Building jobs assigned to other workers.")
+	flag.StringVar(&artifactsRepoURL, "artifacts-repo-url", controller.DefaultArtifactsScriptRepoURL,
+		"Git repository URL used to generate build scripts for artifact packaging.")
+	flag.StringVar(&artifactsRepoRevision, "artifacts-repo-revision", controller.DefaultArtifactsScriptRepoRevision,
+		"Immutable tag or commit to check out from the artifacts repo before generating build scripts.")
+	flag.StringVar(&artifactsRepoCommit, "artifacts-repo-commit", controller.DefaultArtifactsScriptExpectedCommit,
+		"Expected full commit SHA for the pinned artifacts repo revision.")
 
 	// General flags
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -110,6 +117,16 @@ func main() {
 	}
 	if enableAgent && buildPollInterval <= 0 {
 		setupLog.Info("build-poll-interval must be greater than zero")
+		os.Exit(1)
+	}
+
+	artifactsScriptSource, err := (controller.ArtifactsScriptSourceConfig{
+		URL:            artifactsRepoURL,
+		Revision:       artifactsRepoRevision,
+		ExpectedCommit: artifactsRepoCommit,
+	}).Normalize()
+	if enableAgent && err != nil {
+		setupLog.Error(err, "invalid artifacts repo source configuration")
 		os.Exit(1)
 	}
 
@@ -213,11 +230,12 @@ func main() {
 		}
 		setupLog.Info("Starting manager with Worker ID", "workerID", workerID)
 		if err := (&controller.MacBuildReconciler{
-			Client:            mgr.GetClient(),
-			Scheme:            mgr.GetScheme(),
-			WorkerID:          workerID,
-			BuildTimeout:      buildTimeout,
-			BuildPollInterval: buildPollInterval,
+			Client:                mgr.GetClient(),
+			Scheme:                mgr.GetScheme(),
+			WorkerID:              workerID,
+			BuildTimeout:          buildTimeout,
+			BuildPollInterval:     buildPollInterval,
+			ArtifactsScriptSource: artifactsScriptSource,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MacBuildAgent")
 			os.Exit(1)

--- a/mac-builder-operator/internal/controller/artifacts_script_source.go
+++ b/mac-builder-operator/internal/controller/artifacts_script_source.go
@@ -1,0 +1,90 @@
+package controller
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	DefaultArtifactsScriptRepoURL        = "https://github.com/PingCAP-QE/artifacts.git"
+	DefaultArtifactsScriptRepoRevision   = "99e1b3dd576eecb71e7e56f83aac3fd158af3468"
+	DefaultArtifactsScriptExpectedCommit = DefaultArtifactsScriptRepoRevision
+)
+
+var fullCommitSHARegexp = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+// ArtifactsScriptSourceConfig pins the external artifacts repo used to generate build scripts.
+type ArtifactsScriptSourceConfig struct {
+	URL            string
+	Revision       string
+	ExpectedCommit string
+}
+
+// Normalize applies defaults and rejects mutable refs before a worker executes external scripts.
+func (c ArtifactsScriptSourceConfig) Normalize() (ArtifactsScriptSourceConfig, error) {
+	normalized := ArtifactsScriptSourceConfig{
+		URL:            strings.TrimSpace(c.URL),
+		Revision:       strings.TrimSpace(c.Revision),
+		ExpectedCommit: strings.TrimSpace(c.ExpectedCommit),
+	}
+
+	if normalized.URL == "" {
+		normalized.URL = DefaultArtifactsScriptRepoURL
+	}
+	if normalized.Revision == "" {
+		if normalized.ExpectedCommit != "" {
+			normalized.Revision = normalized.ExpectedCommit
+		} else {
+			normalized.Revision = DefaultArtifactsScriptRepoRevision
+		}
+	}
+
+	if normalized.ExpectedCommit == "" {
+		switch {
+		case normalized.Revision == DefaultArtifactsScriptRepoRevision:
+			normalized.ExpectedCommit = DefaultArtifactsScriptExpectedCommit
+		case isFullCommitSHA(normalized.Revision):
+			normalized.ExpectedCommit = normalized.Revision
+		default:
+			return ArtifactsScriptSourceConfig{}, fmt.Errorf(
+				"artifacts repo expected commit must be set when revision %q is not a full commit SHA",
+				normalized.Revision,
+			)
+		}
+	}
+
+	if isMutableGitRevision(normalized.Revision) {
+		return ArtifactsScriptSourceConfig{}, fmt.Errorf(
+			"artifacts repo revision %q must be an immutable commit or tag; branch refs are not allowed",
+			normalized.Revision,
+		)
+	}
+	if !isFullCommitSHA(normalized.ExpectedCommit) {
+		return ArtifactsScriptSourceConfig{}, fmt.Errorf(
+			"artifacts repo expected commit %q must be a full 40-character SHA",
+			normalized.ExpectedCommit,
+		)
+	}
+
+	normalized.ExpectedCommit = strings.ToLower(normalized.ExpectedCommit)
+	return normalized, nil
+}
+
+func isFullCommitSHA(value string) bool {
+	return fullCommitSHARegexp.MatchString(strings.TrimSpace(value))
+}
+
+func isMutableGitRevision(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || isFullCommitSHA(trimmed) {
+		return false
+	}
+
+	lower := strings.ToLower(trimmed)
+	return lower == "main" ||
+		lower == "master" ||
+		strings.HasPrefix(lower, "refs/heads/") ||
+		strings.HasPrefix(lower, "refs/remotes/") ||
+		strings.HasPrefix(lower, "origin/")
+}

--- a/mac-builder-operator/internal/controller/artifacts_script_source_test.go
+++ b/mac-builder-operator/internal/controller/artifacts_script_source_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import "testing"
+
+func TestArtifactsScriptSourceConfigNormalizeDefaults(t *testing.T) {
+	t.Parallel()
+
+	got, err := (ArtifactsScriptSourceConfig{}).Normalize()
+	if err != nil {
+		t.Fatalf("normalize defaults: %v", err)
+	}
+	if got.URL != DefaultArtifactsScriptRepoURL {
+		t.Fatalf("expected default URL %q, got %q", DefaultArtifactsScriptRepoURL, got.URL)
+	}
+	if got.Revision != DefaultArtifactsScriptRepoRevision {
+		t.Fatalf("expected default revision %q, got %q", DefaultArtifactsScriptRepoRevision, got.Revision)
+	}
+	if got.ExpectedCommit != DefaultArtifactsScriptExpectedCommit {
+		t.Fatalf("expected default commit %q, got %q", DefaultArtifactsScriptExpectedCommit, got.ExpectedCommit)
+	}
+}
+
+func TestArtifactsScriptSourceConfigNormalizeRejectsMutableBranch(t *testing.T) {
+	t.Parallel()
+
+	_, err := (ArtifactsScriptSourceConfig{
+		URL:            DefaultArtifactsScriptRepoURL,
+		Revision:       "main",
+		ExpectedCommit: DefaultArtifactsScriptExpectedCommit,
+	}).Normalize()
+	if err == nil {
+		t.Fatal("expected mutable branch revision to be rejected")
+	}
+}
+
+func TestArtifactsScriptSourceConfigNormalizeRequiresCommitForTag(t *testing.T) {
+	t.Parallel()
+
+	_, err := (ArtifactsScriptSourceConfig{
+		URL:      DefaultArtifactsScriptRepoURL,
+		Revision: "v2026.4.12",
+	}).Normalize()
+	if err == nil {
+		t.Fatal("expected tag revision without expected commit to be rejected")
+	}
+}
+
+func TestArtifactsScriptSourceConfigNormalizeAllowsFullCommitWithoutExplicitCommit(t *testing.T) {
+	t.Parallel()
+
+	got, err := (ArtifactsScriptSourceConfig{
+		URL:      DefaultArtifactsScriptRepoURL,
+		Revision: DefaultArtifactsScriptExpectedCommit,
+	}).Normalize()
+	if err != nil {
+		t.Fatalf("normalize full commit: %v", err)
+	}
+	if got.ExpectedCommit != DefaultArtifactsScriptExpectedCommit {
+		t.Fatalf("expected commit %q, got %q", DefaultArtifactsScriptExpectedCommit, got.ExpectedCommit)
+	}
+}
+
+func TestArtifactsScriptSourceConfigNormalizeUsesExpectedCommitWhenRevisionOmitted(t *testing.T) {
+	t.Parallel()
+
+	got, err := (ArtifactsScriptSourceConfig{
+		URL:            DefaultArtifactsScriptRepoURL,
+		ExpectedCommit: DefaultArtifactsScriptExpectedCommit,
+	}).Normalize()
+	if err != nil {
+		t.Fatalf("normalize expected-commit-only config: %v", err)
+	}
+	if got.Revision != DefaultArtifactsScriptExpectedCommit {
+		t.Fatalf("expected revision %q, got %q", DefaultArtifactsScriptExpectedCommit, got.Revision)
+	}
+}

--- a/mac-builder-operator/internal/controller/macbuild_controller.go
+++ b/mac-builder-operator/internal/controller/macbuild_controller.go
@@ -35,10 +35,11 @@ import (
 // MacBuildReconciler reconciles a MacBuild object
 type MacBuildReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
-	WorkerID          string
-	BuildTimeout      time.Duration
-	BuildPollInterval time.Duration
+	Scheme                *runtime.Scheme
+	WorkerID              string
+	BuildTimeout          time.Duration
+	BuildPollInterval     time.Duration
+	ArtifactsScriptSource ArtifactsScriptSourceConfig
 
 	now      func() time.Time
 	runBuild func(context.Context, buildv1alpha1.MacBuild) (*buildResult, error)
@@ -195,7 +196,7 @@ func (r *MacBuildReconciler) runNativeBuild(ctx context.Context, macBuild buildv
 	if r.runBuild != nil {
 		return r.runBuild(ctx, macBuild)
 	}
-	job := newNativeBuildJob(ctx, macBuild)
+	job := newNativeBuildJob(ctx, macBuild, r.ArtifactsScriptSource)
 	return job.Run()
 }
 

--- a/mac-builder-operator/internal/controller/native_build_job.go
+++ b/mac-builder-operator/internal/controller/native_build_job.go
@@ -34,10 +34,11 @@ import (
 
 // nativeBuildJob represents a build job for native Mac builds.
 type nativeBuildJob struct {
-	ctx      context.Context
-	logger   logr.Logger
-	macBuild buildv1alpha1.MacBuild
-	spec     buildv1alpha1.MacBuildSpec // shortcut
+	ctx                   context.Context
+	logger                logr.Logger
+	macBuild              buildv1alpha1.MacBuild
+	spec                  buildv1alpha1.MacBuildSpec // shortcut
+	artifactsScriptSource ArtifactsScriptSourceConfig
 
 	// Paths
 	workspaceDir     string
@@ -49,7 +50,11 @@ type nativeBuildJob struct {
 }
 
 // newNativeBuildJob creates a new instance of nativeBuildJob.
-func newNativeBuildJob(ctx context.Context, macBuild buildv1alpha1.MacBuild) *nativeBuildJob {
+func newNativeBuildJob(
+	ctx context.Context,
+	macBuild buildv1alpha1.MacBuild,
+	artifactsScriptSource ArtifactsScriptSourceConfig,
+) *nativeBuildJob {
 	logger := logf.FromContext(ctx)
 
 	// Create in 'os.TempDir()' (e.g., /var/folders/...)
@@ -59,10 +64,11 @@ func newNativeBuildJob(ctx context.Context, macBuild buildv1alpha1.MacBuild) *na
 	workspaceDir := filepath.Join(baseDir, workspaceName)
 
 	return &nativeBuildJob{
-		ctx:      ctx,
-		logger:   logger.WithValues("job", macBuild.Namespace, "workspace", workspaceDir),
-		macBuild: macBuild,
-		spec:     macBuild.Spec,
+		ctx:                   ctx,
+		logger:                logger.WithValues("job", macBuild.Namespace, "workspace", workspaceDir),
+		macBuild:              macBuild,
+		spec:                  macBuild.Spec,
+		artifactsScriptSource: artifactsScriptSource,
 
 		workspaceDir:     workspaceDir,
 		sourceDir:        filepath.Join(workspaceDir, "source"),
@@ -168,12 +174,46 @@ func (j *nativeBuildJob) exec(cmd *exec.Cmd, dir ...string) error {
 
 // cloneArtifactsRepo clones the artifacts repository.
 func (j *nativeBuildJob) cloneArtifactsRepo() error {
-	j.logger.Info("Cloning artifacts repository...")
-	artifactsRepoURL := "https://github.com/PingCAP-QE/artifacts.git"
-	cmd := exec.Command("git", "clone", "--depth=1", "--branch=main", artifactsRepoURL, j.artifactsRepoDir)
+	source, err := j.artifactsScriptSource.Normalize()
+	if err != nil {
+		return fmt.Errorf("invalid artifacts repo source: %w", err)
+	}
+
+	j.logger.Info(
+		"Cloning artifacts repository...",
+		"repo", source.URL,
+		"revision", source.Revision,
+		"expectedCommit", source.ExpectedCommit,
+	)
+
+	cmd := exec.Command("git", "clone", "--no-checkout", "--filter=blob:none", source.URL, j.artifactsRepoDir)
 	if err := j.exec(cmd); err != nil {
 		return fmt.Errorf("failed to clone artifacts repo: %w", err)
 	}
+
+	checkoutRef, err := j.resolveArtifactsCheckoutRef(source.Revision)
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.Command("git", "checkout", "--detach", checkoutRef)
+	if err := j.exec(cmd, j.artifactsRepoDir); err != nil {
+		return fmt.Errorf("failed to checkout artifacts repo revision %q: %w", source.Revision, err)
+	}
+
+	headCommit, err := j.gitHeadCommit(j.artifactsRepoDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve artifacts repo HEAD commit: %w", err)
+	}
+	if headCommit != source.ExpectedCommit {
+		return fmt.Errorf(
+			"artifacts repo revision %q resolved to %q, expected %q",
+			source.Revision,
+			headCommit,
+			source.ExpectedCommit,
+		)
+	}
+
 	return nil
 }
 
@@ -215,6 +255,39 @@ func (j *nativeBuildJob) cloneAndCheckoutSource() (string, error) {
 	commitHash := strings.TrimSpace(string(hashBytes))
 	j.logger.Info("Source checked out", "commitHash", commitHash)
 	return commitHash, nil
+}
+
+func (j *nativeBuildJob) gitHeadCommit(dir string) (string, error) {
+	cmdHash := exec.Command("git", "rev-parse", "HEAD")
+	cmdHash.Dir = dir
+	hashBytes, err := cmdHash.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(hashBytes)), nil
+}
+
+func (j *nativeBuildJob) resolveArtifactsCheckoutRef(revision string) (string, error) {
+	if isFullCommitSHA(revision) {
+		return revision, nil
+	}
+
+	tagRef := revision
+	if !strings.HasPrefix(tagRef, "refs/tags/") {
+		tagRef = "refs/tags/" + revision
+	}
+
+	cmd := exec.Command("git", "rev-parse", "--verify", tagRef+"^{commit}")
+	cmd.Dir = j.artifactsRepoDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf(
+			"artifacts repo revision %q must be a reachable tag or full commit SHA: %s",
+			revision,
+			strings.TrimSpace(string(output)),
+		)
+	}
+
+	return tagRef, nil
 }
 
 // generateEnvFile generates the environment file for the build.

--- a/mac-builder-operator/internal/controller/native_build_job_manual_test.go
+++ b/mac-builder-operator/internal/controller/native_build_job_manual_test.go
@@ -82,7 +82,7 @@ func TestManualNativeBuildJob(t *testing.T) {
 	logger.Info("Starting manual test for nativeBuildJob")
 
 	// Create a new nativeBuildJob
-	job := newNativeBuildJob(ctx, *macBuild)
+	job := newNativeBuildJob(ctx, *macBuild, ArtifactsScriptSourceConfig{})
 	logger.Info("Created nativeBuildJob", "job", job)
 
 	// Run the job

--- a/mac-builder-operator/internal/controller/native_build_job_test.go
+++ b/mac-builder-operator/internal/controller/native_build_job_test.go
@@ -1,0 +1,161 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	buildv1alpha1 "github.com/PingCAP-QE/ee-apps/mac-builder-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCloneArtifactsRepoChecksOutPinnedTagCommit(t *testing.T) {
+	t.Parallel()
+
+	repoDir, firstCommit, _, firstTag := createArtifactsRepoFixture(t)
+	job := newNativeBuildJob(context.Background(), newTestMacBuild(), ArtifactsScriptSourceConfig{
+		URL:            repoDir,
+		Revision:       firstTag,
+		ExpectedCommit: firstCommit,
+	})
+
+	if err := job.setupWorkspace(); err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	defer job.cleanup()
+
+	if err := job.cloneArtifactsRepo(); err != nil {
+		t.Fatalf("clone artifacts repo: %v", err)
+	}
+
+	headCommit, err := job.gitHeadCommit(job.artifactsRepoDir)
+	if err != nil {
+		t.Fatalf("resolve cloned HEAD: %v", err)
+	}
+	if headCommit != firstCommit {
+		t.Fatalf("expected cloned HEAD %q, got %q", firstCommit, headCommit)
+	}
+}
+
+func TestCloneArtifactsRepoRejectsMismatchedExpectedCommit(t *testing.T) {
+	t.Parallel()
+
+	repoDir, firstCommit, secondCommit, firstTag := createArtifactsRepoFixture(t)
+	job := newNativeBuildJob(context.Background(), newTestMacBuild(), ArtifactsScriptSourceConfig{
+		URL:            repoDir,
+		Revision:       firstTag,
+		ExpectedCommit: secondCommit,
+	})
+
+	if err := job.setupWorkspace(); err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	defer job.cleanup()
+
+	err := job.cloneArtifactsRepo()
+	if err == nil {
+		t.Fatal("expected cloneArtifactsRepo to fail for mismatched commit")
+	}
+	if !strings.Contains(err.Error(), firstCommit) {
+		t.Fatalf("expected error to mention resolved commit %q, got %v", firstCommit, err)
+	}
+}
+
+func TestCloneArtifactsRepoRejectsBranchRevision(t *testing.T) {
+	t.Parallel()
+
+	repoDir, _, firstCommit, _ := createArtifactsRepoFixture(t)
+	job := newNativeBuildJob(context.Background(), newTestMacBuild(), ArtifactsScriptSourceConfig{
+		URL:            repoDir,
+		Revision:       "release/1.0",
+		ExpectedCommit: firstCommit,
+	})
+
+	if err := job.setupWorkspace(); err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	defer job.cleanup()
+
+	err := job.cloneArtifactsRepo()
+	if err == nil {
+		t.Fatal("expected cloneArtifactsRepo to reject branch revision")
+	}
+	if !strings.Contains(err.Error(), "reachable tag or full commit SHA") {
+		t.Fatalf("expected branch rejection error, got %v", err)
+	}
+}
+
+func createArtifactsRepoFixture(t *testing.T) (repoDir string, firstCommit string, secondCommit string, firstTag string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.name", "Tester")
+	runGit(t, repoDir, "config", "user.email", "tester@example.com")
+
+	scriptPath := filepath.Join(repoDir, "packages", "scripts", "gen-package-artifacts-with-config.sh")
+	templatePath := filepath.Join(repoDir, "packages", "packages.yaml.tmpl")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	if err := os.WriteFile(templatePath, []byte("template"), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "first")
+	firstCommit = strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+	firstTag = "v1.0.0"
+	runGit(t, repoDir, "tag", firstTag)
+
+	if err := os.WriteFile(templatePath, []byte("template-updated"), 0o644); err != nil {
+		t.Fatalf("update template: %v", err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "second")
+	secondCommit = strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+	runGit(t, repoDir, "branch", "release/1.0", secondCommit)
+
+	return repoDir, firstCommit, secondCommit, firstTag
+}
+
+func newTestMacBuild() buildv1alpha1.MacBuild {
+	return buildv1alpha1.MacBuild{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-build",
+			Namespace: "default",
+		},
+		Spec: buildv1alpha1.MacBuildSpec{
+			Source: buildv1alpha1.SourceSpec{
+				GitRepository: "https://example.invalid/repo.git",
+				GitRef:        "main",
+			},
+			Build: buildv1alpha1.BuildSpec{
+				Component: "pd",
+				Version:   "v1.0.0",
+				Arch:      "amd64",
+				Profile:   "release",
+			},
+			Artifacts: buildv1alpha1.ArtifactsSpec{
+				Registry: "hub.pingcap.net/devbuild",
+			},
+		},
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}

--- a/mac-builder-operator/spec/DESIGN.md
+++ b/mac-builder-operator/spec/DESIGN.md
@@ -9,6 +9,7 @@ The system consists of two main components:
 1. macOS Agent (External Controller):
    - Deployment: Runs on macOS physical machines or VMs (Outside the K8s cluster).
    - Responsibilities: Proactively watches the K8s API, claims tasks in Pending state, executes local operations (git clone, script generation, compilation, oras push), and updates the CRD Status in real-time.
+   - Supply chain control: The agent pins the external `artifacts.git` script source to a configured immutable revision and verifies the expected commit before executing generated build logic.
    - Communication: Connects to the K8s API Server via Kubeconfig or ServiceAccount Token (Outbound connection).
 
 2. GC Controller (Cluster Internal):


### PR DESCRIPTION
Summary
- pin the external artifacts build-script source to an immutable revision for the mac-builder agent
- verify the checked-out artifacts repo commit before running any generated build logic

Changes
- add agent flags for artifacts repo URL, revision, and expected commit with safe defaults
- reject mutable branch refs, require non-SHA refs to resolve through tags, and compare the checked-out HEAD against the expected commit
- add unit coverage for default normalization, tag checkout, mismatched commit rejection, and branch rejection; document the new pinning behavior

Testing
- `go test ./... -run 'TestArtifactsScriptSourceConfig|TestCloneArtifactsRepo|TestReconcile'`

Risk
- low to medium: the agent will now fail fast if the configured artifacts revision/commit pair is wrong; rollback is reverting commit `b08f9dd`
