### PR TITLE
feat(mac-builder-operator): add arch-aware build lifecycle updates

### DIFF
--- a/mac-builder-operator/internal/controller/macbuild_controller.go
+++ b/mac-builder-operator/internal/controller/macbuild_controller.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,13 +44,15 @@ type MacBuildReconciler struct {
 	ArtifactsScriptSource ArtifactsScriptSourceConfig
 
 	now      func() time.Time
-	runBuild func(context.Context, buildv1alpha1.MacBuild) (*buildResult, error)
+	runBuild func(context.Context, buildv1alpha1.MacBuild, buildPhaseReporter) (*buildResult, error)
 }
 
 type buildResult struct {
 	CommitHash          string
 	PushedArtifactsYaml string
 }
+
+type buildPhaseReporter func(string, string) error
 
 const (
 	defaultBuildTimeout      = 24 * time.Hour
@@ -88,15 +91,14 @@ func (r *MacBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if macBuild.Status.Phase == "" {
 		logger.Info("Setting initial status to Pending")
 
-		newStatus := macBuild.Status.DeepCopy()
-		now := metav1.NewTime(r.currentTime())
-		newStatus.SetPhase(buildv1alpha1.PhasePending, "Waiting for a matching macOS worker to claim this build.", now)
-		macBuild.Status = *newStatus
-
-		if err := r.Status().Update(ctx, &macBuild); err != nil {
+		updatedBuild, err := r.updateBuildStatus(ctx, client.ObjectKeyFromObject(&macBuild), func(status *buildv1alpha1.MacBuildStatus, now metav1.Time) {
+			status.SetPhase(buildv1alpha1.PhasePending, "Waiting for a matching macOS worker to claim this build.", now)
+		})
+		if err != nil {
 			logger.Error(err, "Failed to update MacBuild status to Pending")
 			return ctrl.Result{}, err
 		}
+		macBuild = *updatedBuild
 
 		return ctrl.Result{Requeue: true}, nil
 	}
@@ -104,32 +106,39 @@ func (r *MacBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	logger.Info("MacBuild already has status", "Phase", macBuild.Status.Phase)
 	switch macBuild.Status.Phase {
 	case buildv1alpha1.PhasePending:
-		// adopt the build job and update the status to "Building"
-		logger.Info("Phase: Pending. Claiming and setting to Building.")
-		newStatus := macBuild.Status.DeepCopy()
-		now := metav1.NewTime(r.currentTime())
-		newStatus.SetPhase(buildv1alpha1.PhaseBuilding, "Build claimed by worker and queued for execution.", now)
-		newStatus.WorkerID = &r.WorkerID
-		newStatus.WorkerArch = optionalString(r.WorkerArch)
-		newStatus.StartTime = &now
-		newStatus.CompletionTime = nil
-		newStatus.Message = nil
-		macBuild.Status = *newStatus
+		if !r.matchesBuildArch(macBuild) {
+			logger.Info(
+				"Pending build does not match this worker architecture. Leaving it for another worker.",
+				"workerArch", r.WorkerArch,
+				"buildArch", buildArchFor(macBuild),
+			)
+			return ctrl.Result{}, nil
+		}
 
-		if err := r.Status().Update(ctx, &macBuild); err != nil {
-			logger.Error(err, "Failed to update status to Building")
+		logger.Info("Phase: Pending. Claiming and setting to Preparing.")
+		updatedBuild, err := r.updateBuildStatus(ctx, client.ObjectKeyFromObject(&macBuild), func(status *buildv1alpha1.MacBuildStatus, now metav1.Time) {
+			status.SetPhase(buildv1alpha1.PhasePreparing, "Build claimed by worker and preparing workspace.", now)
+			status.WorkerID = &r.WorkerID
+			status.WorkerArch = optionalString(r.WorkerArch)
+			status.StartTime = &now
+			status.CompletionTime = nil
+			status.Message = nil
+		})
+		if err != nil {
+			logger.Error(err, "Failed to update status to Preparing")
 			return ctrl.Result{}, err
 		}
+		macBuild = *updatedBuild
 
 		return ctrl.Result{Requeue: true}, nil
-	case buildv1alpha1.PhaseBuilding:
-		logger.Info("Phase: Building. Starting build process.")
+	case buildv1alpha1.PhasePreparing, buildv1alpha1.PhaseBuilding, buildv1alpha1.PhasePublishing:
+		logger.Info("Phase: Active build phase. Starting or resuming build process.", "phase", macBuild.Status.Phase)
 
 		if macBuild.Status.StartTime == nil {
-			return r.failBuild(ctx, logger, &macBuild, "build entered Building without startTime")
+			return r.failBuild(ctx, logger, &macBuild, "build entered an active phase without startTime")
 		}
 		if macBuild.Status.WorkerID == nil || *macBuild.Status.WorkerID == "" {
-			return r.failBuild(ctx, logger, &macBuild, "build entered Building without workerID")
+			return r.failBuild(ctx, logger, &macBuild, "build entered an active phase without workerID")
 		}
 		if r.hasTimedOut(macBuild.Status.StartTime.Time) {
 			return r.failBuild(
@@ -149,37 +158,48 @@ func (r *MacBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{RequeueAfter: r.buildPollInterval()}, nil
 		}
 
-		result, err := r.runNativeBuild(ctx, macBuild)
-		newStatus := macBuild.Status.DeepCopy()
-		now := metav1.NewTime(r.currentTime())
-		newStatus.CompletionTime = &now
-		if *macBuild.Status.WorkerID == r.WorkerID {
-			newStatus.WorkerArch = optionalString(r.WorkerArch)
-		}
+		result, err := r.runNativeBuild(ctx, macBuild, func(phase string, message string) error {
+			updatedBuild, err := r.updateBuildStatus(ctx, client.ObjectKeyFromObject(&macBuild), func(status *buildv1alpha1.MacBuildStatus, now metav1.Time) {
+				status.SetPhase(phase, message, now)
+				status.WorkerID = &r.WorkerID
+				status.WorkerArch = optionalString(r.WorkerArch)
+				if status.StartTime == nil {
+					status.StartTime = &now
+				}
+				status.CompletionTime = nil
+				status.Message = nil
+			})
+			if err != nil {
+				return err
+			}
+			macBuild = *updatedBuild
+			return nil
+		})
 
 		if err != nil {
 			logger.Error(err, "Build failed")
-			newStatus.SetPhase(buildv1alpha1.PhaseFailed, err.Error(), now)
-			errMsg := err.Error()
-			newStatus.Message = &errMsg
-		} else {
-			logger.Info("Build succeeded")
-			newStatus.SetPhase(buildv1alpha1.PhaseSucceeded, "Build completed successfully.", now)
-			newStatus.Message = nil
-			newStatus.CommitHash = &result.CommitHash
-			if result.PushedArtifactsYaml != "" {
-				if newStatus.Outputs == nil {
-					newStatus.Outputs = &buildv1alpha1.MacBuildResultOutputs{}
-				}
-				newStatus.Outputs.PushedArtifactsYaml = &result.PushedArtifactsYaml
-			}
+			return r.failBuild(ctx, logger, &macBuild, err.Error())
 		}
 
-		macBuild.Status = *newStatus
-		if errUpdate := r.Status().Update(ctx, &macBuild); errUpdate != nil {
-			logger.Error(errUpdate, "Failed to update status to Succeeded/Failed")
-			return ctrl.Result{}, errUpdate
+		logger.Info("Build succeeded")
+		updatedBuild, err := r.updateBuildStatus(ctx, client.ObjectKeyFromObject(&macBuild), func(status *buildv1alpha1.MacBuildStatus, now metav1.Time) {
+			status.SetPhase(buildv1alpha1.PhaseSucceeded, "Build completed successfully.", now)
+			status.Message = nil
+			status.CompletionTime = &now
+			status.WorkerArch = optionalString(r.WorkerArch)
+			status.CommitHash = &result.CommitHash
+			if result.PushedArtifactsYaml != "" {
+				if status.Outputs == nil {
+					status.Outputs = &buildv1alpha1.MacBuildResultOutputs{}
+				}
+				status.Outputs.PushedArtifactsYaml = &result.PushedArtifactsYaml
+			}
+		})
+		if err != nil {
+			logger.Error(err, "Failed to update status to Succeeded")
+			return ctrl.Result{}, err
 		}
+		macBuild = *updatedBuild
 		return ctrl.Result{}, nil
 	case buildv1alpha1.PhaseSucceeded, buildv1alpha1.PhaseFailed:
 		logger.WithValues("phase", macBuild.Status.Phase).Info("Nothing to do.")
@@ -198,11 +218,16 @@ func (r *MacBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *MacBuildReconciler) runNativeBuild(ctx context.Context, macBuild buildv1alpha1.MacBuild) (*buildResult, error) {
+func (r *MacBuildReconciler) runNativeBuild(
+	ctx context.Context,
+	macBuild buildv1alpha1.MacBuild,
+	reportPhase buildPhaseReporter,
+) (*buildResult, error) {
 	if r.runBuild != nil {
-		return r.runBuild(ctx, macBuild)
+		return r.runBuild(ctx, macBuild, reportPhase)
 	}
 	job := newNativeBuildJob(ctx, macBuild, r.ArtifactsScriptSource)
+	job.reportPhase = reportPhase
 	return job.Run()
 }
 
@@ -239,19 +264,54 @@ func (r *MacBuildReconciler) failBuild(
 ) (ctrl.Result, error) {
 	logger.Info("Marking build as failed", "message", message)
 
-	newStatus := macBuild.Status.DeepCopy()
-	now := metav1.NewTime(r.currentTime())
-	newStatus.SetPhase(buildv1alpha1.PhaseFailed, message, now)
-	newStatus.Message = &message
-	newStatus.CompletionTime = &now
-	macBuild.Status = *newStatus
-
-	if err := r.Status().Update(ctx, macBuild); err != nil {
+	updatedBuild, err := r.updateBuildStatus(ctx, client.ObjectKeyFromObject(macBuild), func(status *buildv1alpha1.MacBuildStatus, now metav1.Time) {
+		status.SetPhase(buildv1alpha1.PhaseFailed, message, now)
+		status.Message = &message
+		status.CompletionTime = &now
+		if status.WorkerID != nil && *status.WorkerID == r.WorkerID {
+			status.WorkerArch = optionalString(r.WorkerArch)
+		}
+	})
+	if err != nil {
 		logger.Error(err, "Failed to update status to Failed")
 		return ctrl.Result{}, err
 	}
+	*macBuild = *updatedBuild
 
 	return ctrl.Result{}, nil
+}
+
+func (r *MacBuildReconciler) updateBuildStatus(
+	ctx context.Context,
+	key client.ObjectKey,
+	mutate func(*buildv1alpha1.MacBuildStatus, metav1.Time),
+) (*buildv1alpha1.MacBuild, error) {
+	var updated buildv1alpha1.MacBuild
+
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := r.Get(ctx, key, &updated); err != nil {
+			return err
+		}
+
+		mutate(&updated.Status, metav1.NewTime(r.currentTime()))
+		return r.Status().Update(ctx, &updated)
+	}); err != nil {
+		return nil, err
+	}
+
+	return updated.DeepCopy(), nil
+}
+
+func (r *MacBuildReconciler) matchesBuildArch(macBuild buildv1alpha1.MacBuild) bool {
+	return buildArchFor(macBuild) == buildv1alpha1.NormalizeBuildArch(r.WorkerArch)
+}
+
+func buildArchFor(macBuild buildv1alpha1.MacBuild) string {
+	arch := buildv1alpha1.NormalizeBuildArch(macBuild.Spec.Build.Arch)
+	if arch == "" {
+		return buildv1alpha1.BuildArchAMD64
+	}
+	return arch
 }
 
 func optionalString(value string) *string {

--- a/mac-builder-operator/internal/controller/macbuild_controller_test.go
+++ b/mac-builder-operator/internal/controller/macbuild_controller_test.go
@@ -90,5 +90,83 @@ var _ = Describe("MacBuild Controller", func() {
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
+
+		It("should only claim builds that match the worker arch and record phase progression", func() {
+			resourceName := "arch-aware-resource"
+			key := types.NamespacedName{Name: resourceName, Namespace: "default"}
+			resource := &buildv1alpha1.MacBuild{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: buildv1alpha1.MacBuildSpec{
+					Source: buildv1alpha1.SourceSpec{
+						GitRepository: "https://github.com/pingcap/tidb.git",
+						GitRef:        "main",
+					},
+					Build: buildv1alpha1.BuildSpec{
+						Component: "tidb",
+						Version:   "nightly",
+						Arch:      buildv1alpha1.BuildArchAMD64,
+					},
+					Artifacts: buildv1alpha1.ArtifactsSpec{
+						Push: true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, resource)
+			})
+
+			foreignReconciler := &MacBuildReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				WorkerID:   "worker-arm64",
+				WorkerArch: buildv1alpha1.BuildArchARM64,
+			}
+			_, err := foreignReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = foreignReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			pending := &buildv1alpha1.MacBuild{}
+			Expect(k8sClient.Get(ctx, key, pending)).To(Succeed())
+			Expect(pending.Status.Phase).To(Equal(buildv1alpha1.PhasePending))
+			Expect(pending.Status.WorkerID).To(BeNil())
+
+			matchingReconciler := &MacBuildReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				WorkerID:   "worker-amd64",
+				WorkerArch: buildv1alpha1.BuildArchAMD64,
+				runBuild: func(ctx context.Context, build buildv1alpha1.MacBuild, reportPhase buildPhaseReporter) (*buildResult, error) {
+					Expect(reportPhase(buildv1alpha1.PhaseBuilding, "Running build steps on the worker.")).To(Succeed())
+					Expect(reportPhase(buildv1alpha1.PhasePublishing, "Publishing build artifacts.")).To(Succeed())
+					return &buildResult{
+						CommitHash:          "deadbeef",
+						PushedArtifactsYaml: "artifacts:\n- name: tidb\n",
+					}, nil
+				},
+			}
+			_, err = matchingReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = matchingReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &buildv1alpha1.MacBuild{}
+			Expect(k8sClient.Get(ctx, key, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(buildv1alpha1.PhaseSucceeded))
+			Expect(updated.Status.WorkerID).NotTo(BeNil())
+			Expect(*updated.Status.WorkerID).To(Equal("worker-amd64"))
+			Expect(updated.Status.WorkerArch).NotTo(BeNil())
+			Expect(*updated.Status.WorkerArch).To(Equal(buildv1alpha1.BuildArchAMD64))
+			Expect(updated.Status.PhaseHistory).To(HaveLen(5))
+			Expect(updated.Status.PhaseHistory[0].Phase).To(Equal(buildv1alpha1.PhasePending))
+			Expect(updated.Status.PhaseHistory[1].Phase).To(Equal(buildv1alpha1.PhasePreparing))
+			Expect(updated.Status.PhaseHistory[2].Phase).To(Equal(buildv1alpha1.PhaseBuilding))
+			Expect(updated.Status.PhaseHistory[3].Phase).To(Equal(buildv1alpha1.PhasePublishing))
+			Expect(updated.Status.PhaseHistory[4].Phase).To(Equal(buildv1alpha1.PhaseSucceeded))
+		})
 	})
 })

--- a/mac-builder-operator/internal/controller/macbuild_controller_unit_test.go
+++ b/mac-builder-operator/internal/controller/macbuild_controller_unit_test.go
@@ -99,8 +99,8 @@ func TestReconcilePendingClaimRecordsWorkerIdentityAndPhaseHistory(t *testing.T)
 	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(macBuild), &updated); err != nil {
 		t.Fatalf("get updated MacBuild: %v", err)
 	}
-	if updated.Status.Phase != buildv1alpha1.PhaseBuilding {
-		t.Fatalf("expected phase %q, got %q", buildv1alpha1.PhaseBuilding, updated.Status.Phase)
+	if updated.Status.Phase != buildv1alpha1.PhasePreparing {
+		t.Fatalf("expected phase %q, got %q", buildv1alpha1.PhasePreparing, updated.Status.Phase)
 	}
 	if updated.Status.WorkerID == nil || *updated.Status.WorkerID != testWorkerA {
 		t.Fatalf("expected worker ID %q, got %#v", testWorkerA, updated.Status.WorkerID)
@@ -117,12 +117,73 @@ func TestReconcilePendingClaimRecordsWorkerIdentityAndPhaseHistory(t *testing.T)
 	if len(updated.Status.PhaseHistory) != 2 {
 		t.Fatalf("expected two phase history entries, got %#v", updated.Status.PhaseHistory)
 	}
-	if updated.Status.PhaseHistory[1].Phase != buildv1alpha1.PhaseBuilding {
-		t.Fatalf("expected second phase history entry to be Building, got %#v", updated.Status.PhaseHistory[1])
+	if updated.Status.PhaseHistory[1].Phase != buildv1alpha1.PhasePreparing {
+		t.Fatalf("expected second phase history entry to be Preparing, got %#v", updated.Status.PhaseHistory[1])
 	}
 }
 
-func TestReconcileBuildingSuccessInitializesOutputs(t *testing.T) {
+func TestReconcilePendingMismatchedArchDoesNotClaimBuild(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	pendingAt := metav1.NewTime(fixedNow.Add(-time.Minute))
+	macBuild := &buildv1alpha1.MacBuild{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "build-mismatch",
+			Namespace: "default",
+		},
+		Spec: buildv1alpha1.MacBuildSpec{
+			Build: buildv1alpha1.BuildSpec{
+				Arch: buildv1alpha1.BuildArchARM64,
+			},
+		},
+		Status: buildv1alpha1.MacBuildStatus{
+			Phase:        buildv1alpha1.PhasePending,
+			PhaseMessage: stringPtr("Waiting for a matching macOS worker to claim this build."),
+			PhaseHistory: []buildv1alpha1.MacBuildPhaseHistoryEntry{
+				{
+					Phase:          buildv1alpha1.PhasePending,
+					TransitionTime: pendingAt,
+					Message:        stringPtr("Waiting for a matching macOS worker to claim this build."),
+				},
+			},
+		},
+	}
+
+	reconciler, k8sClient := newTestMacBuildReconciler(t, fixedNow, macBuild)
+	reconciler.WorkerID = testWorkerA
+	reconciler.WorkerArch = testWorkerArch
+	reconciler.runBuild = func(context.Context, buildv1alpha1.MacBuild, buildPhaseReporter) (*buildResult, error) {
+		t.Fatal("runBuild should not be called for an arch mismatch")
+		return nil, nil
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: macBuild.Name, Namespace: macBuild.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("expected no requeue on arch mismatch, got %+v", result)
+	}
+
+	var updated buildv1alpha1.MacBuild
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(macBuild), &updated); err != nil {
+		t.Fatalf("get updated MacBuild: %v", err)
+	}
+	if updated.Status.Phase != buildv1alpha1.PhasePending {
+		t.Fatalf("expected phase to remain %q, got %q", buildv1alpha1.PhasePending, updated.Status.Phase)
+	}
+	if updated.Status.WorkerID != nil {
+		t.Fatalf("expected workerID to remain nil, got %#v", updated.Status.WorkerID)
+	}
+	if updated.Status.WorkerArch != nil {
+		t.Fatalf("expected workerArch to remain nil, got %#v", updated.Status.WorkerArch)
+	}
+}
+
+func TestReconcilePreparingSuccessInitializesOutputs(t *testing.T) {
 	t.Parallel()
 
 	fixedNow := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
@@ -132,13 +193,13 @@ func TestReconcileBuildingSuccessInitializesOutputs(t *testing.T) {
 			Namespace: "default",
 		},
 		Status: buildv1alpha1.MacBuildStatus{
-			Phase:        buildv1alpha1.PhaseBuilding,
-			PhaseMessage: stringPtr("Build claimed by worker and queued for execution."),
+			Phase:        buildv1alpha1.PhasePreparing,
+			PhaseMessage: stringPtr("Build claimed by worker and preparing workspace."),
 			PhaseHistory: []buildv1alpha1.MacBuildPhaseHistoryEntry{
 				{
-					Phase:          buildv1alpha1.PhaseBuilding,
+					Phase:          buildv1alpha1.PhasePreparing,
 					TransitionTime: metav1.NewTime(fixedNow.Add(-time.Minute)),
-					Message:        stringPtr("Build claimed by worker and queued for execution."),
+					Message:        stringPtr("Build claimed by worker and preparing workspace."),
 				},
 			},
 			WorkerID:  stringPtr(testWorkerA),
@@ -149,7 +210,13 @@ func TestReconcileBuildingSuccessInitializesOutputs(t *testing.T) {
 	reconciler, k8sClient := newTestMacBuildReconciler(t, fixedNow, macBuild)
 	reconciler.WorkerID = testWorkerA
 	reconciler.WorkerArch = testWorkerArch
-	reconciler.runBuild = func(context.Context, buildv1alpha1.MacBuild) (*buildResult, error) {
+	reconciler.runBuild = func(_ context.Context, _ buildv1alpha1.MacBuild, reportPhase buildPhaseReporter) (*buildResult, error) {
+		if err := reportPhase(buildv1alpha1.PhaseBuilding, "Running build steps on the worker."); err != nil {
+			return nil, err
+		}
+		if err := reportPhase(buildv1alpha1.PhasePublishing, "Publishing build artifacts."); err != nil {
+			return nil, err
+		}
 		return &buildResult{
 			CommitHash:          "abc123",
 			PushedArtifactsYaml: "artifacts:\n- name: pd\n",
@@ -188,11 +255,17 @@ func TestReconcileBuildingSuccessInitializesOutputs(t *testing.T) {
 	if updated.Status.PhaseMessage == nil || *updated.Status.PhaseMessage != "Build completed successfully." {
 		t.Fatalf("expected success phase message, got %#v", updated.Status.PhaseMessage)
 	}
-	if len(updated.Status.PhaseHistory) != 2 {
-		t.Fatalf("expected two phase history entries, got %#v", updated.Status.PhaseHistory)
+	if len(updated.Status.PhaseHistory) != 4 {
+		t.Fatalf("expected four phase history entries, got %#v", updated.Status.PhaseHistory)
 	}
-	if updated.Status.PhaseHistory[1].Phase != buildv1alpha1.PhaseSucceeded {
-		t.Fatalf("expected final phase history entry to be Succeeded, got %#v", updated.Status.PhaseHistory[1])
+	if updated.Status.PhaseHistory[1].Phase != buildv1alpha1.PhaseBuilding {
+		t.Fatalf("expected second phase history entry to be Building, got %#v", updated.Status.PhaseHistory[1])
+	}
+	if updated.Status.PhaseHistory[2].Phase != buildv1alpha1.PhasePublishing {
+		t.Fatalf("expected third phase history entry to be Publishing, got %#v", updated.Status.PhaseHistory[2])
+	}
+	if updated.Status.PhaseHistory[3].Phase != buildv1alpha1.PhaseSucceeded {
+		t.Fatalf("expected final phase history entry to be Succeeded, got %#v", updated.Status.PhaseHistory[3])
 	}
 	if updated.Status.CompletionTime == nil || !updated.Status.CompletionTime.Time.Equal(fixedNow) {
 		t.Fatalf("expected completion time %s, got %#v", fixedNow, updated.Status.CompletionTime)
@@ -209,13 +282,13 @@ func TestReconcileRequeuesForeignBuildBeforeTimeout(t *testing.T) {
 			Namespace: "default",
 		},
 		Status: buildv1alpha1.MacBuildStatus{
-			Phase:        buildv1alpha1.PhaseBuilding,
-			PhaseMessage: stringPtr("Build claimed by worker and queued for execution."),
+			Phase:        buildv1alpha1.PhasePreparing,
+			PhaseMessage: stringPtr("Build claimed by worker and preparing workspace."),
 			PhaseHistory: []buildv1alpha1.MacBuildPhaseHistoryEntry{
 				{
-					Phase:          buildv1alpha1.PhaseBuilding,
+					Phase:          buildv1alpha1.PhasePreparing,
 					TransitionTime: metav1.NewTime(fixedNow.Add(-10 * time.Minute)),
-					Message:        stringPtr("Build claimed by worker and queued for execution."),
+					Message:        stringPtr("Build claimed by worker and preparing workspace."),
 				},
 			},
 			WorkerID:  stringPtr(testWorkerB),
@@ -228,7 +301,7 @@ func TestReconcileRequeuesForeignBuildBeforeTimeout(t *testing.T) {
 	reconciler.WorkerArch = testWorkerArch
 	reconciler.BuildTimeout = time.Hour
 	reconciler.BuildPollInterval = 2 * time.Minute
-	reconciler.runBuild = func(context.Context, buildv1alpha1.MacBuild) (*buildResult, error) {
+	reconciler.runBuild = func(context.Context, buildv1alpha1.MacBuild, buildPhaseReporter) (*buildResult, error) {
 		t.Fatal("runBuild should not be called for a foreign build")
 		return nil, nil
 	}
@@ -247,8 +320,8 @@ func TestReconcileRequeuesForeignBuildBeforeTimeout(t *testing.T) {
 	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(macBuild), &updated); err != nil {
 		t.Fatalf("get updated MacBuild: %v", err)
 	}
-	if updated.Status.Phase != buildv1alpha1.PhaseBuilding {
-		t.Fatalf("expected phase to remain %q, got %q", buildv1alpha1.PhaseBuilding, updated.Status.Phase)
+	if updated.Status.Phase != buildv1alpha1.PhasePreparing {
+		t.Fatalf("expected phase to remain %q, got %q", buildv1alpha1.PhasePreparing, updated.Status.Phase)
 	}
 	if len(updated.Status.PhaseHistory) != 1 {
 		t.Fatalf("expected phase history to remain unchanged, got %#v", updated.Status.PhaseHistory)
@@ -265,13 +338,13 @@ func TestReconcileMarksStaleForeignBuildFailed(t *testing.T) {
 			Namespace: "default",
 		},
 		Status: buildv1alpha1.MacBuildStatus{
-			Phase:        buildv1alpha1.PhaseBuilding,
-			PhaseMessage: stringPtr("Build claimed by worker and queued for execution."),
+			Phase:        buildv1alpha1.PhasePreparing,
+			PhaseMessage: stringPtr("Build claimed by worker and preparing workspace."),
 			PhaseHistory: []buildv1alpha1.MacBuildPhaseHistoryEntry{
 				{
-					Phase:          buildv1alpha1.PhaseBuilding,
+					Phase:          buildv1alpha1.PhasePreparing,
 					TransitionTime: metav1.NewTime(fixedNow.Add(-2 * time.Hour)),
-					Message:        stringPtr("Build claimed by worker and queued for execution."),
+					Message:        stringPtr("Build claimed by worker and preparing workspace."),
 				},
 			},
 			WorkerID:  stringPtr(testWorkerB),
@@ -284,7 +357,7 @@ func TestReconcileMarksStaleForeignBuildFailed(t *testing.T) {
 	reconciler.WorkerArch = testWorkerArch
 	reconciler.BuildTimeout = time.Hour
 	reconciler.BuildPollInterval = 2 * time.Minute
-	reconciler.runBuild = func(context.Context, buildv1alpha1.MacBuild) (*buildResult, error) {
+	reconciler.runBuild = func(context.Context, buildv1alpha1.MacBuild, buildPhaseReporter) (*buildResult, error) {
 		t.Fatal("runBuild should not be called for a stale foreign build")
 		return nil, nil
 	}

--- a/mac-builder-operator/internal/controller/native_build_job.go
+++ b/mac-builder-operator/internal/controller/native_build_job.go
@@ -17,14 +17,14 @@ limitations under the License.
 package controller
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	buildv1alpha1 "github.com/PingCAP-QE/ee-apps/mac-builder-operator/api/v1alpha1"
@@ -47,6 +47,10 @@ type nativeBuildJob struct {
 	buildScriptPath  string
 	envFilePath      string
 	pushedResultPath string
+
+	reportPhase  buildPhaseReporter
+	stdoutWriter io.Writer
+	stderrWriter io.Writer
 }
 
 // newNativeBuildJob creates a new instance of nativeBuildJob.
@@ -76,6 +80,8 @@ func newNativeBuildJob(
 		buildScriptPath:  filepath.Join(workspaceDir, "build-package-artifacts.sh"),
 		envFilePath:      filepath.Join(workspaceDir, "remote.env"),
 		pushedResultPath: filepath.Join(workspaceDir, "pushed.yaml"),
+		stdoutWriter:     os.Stdout,
+		stderrWriter:     os.Stderr,
 	}
 }
 
@@ -115,6 +121,9 @@ func (j *nativeBuildJob) Run() (*buildResult, error) {
 		return result, nil
 	}
 
+	if err := j.updatePhase(buildv1alpha1.PhaseBuilding, "Running build steps on the worker."); err != nil {
+		return result, err
+	}
 	if err := j.executeBuild(); err != nil {
 		return result, err
 	}
@@ -123,6 +132,9 @@ func (j *nativeBuildJob) Run() (*buildResult, error) {
 		return result, nil
 	}
 
+	if err := j.updatePhase(buildv1alpha1.PhasePublishing, "Publishing build artifacts."); err != nil {
+		return result, err
+	}
 	pushedYAML, err := j.executePublish()
 	if err != nil {
 		return result, err
@@ -151,24 +163,35 @@ func (j *nativeBuildJob) cleanup() {
 
 // exec executes a command and logs its output.
 func (j *nativeBuildJob) exec(cmd *exec.Cmd, dir ...string) error {
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
 	if len(dir) > 0 {
 		cmd.Dir = dir[0]
 	}
 
+	stdoutWriter := j.stdoutWriter
+	if stdoutWriter == nil {
+		stdoutWriter = io.Discard
+	}
+	stderrWriter := j.stderrWriter
+	if stderrWriter == nil {
+		stderrWriter = io.Discard
+	}
+	tail := newTailBuffer(8 * 1024)
+	cmd.Stdout = io.MultiWriter(stdoutWriter, tail)
+	cmd.Stderr = io.MultiWriter(stderrWriter, tail)
+
 	j.logger.Info("Executing command", "cmd", cmd.String(), "dir", cmd.Dir)
 
 	if err := cmd.Run(); err != nil {
-		stderrStr := stderr.String()
-		j.logger.Error(err, "Command execution failed", "stderr", stderrStr)
-		// Return stderr as the error message; this is useful
-		return errors.New(stderrStr)
+		tailSummary := strings.TrimSpace(tail.String())
+		if tailSummary != "" {
+			j.logger.Error(err, "Command execution failed", "tail", tailSummary)
+			return fmt.Errorf("command execution failed: %s", tailSummary)
+		}
+		j.logger.Error(err, "Command execution failed")
+		return fmt.Errorf("command execution failed: %w", err)
 	}
 
-	j.logger.Info("Command executed successfully", "stdout", stdout.String())
+	j.logger.Info("Command executed successfully", "cmd", cmd.String())
 	return nil
 }
 
@@ -406,4 +429,48 @@ func (j *nativeBuildJob) executePublish() (string, error) {
 	}
 
 	return string(pushedYAMLBytes), nil
+}
+
+func (j *nativeBuildJob) updatePhase(phase string, message string) error {
+	if j.reportPhase == nil {
+		return nil
+	}
+	return j.reportPhase(phase, message)
+}
+
+type tailBuffer struct {
+	mu        sync.Mutex
+	buf       []byte
+	maxBytes  int
+	truncated bool
+}
+
+func newTailBuffer(maxBytes int) *tailBuffer {
+	return &tailBuffer{maxBytes: maxBytes}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > b.maxBytes {
+		b.truncated = true
+		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.maxBytes:]...)
+	}
+
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if len(b.buf) == 0 {
+		return ""
+	}
+	if b.truncated {
+		return "...\n" + string(b.buf)
+	}
+	return string(b.buf)
 }

--- a/mac-builder-operator/internal/controller/native_build_job_test.go
+++ b/mac-builder-operator/internal/controller/native_build_job_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
@@ -85,6 +86,29 @@ func TestCloneArtifactsRepoRejectsBranchRevision(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "reachable tag or full commit SHA") {
 		t.Fatalf("expected branch rejection error, got %v", err)
+	}
+}
+
+func TestExecStreamsOutputAndReturnsFailureTail(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	job := newNativeBuildJob(context.Background(), newTestMacBuild(), ArtifactsScriptSourceConfig{})
+	job.stdoutWriter = &stdout
+	job.stderrWriter = &stderr
+
+	err := job.exec(exec.Command("sh", "-c", "printf 'stdout-line\\n'; printf 'stderr-line\\n' >&2; exit 7"))
+	if err == nil {
+		t.Fatal("expected exec to fail")
+	}
+	if !strings.Contains(err.Error(), "stdout-line") || !strings.Contains(err.Error(), "stderr-line") {
+		t.Fatalf("expected error tail to include stdout and stderr, got %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "stdout-line") {
+		t.Fatalf("expected stdout writer to receive streamed output, got %q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "stderr-line") {
+		t.Fatalf("expected stderr writer to receive streamed output, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Summary
- make mac build claiming arch-aware so workers only adopt matching pending builds
- track the full preparing/building/publishing lifecycle in status updates
- stream native build stdout/stderr to controller logs while keeping a bounded failure tail

Changes
- claim `Pending` builds only when `spec.build.arch` matches the worker arch, then transition through `Preparing`, `Building`, `Publishing`, and terminal states with conflict-safe status updates
- wire phase callbacks into the native build job so build and publish transitions are recorded during execution
- stream command stdout/stderr directly to pod logs and return a concise tail summary on failures
- extend unit and envtest coverage for arch-aware claiming, phase history progression, and streamed command output

Testing
- `make test`
- `make lint`

Risk
- status updates now happen more frequently during a build, so any unexpected conflict handling bug would show up as stalled phase transitions rather than silent success
