### PR TITLE
feat(ci-dashboard): refine cost dashboard filters and budget pacing

### DIFF
--- a/ci-dashboard/src/ci_dashboard/api/queries/base.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from typing import Any
@@ -24,6 +24,8 @@ class CommonFilters:
     start_date: date | None = None
     end_date: date | None = None
     granularity: str = "day"
+    cost_vendor: str | None = None
+    cost_account_id: str | None = None
 
     def meta(self) -> dict[str, Any]:
         return {
@@ -36,6 +38,13 @@ class CommonFilters:
             "start_date": self.start_date.isoformat() if self.start_date else None,
             "end_date": self.end_date.isoformat() if self.end_date else None,
             "granularity": self.granularity,
+            "cost_vendor": self.cost_vendor,
+            "cost_account_id": self.cost_account_id,
+            "cost_source": (
+                f"{self.cost_vendor}:{self.cost_account_id}"
+                if self.cost_vendor and self.cost_account_id
+                else None
+            ),
         }
 
     @property
@@ -43,40 +52,13 @@ class CommonFilters:
         return split_filter_values(self.job_name)
 
     def without_issue_status(self) -> "CommonFilters":
-        return CommonFilters(
-            repo=self.repo,
-            branch=self.branch,
-            job_name=self.job_name,
-            cloud_phase=self.cloud_phase,
-            issue_status=None,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            granularity=self.granularity,
-        )
+        return replace(self, issue_status=None)
 
     def without_cloud_phase(self) -> "CommonFilters":
-        return CommonFilters(
-            repo=self.repo,
-            branch=self.branch,
-            job_name=self.job_name,
-            cloud_phase=None,
-            issue_status=self.issue_status,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            granularity=self.granularity,
-        )
+        return replace(self, cloud_phase=None)
 
     def without_repo(self) -> "CommonFilters":
-        return CommonFilters(
-            repo=None,
-            branch=self.branch,
-            job_name=self.job_name,
-            cloud_phase=self.cloud_phase,
-            issue_status=self.issue_status,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            granularity=self.granularity,
-        )
+        return replace(self, repo=None)
 
 
 def build_common_where(

--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -13,9 +13,6 @@ from ci_dashboard.api.queries.base import CommonFilters, bucket_expr, rate_pct, 
 COST_STACK_LIMIT = 8
 UNMATCHED_RESOURCE_LIMIT = 20
 ENGINEERING_GROUP_NAME = "Engineering Group"
-PRIMARY_BUDGET_VENDOR = "gcp"
-PRIMARY_BUDGET_ACCOUNT_ID = "pingcap-testing-account"
-PRIMARY_ANNUAL_BUDGET = 17300 * 12
 COST_DATA_LAG_DAYS = 4
 FORECAST_WINDOW_DAYS = 14
 UNALLOCATED_GKE_NAMESPACE_BUCKETS = (
@@ -78,6 +75,11 @@ def get_cost_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
             params,
         ).mappings()
         data_rows = [dict(row) for row in rows]
+        annual_budgets = _annual_budgets_for_filters(
+            connection,
+            filters,
+            years=_budget_years(filters, data_rows),
+        )
         coverage_row = connection.execute(
             text(
                 f"""
@@ -123,6 +125,7 @@ def get_cost_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
         ],
         "meta": {
             **filters.meta(),
+            "annual_budgets": annual_budgets,
             "summary": {
                 "net_cost": round(summary_net_cost, 2),
                 "effective_cost": round(summary_effective_cost, 2),
@@ -724,12 +727,15 @@ def _budget_health_snapshot(
     connection: Connection,
     filters: CommonFilters,
 ) -> dict[str, Any] | None:
-    annual_budget = _annual_budget_for_filters(filters)
-    if annual_budget is None:
-        return None
-
     today = _today()
     year_start = date(today.year, 1, 1)
+    annual_budget = _annual_budget_for_filters(
+        connection,
+        filters,
+        year=today.year,
+    )
+    if annual_budget is None:
+        return None
     observed_through = max(year_start, today - timedelta(days=COST_DATA_LAG_DAYS))
     current_scope = CommonFilters(
         start_date=year_start,
@@ -831,13 +837,81 @@ def _number_or_zero(value: Any) -> float:
     return float(to_number(value) or 0)
 
 
-def _annual_budget_for_filters(filters: CommonFilters) -> float | None:
-    if (
-        filters.cost_vendor == PRIMARY_BUDGET_VENDOR
-        and filters.cost_account_id == PRIMARY_BUDGET_ACCOUNT_ID
-    ):
-        return float(PRIMARY_ANNUAL_BUDGET)
-    return None
+def _annual_budget_for_filters(
+    connection: Connection,
+    filters: CommonFilters,
+    *,
+    year: int,
+) -> float | None:
+    if not filters.cost_vendor or not filters.cost_account_id:
+        return None
+
+    year_start = date(year, 1, 1)
+    year_end = date(year, 12, 31)
+    params = {
+        "vendor": filters.cost_vendor,
+        "account_id": filters.cost_account_id,
+        "year_start": year_start,
+        "year_end": year_end,
+    }
+    source_wide_total = connection.execute(
+        text(
+            """
+            SELECT COALESCE(SUM(budget_amount), 0) AS budget_amount
+            FROM cost_budgets
+            WHERE vendor = :vendor
+              AND account_id = :account_id
+              AND period_start_date <= :year_start
+              AND period_end_date >= :year_end
+              AND group_id IS NULL
+              AND manager_id IS NULL
+              AND repo IS NULL
+              AND label_filters IS NULL
+            """
+        ),
+        params,
+    ).scalar_one()
+    source_wide_budget = _money(source_wide_total)
+    if source_wide_budget > 0:
+        return round(source_wide_budget, 2)
+
+    fallback_total = connection.execute(
+        text(
+            """
+            SELECT COALESCE(SUM(budget_amount), 0) AS budget_amount
+            FROM cost_budgets
+            WHERE vendor = :vendor
+              AND account_id = :account_id
+              AND period_start_date <= :year_start
+              AND period_end_date >= :year_end
+              AND group_id IS NULL
+              AND manager_id IS NULL
+            """
+        ),
+        params,
+    ).scalar_one()
+    fallback_budget = _money(fallback_total)
+    if fallback_budget <= 0:
+        return None
+    return round(fallback_budget, 2)
+
+
+def _annual_budgets_for_filters(
+    connection: Connection,
+    filters: CommonFilters,
+    *,
+    years: list[int],
+) -> dict[str, float]:
+    budgets: dict[str, float] = {}
+    for year in years:
+        annual_budget = _annual_budget_for_filters(
+            connection,
+            filters,
+            year=year,
+        )
+        if annual_budget is not None:
+            budgets[str(year)] = annual_budget
+    return budgets
 
 
 def _cost_filters(filters: CommonFilters) -> CommonFilters:
@@ -906,6 +980,18 @@ def _bucket_starts(filters: CommonFilters, rows: list[dict[str, Any]]) -> list[s
             return _month_bucket_starts(filters.start_date, filters.end_date)
         return _week_bucket_starts(filters.start_date, filters.end_date)
     return sorted({str(row["bucket_start"]) for row in rows})
+
+
+def _budget_years(filters: CommonFilters, rows: list[dict[str, Any]]) -> list[int]:
+    if filters.start_date and filters.end_date:
+        return list(range(filters.start_date.year, filters.end_date.year + 1))
+
+    years = {
+        parsed.year
+        for row in rows
+        if (parsed := _parse_date(row.get("bucket_start"))) is not None
+    }
+    return sorted(years)
 
 
 def _week_bucket_starts(start_date: date, end_date: date) -> list[str]:

--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import calendar
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, timedelta
 from typing import Any, Mapping
@@ -12,6 +13,11 @@ from ci_dashboard.api.queries.base import CommonFilters, bucket_expr, rate_pct, 
 COST_STACK_LIMIT = 8
 UNMATCHED_RESOURCE_LIMIT = 20
 ENGINEERING_GROUP_NAME = "Engineering Group"
+PRIMARY_BUDGET_VENDOR = "gcp"
+PRIMARY_BUDGET_ACCOUNT_ID = "pingcap-testing-account"
+PRIMARY_ANNUAL_BUDGET = 17300 * 12
+COST_DATA_LAG_DAYS = 4
+FORECAST_WINDOW_DAYS = 14
 UNALLOCATED_GKE_NAMESPACE_BUCKETS = (
     "kube:unallocated",
     "kube:system-overhead",
@@ -136,11 +142,14 @@ def get_weekly_overview(engine: Engine, filters: CommonFilters) -> dict[str, Any
         start_date=previous_start,
         end_date=previous_end,
         granularity=cost_filters.granularity,
+        cost_vendor=cost_filters.cost_vendor,
+        cost_account_id=cost_filters.cost_account_id,
     )
     if engine.dialect.name == "sqlite":
         with engine.begin() as connection:
             current_summary = _cost_summary(connection, cost_filters)
             previous_summary = _cost_summary(connection, previous_filters)
+            budget_health = _budget_health_snapshot(connection, cost_filters)
             service_share = _service_share_by_threshold(
                 connection,
                 cost_filters,
@@ -153,10 +162,11 @@ def get_weekly_overview(engine: Engine, filters: CommonFilters) -> dict[str, Any
                 min_share_pct=1.0,
             )
     else:
-        with ThreadPoolExecutor(max_workers=4) as executor:
+        with ThreadPoolExecutor(max_workers=5) as executor:
             futures = {
                 "current_summary": executor.submit(_get_cost_summary, engine, cost_filters),
                 "previous_summary": executor.submit(_get_cost_summary, engine, previous_filters),
+                "budget_health": executor.submit(_get_budget_health_snapshot, engine, cost_filters),
                 "service_share": executor.submit(
                     _get_service_share_by_threshold,
                     engine,
@@ -174,6 +184,7 @@ def get_weekly_overview(engine: Engine, filters: CommonFilters) -> dict[str, Any
             sections = {name: future.result() for name, future in futures.items()}
         current_summary = sections["current_summary"]
         previous_summary = sections["previous_summary"]
+        budget_health = sections["budget_health"]
         service_share = sections["service_share"]
         level2_share = sections["level2_share"]
 
@@ -194,6 +205,7 @@ def get_weekly_overview(engine: Engine, filters: CommonFilters) -> dict[str, Any
                 previous_summary["net_cost"],
             ),
         },
+        "budget_health": budget_health,
         "service_share": service_share,
         "level2_share": level2_share,
     }
@@ -212,6 +224,14 @@ def _get_service_share_by_threshold(
 ) -> dict[str, Any]:
     with engine.begin() as connection:
         return _service_share_by_threshold(connection, filters, min_share_pct=min_share_pct)
+
+
+def _get_budget_health_snapshot(
+    engine: Engine,
+    filters: CommonFilters,
+) -> dict[str, Any] | None:
+    with engine.begin() as connection:
+        return _budget_health_snapshot(connection, filters)
 
 
 def _get_engineering_share_by_level_threshold(
@@ -351,6 +371,32 @@ def get_engineering_group_share(engine: Engine, filters: CommonFilters) -> dict[
         "level1": level1,
         "level2": level2,
     }
+
+
+def list_cost_sources(engine: Engine) -> dict[str, Any]:
+    with engine.begin() as connection:
+        rows = connection.execute(
+            text(
+                """
+                SELECT vendor, account_id, display_name
+                FROM cost_sources
+                WHERE is_active = :is_active
+                ORDER BY vendor, account_id
+                """
+            ),
+            {"is_active": 1},
+        ).mappings()
+        items = [
+            {
+                "value": _cost_source_value(str(row["vendor"]), str(row["account_id"])),
+                "label": _cost_source_label(str(row["vendor"]), str(row["account_id"])),
+                "vendor": str(row["vendor"]),
+                "account_id": str(row["account_id"]),
+                "display_name": str(row["display_name"] or ""),
+            }
+            for row in rows
+        ]
+    return {"items": items}
 
 
 def get_unmatched_resources(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
@@ -674,6 +720,75 @@ def _service_share_by_threshold(
     }
 
 
+def _budget_health_snapshot(
+    connection: Connection,
+    filters: CommonFilters,
+) -> dict[str, Any] | None:
+    annual_budget = _annual_budget_for_filters(filters)
+    if annual_budget is None:
+        return None
+
+    today = _today()
+    year_start = date(today.year, 1, 1)
+    observed_through = max(year_start, today - timedelta(days=COST_DATA_LAG_DAYS))
+    current_scope = CommonFilters(
+        start_date=year_start,
+        end_date=observed_through,
+        granularity=filters.granularity,
+        cost_vendor=filters.cost_vendor,
+        cost_account_id=filters.cost_account_id,
+    )
+    current_summary = _cost_summary(connection, current_scope)
+    current_cost = current_summary["net_cost"]
+    days_elapsed = max((observed_through - year_start).days + 1, 1)
+    days_in_year = 366 if calendar.isleap(today.year) else 365
+    days_remaining = max(days_in_year - days_elapsed, 0)
+    budget_to_date = round(annual_budget * days_elapsed / days_in_year, 2)
+    variance = round(current_cost - budget_to_date, 2)
+
+    recent_window_days = min(days_elapsed, FORECAST_WINDOW_DAYS)
+    recent_window_start = observed_through - timedelta(days=recent_window_days - 1)
+    recent_scope = CommonFilters(
+        start_date=recent_window_start,
+        end_date=observed_through,
+        granularity=filters.granularity,
+        cost_vendor=filters.cost_vendor,
+        cost_account_id=filters.cost_account_id,
+    )
+    recent_summary = _cost_summary(connection, recent_scope)
+    recent_window_cost = recent_summary["net_cost"]
+    recent_daily_cost = round(recent_window_cost / recent_window_days, 2) if recent_window_days else 0.0
+    forecast_remaining_cost = round(recent_daily_cost * days_remaining, 2)
+    forecast_total_cost = round(current_cost + forecast_remaining_cost, 2)
+    forecast_variance = round(forecast_total_cost - annual_budget, 2)
+    is_healthy = forecast_total_cost <= annual_budget
+
+    return {
+        "metric_key": "net_cost",
+        "annual_budget": round(annual_budget, 2),
+        "budget_to_date": budget_to_date,
+        "current_cost": current_cost,
+        "through_date": observed_through.isoformat(),
+        "days_elapsed": days_elapsed,
+        "days_in_year": days_in_year,
+        "days_remaining": days_remaining,
+        "annual_budget_pct": rate_pct(current_cost, annual_budget),
+        "budget_to_date_pct": rate_pct(current_cost, budget_to_date),
+        "variance": variance,
+        "variance_pct": rate_pct(variance, budget_to_date),
+        "recent_window_days": recent_window_days,
+        "recent_window_cost": recent_window_cost,
+        "recent_daily_cost": recent_daily_cost,
+        "forecast_remaining_cost": forecast_remaining_cost,
+        "forecast_total_cost": forecast_total_cost,
+        "forecast_budget_pct": rate_pct(forecast_total_cost, annual_budget),
+        "forecast_variance": forecast_variance,
+        "forecast_variance_pct": rate_pct(forecast_variance, annual_budget),
+        "status": "healthy" if is_healthy else "warning",
+        "status_label": "Healthy" if is_healthy else "Warning",
+    }
+
+
 def _share_items_above_threshold_with_others(
     all_items: list[dict[str, Any]],
     *,
@@ -716,12 +831,23 @@ def _number_or_zero(value: Any) -> float:
     return float(to_number(value) or 0)
 
 
+def _annual_budget_for_filters(filters: CommonFilters) -> float | None:
+    if (
+        filters.cost_vendor == PRIMARY_BUDGET_VENDOR
+        and filters.cost_account_id == PRIMARY_BUDGET_ACCOUNT_ID
+    ):
+        return float(PRIMARY_ANNUAL_BUDGET)
+    return None
+
+
 def _cost_filters(filters: CommonFilters) -> CommonFilters:
     granularity = filters.granularity if filters.granularity in {"week", "month"} else "week"
     return CommonFilters(
         start_date=filters.start_date,
         end_date=filters.end_date,
         granularity=granularity,
+        cost_vendor=filters.cost_vendor,
+        cost_account_id=filters.cost_account_id,
     )
 
 
@@ -739,6 +865,12 @@ def _build_cost_where(
     if filters.end_date:
         conditions.append(f"{prefix}usage_date <= :usage_date_to")
         params["usage_date_to"] = filters.end_date
+    if filters.cost_vendor:
+        conditions.append(f"{prefix}vendor = :cost_vendor")
+        params["cost_vendor"] = filters.cost_vendor
+    if filters.cost_account_id:
+        conditions.append(f"{prefix}account_id = :cost_account_id")
+        params["cost_account_id"] = filters.cost_account_id
     return " AND ".join(conditions), params
 
 
@@ -758,6 +890,14 @@ def _repo_key(repo_name: str, index: int) -> str:
     if repo_name == "(no repo)":
         return "repo__no_repo"
     return f"repo__{index}"
+
+
+def _cost_source_value(vendor: str, account_id: str) -> str:
+    return f"{vendor}:{account_id}"
+
+
+def _cost_source_label(vendor: str, account_id: str) -> str:
+    return f"{vendor} / {account_id}"
 
 
 def _bucket_starts(filters: CommonFilters, rows: list[dict[str, Any]]) -> list[str]:
@@ -817,6 +957,10 @@ def _build_unallocated_namespace_where(column: str) -> tuple[str, dict[str, Any]
 def _money(value: Any) -> float:
     numeric = to_number(value)
     return round(float(numeric or 0), 2)
+
+
+def _today() -> date:
+    return date.today()
 
 
 def _date_text(value: Any) -> str | None:

--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -20,6 +20,7 @@ from ci_dashboard.api.queries.builds import (
 )
 from ci_dashboard.api.queries.cost import (
     get_cost_page,
+    list_cost_sources,
     get_cost_trend,
     get_engineering_group_share,
     get_repo_group_cost_stack,
@@ -221,6 +222,10 @@ def get_cost_insight_page(engine: Engine, filters: CommonFilters) -> dict[str, A
     return get_cost_page(engine, _normalize_cost_filters(filters))
 
 
+def get_cost_sources_page(engine: Engine) -> dict[str, Any]:
+    return list_cost_sources(engine)
+
+
 def get_cost_unmatched_resources_page(
     engine: Engine,
     filters: CommonFilters,
@@ -261,6 +266,8 @@ def _normalize_cost_filters(filters: CommonFilters) -> CommonFilters:
         start_date=filters.start_date,
         end_date=filters.end_date,
         granularity=filters.granularity if filters.granularity in {"week", "month"} else "week",
+        cost_vendor=filters.cost_vendor,
+        cost_account_id=filters.cost_account_id,
     )
 
 

--- a/ci-dashboard/src/ci_dashboard/api/routes/common.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/common.py
@@ -16,10 +16,12 @@ def get_common_filters(
     start_date: date | None = None,
     end_date: date | None = None,
     granularity: str = Query(default="day"),
+    cost_source: str | None = None,
 ) -> CommonFilters:
     validate_granularity(granularity)
     validate_date_range(start_date, end_date)
     validate_issue_status(issue_status)
+    cost_vendor, cost_account_id = parse_cost_source(cost_source)
     return CommonFilters(
         repo=repo,
         branch=branch,
@@ -29,6 +31,8 @@ def get_common_filters(
         start_date=start_date,
         end_date=end_date,
         granularity=granularity,
+        cost_vendor=cost_vendor,
+        cost_account_id=cost_account_id,
     )
 
 
@@ -47,3 +51,16 @@ def validate_issue_status(issue_status: str | None) -> None:
         return
     if issue_status not in {"open", "closed"}:
         raise HTTPException(status_code=400, detail="issue_status must be one of: open, closed")
+
+
+def parse_cost_source(cost_source: str | None) -> tuple[str | None, str | None]:
+    if cost_source is None or cost_source == "" or cost_source == "all":
+        return None, None
+
+    vendor, separator, account_id = cost_source.partition(":")
+    if not separator or not vendor or not account_id:
+        raise HTTPException(
+            status_code=400,
+            detail="cost_source must be 'all' or formatted as '<vendor>:<account_id>'",
+        )
+    return vendor, account_id

--- a/ci-dashboard/src/ci_dashboard/api/routes/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/pages.py
@@ -10,6 +10,7 @@ from ci_dashboard.api.queries.pages import (
     get_build_trend_page,
     get_cost_engineering_group_share_page,
     get_cost_insight_page,
+    get_cost_sources_page,
     get_cost_repo_group_stack_page,
     get_cost_trend_page,
     get_cost_unmatched_resources_page,
@@ -74,6 +75,13 @@ def cost_page(
     engine: Engine = Depends(get_engine),
 ) -> dict[str, object]:
     return get_cost_insight_page(engine, filters)
+
+
+@router.get("/cost-sources")
+def cost_sources_page(
+    engine: Engine = Depends(get_engine),
+) -> dict[str, object]:
+    return get_cost_sources_page(engine)
 
 
 @router.get("/cost-trend")

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -439,6 +439,61 @@ def _insert_cost_source(
         )
 
 
+def _insert_cost_budget(
+    sqlite_engine,
+    *,
+    vendor: str,
+    account_id: str,
+    period_start_date: str,
+    period_end_date: str,
+    budget_amount: float,
+    budget_name: str | None = None,
+    label_filters: dict | list | str | None = None,
+    group_id: int | None = None,
+    manager_id: int | None = None,
+    repo: str | None = None,
+    filter_hash: str | None = None,
+    source_type: str = "manual",
+    source_ref: str | None = None,
+) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cost_budgets (
+                  vendor, account_id, period_start_date, period_end_date, budget_name,
+                  label_filters, filter_hash, group_id, manager_id, repo, budget_amount,
+                  source_type, source_ref
+                ) VALUES (
+                  :vendor, :account_id, :period_start_date, :period_end_date, :budget_name,
+                  :label_filters, :filter_hash, :group_id, :manager_id, :repo, :budget_amount,
+                  :source_type, :source_ref
+                )
+                """
+            ),
+            {
+                "vendor": vendor,
+                "account_id": account_id,
+                "period_start_date": period_start_date,
+                "period_end_date": period_end_date,
+                "budget_name": budget_name,
+                "label_filters": (
+                    json.dumps(label_filters, sort_keys=True)
+                    if isinstance(label_filters, (dict, list))
+                    else label_filters
+                ),
+                "filter_hash": filter_hash
+                or f"{vendor}:{account_id}:{period_start_date}:{period_end_date}:{budget_name or 'scope'}",
+                "group_id": group_id,
+                "manager_id": manager_id,
+                "repo": repo,
+                "budget_amount": budget_amount,
+                "source_type": source_type,
+                "source_ref": source_ref,
+            },
+        )
+
+
 def _insert_cost_attribution(
     sqlite_engine,
     *,
@@ -2527,6 +2582,15 @@ def test_cost_source_filter_and_sources_route(sqlite_engine, api_client: TestCli
         display_name="disabled-project",
         is_active=0,
     )
+    _insert_cost_budget(
+        sqlite_engine,
+        vendor="aws",
+        account_id="946646677266",
+        period_start_date="2026-01-01",
+        period_end_date="2026-12-31",
+        budget_amount=36000.0,
+        budget_name="qa-infra-dev 2026",
+    )
     _insert_roster_group(
         sqlite_engine,
         group_id=100,
@@ -2621,6 +2685,7 @@ def test_cost_source_filter_and_sources_route(sqlite_engine, api_client: TestCli
     assert trend_body["meta"]["cost_vendor"] == "aws"
     assert trend_body["meta"]["cost_account_id"] == "946646677266"
     assert trend_body["meta"]["cost_source"] == "aws:946646677266"
+    assert trend_body["meta"]["annual_budgets"] == {"2026": 36000.0}
     assert trend_body["meta"]["summary"]["list_cost"] == 30.0
     assert trend_body["meta"]["summary"]["net_cost"] == 28.0
     assert {series["key"]: series["points"] for series in trend_body["series"]}["list_cost"] == [
@@ -2638,6 +2703,15 @@ def test_cost_weekly_overview_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(cost_queries, "_today", lambda: date(2026, 5, 20))
+    _insert_cost_budget(
+        sqlite_engine,
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+        period_start_date="2026-01-01",
+        period_end_date="2026-12-31",
+        budget_amount=207600.0,
+        budget_name="PingCAP Testing 2026",
+    )
 
     _insert_roster_group(
         sqlite_engine,
@@ -3049,7 +3123,14 @@ def test_budget_health_snapshot_marks_warning_when_over_pace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(cost_queries, "_today", lambda: date(2026, 1, 10))
-    monkeypatch.setattr(cost_queries, "PRIMARY_ANNUAL_BUDGET", 100.0)
+    _insert_cost_budget(
+        sqlite_engine,
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+        period_start_date="2026-01-01",
+        period_end_date="2026-12-31",
+        budget_amount=100.0,
+    )
     _insert_roster_group(
         sqlite_engine,
         group_id=100,
@@ -3111,7 +3192,14 @@ def test_budget_health_snapshot_marks_warning_when_forecast_exceeds_budget_even_
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(cost_queries, "_today", lambda: date(2026, 6, 30))
-    monkeypatch.setattr(cost_queries, "PRIMARY_ANNUAL_BUDGET", 100.0)
+    _insert_cost_budget(
+        sqlite_engine,
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+        period_start_date="2026-01-01",
+        period_end_date="2026-12-31",
+        budget_amount=100.0,
+    )
     _insert_roster_group(
         sqlite_engine,
         group_id=100,
@@ -3163,6 +3251,82 @@ def test_budget_health_snapshot_marks_warning_when_forecast_exceeds_budget_even_
     assert snapshot["forecast_total_cost"] == 447.32
     assert snapshot["forecast_variance"] == 347.32
     assert snapshot["status"] == "warning"
+
+
+def test_annual_budget_for_filters_falls_back_to_summing_partitioned_budget_rows(
+    sqlite_engine,
+) -> None:
+    _insert_cost_budget(
+        sqlite_engine,
+        vendor="aws",
+        account_id="946646677266",
+        period_start_date="2026-01-01",
+        period_end_date="2026-12-31",
+        budget_amount=120.0,
+        budget_name="Apps",
+        label_filters={"repo": "apps"},
+        repo="apps",
+    )
+    _insert_cost_budget(
+        sqlite_engine,
+        vendor="aws",
+        account_id="946646677266",
+        period_start_date="2026-01-01",
+        period_end_date="2026-12-31",
+        budget_amount=80.0,
+        budget_name="Infra",
+        label_filters={"repo": "infra"},
+        repo="infra",
+    )
+
+    with sqlite_engine.begin() as connection:
+        budget = cost_queries._annual_budget_for_filters(
+            connection,
+            CommonFilters(
+                cost_vendor="aws",
+                cost_account_id="946646677266",
+            ),
+            year=2026,
+        )
+
+    assert budget == 200.0
+
+
+def test_annual_budget_for_filters_prefers_source_wide_budget_rows(
+    sqlite_engine,
+) -> None:
+    _insert_cost_budget(
+        sqlite_engine,
+        vendor="gcp",
+        account_id="qa-infra-dev",
+        period_start_date="2026-01-01",
+        period_end_date="2026-12-31",
+        budget_amount=300.0,
+        budget_name="Whole source",
+    )
+    _insert_cost_budget(
+        sqlite_engine,
+        vendor="gcp",
+        account_id="qa-infra-dev",
+        period_start_date="2026-01-01",
+        period_end_date="2026-12-31",
+        budget_amount=120.0,
+        budget_name="Apps",
+        label_filters={"repo": "apps"},
+        repo="apps",
+    )
+
+    with sqlite_engine.begin() as connection:
+        budget = cost_queries._annual_budget_for_filters(
+            connection,
+            CommonFilters(
+                cost_vendor="gcp",
+                cost_account_id="qa-infra-dev",
+            ),
+            year=2026,
+        )
+
+    assert budget == 300.0
 
 
 def test_cost_repo_group_stack_keeps_distinct_repo_keys_on_slug_collisions(sqlite_engine, api_client: TestClient) -> None:

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -409,6 +409,36 @@ def _insert_roster_group(
         )
 
 
+def _insert_cost_source(
+    sqlite_engine,
+    *,
+    vendor: str,
+    account_id: str,
+    display_name: str | None = None,
+    billing_account_id: str | None = None,
+    is_active: int = 1,
+) -> None:
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cost_sources (
+                  vendor, account_id, billing_account_id, display_name, is_active
+                ) VALUES (
+                  :vendor, :account_id, :billing_account_id, :display_name, :is_active
+                )
+                """
+            ),
+            {
+                "vendor": vendor,
+                "account_id": account_id,
+                "billing_account_id": billing_account_id,
+                "display_name": display_name,
+                "is_active": is_active,
+            },
+        )
+
+
 def _insert_cost_attribution(
     sqlite_engine,
     *,
@@ -416,6 +446,8 @@ def _insert_cost_attribution(
     repo: str,
     group_id: int,
     net_cost: float,
+    vendor: str = "gcp",
+    account_id: str = "pingcap-testing-account",
     effective_cost: float | None = None,
     list_cost: float | None = None,
     dimension_hash: str | None = None,
@@ -439,7 +471,7 @@ def _insert_cost_attribution(
                   attribution_status, employee_id, group_id, manager_id, usage_seconds,
                   list_cost, effective_cost, credit_amount, net_cost, source_rows, dimension_hash
                 ) VALUES (
-                  :usage_date, 'gcp', 'pingcap-testing-account', :service_name, 'runner',
+                  :usage_date, :vendor, :account_id, :service_name, 'runner',
                   'pingcap', :repo, :resource_name, :author, :owner, :attribution_key, :attribution_source,
                   :attribution_status, :employee_id, :group_id, NULL, :usage_seconds, :list_cost, :effective_cost,
                   0, :net_cost, 1, :dimension_hash
@@ -448,6 +480,8 @@ def _insert_cost_attribution(
             ),
             {
                 "usage_date": usage_date,
+                "vendor": vendor,
+                "account_id": account_id,
                 "repo": repo,
                 "group_id": group_id,
                 "resource_name": resource_name,
@@ -523,6 +557,9 @@ def _insert_cost_unmatched_resource(
     resource_name: str,
     namespace: str | None,
     list_cost: float,
+    vendor: str = "gcp",
+    account_id: str = "pingcap-testing-account",
+    billing_account_id: str = "billing-account-1",
     effective_cost: float | None = None,
     net_cost: float | None = None,
     author: str | None = "alice",
@@ -541,7 +578,7 @@ def _insert_cost_unmatched_resource(
                   usage_seconds, list_cost, effective_cost, credit_amount, net_cost,
                   source_export_time, source_row_hash
                 ) VALUES (
-                  'gcp', 'pingcap-testing-account', 'billing-account-1', :usage_date, :usage_date,
+                  :vendor, :account_id, :billing_account_id, :usage_date, :usage_date,
                   :service_name, :sku_name, :namespace, :author, 'pingcap', :repo, :resource_name,
                   :usage_seconds, :list_cost, :effective_cost, 0, :net_cost,
                   '2026-05-19 00:00:00', :source_row_hash
@@ -550,6 +587,9 @@ def _insert_cost_unmatched_resource(
             ),
             {
                 "usage_date": usage_date,
+                "vendor": vendor,
+                "account_id": account_id,
+                "billing_account_id": billing_account_id,
                 "service_name": service_name,
                 "sku_name": sku_name,
                 "namespace": namespace,
@@ -2458,7 +2498,147 @@ def test_cost_page_supporting_routes(sqlite_engine, api_client: TestClient) -> N
     ]
 
 
-def test_cost_weekly_overview_route(sqlite_engine, api_client: TestClient) -> None:
+def test_cost_source_filter_and_sources_route(sqlite_engine, api_client: TestClient) -> None:
+    _insert_cost_source(
+        sqlite_engine,
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+        display_name="pingcap-testing-account",
+        billing_account_id="01D088-8F9CF2-8AF1C6",
+    )
+    _insert_cost_source(
+        sqlite_engine,
+        vendor="gcp",
+        account_id="qa-infra-dev",
+        display_name="qa-infra-dev",
+        billing_account_id="01D088-8F9CF2-8AF1C6",
+    )
+    _insert_cost_source(
+        sqlite_engine,
+        vendor="aws",
+        account_id="946646677266",
+        display_name="qa-infra-dev",
+        billing_account_id="317766989874",
+    )
+    _insert_cost_source(
+        sqlite_engine,
+        vendor="gcp",
+        account_id="disabled-project",
+        display_name="disabled-project",
+        is_active=0,
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=100,
+        lark_group_id="eng",
+        name="Engineering Group",
+        path="/100/",
+    )
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=110,
+        lark_group_id="database",
+        name="Database",
+        parent_id=100,
+        path="/100/110/",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-02",
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+        repo="tidb",
+        group_id=110,
+        net_cost=8,
+        effective_cost=9,
+        list_cost=10,
+        dimension_hash="gcp-main",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-02",
+        vendor="gcp",
+        account_id="qa-infra-dev",
+        repo="tidb",
+        group_id=110,
+        net_cost=18,
+        effective_cost=19,
+        list_cost=20,
+        dimension_hash="gcp-qa",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-05-02",
+        vendor="aws",
+        account_id="946646677266",
+        repo="tidb",
+        group_id=110,
+        net_cost=28,
+        effective_cost=29,
+        list_cost=30,
+        dimension_hash="aws-qa",
+    )
+
+    sources_response = api_client.get("/api/v1/pages/cost-sources")
+
+    assert sources_response.status_code == 200
+    assert sources_response.json()["items"] == [
+        {
+            "value": "aws:946646677266",
+            "label": "aws / 946646677266",
+            "vendor": "aws",
+            "account_id": "946646677266",
+            "display_name": "qa-infra-dev",
+        },
+        {
+            "value": "gcp:pingcap-testing-account",
+            "label": "gcp / pingcap-testing-account",
+            "vendor": "gcp",
+            "account_id": "pingcap-testing-account",
+            "display_name": "pingcap-testing-account",
+        },
+        {
+            "value": "gcp:qa-infra-dev",
+            "label": "gcp / qa-infra-dev",
+            "vendor": "gcp",
+            "account_id": "qa-infra-dev",
+            "display_name": "qa-infra-dev",
+        },
+    ]
+
+    trend_response = api_client.get(
+        "/api/v1/pages/cost-trend",
+        params={
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-31",
+            "granularity": "day",
+            "cost_source": "aws:946646677266",
+        },
+    )
+
+    assert trend_response.status_code == 200
+    trend_body = trend_response.json()
+    assert trend_body["meta"]["cost_vendor"] == "aws"
+    assert trend_body["meta"]["cost_account_id"] == "946646677266"
+    assert trend_body["meta"]["cost_source"] == "aws:946646677266"
+    assert trend_body["meta"]["summary"]["list_cost"] == 30.0
+    assert trend_body["meta"]["summary"]["net_cost"] == 28.0
+    assert {series["key"]: series["points"] for series in trend_body["series"]}["list_cost"] == [
+        ["2026-04-27", 30.0],
+        ["2026-05-04", 0.0],
+        ["2026-05-11", 0.0],
+        ["2026-05-18", 0.0],
+        ["2026-05-25", 0.0],
+    ]
+
+
+def test_cost_weekly_overview_route(
+    sqlite_engine,
+    api_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cost_queries, "_today", lambda: date(2026, 5, 20))
+
     _insert_roster_group(
         sqlite_engine,
         group_id=100,
@@ -2521,6 +2701,7 @@ def test_cost_weekly_overview_route(sqlite_engine, api_client: TestClient) -> No
             "start_date": "2026-05-16",
             "end_date": "2026-05-22",
             "granularity": "day",
+            "cost_source": "gcp:pingcap-testing-account",
         },
     )
 
@@ -2529,6 +2710,7 @@ def test_cost_weekly_overview_route(sqlite_engine, api_client: TestClient) -> No
     assert body["scope"]["start_date"] == "2026-05-16"
     assert body["scope"]["end_date"] == "2026-05-22"
     assert body["scope"]["granularity"] == "week"
+    assert body["scope"]["cost_source"] == "gcp:pingcap-testing-account"
     assert body["previous_scope"]["start_date"] == "2026-05-09"
     assert body["previous_scope"]["end_date"] == "2026-05-15"
     assert body["summary"] == {
@@ -2538,6 +2720,30 @@ def test_cost_weekly_overview_route(sqlite_engine, api_client: TestClient) -> No
         "previous_net_cost": 350.0,
         "list_cost_wow_pct": 104.0,
         "net_cost_wow_pct": 100.0,
+    }
+    assert body["budget_health"] == {
+        "metric_key": "net_cost",
+        "annual_budget": 207600.0,
+        "budget_to_date": 77352.33,
+        "current_cost": 350.0,
+        "through_date": "2026-05-16",
+        "days_elapsed": 136,
+        "days_in_year": 365,
+        "days_remaining": 229,
+        "annual_budget_pct": 0.17,
+        "budget_to_date_pct": 0.45,
+        "variance": -77002.33,
+        "variance_pct": -99.55,
+        "recent_window_days": 14,
+        "recent_window_cost": 350.0,
+        "recent_daily_cost": 25.0,
+        "forecast_remaining_cost": 5725.0,
+        "forecast_total_cost": 6075.0,
+        "forecast_budget_pct": 2.93,
+        "forecast_variance": -201525.0,
+        "forecast_variance_pct": -97.07,
+        "status": "healthy",
+        "status_label": "Healthy",
     }
     assert [item["name"] for item in body["service_share"]["items"]] == [
         "Compute Engine",
@@ -2609,11 +2815,15 @@ def test_cost_query_page_helpers_cover_parallel_paths(monkeypatch: pytest.Monkey
             start_date=date(2026, 5, 1),
             end_date=date(2026, 5, 31),
             granularity="day",
+            cost_vendor="aws",
+            cost_account_id="946646677266",
         )
     ) == CommonFilters(
         start_date=date(2026, 5, 1),
         end_date=date(2026, 5, 31),
         granularity="week",
+        cost_vendor="aws",
+        cost_account_id="946646677266",
     )
 
 
@@ -2658,12 +2868,16 @@ def test_get_cost_page_parallelizes_for_non_sqlite(monkeypatch: pytest.MonkeyPat
             start_date=date(2026, 5, 1),
             end_date=date(2026, 5, 31),
             granularity="day",
+            cost_vendor="aws",
+            cost_account_id="946646677266",
         ),
     )
 
     assert result["scope"]["start_date"] == "2026-05-01"
     assert result["scope"]["end_date"] == "2026-05-31"
     assert result["scope"]["granularity"] == "week"
+    assert result["scope"]["cost_vendor"] == "aws"
+    assert result["scope"]["cost_account_id"] == "946646677266"
     assert result["scope"]["job_names"] == []
     assert result["cost_trend"] == {"name": "trend", "granularity": "week"}
     assert result["repo_group_stack"] == {"name": "stack", "granularity": "week"}
@@ -2714,6 +2928,16 @@ def test_get_weekly_overview_parallelizes_for_non_sqlite(monkeypatch: pytest.Mon
     monkeypatch.setattr(cost_queries, "_cost_summary", _summary)
     monkeypatch.setattr(
         cost_queries,
+        "_get_budget_health_snapshot",
+        lambda _engine, _filters: {
+            "status": "healthy",
+            "current_cost": 90.0,
+            "budget_to_date": 120.0,
+            "annual_budget": 240.0,
+        },
+    )
+    monkeypatch.setattr(
+        cost_queries,
         "_service_share_by_threshold",
         lambda _connection, _filters, *, min_share_pct: {
             "items": [{"name": "Compute Engine", "value": 120.0, "share_pct": 100.0}],
@@ -2740,6 +2964,7 @@ def test_get_weekly_overview_parallelizes_for_non_sqlite(monkeypatch: pytest.Mon
 
     assert result["summary"]["list_cost_wow_pct"] == 20.0
     assert result["summary"]["net_cost_wow_pct"] == 12.5
+    assert result["budget_health"]["status"] == "healthy"
     assert result["service_share"]["items"][0]["name"] == "Compute Engine"
     assert result["level2_share"]["items"][0]["name"] == "TiDB"
 
@@ -2817,6 +3042,127 @@ def test_cost_query_helpers_cover_edge_cases(sqlite_engine) -> None:
     ]
     assert cost_queries._repo_key("(no repo)", 0) == "repo__no_repo"
     assert cost_queries._repo_key("repo-1", 0) != cost_queries._repo_key("repo.1", 1)
+
+
+def test_budget_health_snapshot_marks_warning_when_over_pace(
+    sqlite_engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cost_queries, "_today", lambda: date(2026, 1, 10))
+    monkeypatch.setattr(cost_queries, "PRIMARY_ANNUAL_BUDGET", 100.0)
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=100,
+        lark_group_id="eng",
+        name="Engineering Group",
+        path="/100/",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-01-05",
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+        repo="tidb",
+        group_id=100,
+        net_cost=10,
+        effective_cost=10,
+        list_cost=10,
+        dimension_hash="budget-health-warning",
+    )
+
+    with sqlite_engine.begin() as connection:
+        snapshot = cost_queries._budget_health_snapshot(
+            connection,
+            CommonFilters(
+                cost_vendor="gcp",
+                cost_account_id="pingcap-testing-account",
+                granularity="week",
+            ),
+        )
+
+    assert snapshot == {
+        "metric_key": "net_cost",
+        "annual_budget": 100.0,
+        "budget_to_date": 1.64,
+        "current_cost": 10.0,
+        "through_date": "2026-01-06",
+        "days_elapsed": 6,
+        "days_in_year": 365,
+        "days_remaining": 359,
+        "annual_budget_pct": 10.0,
+        "budget_to_date_pct": 609.76,
+        "variance": 8.36,
+        "variance_pct": 509.76,
+        "recent_window_days": 6,
+        "recent_window_cost": 10.0,
+        "recent_daily_cost": 1.67,
+        "forecast_remaining_cost": 599.53,
+        "forecast_total_cost": 609.53,
+        "forecast_budget_pct": 609.53,
+        "forecast_variance": 509.53,
+        "forecast_variance_pct": 509.53,
+        "status": "warning",
+        "status_label": "Warning",
+    }
+
+
+def test_budget_health_snapshot_marks_warning_when_forecast_exceeds_budget_even_if_current_is_under_pace(
+    sqlite_engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cost_queries, "_today", lambda: date(2026, 6, 30))
+    monkeypatch.setattr(cost_queries, "PRIMARY_ANNUAL_BUDGET", 100.0)
+    _insert_roster_group(
+        sqlite_engine,
+        group_id=100,
+        lark_group_id="eng",
+        name="Engineering Group",
+        path="/100/",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-01-05",
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+        repo="tidb",
+        group_id=100,
+        net_cost=15,
+        effective_cost=15,
+        list_cost=15,
+        dimension_hash="budget-health-forecast-early",
+    )
+    _insert_cost_attribution(
+        sqlite_engine,
+        usage_date="2026-06-20",
+        vendor="gcp",
+        account_id="pingcap-testing-account",
+        repo="tidb",
+        group_id=100,
+        net_cost=30,
+        effective_cost=30,
+        list_cost=30,
+        dimension_hash="budget-health-forecast-recent",
+    )
+
+    with sqlite_engine.begin() as connection:
+        snapshot = cost_queries._budget_health_snapshot(
+            connection,
+            CommonFilters(
+                cost_vendor="gcp",
+                cost_account_id="pingcap-testing-account",
+                granularity="week",
+            ),
+        )
+
+    assert snapshot["current_cost"] == 45.0
+    assert snapshot["through_date"] == "2026-06-26"
+    assert snapshot["budget_to_date"] == 48.49
+    assert snapshot["variance"] == -3.49
+    assert snapshot["recent_window_days"] == 14
+    assert snapshot["recent_daily_cost"] == 2.14
+    assert snapshot["forecast_total_cost"] == 447.32
+    assert snapshot["forecast_variance"] == 347.32
+    assert snapshot["status"] == "warning"
 
 
 def test_cost_repo_group_stack_keeps_distinct_repo_keys_on_slug_collisions(sqlite_engine, api_client: TestClient) -> None:

--- a/ci-dashboard/tests/conftest.py
+++ b/ci-dashboard/tests/conftest.py
@@ -293,6 +293,19 @@ def _create_test_schema(engine: Engine) -> None:
         )
         """,
         """
+        CREATE TABLE cost_sources (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          vendor TEXT NOT NULL,
+          account_id TEXT NOT NULL,
+          billing_account_id TEXT NULL,
+          display_name TEXT NULL,
+          is_active INTEGER NOT NULL DEFAULT 1,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(vendor, account_id)
+        )
+        """,
+        """
         CREATE TABLE cost_attribution_daily (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           usage_date TEXT NOT NULL,

--- a/ci-dashboard/tests/conftest.py
+++ b/ci-dashboard/tests/conftest.py
@@ -335,6 +335,26 @@ def _create_test_schema(engine: Engine) -> None:
         )
         """,
         """
+        CREATE TABLE cost_budgets (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          vendor TEXT NOT NULL,
+          account_id TEXT NOT NULL,
+          period_start_date TEXT NOT NULL,
+          period_end_date TEXT NOT NULL,
+          budget_name TEXT NULL,
+          label_filters TEXT NULL,
+          filter_hash TEXT NOT NULL,
+          group_id INTEGER NULL,
+          manager_id INTEGER NULL,
+          repo TEXT NULL,
+          budget_amount REAL NOT NULL,
+          source_type TEXT NOT NULL DEFAULT 'manual',
+          source_ref TEXT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
         CREATE TABLE cost_raw_details (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           vendor TEXT NOT NULL,

--- a/ci-dashboard/web/src/App.jsx
+++ b/ci-dashboard/web/src/App.jsx
@@ -8,13 +8,19 @@ import MigrateStatusPage from "./pages/MigrateStatusPage";
 import FlakyPage from "./pages/FlakyPage";
 import RuntimeInsightsPage from "./pages/RuntimeInsightsPage";
 import CostPage from "./pages/CostPage";
-import { buildScopeLabel, getDefaultDateRange, useApiData } from "./lib/api";
+import {
+  buildCostSourceOptions,
+  buildScopeLabel,
+  getDefaultDateRange,
+  useApiData,
+} from "./lib/api";
 import {
   buildDefaultFilters,
   buildFilterSearch,
   buildNavSearchByPath,
   CI_STATUS_PATH,
   COST_PATH,
+  DEFAULT_COST_SOURCE,
   MIGRATE_STATUS_PATH,
   readFiltersFromSearch,
   RUNTIME_INSIGHTS_PATH,
@@ -38,6 +44,7 @@ export default function App() {
   }));
   const filters = filtersByPath[location.pathname]
     || readFiltersFromSearch(defaultRange, location.pathname, location.search);
+  const isCostPage = location.pathname === COST_PATH;
   const navigation = useApiData("/api/v1/pages/navigation");
   const runtimeInsightsEnabled = navigation.data?.features?.runtime_insights_enabled === true;
   const costDashboardEnabled = navigation.data?.features?.cost_dashboard_enabled === true;
@@ -143,6 +150,7 @@ export default function App() {
       start_date: filters.start_date,
       end_date: filters.end_date,
     },
+    !isCostPage,
   );
   const cloudPhases = useApiData("/api/v1/filters/cloud-phases", {
     repo: filters.repo,
@@ -150,7 +158,19 @@ export default function App() {
     job_name: filters.job_name,
     start_date: filters.start_date,
     end_date: filters.end_date,
-  });
+  }, !isCostPage);
+  const costSources = useApiData(
+    "/api/v1/pages/cost-sources",
+    {},
+    isCostPage && costDashboardEnabled,
+  );
+  const costSourceOptions = buildCostSourceOptions(
+    costSources.data?.items,
+    filters.cost_source || DEFAULT_COST_SOURCE,
+  );
+  const selectedCostSource = costSourceOptions.find(
+    (item) => item.value === (filters.cost_source || DEFAULT_COST_SOURCE),
+  ) || costSourceOptions[0];
 
   function handleFilterChange(key, value) {
     setFiltersByPath((current) => {
@@ -190,11 +210,13 @@ export default function App() {
   const navSearchByPath = buildNavSearchByPath(filtersByPath, defaultRange, filters);
 
   const filterOptions = {
+    isCostPage,
     repos: REPO_OPTIONS,
     branches: BRANCH_OPTIONS,
     jobs: jobs.data?.items || [],
     cloudPhases: cloudPhases.data?.items || [],
-    scopeLabel: buildScopeLabel(filters),
+    costSources: costSourceOptions,
+    scopeLabel: buildScopeLabel(filters, location.pathname, selectedCostSource?.label),
   };
 
   return (

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -51,7 +51,7 @@ const SERIES_COLORS = {
   net_cost: "#0f766e",
   effective_cost: "#2a9d8f",
   list_cost: "#d88b3d",
-  gcp_budget: "#d1495b",
+  budget_target: "#d1495b",
   repo__no_repo: "#c8d0d6",
   total_failure_like_count: "#264653",
   issue_filtered_flaky_rate_pct: "#0f7c82",

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -920,6 +920,7 @@ export function DonutShareChart({
   title,
   subtitle,
   items,
+  totalValue = null,
   totalLabel = "builds",
   emptyMessage = "No share data for the current filters.",
   onItemSelect,
@@ -929,8 +930,9 @@ export function DonutShareChart({
     return <EmptyState message={emptyMessage} compact />;
   }
 
-  const total = items.reduce((sum, item) => sum + Number(item.value || 0), 0);
-  if (!total) {
+  const itemsTotal = items.reduce((sum, item) => sum + Number(item.value || 0), 0);
+  const total = Number(totalValue || 0) > 0 ? Number(totalValue) : itemsTotal;
+  if (!itemsTotal || !total) {
     return <EmptyState message={emptyMessage} compact />;
   }
 
@@ -1215,6 +1217,114 @@ export function LabeledDonutShareChart({
           );
         })}
       </svg>
+    </article>
+  );
+}
+
+export function BudgetHealthGauge({
+  title,
+  subtitle,
+  data,
+  emptyMessage = "Budget pace is not configured for the selected cost source yet.",
+}) {
+  if (!data) {
+    return <EmptyState message={emptyMessage} compact />;
+  }
+
+  const annualBudget = Number(data.annual_budget || 0);
+  const currentCost = Number(data.current_cost || 0);
+  const budgetToDate = Number(data.budget_to_date || 0);
+  if (!annualBudget) {
+    return <EmptyState message={emptyMessage} compact />;
+  }
+
+  const status = data.status === "warning" ? "warning" : "healthy";
+  const progressColor = status === "warning" ? "#d1495b" : "#0f7c82";
+  const markerColor = "#315772";
+  const width = 220;
+  const height = 196;
+  const centerX = width / 2;
+  const centerY = 140;
+  const radius = 74;
+  const startAngle = Math.PI;
+  const endAngle = Math.PI * 2;
+  const progressRatio = Math.min(Math.max(currentCost / annualBudget, 0), 1);
+  const markerRatio = Math.min(Math.max(budgetToDate / annualBudget, 0), 1);
+  const progressAngle = startAngle + progressRatio * Math.PI;
+  const markerAngle = startAngle + markerRatio * Math.PI;
+  const progressPoint = polarToCartesian(centerX, centerY, radius, progressAngle);
+  const markerInner = polarToCartesian(centerX, centerY, radius - 13, markerAngle);
+  const markerOuter = polarToCartesian(centerX, centerY, radius + 13, markerAngle);
+
+  return (
+    <article className={`budget-gauge budget-gauge--${status}`}>
+      <header className="budget-gauge__header">
+        <div>
+          <strong>{title}</strong>
+          {subtitle ? <p>{subtitle}</p> : null}
+        </div>
+        <span className={`budget-gauge__status budget-gauge__status--${status}`}>
+          {data.status_label || (status === "warning" ? "Warning" : "Healthy")}
+        </span>
+      </header>
+
+      <div className="budget-gauge__chart">
+        <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`${title} gauge`}>
+          <path
+            d={describeOpenArc(centerX, centerY, radius, startAngle, endAngle)}
+            fill="none"
+            stroke="rgba(49, 87, 114, 0.12)"
+            strokeWidth="16"
+            strokeLinecap="round"
+          />
+          <path
+            d={describeOpenArc(centerX, centerY, radius, startAngle, progressAngle)}
+            fill="none"
+            stroke={progressColor}
+            strokeWidth="16"
+            strokeLinecap="round"
+          />
+          <line
+            x1={markerInner.x}
+            y1={markerInner.y}
+            x2={markerOuter.x}
+            y2={markerOuter.y}
+            stroke={markerColor}
+            strokeWidth="4"
+            strokeLinecap="round"
+          />
+          <circle cx={progressPoint.x} cy={progressPoint.y} r="6" fill={progressColor} />
+          <text x={centerX} y={108} textAnchor="middle" className="budget-gauge__value">
+            {formatCurrency(currentCost)}
+          </text>
+          <text x={centerX} y={128} textAnchor="middle" className="budget-gauge__label">
+            observed net cost
+          </text>
+        </svg>
+      </div>
+
+      <dl className="budget-gauge__metrics">
+        <div>
+          <dt>Annual budget</dt>
+          <dd>{formatCurrency(annualBudget)}</dd>
+        </div>
+        <div>
+          <dt>Budget at cutoff</dt>
+          <dd>{formatCurrency(budgetToDate)}</dd>
+        </div>
+        <div>
+          <dt>Pace</dt>
+          <dd>{formatPercent(data.budget_to_date_pct)}</dd>
+        </div>
+        <div>
+          <dt>14d avg / day</dt>
+          <dd>{formatCurrency(data.recent_daily_cost)}</dd>
+        </div>
+        <div>
+          <dt>Forecast total</dt>
+          <dd>{formatCurrency(data.forecast_total_cost)}</dd>
+        </div>
+      </dl>
     </article>
   );
 }
@@ -1689,6 +1799,16 @@ function describeDonutArc(cx, cy, innerRadius, outerRadius, startAngle, endAngle
     `L ${innerStart.x} ${innerStart.y}`,
     `A ${innerRadius} ${innerRadius} 0 ${largeArcFlag} 1 ${innerEnd.x} ${innerEnd.y}`,
     "Z",
+  ].join(" ");
+}
+
+function describeOpenArc(cx, cy, radius, startAngle, endAngle) {
+  const start = polarToCartesian(cx, cy, radius, startAngle);
+  const end = polarToCartesian(cx, cy, radius, endAngle);
+  const largeArcFlag = endAngle - startAngle <= Math.PI ? "0" : "1";
+  return [
+    `M ${start.x} ${start.y}`,
+    `A ${radius} ${radius} 0 ${largeArcFlag} 1 ${end.x} ${end.y}`,
   ].join(" ");
 }
 

--- a/ci-dashboard/web/src/components/layout.jsx
+++ b/ci-dashboard/web/src/components/layout.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 import packageInfo from "../../package.json";
+
+import { COST_PATH } from "../lib/filterUrl";
 
 export function DashboardLayout({
   filters,
@@ -98,14 +100,24 @@ function NavItem({ to, search = "", label, caption }) {
 
 function FilterBar({ filters, onFilterChange, filterOptions }) {
   const [isCompact, setIsCompact] = useState(false);
-  const scopePills = [
-    { label: "Repo", value: filters.repo || "All repos" },
-    { label: "Branch", value: filters.branch || "All branches" },
-    { label: "Job", value: filters.job_name || "All jobs" },
-    { label: "Cloud", value: filters.cloud_phase || "All clouds" },
-    { label: "Issues", value: filters.issue_status || "All issues" },
-    { label: "Bucket", value: filters.granularity },
-  ];
+  const location = useLocation();
+  const isCostPage = location.pathname === COST_PATH;
+  const selectedCostSource = filterOptions.costSources?.find(
+    (item) => item.value === filters.cost_source,
+  ) || filterOptions.costSources?.[0];
+  const scopePills = isCostPage
+    ? [
+        { label: "Source", value: selectedCostSource?.label || "All sources" },
+        { label: "Bucket", value: filters.granularity },
+      ]
+    : [
+        { label: "Repo", value: filters.repo || "All repos" },
+        { label: "Branch", value: filters.branch || "All branches" },
+        { label: "Job", value: filters.job_name || "All jobs" },
+        { label: "Cloud", value: filters.cloud_phase || "All clouds" },
+        { label: "Issues", value: filters.issue_status || "All issues" },
+        { label: "Bucket", value: filters.granularity },
+      ];
 
   useEffect(() => {
     let frameId = 0;
@@ -151,7 +163,9 @@ function FilterBar({ filters, onFilterChange, filterOptions }) {
       </div>
 
       <p className="filter-bar__note">
-        Each tab keeps its own filter state. Ingestion stays all-repo and all-branch.
+        {isCostPage
+          ? "Each tab keeps its own filter state. Source only changes cost panels."
+          : "Each tab keeps its own filter state. Ingestion stays all-repo and all-branch."}
       </p>
 
       <div className="filter-grid">
@@ -175,100 +189,136 @@ function FilterBar({ filters, onFilterChange, filterOptions }) {
             />
           }
         />
-        <FilterField
-          label="Repo"
-          control={
-            <select
-              value={filters.repo}
-              onChange={(event) => onFilterChange("repo", event.target.value)}
-            >
-              <option value="">All repos</option>
-              {filterOptions.repos.map((item) => (
-                <option key={item.value} value={item.value}>
-                  {item.label}
-                </option>
-              ))}
-            </select>
-          }
-        />
-        <FilterField
-          label="Branch"
-          control={
-            <select
-              value={filters.branch}
-              onChange={(event) => onFilterChange("branch", event.target.value)}
-            >
-              <option value="">All branches</option>
-              {filterOptions.branches.map((item) => (
-                <option key={item.value} value={item.value}>
-                  {item.label}
-                </option>
-              ))}
-            </select>
-          }
-        />
+        {isCostPage ? (
+          <>
+            <FilterField
+              label="Source"
+              control={
+                <select
+                  value={filters.cost_source}
+                  onChange={(event) => onFilterChange("cost_source", event.target.value)}
+                >
+                  {filterOptions.costSources.map((item) => (
+                    <option key={item.value} value={item.value}>
+                      {item.label}
+                    </option>
+                  ))}
+                </select>
+              }
+            />
+            <FilterField
+              label="Bucket"
+              control={
+                <select
+                  value={filters.granularity}
+                  onChange={(event) => onFilterChange("granularity", event.target.value)}
+                >
+                  <option value="week">Week</option>
+                  <option value="month">Month</option>
+                </select>
+              }
+            />
+          </>
+        ) : (
+          <>
+            <FilterField
+              label="Repo"
+              control={
+                <select
+                  value={filters.repo}
+                  onChange={(event) => onFilterChange("repo", event.target.value)}
+                >
+                  <option value="">All repos</option>
+                  {filterOptions.repos.map((item) => (
+                    <option key={item.value} value={item.value}>
+                      {item.label}
+                    </option>
+                  ))}
+                </select>
+              }
+            />
+            <FilterField
+              label="Branch"
+              control={
+                <select
+                  value={filters.branch}
+                  onChange={(event) => onFilterChange("branch", event.target.value)}
+                >
+                  <option value="">All branches</option>
+                  {filterOptions.branches.map((item) => (
+                    <option key={item.value} value={item.value}>
+                      {item.label}
+                    </option>
+                  ))}
+                </select>
+              }
+            />
+          </>
+        )}
       </div>
 
-      <div className="filter-grid filter-grid--advanced">
-        <FilterField
-          label="Job"
-          control={
-            <select
-              value={filters.job_name}
-              onChange={(event) => onFilterChange("job_name", event.target.value)}
-            >
-              <option value="">All jobs</option>
-              {filterOptions.jobs.map((item) => (
-                <option key={item.value} value={item.value}>
-                  {item.label}
-                </option>
-              ))}
-            </select>
-          }
-        />
-        <FilterField
-          label="Cloud"
-          control={
-            <select
-              value={filters.cloud_phase}
-              onChange={(event) => onFilterChange("cloud_phase", event.target.value)}
-            >
-              <option value="">All clouds</option>
-              {filterOptions.cloudPhases.map((item) => (
-                <option key={item.value} value={item.value}>
-                  {item.label}
-                </option>
-              ))}
-            </select>
-          }
-        />
-        <FilterField
-          label="Issue status"
-          control={
-            <select
-              value={filters.issue_status}
-              onChange={(event) => onFilterChange("issue_status", event.target.value)}
-            >
-              <option value="">All issues</option>
-              <option value="open">Open</option>
-              <option value="closed">Closed</option>
-            </select>
-          }
-        />
-        <FilterField
-          label="Bucket"
-          control={
-            <select
-              value={filters.granularity}
-              onChange={(event) => onFilterChange("granularity", event.target.value)}
-            >
-              <option value="day">Day</option>
-              <option value="week">Week</option>
-              <option value="month">Month</option>
-            </select>
-          }
-        />
-      </div>
+      {!isCostPage && (
+        <div className="filter-grid filter-grid--advanced">
+          <FilterField
+            label="Job"
+            control={
+              <select
+                value={filters.job_name}
+                onChange={(event) => onFilterChange("job_name", event.target.value)}
+              >
+                <option value="">All jobs</option>
+                {filterOptions.jobs.map((item) => (
+                  <option key={item.value} value={item.value}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+            }
+          />
+          <FilterField
+            label="Cloud"
+            control={
+              <select
+                value={filters.cloud_phase}
+                onChange={(event) => onFilterChange("cloud_phase", event.target.value)}
+              >
+                <option value="">All clouds</option>
+                {filterOptions.cloudPhases.map((item) => (
+                  <option key={item.value} value={item.value}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+            }
+          />
+          <FilterField
+            label="Issue status"
+            control={
+              <select
+                value={filters.issue_status}
+                onChange={(event) => onFilterChange("issue_status", event.target.value)}
+              >
+                <option value="">All issues</option>
+                <option value="open">Open</option>
+                <option value="closed">Closed</option>
+              </select>
+            }
+          />
+          <FilterField
+            label="Bucket"
+            control={
+              <select
+                value={filters.granularity}
+                onChange={(event) => onFilterChange("granularity", event.target.value)}
+              >
+                <option value="day">Day</option>
+                <option value="week">Week</option>
+                <option value="month">Month</option>
+              </select>
+            }
+          />
+        </div>
+      )}
     </section>
   );
 }

--- a/ci-dashboard/web/src/lib/api.js
+++ b/ci-dashboard/web/src/lib/api.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { ALL_COST_SOURCES, COST_PATH } from "./filterUrl";
+
 function normalizePrefix(value) {
   if (!value || value === "/") {
     return "";
@@ -9,6 +11,7 @@ function normalizePrefix(value) {
 }
 
 const API_BASE = normalizePrefix(import.meta.env.VITE_API_BASE_URL || import.meta.env.BASE_URL);
+export const COST_DATA_LAG_DAYS = 4;
 
 export function getDefaultDateRange() {
   const end = new Date();
@@ -60,6 +63,22 @@ export function getPreviousCompleteSaturdayWeek(referenceDate = new Date()) {
   end.setDate(end.getDate() - daysSinceFriday);
   const start = new Date(end);
   start.setDate(start.getDate() - 6);
+  return {
+    start_date: toDateInputValue(start),
+    end_date: toDateInputValue(end),
+  };
+}
+
+export function getLaggedTrailingDateRange(
+  referenceDate = new Date(),
+  windowDays = 7,
+  lagDays = COST_DATA_LAG_DAYS,
+) {
+  const end = new Date(referenceDate);
+  end.setHours(0, 0, 0, 0);
+  end.setDate(end.getDate() - lagDays);
+  const start = new Date(end);
+  start.setDate(start.getDate() - windowDays + 1);
   return {
     start_date: toDateInputValue(start),
     end_date: toDateInputValue(end),
@@ -277,6 +296,35 @@ export function formatBrowserDateTime(value) {
   }).format(parsed);
 }
 
+export function formatCostSourceLabel(value) {
+  if (!value || value === ALL_COST_SOURCES) {
+    return "All sources";
+  }
+  const [vendor, accountId] = String(value || "").split(":");
+  if (!vendor || !accountId) {
+    return "Selected source";
+  }
+  return `${vendor} / ${accountId}`;
+}
+
+export function buildCostSourceOptions(items, selectedCostSource) {
+  const options = [
+    { value: ALL_COST_SOURCES, label: "All sources" },
+    ...(items || []),
+  ];
+  if (
+    selectedCostSource
+    && selectedCostSource !== ALL_COST_SOURCES
+    && !options.some((item) => item.value === selectedCostSource)
+  ) {
+    options.splice(1, 0, {
+      value: selectedCostSource,
+      label: formatCostSourceLabel(selectedCostSource),
+    });
+  }
+  return options;
+}
+
 export function formatDelta(current, previous, suffix = "") {
   const delta = Number(current || 0) - Number(previous || 0);
   const sign = delta > 0 ? "+" : "";
@@ -295,7 +343,14 @@ function parseIsoDate(value) {
   return new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
 }
 
-export function buildScopeLabel(filters) {
+export function buildScopeLabel(filters, pathname, costSourceLabel = "") {
+  if (pathname === COST_PATH) {
+    return [
+      costSourceLabel || formatCostSourceLabel(filters.cost_source),
+      `${filters.start_date} to ${filters.end_date}`,
+    ].join(" · ");
+  }
+
   const parts = [];
   if (filters.repo) {
     parts.push(filters.repo);

--- a/ci-dashboard/web/src/lib/filterUrl.js
+++ b/ci-dashboard/web/src/lib/filterUrl.js
@@ -2,6 +2,8 @@ export const CI_STATUS_PATH = "/ci-status";
 export const MIGRATE_STATUS_PATH = "/migrate-status";
 export const RUNTIME_INSIGHTS_PATH = "/runtime-insights";
 export const COST_PATH = "/cost";
+export const ALL_COST_SOURCES = "all";
+export const DEFAULT_COST_SOURCE = "gcp:pingcap-testing-account";
 export const FILTER_QUERY_KEYS = [
   "start_date",
   "end_date",
@@ -10,6 +12,7 @@ export const FILTER_QUERY_KEYS = [
   "job_name",
   "cloud_phase",
   "issue_status",
+  "cost_source",
   "granularity",
 ];
 export const WEEK_GRANULARITY_PATHS = new Set([
@@ -41,6 +44,7 @@ export function buildDefaultFilters(defaultRange, pathname) {
     job_name: "",
     cloud_phase: "",
     issue_status: "",
+    cost_source: pathname === COST_PATH ? DEFAULT_COST_SOURCE : "",
     granularity: WEEK_GRANULARITY_PATHS.has(pathname) ? "week" : "day",
     start_date: costRange.start_date,
     end_date: costRange.end_date,
@@ -68,6 +72,16 @@ export function normalizeFiltersForPath(pathname, filters) {
   }
   if (WEEK_GRANULARITY_PATHS.has(pathname) && pathname !== COST_PATH) {
     next.granularity = "week";
+  }
+  if (pathname === COST_PATH) {
+    next.repo = "";
+    next.branch = "";
+    next.job_name = "";
+    next.cloud_phase = "";
+    next.issue_status = "";
+    next.cost_source = next.cost_source || DEFAULT_COST_SOURCE;
+  } else {
+    next.cost_source = "";
   }
   return next;
 }

--- a/ci-dashboard/web/src/lib/filterUrl.test.js
+++ b/ci-dashboard/web/src/lib/filterUrl.test.js
@@ -60,6 +60,47 @@ test("keeps cost dashboard month buckets but normalizes invalid values", () => {
   );
 });
 
+test("keeps cost source on the cost tab and drops unrelated filters", () => {
+  const filters = readFiltersFromSearch(
+    defaultRange,
+    "/cost",
+    "?repo=pingcap%2Ftidb&branch=main&job_name=unit&cloud_phase=GCP&issue_status=open&cost_source=aws%3A946646677266&granularity=month",
+  );
+
+  assert.equal(filters.repo, "");
+  assert.equal(filters.branch, "");
+  assert.equal(filters.job_name, "");
+  assert.equal(filters.cloud_phase, "");
+  assert.equal(filters.issue_status, "");
+  assert.equal(filters.cost_source, "aws:946646677266");
+  assert.equal(filters.granularity, "month");
+});
+
+test("does not keep cost source outside the cost tab", () => {
+  const filters = readFiltersFromSearch(
+    defaultRange,
+    "/ci-status",
+    "?cost_source=aws%3A946646677266",
+  );
+
+  assert.equal(filters.cost_source, "");
+});
+
+test("serializes cost source for cost links", () => {
+  const search = buildFilterSearch(
+    {
+      ...buildDefaultFilters(defaultRange, "/cost"),
+      cost_source: "aws:946646677266",
+      granularity: "month",
+    },
+    "/cost",
+  );
+  const params = new URLSearchParams(search);
+
+  assert.equal(params.get("cost_source"), "aws:946646677266");
+  assert.equal(params.get("granularity"), "month");
+});
+
 test("compares filter values without being sensitive to object identity", () => {
   assert.equal(
     sameFilters(

--- a/ci-dashboard/web/src/pages/CostPage.jsx
+++ b/ci-dashboard/web/src/pages/CostPage.jsx
@@ -20,8 +20,6 @@ import {
   UnmatchedResourceTable,
 } from "../components/charts";
 
-const ANNUAL_GCP_BUDGET = 17300 * 12;
-const ANNUAL_TICDC_BUDGET = 4500 * 12;
 const SHARED_COST_GROUP = "Efficiency & Quality";
 
 export default function CostPage({ filters }) {
@@ -30,7 +28,6 @@ export default function CostPage({ filters }) {
   const weeklyOverviewRange = getLaggedTrailingDateRange();
   const selectedCostSource = filters.cost_source || DEFAULT_COST_SOURCE;
   const selectedCostSourceLabel = formatCostSourceLabel(selectedCostSource);
-  const isPrimaryBudgetScope = selectedCostSource === DEFAULT_COST_SOURCE;
   const selectedCostSourceValue =
     selectedCostSource === ALL_COST_SOURCES ? "" : selectedCostSource;
 
@@ -51,6 +48,8 @@ export default function CostPage({ filters }) {
   const engineeringGroupShare = useApiData("/api/v1/pages/cost-engineering-group-share", costFilters);
   const unmatchedResources = useApiData("/api/v1/pages/cost-unmatched-resources", costFilters);
   const summary = trend.data?.meta?.summary || {};
+  const configuredAnnualBudget = Number(weeklyOverview.data?.budget_health?.annual_budget || 0);
+  const hasConfiguredBudget = configuredAnnualBudget > 0;
   const stackTotal = (repoGroupStack.data?.items || []).reduce(
     (sum, item) => sum + Number(item.value || 0),
     0,
@@ -60,7 +59,7 @@ export default function CostPage({ filters }) {
   const costTrendSeries = withBudgetSeries(
     trend.data?.series,
     costFilters.granularity,
-    isPrimaryBudgetScope,
+    trend.data?.meta?.annual_budgets,
   );
   const weeklyLevel2Items = withSharedCostAllocation(
     weeklyOverview.data?.level2_share?.items,
@@ -100,8 +99,8 @@ export default function CostPage({ filters }) {
               label="Net cost"
               value={formatCurrency(weeklyOverview.data?.summary?.net_cost)}
               detail={
-                isPrimaryBudgetScope
-                  ? `Weekly budget ${formatCurrency(ANNUAL_GCP_BUDGET / 52)}`
+                hasConfiguredBudget
+                  ? `Weekly budget ${formatCurrency(configuredAnnualBudget / 52)}`
                   : "Budget not configured for this source"
               }
               delta={formatDelta(weeklyOverview.data?.summary?.net_cost_wow_pct)}
@@ -173,10 +172,10 @@ export default function CostPage({ filters }) {
         />
         <StatCard
           label="Annual budget"
-          value={isPrimaryBudgetScope ? formatCurrency(ANNUAL_GCP_BUDGET) : "--"}
+          value={hasConfiguredBudget ? formatCurrency(configuredAnnualBudget) : "--"}
           detail={
-            isPrimaryBudgetScope
-              ? `Includes ticdc ${formatCurrency(ANNUAL_TICDC_BUDGET)} / year`
+            hasConfiguredBudget
+              ? "Configured annual budget for the selected source"
               : "Budget not configured for the selected source"
           }
           tone="rose"
@@ -311,28 +310,42 @@ function formatDelta(value) {
   return `WoW ${sign}${formatPercent(numeric)}`;
 }
 
-function withBudgetSeries(series, granularity, enabled) {
+function withBudgetSeries(series, granularity, annualBudgets) {
   if (!series?.length) {
     return series;
   }
-  if (!enabled) {
+  const budgetByYear =
+    annualBudgets && typeof annualBudgets === "object" ? annualBudgets : {};
+  const budgetYears = Object.keys(budgetByYear);
+  if (!budgetYears.length) {
     return series;
   }
   const labels = Array.from(
     new Set(series.flatMap((item) => item.points.map((point) => point[0]))),
   ).sort();
-  const budgetPerBucket =
-    granularity === "month" ? ANNUAL_GCP_BUDGET / 12 : ANNUAL_GCP_BUDGET / 52;
+  const budgetPoints = labels.map((label) => {
+    const budgetYear = String(label).slice(0, 4);
+    const annualBudget = Number(budgetByYear[budgetYear] || 0);
+    if (!annualBudget) {
+      return [label, null];
+    }
+    const budgetPerBucket =
+      granularity === "month" ? annualBudget / 12 : annualBudget / 52;
+    return [label, budgetPerBucket];
+  });
+  if (!budgetPoints.some(([, value]) => value != null)) {
+    return series;
+  }
 
   return [
     ...series,
     {
-      key: "gcp_budget",
+      key: "budget_target",
       label: granularity === "month" ? "Monthly budget" : "Weekly budget",
       type: "line",
       dash: true,
       showPoints: false,
-      points: labels.map((label) => [label, budgetPerBucket]),
+      points: budgetPoints,
     },
   ];
 }

--- a/ci-dashboard/web/src/pages/CostPage.jsx
+++ b/ci-dashboard/web/src/pages/CostPage.jsx
@@ -1,16 +1,18 @@
 import { useState } from "react";
 
 import {
+  formatCostSourceLabel,
   formatCompactCurrency,
   formatCurrency,
   formatDateRangeLabel,
   formatPercent,
-  getPreviousCompleteSaturdayWeek,
+  getLaggedTrailingDateRange,
   useApiData,
 } from "../lib/api";
+import { ALL_COST_SOURCES, DEFAULT_COST_SOURCE } from "../lib/filterUrl";
 import {
+  BudgetHealthGauge,
   DonutShareChart,
-  LabeledDonutShareChart,
   PageIntro,
   Panel,
   StatCard,
@@ -25,15 +27,23 @@ const SHARED_COST_GROUP = "Efficiency & Quality";
 export default function CostPage({ filters }) {
   const [isWeeklyLevel2Shared, setIsWeeklyLevel2Shared] = useState(false);
   const [isSelectedLevel2Shared, setIsSelectedLevel2Shared] = useState(false);
-  const weeklyOverviewRange = getPreviousCompleteSaturdayWeek();
+  const weeklyOverviewRange = getLaggedTrailingDateRange();
+  const selectedCostSource = filters.cost_source || DEFAULT_COST_SOURCE;
+  const selectedCostSourceLabel = formatCostSourceLabel(selectedCostSource);
+  const isPrimaryBudgetScope = selectedCostSource === DEFAULT_COST_SOURCE;
+  const selectedCostSourceValue =
+    selectedCostSource === ALL_COST_SOURCES ? "" : selectedCostSource;
+
   const weeklyOverviewFilters = {
     ...weeklyOverviewRange,
     granularity: "week",
+    cost_source: selectedCostSourceValue,
   };
   const costFilters = {
     start_date: filters.start_date,
     end_date: filters.end_date,
     granularity: filters.granularity === "month" ? "month" : "week",
+    cost_source: selectedCostSourceValue,
   };
   const weeklyOverview = useApiData("/api/v1/pages/cost-weekly-overview", weeklyOverviewFilters);
   const trend = useApiData("/api/v1/pages/cost-trend", costFilters);
@@ -50,6 +60,7 @@ export default function CostPage({ filters }) {
   const costTrendSeries = withBudgetSeries(
     trend.data?.series,
     costFilters.granularity,
+    isPrimaryBudgetScope,
   );
   const weeklyLevel2Items = withSharedCostAllocation(
     weeklyOverview.data?.level2_share?.items,
@@ -65,8 +76,8 @@ export default function CostPage({ filters }) {
       <PageIntro
         eyebrow="Cost Insight"
         title="Cloud spend by time, repo, and engineering ownership"
-        description="A first read on GCP cost attribution after raw billing rows are joined with roster ownership."
-        kicker={`${costFilters.granularity} buckets`}
+        description="Cloud cost attribution across configured billing sources after billing rows are joined with roster ownership."
+        kicker={`${costFilters.granularity} buckets · ${selectedCostSourceLabel}`}
       />
 
       <Panel
@@ -88,49 +99,57 @@ export default function CostPage({ filters }) {
             <StatCard
               label="Net cost"
               value={formatCurrency(weeklyOverview.data?.summary?.net_cost)}
-              detail={`Weekly budget ${formatCurrency(ANNUAL_GCP_BUDGET / 52)}`}
+              detail={
+                isPrimaryBudgetScope
+                  ? `Weekly budget ${formatCurrency(ANNUAL_GCP_BUDGET / 52)}`
+                  : "Budget not configured for this source"
+              }
               delta={formatDelta(weeklyOverview.data?.summary?.net_cost_wow_pct)}
               tone="amber"
             />
           </div>
-          <div className="cost-weekly-overview__charts">
-            <LabeledDonutShareChart
-              title="GCP services"
-              subtitle="Services above 1% of list cost."
-              items={weeklyOverview.data?.service_share?.items}
-              totalValue={weeklyOverview.data?.service_share?.meta?.total_list_cost}
-              totalLabel="list cost"
-              emptyMessage="No service cost data for the previous complete week."
-            />
-            <LabeledDonutShareChart
-              title="Level 2 groups"
-              subtitle={
-                isWeeklyLevel2Shared
-                  ? `${SHARED_COST_GROUP} cost redistributed proportionally.`
-                  : "Groups above 1% of list cost."
+          <DonutShareChart
+            title="Level 2 groups"
+            subtitle={
+              isWeeklyLevel2Shared
+                ? `${SHARED_COST_GROUP} cost redistributed proportionally.`
+                : "Groups above 1% of list cost."
+            }
+            items={weeklyLevel2Items}
+            totalValue={weeklyOverview.data?.level2_share?.meta?.total_list_cost}
+            totalLabel="list cost"
+            emptyMessage="No Level 2 group above 1% for the previous complete week."
+            onItemSelect={(item) => {
+              if (item.name === SHARED_COST_GROUP) {
+                setIsWeeklyLevel2Shared(true);
               }
-              items={weeklyLevel2Items}
-              totalValue={weeklyOverview.data?.level2_share?.meta?.total_list_cost}
-              totalLabel="list cost"
-              emptyMessage="No Level 2 group above 1% for the previous complete week."
-              onItemSelect={(item) => {
-                if (item.name === SHARED_COST_GROUP) {
-                  setIsWeeklyLevel2Shared(true);
-                }
-              }}
-              headerAction={
-                isWeeklyLevel2Shared ? (
-                  <button
-                    type="button"
-                    className="donut-card__action"
-                    onClick={() => setIsWeeklyLevel2Shared(false)}
-                  >
-                    Reset
-                  </button>
-                ) : null
-              }
-            />
-          </div>
+            }}
+            headerAction={
+              isWeeklyLevel2Shared ? (
+                <button
+                  type="button"
+                  className="donut-card__action"
+                  onClick={() => setIsWeeklyLevel2Shared(false)}
+                >
+                  Reset
+                </button>
+              ) : null
+            }
+          />
+          <DonutShareChart
+            title="GCP services"
+            subtitle="Services above 1% of list cost."
+            items={weeklyOverview.data?.service_share?.items}
+            totalValue={weeklyOverview.data?.service_share?.meta?.total_list_cost}
+            totalLabel="list cost"
+            emptyMessage="No service cost data for the previous complete week."
+          />
+          <BudgetHealthGauge
+            title="Budget pace"
+            subtitle="Observed YTD net cost, a lag-adjusted checkpoint, and a year-end forecast from the prior 14 observed days."
+            data={weeklyOverview.data?.budget_health}
+            emptyMessage="Budget pace is not configured for this source yet."
+          />
         </div>
       </Panel>
 
@@ -154,8 +173,12 @@ export default function CostPage({ filters }) {
         />
         <StatCard
           label="Annual budget"
-          value={formatCurrency(ANNUAL_GCP_BUDGET)}
-          detail={`Includes ticdc ${formatCurrency(ANNUAL_TICDC_BUDGET)} / year`}
+          value={isPrimaryBudgetScope ? formatCurrency(ANNUAL_GCP_BUDGET) : "--"}
+          detail={
+            isPrimaryBudgetScope
+              ? `Includes ticdc ${formatCurrency(ANNUAL_TICDC_BUDGET)} / year`
+              : "Budget not configured for the selected source"
+          }
           tone="rose"
         />
       </section>
@@ -288,8 +311,11 @@ function formatDelta(value) {
   return `WoW ${sign}${formatPercent(numeric)}`;
 }
 
-function withBudgetSeries(series, granularity) {
+function withBudgetSeries(series, granularity, enabled) {
   if (!series?.length) {
+    return series;
+  }
+  if (!enabled) {
     return series;
   }
   const labels = Array.from(

--- a/ci-dashboard/web/src/styles.css
+++ b/ci-dashboard/web/src/styles.css
@@ -355,6 +355,24 @@ select {
   line-height: 1.45;
 }
 
+.cost-page__toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cost-page__filter {
+  width: min(100%, 360px);
+  padding: 1rem 1.05rem;
+  border-radius: 22px;
+  background: rgba(255, 253, 248, 0.8);
+  border: 1px solid var(--surface-border);
+}
+
+.cost-page__filter small {
+  color: var(--muted);
+  line-height: 1.4;
+}
+
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -416,22 +434,102 @@ select {
 
 .cost-weekly-overview__grid {
   display: grid;
-  grid-template-columns: minmax(220px, 0.7fr) minmax(0, 2fr);
+  grid-template-columns: minmax(220px, 0.95fr) repeat(3, minmax(0, 1fr));
   gap: 1rem;
   align-items: stretch;
 }
 
 .cost-weekly-overview__cards {
   display: grid;
-  grid-template-rows: repeat(2, minmax(0, 1fr));
   gap: 0.9rem;
+  align-content: start;
 }
 
-.cost-weekly-overview__charts {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.9rem;
+.cost-weekly-overview > .panel__body,
+.cost-weekly-overview__grid > * {
   min-width: 0;
+}
+
+.cost-weekly-overview .budget-gauge,
+.cost-weekly-overview .donut-card {
+  height: 100%;
+}
+
+.cost-weekly-overview .budget-gauge,
+.cost-weekly-overview .donut-card,
+.cost-weekly-overview .stat-card {
+  border-radius: 22px;
+}
+
+.cost-weekly-overview .budget-gauge,
+.cost-weekly-overview .donut-card {
+  padding: 0.9rem;
+}
+
+.cost-weekly-overview .budget-gauge {
+  gap: 0.72rem;
+}
+
+.cost-weekly-overview .budget-gauge__chart svg {
+  max-width: 204px;
+}
+
+.cost-weekly-overview .budget-gauge__summary {
+  font-size: 0.92rem;
+}
+
+.cost-weekly-overview .budget-gauge__metrics {
+  gap: 0.6rem;
+}
+
+.cost-weekly-overview .donut-card__header,
+.cost-weekly-overview .budget-gauge__header {
+  gap: 0.55rem;
+}
+
+.cost-weekly-overview .donut-card__header strong,
+.cost-weekly-overview .budget-gauge__header strong {
+  font-size: 0.98rem;
+}
+
+.cost-weekly-overview .donut-card__header p,
+.cost-weekly-overview .budget-gauge__header p {
+  font-size: 0.84rem;
+}
+
+.cost-weekly-overview .donut-card__body {
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.cost-weekly-overview .donut-chart svg {
+  max-width: 182px;
+}
+
+.cost-weekly-overview .donut-legend {
+  gap: 0.45rem;
+}
+
+.cost-weekly-overview .donut-legend__item {
+  padding: 0.58rem 0.64rem;
+  border-radius: 16px;
+  gap: 0.4rem;
+}
+
+.cost-weekly-overview .donut-legend__name,
+.cost-weekly-overview .donut-legend__value,
+.cost-weekly-overview .donut-legend__share {
+  font-size: 0.8rem;
+}
+
+.cost-weekly-overview .panel-badge {
+  font-size: 0.8rem;
+}
+
+.cost-weekly-overview .donut-card__action {
+  min-height: 2.05rem;
+  padding: 0.3rem 0.58rem;
 }
 
 @media (max-width: 900px) {
@@ -1037,6 +1135,122 @@ select {
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.62);
   border: 1px solid rgba(49, 87, 114, 0.08);
+}
+
+.budget-gauge {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid rgba(49, 87, 114, 0.08);
+}
+
+.budget-gauge--healthy {
+  background:
+    linear-gradient(180deg, rgba(15, 124, 130, 0.08), rgba(255, 255, 255, 0.72)),
+    rgba(255, 255, 255, 0.62);
+}
+
+.budget-gauge--warning {
+  background:
+    linear-gradient(180deg, rgba(209, 73, 91, 0.08), rgba(255, 255, 255, 0.72)),
+    rgba(255, 255, 255, 0.62);
+}
+
+.budget-gauge__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.budget-gauge__header strong {
+  display: block;
+}
+
+.budget-gauge__header p {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.budget-gauge__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.budget-gauge__status--healthy {
+  background: rgba(15, 124, 130, 0.12);
+  color: var(--accent);
+}
+
+.budget-gauge__status--warning {
+  background: rgba(209, 73, 91, 0.12);
+  color: var(--rose);
+}
+
+.budget-gauge__chart {
+  display: flex;
+  justify-content: center;
+}
+
+.budget-gauge__chart svg {
+  width: 100%;
+  max-width: 220px;
+  height: auto;
+}
+
+.budget-gauge__value {
+  fill: var(--ink);
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.budget-gauge__label {
+  fill: var(--muted);
+  font-size: 0.74rem;
+}
+
+.budget-gauge__summary {
+  margin: 0;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.budget-gauge__summary--healthy {
+  color: var(--accent);
+}
+
+.budget-gauge__summary--warning {
+  color: var(--rose);
+}
+
+.budget-gauge__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.budget-gauge__metrics div {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.budget-gauge__metrics dt {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.budget-gauge__metrics dd {
+  margin: 0;
+  font-weight: 600;
 }
 
 .donut-card__header {
@@ -1722,7 +1936,6 @@ select {
   }
 
   .donut-grid,
-  .cost-weekly-overview__charts,
   .runtime-compare-grid,
   .donut-card__body {
     grid-template-columns: 1fr;
@@ -1748,7 +1961,6 @@ select {
   .stats-grid,
   .progress-summary-grid,
   .cost-weekly-overview__grid,
-  .cost-weekly-overview__charts,
   .page-grid--overview,
   .flaky-highlight-row,
   .flaky-highlight-stack,
@@ -1761,6 +1973,7 @@ select {
   .page-intro,
   .filter-bar__header,
   .panel__header,
+  .budget-gauge__header,
   .donut-card__header,
   .runtime-compare-card__header,
   .modal-card__header,
@@ -1776,6 +1989,10 @@ select {
   }
 
   .runtime-compare-item__header {
+    grid-template-columns: 1fr;
+  }
+
+  .budget-gauge__metrics {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- move the Cost tab to a source-aware filter bar and hide unrelated global filters
- reorganize weekly overview and add a lag-aware budget pace card with 14-day forecast logic
- read annual budgets from `cost_budgets` for the selected source instead of hardcoded values, including the cost trend budget line
- tighten cost dashboard tests around source filtering, weekly overview windows, and budget health

## Testing
- PYTHONPATH=src ./.venv/bin/pytest --cov=src --cov-report=term
- PYTHONPATH=src ./.venv/bin/ruff check src tests
- npm run build
- node --test web/src/lib/filterUrl.test.js
