### PR TITLE
feat(cost-insight): add gcs cache cleanup dry-run jobs

### DIFF
--- a/cost-insight/README.md
+++ b/cost-insight/README.md
@@ -14,6 +14,7 @@ Current design:
 
 - [System design](docs/system-design.md)
 - [BigQuery cost optimization design](docs/bigquery-cost-optimization-design.md)
+- [GCS Bazel cache cleanup design](docs/gcs-bazel-cache-cleanup-design.md)
 
 ## Local Setup
 
@@ -170,3 +171,29 @@ summary importer from scanning already-backfilled historical export partitions.
 
 See [docs/bigquery-cost-optimization-design.md](docs/bigquery-cost-optimization-design.md)
 for the detailed table design, query shapes, and cost estimates.
+
+## GCS Bazel Cache Cleanup
+
+Summarize one day of access logs into BigQuery object last-seen tables:
+
+```bash
+cost-insight sync-gcs-cache-last-seen --run-date 2026-06-08
+```
+
+Validate the query shape without writing BigQuery summary tables:
+
+```bash
+cost-insight sync-gcs-cache-last-seen --run-date 2026-06-08 --dry-run
+```
+
+Build a weekly dry-run candidate report from the current last-seen table:
+
+```bash
+cost-insight cleanup-gcs-cache --mode dry-run
+```
+
+Override retention windows during validation:
+
+```bash
+cost-insight cleanup-gcs-cache --mode dry-run --ac-retention-days 21 --cas-retention-days 35
+```

--- a/cost-insight/docs/gcs-bazel-cache-cleanup-design.md
+++ b/cost-insight/docs/gcs-bazel-cache-cleanup-design.md
@@ -1,0 +1,685 @@
+# GCS Bazel Cache Cleanup Design
+
+## Context
+
+CI Bazel jobs use the GCS bucket
+`pingcap-ci-bazel-remote-cache-us-central1` as a remote cache backend.
+
+As of 2026-06-09, this bucket is the dominant storage consumer in the
+`pingcap-testing-account` project:
+
+- bucket size: about `589.97 TiB`
+- lifecycle: none
+- access log source: `pingcap-testing-account.ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access`
+- log sink: `ci-bazel-cache-gcs-data-access-to-bq`
+
+The bucket is already exporting Cloud Storage Data Access audit logs into
+BigQuery. The next step is to turn that access history into a safe cleanup
+workflow based on `last_seen_at`, not object age.
+
+One important caveat is that the access log was enabled recently, not at
+bucket inception. This bucket already contains a large historical object set,
+and many older objects may have produced neither `storage.objects.create` nor
+`storage.objects.get` events during the current audit-log window.
+
+This design keeps the implementation in `cost-insight`, because the project
+already owns:
+
+- BigQuery-backed cost and usage jobs
+- recurring batch jobs packaged into `cost-insight-jobs`
+- the `ee-apps` to `ee-ops` CronJob rollout flow
+
+## Goals
+
+1. Compute object-level `last_seen_at` for the Bazel remote cache with low
+   recurring BigQuery cost.
+2. Support a weekly dry-run and delete workflow based on "N days without
+   access".
+3. Keep the logic versioned in `ee-apps`, with deployment through `ee-ops`
+   CronJobs.
+4. Make the first slice conservative enough to observe safely before enabling
+   deletes.
+5. Cover the full current bucket object set before enabling delete, including
+   historical objects that predate the audit-log window.
+
+## Non-goals
+
+- Adding a dashboard page in the first slice.
+- Building a general GCS janitor for arbitrary buckets.
+- Exact deleted-byte accounting in the first slice.
+- Replacing GCS lifecycle rules for buckets whose retention can be expressed by
+  object age alone.
+- Enabling production delete from a logs-only view of the bucket.
+
+## Live Findings
+
+### Access window maturity
+
+As of 2026-06-09, the access-log table covers:
+
+- `first_ts = 2026-05-25 07:01:34 UTC`
+- `last_ts = 2026-06-09 06:35:08 UTC`
+
+That is enough to evaluate short-term reuse and to start a dry-run workflow,
+but not enough to claim that a `28-day no access` deletion policy is already
+validated by a full 28-day window. The earliest date when a full 28-day policy
+can be judged from this log stream is approximately 2026-06-22.
+
+### Read activity shape
+
+Recent log shape from the live table:
+
+- total rows in current window: about `659.7M`
+- `storage.objects.get`: about `575.0M`
+- `storage.objects.create`: about `84.7M`
+- one sampled day (`2026-06-08`) had about `39.6M` gets and about `7.24M`
+  creates
+
+### Reuse sample
+
+A deterministic `0.1%` sample of objects created between 2026-05-26 and
+2026-06-01 was checked against subsequent reads through 2026-06-09.
+
+Key findings:
+
+- sampled cohort size: `23,199` objects
+- `75.1%` were never read again after create
+- only `0.35%` were still read on or after day 7
+- only `0.14%` were still read on or after day 10
+- only `0.02%` were still read on or after day 14
+
+Split by kind:
+
+- `ac/` cools slightly faster than `cas/`
+- both prefixes become very cold after the first few days
+
+This supports a future LRU cleanup policy, but the first delete threshold
+should still be conservative because the available observation window is short.
+
+### Historical object gap
+
+Objects that were created before `2026-05-25` and have not produced any
+`storage.objects.get` or `storage.objects.create` event since that date will
+not be visible to the first-slice summary tables. This is not a small edge
+case. Because the access log was enabled after the bucket had already been in
+use, there may be a large historical population of still-existing objects that
+are completely invisible to the log-derived tables.
+
+That means:
+
+1. the current `last_seen` tables are accurate only for the log-visible subset
+   of objects
+2. a logs-only dry-run can help validate query shape and recent reuse behavior,
+   but it is not a complete candidate view for the whole bucket
+3. production delete must not rely only on the log-derived tables
+
+The design correction is to add a full object inventory source before delete.
+The recommended approach is GCS Inventory or Storage Insights exported into
+BigQuery, then joined with the log-derived `last_seen` state.
+
+After inventory is added, historical silent objects can still participate in a
+conservative LRU policy:
+
+- if an object existed before `2026-05-25` and no read has been observed since
+  `2026-05-25 07:01:34 UTC`, then by `2026-06-22 07:01:34 UTC` it is provably
+  at least 28 days cold
+- the same logic makes `42-day` silence provable on
+  `2026-07-06 07:01:34 UTC`
+
+So the real missing piece is not only `last_seen_at`, but full object
+enumeration.
+
+## Why Keep Object State in BigQuery
+
+The canonical object-access state should live in BigQuery, not TiDB.
+
+Reasons:
+
+1. The source of truth already lives in BigQuery.
+2. Object cardinality is high enough that daily object-level upserts would make
+   TiDB a poor fit for the first slice.
+3. The primary consumer is the cleanup job, not a latency-sensitive product
+   API.
+4. Keeping object state close to the source avoids an extra BigQuery -> app ->
+   TiDB transport step for millions of objects per day.
+
+TiDB may still be useful later for small control-plane or reporting tables, but
+the first slice should not mirror object-level cache state into TiDB.
+
+## Proposed Architecture
+
+```text
+GCS Data Access logs
+  -> BigQuery raw table
+  -> cost-insight daily summary job
+  -> BigQuery object_last_seen tables
+
+GCS Inventory / Storage Insights
+  -> BigQuery inventory snapshot table
+
+object_last_seen + inventory snapshot
+  -> cleanup state / candidate query
+  -> cost-insight weekly cleanup job
+  -> GCS delete operations
+```
+
+Implementation ownership:
+
+- `ee-apps/cost-insight`
+  - Python job code
+  - SQL templates
+  - design docs
+- `ee-ops/apps/gcp/cost-insight`
+  - CronJob manifests
+  - service account wiring
+  - rollout sequencing
+
+## BigQuery Data Model
+
+Use the existing dataset `ci_bazel_cache_logs` in project
+`pingcap-testing-account`, because it is already in the same region as the raw
+audit-log table.
+
+### `gcs_cache_object_last_seen_daily`
+
+Daily object-level aggregation from both `storage.objects.get` and
+`storage.objects.create`.
+
+Suggested schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_daily` (
+  ds DATE NOT NULL,
+  object_name STRING NOT NULL,
+  object_kind STRING NOT NULL,
+  first_seen_at TIMESTAMP NOT NULL,
+  last_seen_at TIMESTAMP NOT NULL,
+  get_count_in_day INT64 NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+PARTITION BY ds
+CLUSTER BY object_kind, object_name;
+```
+
+Column meanings:
+
+- `ds`: logical source day from `DATE(timestamp)`
+- `object_name`: extracted from
+  `protopayload_auditlog.resourceName`
+- `object_kind`: `cas`, `ac`, or `other`
+- `first_seen_at`: earliest event timestamp for that object in that day
+- `last_seen_at`: latest create-or-read timestamp for that object in that day
+- `get_count_in_day`: daily read count for that object
+- `updated_at`: job write timestamp
+
+### `gcs_cache_object_last_seen_current`
+
+Current object state, one row per object.
+
+Suggested schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current` (
+  object_name STRING NOT NULL,
+  object_kind STRING NOT NULL,
+  first_seen_at TIMESTAMP,
+  last_seen_at TIMESTAMP NOT NULL,
+  last_seen_date DATE NOT NULL,
+  total_get_count INT64 NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+CLUSTER BY object_kind, last_seen_date;
+```
+
+This table is one input to the weekly cleanup job, but it is not sufficient by
+itself for full-bucket cleanup decisions.
+
+By itself, this table is not a full-bucket inventory. It only tracks objects
+that are visible in the current audit-log window.
+
+### Required second-source table: `gcs_cache_object_inventory_current`
+
+Current object inventory, one row per object currently present in the bucket.
+
+Suggested schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_inventory_current` (
+  snapshot_date DATE NOT NULL,
+  object_name STRING NOT NULL,
+  object_kind STRING NOT NULL,
+  time_created TIMESTAMP,
+  size_bytes INT64,
+  updated_at TIMESTAMP NOT NULL
+)
+PARTITION BY snapshot_date
+CLUSTER BY object_kind, object_name;
+```
+
+Expected source:
+
+- preferred: GCS Inventory or Storage Insights export into BigQuery
+- fallback: a one-time bootstrap listing job plus periodic refresh, if the
+  platform path for inventory is blocked
+
+Purpose:
+
+- enumerate the whole current bucket object set
+- provide size metadata for better dry-run reporting
+- expose historical silent objects that do not appear in audit logs
+
+### Derived cleanup view: `gcs_cache_object_cleanup_state_current`
+
+This can be a table or a query-level CTE. It joins current inventory with
+log-derived `last_seen` state.
+
+Suggested fields:
+
+- `object_name`
+- `object_kind`
+- `time_created`
+- `size_bytes`
+- `log_first_seen_at`
+- `log_last_seen_at`
+- `has_log_activity`
+- `is_pre_window_inventory_only`
+- `no_access_observed_since`
+
+Semantics:
+
+- for log-visible objects, `log_last_seen_at` is the cleanup decision input
+- for inventory-only historical objects, `log_last_seen_at` is unknown, but
+  `no_access_observed_since = 2026-05-25 07:01:34 UTC` is still provable if the
+  object exists in inventory and has no post-window log activity
+- delete eligibility for inventory-only historical objects must be based on
+  provable silence since log start, not guessed last access time
+
+### Optional future table: `gcs_cache_cleanup_run_reports`
+
+The first slice can log run summaries to stdout and Cloud Logging only.
+If later we want durable run history in BigQuery, add a small report table such
+as:
+
+- `run_ts`
+- `mode`
+- `ac_retention_days`
+- `cas_retention_days`
+- `candidate_object_count`
+- `deleted_object_count`
+- `error_count`
+
+No object-level candidate archive is required in the first slice.
+
+## Job Design
+
+### 1. Daily summary job
+
+CLI shape:
+
+```bash
+cost-insight sync-gcs-cache-last-seen --run-date 2026-06-08
+```
+
+Responsibilities:
+
+1. Read one source day from
+   `ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access`
+2. Filter to:
+   - `resource.labels.bucket_name = "pingcap-ci-bazel-remote-cache-us-central1"`
+   - `protopayload_auditlog.methodName IN ("storage.objects.get", "storage.objects.create")`
+3. Extract `object_name`
+4. Classify `object_kind`
+5. Seed newly created objects into the summary even if they were never read
+6. Aggregate into `gcs_cache_object_last_seen_daily`
+7. `MERGE` daily results into `gcs_cache_object_last_seen_current`
+8. Emit a JSON summary with:
+   - source rows scanned
+   - distinct objects touched
+   - BigQuery bytes processed
+   - run date
+
+Important behavior:
+
+- rerunnable for the same `run-date`
+- one source day per run
+- no GCS delete behavior
+- not a complete bucket inventory on its own
+
+Suggested merge behavior:
+
+- `first_seen_at`: keep the earliest known timestamp
+- `last_seen_at`: keep the greatest value
+- `total_get_count`: add only `storage.objects.get` counts
+- `updated_at`: set to current run time
+
+### 2. Weekly cleanup job
+
+CLI shape:
+
+```bash
+cost-insight cleanup-gcs-cache --mode dry-run
+cost-insight cleanup-gcs-cache --mode delete
+```
+
+Responsibilities:
+
+1. Read the inventory-backed cleanup state
+2. Join with `gcs_cache_object_inventory_current` so the job sees the full
+   current bucket object set
+3. Build candidates with separate retention windows for `ac` and `cas`
+4. Exclude `other`
+5. In `dry-run` mode:
+   - print summary
+   - split counts into `log-visible` and `inventory-only historical`
+   - print example candidate samples
+   - exit without deleting
+6. In `delete` mode:
+   - delete candidates in batches
+   - collect success and error counts
+   - stop if safety thresholds are exceeded
+
+Suggested first-slice flags:
+
+```text
+--mode dry-run|delete
+--ac-retention-days 28
+--cas-retention-days 42
+--max-delete-objects 50000
+--batch-size 1000
+--sample-limit 100
+```
+
+Deletion should use the Python GCS client rather than shelling out to
+`gcloud storage rm`, so retries and per-object error handling stay in one
+process.
+
+## Query Shapes
+
+### Daily summary query
+
+Core aggregation shape:
+
+```sql
+SELECT
+  DATE(timestamp) AS ds,
+  REGEXP_EXTRACT(protopayload_auditlog.resourceName, r"/objects/(.+)$") AS object_name,
+  CASE
+    WHEN STARTS_WITH(REGEXP_EXTRACT(protopayload_auditlog.resourceName, r"/objects/(.+)$"), "cas/") THEN "cas"
+    WHEN STARTS_WITH(REGEXP_EXTRACT(protopayload_auditlog.resourceName, r"/objects/(.+)$"), "ac/") THEN "ac"
+    ELSE "other"
+  END AS object_kind,
+  MIN(timestamp) AS first_seen_at,
+  MAX(timestamp) AS last_seen_at,
+  COUNTIF(protopayload_auditlog.methodName = "storage.objects.get") AS get_count_in_day,
+  CURRENT_TIMESTAMP() AS updated_at
+FROM `pingcap-testing-account.ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access`
+WHERE DATE(timestamp) = @run_date
+  AND resource.labels.bucket_name = "pingcap-ci-bazel-remote-cache-us-central1"
+  AND protopayload_auditlog.methodName IN ("storage.objects.get", "storage.objects.create")
+GROUP BY ds, object_name, object_kind;
+```
+
+Measured dry-run cost for one daily source partition:
+
+- bytes processed: `9,885,639,778` bytes
+- about `9.89 GB`
+
+### Weekly cleanup query
+
+The weekly cleanup job should not read the raw audit-log table. It should read
+the inventory-backed cleanup state built from
+`gcs_cache_object_last_seen_current` plus
+`gcs_cache_object_inventory_current`.
+
+Example candidate query:
+
+```sql
+SELECT object_name, object_kind, size_bytes, effective_last_seen_at
+FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_cleanup_state_current`
+WHERE (
+    object_kind = 'ac'
+    AND (
+      (
+        has_log_activity
+        AND effective_last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_retention_days DAY)
+      ) OR (
+        is_pre_window_inventory_only
+        AND no_access_observed_since <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_retention_days DAY)
+      )
+    )
+  ) OR (
+    object_kind = 'cas'
+    AND (
+      (
+        has_log_activity
+        AND effective_last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_retention_days DAY)
+      ) OR (
+        is_pre_window_inventory_only
+        AND no_access_observed_since <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_retention_days DAY)
+      )
+    )
+  )
+ORDER BY object_kind, effective_last_seen_at
+LIMIT @max_delete_objects;
+```
+
+## Cost Model
+
+BigQuery scheduled queries and manual queries are priced the same. The first
+slice will run from a CronJob in `ee-ops`, but the underlying pricing model is
+still regular BigQuery query processing.
+
+At the current documented on-demand US rate:
+
+- first `1 TiB` per month per billing account: free
+- above that: `US $6.25 / TiB`
+
+Reference:
+
+- [BigQuery pricing](https://cloud.google.com/bigquery/pricing?hl=en_US)
+- [Scheduling queries](https://docs.cloud.google.com/bigquery/docs/scheduling-queries)
+
+### Estimated recurring scan cost
+
+Measured daily summary query:
+
+- about `9.89 GB/day`
+- about `69.2 GB/week`
+- about `0.0629 TiB/week`
+- about `US $0.39/week` at on-demand pricing before free-tier effects
+
+This means the recurring summary pipeline is cheap enough to run daily.
+
+### Why daily instead of weekly summary
+
+Daily summary is not chosen because it is dramatically cheaper than an ideal
+weekly incremental summary. If both scan each source day exactly once, total
+scan volume is similar.
+
+Daily summary is chosen because it gives:
+
+1. smaller failure domains
+2. simpler reruns
+3. a stable object-state table for weekly cleanup
+4. no need for the weekly cleaner to rescan raw access logs
+
+### Ad hoc analysis cost
+
+Measured sample query cost for a 14-day cohort study:
+
+- bytes processed: `128,657,528,203`
+- about `128.7 GB`
+- about `US $0.73/run`
+
+A similar 28-day access-pattern study would be expected to cost on the order of
+`~US $1.46/run`, assuming roughly linear growth in scanned days.
+
+This is acceptable for one-off validation, but it is not the right shape for a
+recurring weekly cleanup decision path.
+
+## What the First Slice Will Not Measure Exactly
+
+The current access-log table is strong on access recency, but weak on object
+size and whole-bucket coverage:
+
+- `storage.objects.get` rows often contain `metadataJson.requested_bytes`
+- `storage.objects.create` rows do not reliably expose full object size
+- historical silent objects may have no log rows in the current window
+
+Therefore, the first slice should report:
+
+- candidate object count
+- candidate split by `ac` and `cas`
+- oldest and newest candidate `last_seen_at`
+- example candidate names
+
+The first slice should not promise exact reclaimable TiB per run.
+
+If exact deleted-byte accounting and full-bucket coverage are required, add a
+second source such as GCS Inventory or Storage Insights and join it by
+`object_name`.
+
+## Recommended Retention Policy
+
+### Dry-run phase
+
+Start immediately with weekly dry-runs:
+
+- `ac`: `28 days no access`
+- `cas`: `42 days no access`
+
+Reasoning:
+
+- the sample shows very fast cooling
+- `cas` is the dominant storage consumer, but it is safer to retain longer in
+  the first delete slice
+- `ac` can be more aggressive because cache misses on action metadata are less
+  risky than a broken reference chain to missing content blobs
+
+### Delete phase
+
+Do not enable recurring delete until both conditions are true:
+
+1. the access-log window has matured far enough for the chosen retention
+2. inventory has been added so historical silent objects are not invisible
+
+Earliest possible dates after the current log start are:
+
+- `ac = 28 days`: approximately `2026-06-22 07:01:34 UTC`
+- `cas = 42 days`: approximately `2026-07-06 07:01:34 UTC`
+
+These dates are necessary but not sufficient. Delete should still remain
+blocked until the inventory join is in place.
+
+Even after that date, the first production step should be:
+
+1. keep the delete CronJob present but suspended
+2. run dry-run for at least 2-3 consecutive weeks
+3. inspect candidate volume and job health
+4. unsuspend delete with conservative per-run limits
+
+## Safety Guards
+
+The weekly delete job should include the following guards:
+
+1. `dry-run` as the default mode
+2. separate retention windows for `ac` and `cas`
+3. exclude `other`
+4. `concurrencyPolicy: Forbid`
+5. `suspend: true` for delete CronJob at initial rollout
+6. per-run maximum object limit
+7. batch delete limit
+8. stop the run if error rate exceeds a threshold
+9. idempotent handling for already-missing objects
+10. inventory snapshot freshness check before any delete run
+
+Suggested first values:
+
+- `max-delete-objects = 50,000`
+- `batch-size = 1,000`
+- stop if delete errors exceed `1%` or a fixed small absolute threshold
+
+Because exact object bytes are not available in the first slice, a strict
+`max-delete-bytes` guard should be deferred until inventory is added.
+
+## Rollout Shape
+
+### Code placement
+
+Add new code under:
+
+```text
+cost-insight/
+  docs/gcs-bazel-cache-cleanup-design.md
+  src/cost_insight/jobs/sync_gcs_cache_last_seen.py
+  src/cost_insight/jobs/cleanup_gcs_cache.py
+```
+
+CLI additions in:
+
+```text
+cost-insight/src/cost_insight/jobs/cli.py
+```
+
+### CronJob placement
+
+Add new manifests beside the existing cost-insight CronJobs in:
+
+```text
+ee-ops/apps/gcp/cost-insight/cronjobs.yaml
+```
+
+Suggested CronJobs:
+
+1. `cost-insight-sync-gcs-cache-last-seen`
+   - daily
+   - BQ read + BQ merge only
+2. `cost-insight-sync-gcs-cache-inventory`
+   - daily or weekly, depending on inventory export frequency
+   - refresh inventory-backed current table
+3. `cost-insight-cleanup-gcs-cache-dry-run`
+   - weekly
+   - full-bucket dry-run only
+4. `cost-insight-cleanup-gcs-cache-delete`
+   - weekly
+   - initially `suspend: true`
+
+The same `cost-insight-jobs` image can own all three commands.
+
+### IAM and runtime
+
+The CronJob service account needs:
+
+- BigQuery job execution
+- read/write access to dataset `ci_bazel_cache_logs`
+- GCS object delete permission on
+  `pingcap-ci-bazel-remote-cache-us-central1`
+
+If the existing `ci-dashboard` workload identity path is reused, add only the
+minimum incremental GCS permission needed for delete.
+
+## Concurrency and Recovery
+
+Only one active instance of each cleanup job type should run at a time.
+
+Recommended rules:
+
+- summary job may rerun safely for the same day
+- inventory sync may rerun safely for the same snapshot day
+- dry-run and delete must never overlap
+- a failed delete run should be rerunnable without manual cleanup of partially
+  processed object lists
+
+If later we need stronger operator visibility, add a small run-state table in
+TiDB or a BigQuery run-report table. That is not required for the first slice.
+
+## Open Questions
+
+1. Do we want to use GCS Inventory or Storage Insights as the full object
+   inventory source?
+2. If inventory export is not immediately available, do we want a one-time
+   bootstrap listing job as an interim fallback?
+3. Should the first delete slice remove only `ac`, or is `ac=28d` and
+   `cas=42d` acceptable immediately after the dry-run period?
+4. Do we want a small API or SQL report later for cleanup history, or are
+   CronJob logs enough?

--- a/cost-insight/src/cost_insight/common/bigquery.py
+++ b/cost-insight/src/cost_insight/common/bigquery.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+class BigQueryExecutionError(RuntimeError):
+    """Raised when a BigQuery query cannot be executed successfully."""
+
+
+@dataclass(frozen=True)
+class BigQueryParameter:
+    name: str
+    type_: str
+    value: Any
+
+
+@dataclass(frozen=True)
+class BigQueryQueryResult:
+    rows: tuple[dict[str, Any], ...]
+    total_bytes_processed: int | None
+
+
+def execute_query(
+    query: str,
+    *,
+    parameters: Sequence[BigQueryParameter] = (),
+) -> BigQueryQueryResult:
+    from google.cloud import bigquery
+
+    client = bigquery.Client()
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter(param.name, param.type_, param.value) for param in parameters
+        ]
+    )
+    try:
+        job = client.query(query, job_config=job_config)
+        rows = tuple(dict(row.items()) for row in job.result())
+    except Exception as exc:
+        parameter_names = ", ".join(param.name for param in parameters) or "none"
+        raise BigQueryExecutionError(
+            f"BigQuery query failed ({type(exc).__name__}) with parameters [{parameter_names}]: {exc}"
+        ) from exc
+    total_bytes_processed = getattr(job, "total_bytes_processed", None)
+    return BigQueryQueryResult(
+        rows=rows,
+        total_bytes_processed=int(total_bytes_processed) if total_bytes_processed is not None else None,
+    )

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -13,6 +13,11 @@ DEFAULT_GCP_BILLING_TABLE = (
 DEFAULT_GCP_ACCOUNT_ID = "pingcap-testing-account"
 DEFAULT_AWS_BILLING_TABLE = "gcp-digital-bi.stg_cloud_billing.stg_aws_billing"
 DEFAULT_EARLIEST_USAGE_DATE = date(2026, 1, 1)
+DEFAULT_GCS_CACHE_BUCKET = "pingcap-ci-bazel-remote-cache-us-central1"
+DEFAULT_GCS_CACHE_DATASET = "ci_bazel_cache_logs"
+DEFAULT_GCS_CACHE_AUDIT_LOG_TABLE = "cloudaudit_googleapis_com_data_access"
+DEFAULT_GCS_CACHE_LAST_SEEN_DAILY_TABLE = "gcs_cache_object_last_seen_daily"
+DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE = "gcs_cache_object_last_seen_current"
 
 
 @dataclass(frozen=True)
@@ -50,10 +55,26 @@ class AwsBillingSettings:
 
 
 @dataclass(frozen=True)
+class GcsCacheSettings:
+    project_id: str = DEFAULT_GCP_ACCOUNT_ID
+    bucket_name: str = DEFAULT_GCS_CACHE_BUCKET
+    dataset: str = DEFAULT_GCS_CACHE_DATASET
+    audit_log_table: str = DEFAULT_GCS_CACHE_AUDIT_LOG_TABLE
+    last_seen_daily_table: str = DEFAULT_GCS_CACHE_LAST_SEEN_DAILY_TABLE
+    last_seen_current_table: str = DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE
+    ac_retention_days: int = 28
+    cas_retention_days: int = 42
+    cleanup_sample_limit: int = 100
+    cleanup_max_delete_objects: int = 50000
+    cleanup_batch_size: int = 1000
+
+
+@dataclass(frozen=True)
 class Settings:
     database: DatabaseSettings
     gcp_billing: GcpBillingSettings = GcpBillingSettings()
     aws_billing: AwsBillingSettings = AwsBillingSettings()
+    gcs_cache: GcsCacheSettings = GcsCacheSettings()
     log_level: str = "INFO"
 
 
@@ -158,6 +179,85 @@ def load_settings(
                 5000,
             ),
         ),
+        gcs_cache=GcsCacheSettings(
+            project_id=_read_any(
+                env,
+                DEFAULT_GCP_ACCOUNT_ID,
+                "COST_INSIGHT_GCS_CACHE_PROJECT_ID",
+                "COST_GCS_CACHE_PROJECT_ID",
+                "GOOGLE_CLOUD_PROJECT",
+            ),
+            bucket_name=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_BUCKET,
+                "COST_INSIGHT_GCS_CACHE_BUCKET_NAME",
+                "COST_GCS_CACHE_BUCKET_NAME",
+            ),
+            dataset=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_DATASET,
+                "COST_INSIGHT_GCS_CACHE_DATASET",
+                "COST_GCS_CACHE_DATASET",
+            ),
+            audit_log_table=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_AUDIT_LOG_TABLE,
+                "COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE",
+                "COST_GCS_CACHE_AUDIT_LOG_TABLE",
+            ),
+            last_seen_daily_table=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_LAST_SEEN_DAILY_TABLE,
+                "COST_INSIGHT_GCS_CACHE_LAST_SEEN_DAILY_TABLE",
+                "COST_GCS_CACHE_LAST_SEEN_DAILY_TABLE",
+            ),
+            last_seen_current_table=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE,
+                "COST_INSIGHT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE",
+                "COST_GCS_CACHE_LAST_SEEN_CURRENT_TABLE",
+            ),
+            ac_retention_days=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS",
+                    "COST_GCS_CACHE_AC_RETENTION_DAYS",
+                ),
+                28,
+            ),
+            cas_retention_days=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS",
+                    "COST_GCS_CACHE_CAS_RETENTION_DAYS",
+                ),
+                42,
+            ),
+            cleanup_sample_limit=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_SAMPLE_LIMIT",
+                    "COST_GCS_CACHE_CLEANUP_SAMPLE_LIMIT",
+                ),
+                100,
+            ),
+            cleanup_max_delete_objects=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS",
+                    "COST_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS",
+                ),
+                50000,
+            ),
+            cleanup_batch_size=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_BATCH_SIZE",
+                    "COST_GCS_CACHE_CLEANUP_BATCH_SIZE",
+                ),
+                1000,
+            ),
+        ),
         log_level=_read_any(env, "INFO", "COST_INSIGHT_LOG_LEVEL", "COST_LOG_LEVEL").upper(),
     )
 
@@ -258,6 +358,10 @@ def _read_int_any(environ: Mapping[str, str], keys: tuple[str, ...], default: in
         if key in environ:
             return _read_int(environ, key, default)
     return default
+
+
+def _read_positive_int_any(environ: Mapping[str, str], keys: tuple[str, ...], default: int) -> int:
+    return _read_int_any(environ, keys, default)
 
 
 def _read_non_negative_int(

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+
+from cost_insight.common.bigquery import BigQueryParameter, BigQueryQueryResult, execute_query
+from cost_insight.common.config import GcsCacheSettings
+
+QueryExecutor = Callable[[str, list[BigQueryParameter]], BigQueryQueryResult]
+
+
+@dataclass(frozen=True)
+class CleanupGcsCacheSample:
+    object_name: str
+    object_kind: str
+    last_seen_at: datetime
+    idle_days: int
+
+
+@dataclass(frozen=True)
+class CleanupGcsCacheSummary:
+    account_id: str
+    bucket_name: str
+    mode: str
+    dry_run: bool
+    ac_retention_days: int
+    cas_retention_days: int
+    candidate_object_count: int
+    ac_candidate_count: int
+    cas_candidate_count: int
+    oldest_last_seen_at: datetime | None
+    newest_last_seen_at: datetime | None
+    sample_candidates: tuple[CleanupGcsCacheSample, ...]
+    bytes_processed: int | None
+
+
+def run_cleanup_gcs_cache(
+    *,
+    settings: GcsCacheSettings,
+    mode: str = "dry-run",
+    ac_retention_days: int | None = None,
+    cas_retention_days: int | None = None,
+    sample_limit: int | None = None,
+    execute: QueryExecutor = execute_query,
+) -> CleanupGcsCacheSummary:
+    if mode != "dry-run":
+        raise ValueError("cleanup-gcs-cache only supports --mode dry-run in the first slice")
+    resolved_ac_days = ac_retention_days or settings.ac_retention_days
+    resolved_cas_days = cas_retention_days or settings.cas_retention_days
+    resolved_sample_limit = sample_limit or settings.cleanup_sample_limit
+    parameters = [
+        BigQueryParameter("ac_retention_days", "INT64", resolved_ac_days),
+        BigQueryParameter("cas_retention_days", "INT64", resolved_cas_days),
+        BigQueryParameter("sample_limit", "INT64", resolved_sample_limit),
+    ]
+    result = execute(build_cleanup_gcs_cache_dry_run_query(settings), parameters=parameters)
+    row = result.rows[0] if result.rows else {}
+    sample_candidates = tuple(
+        CleanupGcsCacheSample(
+            object_name=str(item["object_name"]),
+            object_kind=str(item["object_kind"]),
+            last_seen_at=_coerce_datetime(item["last_seen_at"]),
+            idle_days=int(item["idle_days"]),
+        )
+        for item in (row.get("sample_candidates") or [])
+    )
+    return CleanupGcsCacheSummary(
+        account_id=settings.project_id,
+        bucket_name=settings.bucket_name,
+        mode=mode,
+        dry_run=True,
+        ac_retention_days=resolved_ac_days,
+        cas_retention_days=resolved_cas_days,
+        candidate_object_count=int(row.get("candidate_object_count", 0) or 0),
+        ac_candidate_count=int(row.get("ac_candidate_count", 0) or 0),
+        cas_candidate_count=int(row.get("cas_candidate_count", 0) or 0),
+        oldest_last_seen_at=_coerce_optional_datetime(row.get("oldest_last_seen_at")),
+        newest_last_seen_at=_coerce_optional_datetime(row.get("newest_last_seen_at")),
+        sample_candidates=sample_candidates,
+        bytes_processed=result.total_bytes_processed,
+    )
+
+
+def build_cleanup_gcs_cache_dry_run_query(settings: GcsCacheSettings) -> str:
+    current_table = _table_ref(
+        settings.project_id,
+        settings.dataset,
+        settings.last_seen_current_table,
+    )
+    return f"""
+WITH candidates AS (
+  SELECT
+    object_name,
+    object_kind,
+    last_seen_at,
+    TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), last_seen_at, DAY) AS idle_days
+  FROM {current_table}
+  WHERE (
+      object_kind = 'ac'
+      AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_retention_days DAY)
+    ) OR (
+      object_kind = 'cas'
+      AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_retention_days DAY)
+    )
+)
+SELECT
+  COUNT(*) AS candidate_object_count,
+  COUNTIF(object_kind = 'ac') AS ac_candidate_count,
+  COUNTIF(object_kind = 'cas') AS cas_candidate_count,
+  MIN(last_seen_at) AS oldest_last_seen_at,
+  MAX(last_seen_at) AS newest_last_seen_at,
+  ARRAY_AGG(
+    STRUCT(
+      object_name AS object_name,
+      object_kind AS object_kind,
+      last_seen_at AS last_seen_at,
+      idle_days AS idle_days
+    )
+    ORDER BY last_seen_at
+    LIMIT @sample_limit
+  ) AS sample_candidates
+FROM candidates
+""".strip()
+
+
+def _table_ref(project_id: str, dataset: str, table: str) -> str:
+    return f"`{project_id}.{dataset}.{table}`"
+
+
+def _coerce_optional_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    return _coerce_datetime(value)
+
+
+def _coerce_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    raise ValueError(f"Unsupported datetime value: {value!r}")

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -11,12 +11,14 @@ from cost_insight.common.config import AwsBillingSettings, GcpBillingSettings, g
 from cost_insight.common.db import build_engine
 from cost_insight.common.logging import configure_logging
 from cost_insight.jobs.backfill_cost_refine_from_raw import run_backfill_cost_refine_from_raw
+from cost_insight.jobs.cleanup_gcs_cache import run_cleanup_gcs_cache
 from cost_insight.jobs.cost_sources import list_active_cost_sources
 from cost_insight.jobs.refresh_attribution_daily import (
     CostAttributionSource,
     run_refresh_cost_attribution_daily,
     run_refresh_cost_attribution_from_summary,
 )
+from cost_insight.jobs.sync_gcs_cache_last_seen import run_sync_gcs_cache_last_seen
 from cost_insight.jobs.sync_aws_billing_summary import run_sync_aws_billing_summary
 from cost_insight.jobs.sync_aws_unmatched_resources import run_sync_aws_unmatched_resources
 from cost_insight.jobs.sync_gcp_billing_summary import run_sync_gcp_billing_summary
@@ -128,12 +130,35 @@ def build_parser() -> argparse.ArgumentParser:
         help="Refresh one usage date at a time; recommended for larger ranges.",
     )
 
+    sync_gcs_cache = subparsers.add_parser(
+        "sync-gcs-cache-last-seen",
+        help="Summarize one day of GCS Bazel cache access logs into BigQuery last-seen tables",
+    )
+    sync_gcs_cache.set_defaults(require_database=False)
+    sync_gcs_cache.add_argument("--run-date", type=_parse_date, default=None)
+    sync_gcs_cache.add_argument("--dry-run", action="store_true")
+
+    cleanup_gcs_cache = subparsers.add_parser(
+        "cleanup-gcs-cache",
+        help="Build dry-run cleanup candidates from GCS cache last-seen summaries",
+    )
+    cleanup_gcs_cache.set_defaults(require_database=False)
+    cleanup_gcs_cache.add_argument(
+        "--mode",
+        choices=("dry-run", "delete"),
+        default="dry-run",
+    )
+    cleanup_gcs_cache.add_argument("--ac-retention-days", type=int, default=None)
+    cleanup_gcs_cache.add_argument("--cas-retention-days", type=int, default=None)
+    cleanup_gcs_cache.add_argument("--sample-limit", type=int, default=None)
+
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    settings = get_settings(require_database=True)
+    require_database = getattr(args, "require_database", True)
+    settings = get_settings(require_database=require_database)
     configure_logging(settings.log_level)
 
     if args.command == "sync-gcp-billing-export":
@@ -287,6 +312,26 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         finally:
             engine.dispose()
+
+    if args.command == "sync-gcs-cache-last-seen":
+        summary = run_sync_gcs_cache_last_seen(
+            settings=settings.gcs_cache,
+            run_date=args.run_date,
+            dry_run=args.dry_run,
+        )
+        print(json.dumps(_summaries_to_json([summary]), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "cleanup-gcs-cache":
+        summary = run_cleanup_gcs_cache(
+            settings=settings.gcs_cache,
+            mode=args.mode,
+            ac_retention_days=args.ac_retention_days,
+            cas_retention_days=args.cas_retention_days,
+            sample_limit=args.sample_limit,
+        )
+        print(json.dumps(_summaries_to_json([summary]), indent=2, sort_keys=True))
+        return 0
 
     raise AssertionError(f"Unhandled command: {args.command}")  # pragma: no cover
 
@@ -468,43 +513,34 @@ def _summaries_to_json(summaries: Sequence[object]) -> object:
 
 
 def _summary_to_json(summary) -> dict[str, object]:
-    payload = {
-        "account_id": summary.account_id,
-        "dry_run": summary.dry_run,
+    return {
+        key: _jsonable(value)
+        for key, value in vars(summary).items()
+        if value is not None
     }
-    if hasattr(summary, "vendor") and getattr(summary, "vendor") is not None:
-        payload["vendor"] = getattr(summary, "vendor")
-    for field in (
-        "start_date",
-        "end_date",
-        "usage_start_date",
-        "usage_end_date",
-        "export_partition_start",
-        "export_partition_end",
-    ):
-        if hasattr(summary, field) and getattr(summary, field) is not None:
-            payload[field] = getattr(summary, field).isoformat()
-    for field in (
-        "rows_seen",
-        "rows_written",
-        "rows_deleted",
-        "rows_inserted",
-        "raw_rows",
-        "summary_rows",
-        "summary_rows_seen",
-        "summary_rows_written",
-        "unmatched_rows_seen",
-        "unmatched_rows_written",
-    ):
-        if hasattr(summary, field) and getattr(summary, field) is not None:
-            payload[field] = getattr(summary, field)
-    if hasattr(summary, "marked_summary_watermark"):
-        payload["marked_summary_watermark"] = summary.marked_summary_watermark
-    if hasattr(summary, "touched_usage_dates"):
-        payload["touched_usage_dates"] = [
-            usage_date.isoformat() for usage_date in summary.touched_usage_dates
-        ]
-    return payload
+
+
+def _jsonable(value):
+    if isinstance(value, date):
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except TypeError:
+            pass
+    if isinstance(value, tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _jsonable(item) for key, item in value.items()}
+    if hasattr(value, "__dict__"):
+        return {
+            key: _jsonable(item)
+            for key, item in vars(value).items()
+            if item is not None
+        }
+    return value
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -148,9 +148,9 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("dry-run", "delete"),
         default="dry-run",
     )
-    cleanup_gcs_cache.add_argument("--ac-retention-days", type=int, default=None)
-    cleanup_gcs_cache.add_argument("--cas-retention-days", type=int, default=None)
-    cleanup_gcs_cache.add_argument("--sample-limit", type=int, default=None)
+    cleanup_gcs_cache.add_argument("--ac-retention-days", type=_parse_positive_int, default=None)
+    cleanup_gcs_cache.add_argument("--cas-retention-days", type=_parse_positive_int, default=None)
+    cleanup_gcs_cache.add_argument("--sample-limit", type=_parse_positive_int, default=None)
 
     return parser
 
@@ -338,6 +338,16 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 def _parse_date(value: str) -> date:
     return date.fromisoformat(value)
+
+
+def _parse_positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+    return parsed
 
 
 def _run_sync_gcp_command(engine, *, settings, args):

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_last_seen.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_last_seen.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+
+from cost_insight.common.bigquery import BigQueryParameter, BigQueryQueryResult, execute_query
+from cost_insight.common.config import GcsCacheSettings
+
+QueryExecutor = Callable[[str, list[BigQueryParameter]], BigQueryQueryResult]
+
+
+@dataclass(frozen=True)
+class SyncGcsCacheLastSeenResult:
+    account_id: str
+    bucket_name: str
+    run_date: date
+    source_rows_seen: int
+    distinct_objects: int
+    dry_run: bool
+    bytes_processed: int | None
+
+
+def run_sync_gcs_cache_last_seen(
+    *,
+    settings: GcsCacheSettings,
+    run_date: date | None = None,
+    dry_run: bool = False,
+    execute: QueryExecutor = execute_query,
+) -> SyncGcsCacheLastSeenResult:
+    resolved_run_date = run_date or (datetime.now(timezone.utc).date() - timedelta(days=1))
+    parameters = [
+        BigQueryParameter("run_date", "DATE", resolved_run_date),
+        BigQueryParameter("bucket_name", "STRING", settings.bucket_name),
+    ]
+    query = (
+        build_sync_gcs_cache_last_seen_dry_run_query(settings)
+        if dry_run
+        else build_sync_gcs_cache_last_seen_query(settings)
+    )
+    result = execute(query, parameters=parameters)
+    row = result.rows[0] if result.rows else {}
+    return SyncGcsCacheLastSeenResult(
+        account_id=settings.project_id,
+        bucket_name=settings.bucket_name,
+        run_date=resolved_run_date,
+        source_rows_seen=int(row.get("source_rows_seen", 0) or 0),
+        distinct_objects=int(row.get("distinct_objects", 0) or 0),
+        dry_run=dry_run,
+        bytes_processed=result.total_bytes_processed,
+    )
+
+
+def build_sync_gcs_cache_last_seen_dry_run_query(settings: GcsCacheSettings) -> str:
+    return f"""
+WITH daily_rollup AS (
+  {_build_daily_rollup_select(settings)}
+)
+SELECT
+  COUNT(*) AS distinct_objects,
+  COALESCE(SUM(event_count_in_day), 0) AS source_rows_seen
+FROM daily_rollup
+""".strip()
+
+
+def build_sync_gcs_cache_last_seen_query(settings: GcsCacheSettings) -> str:
+    daily_table = _table_ref(
+        settings.project_id,
+        settings.dataset,
+        settings.last_seen_daily_table,
+    )
+    current_table = _table_ref(
+        settings.project_id,
+        settings.dataset,
+        settings.last_seen_current_table,
+    )
+    return f"""
+CREATE TABLE IF NOT EXISTS {daily_table} (
+  ds DATE NOT NULL,
+  object_name STRING NOT NULL,
+  object_kind STRING NOT NULL,
+  first_seen_at TIMESTAMP NOT NULL,
+  last_seen_at TIMESTAMP NOT NULL,
+  get_count_in_day INT64 NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+PARTITION BY ds
+CLUSTER BY object_kind, object_name;
+
+CREATE TABLE IF NOT EXISTS {current_table} (
+  object_name STRING NOT NULL,
+  object_kind STRING NOT NULL,
+  first_seen_at TIMESTAMP,
+  last_seen_at TIMESTAMP NOT NULL,
+  last_seen_date DATE NOT NULL,
+  total_get_count INT64 NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+CLUSTER BY object_kind, last_seen_date;
+
+CREATE TEMP TABLE daily_rollup AS
+{_build_daily_rollup_select(settings)};
+
+DELETE FROM {daily_table}
+WHERE ds = @run_date;
+
+INSERT INTO {daily_table} (
+  ds,
+  object_name,
+  object_kind,
+  first_seen_at,
+  last_seen_at,
+  get_count_in_day,
+  updated_at
+)
+SELECT
+  ds,
+  object_name,
+  object_kind,
+  first_seen_at,
+  last_seen_at,
+  get_count_in_day,
+  updated_at
+FROM daily_rollup;
+
+MERGE {current_table} AS target
+USING daily_rollup AS source
+ON target.object_name = source.object_name
+WHEN MATCHED THEN
+  UPDATE SET
+    object_kind = source.object_kind,
+    first_seen_at = IF(
+      target.first_seen_at IS NULL,
+      source.first_seen_at,
+      LEAST(target.first_seen_at, source.first_seen_at)
+    ),
+    last_seen_at = GREATEST(target.last_seen_at, source.last_seen_at),
+    last_seen_date = DATE(GREATEST(target.last_seen_at, source.last_seen_at)),
+    total_get_count = target.total_get_count + source.get_count_in_day,
+    updated_at = CURRENT_TIMESTAMP()
+WHEN NOT MATCHED THEN
+  INSERT (
+    object_name,
+    object_kind,
+    first_seen_at,
+    last_seen_at,
+    last_seen_date,
+    total_get_count,
+    updated_at
+  )
+  VALUES (
+    source.object_name,
+    source.object_kind,
+    source.first_seen_at,
+    source.last_seen_at,
+    DATE(source.last_seen_at),
+    source.get_count_in_day,
+    CURRENT_TIMESTAMP()
+  );
+
+SELECT
+  COUNT(*) AS distinct_objects,
+  COALESCE(SUM(event_count_in_day), 0) AS source_rows_seen
+FROM daily_rollup
+""".strip()
+
+
+def _build_daily_rollup_select(settings: GcsCacheSettings) -> str:
+    audit_log_table = _table_ref(
+        settings.project_id,
+        settings.dataset,
+        settings.audit_log_table,
+    )
+    return f"""
+WITH extracted AS (
+  SELECT
+    DATE(timestamp) AS ds,
+    REGEXP_EXTRACT(protopayload_auditlog.resourceName, r"/objects/(.+)$") AS object_name,
+    timestamp,
+    protopayload_auditlog.methodName AS method_name
+  FROM {audit_log_table}
+  WHERE DATE(timestamp) = @run_date
+    AND resource.labels.bucket_name = @bucket_name
+    AND protopayload_auditlog.methodName IN ("storage.objects.get", "storage.objects.create")
+)
+SELECT
+  ds,
+  object_name,
+  CASE
+    WHEN STARTS_WITH(object_name, "cas/") THEN "cas"
+    WHEN STARTS_WITH(object_name, "ac/") THEN "ac"
+    ELSE "other"
+  END AS object_kind,
+  MIN(timestamp) AS first_seen_at,
+  MAX(timestamp) AS last_seen_at,
+  COUNT(*) AS event_count_in_day,
+  COUNTIF(method_name = "storage.objects.get") AS get_count_in_day,
+  CURRENT_TIMESTAMP() AS updated_at
+FROM extracted
+GROUP BY ds, object_name, object_kind
+""".strip()
+
+
+def _table_ref(project_id: str, dataset: str, table: str) -> str:
+    return f"`{project_id}.{dataset}.{table}`"

--- a/cost-insight/tests/test_bigquery.py
+++ b/cost-insight/tests/test_bigquery.py
@@ -1,0 +1,80 @@
+import sys
+from types import ModuleType
+
+import pytest
+
+from cost_insight.common.bigquery import (
+    BigQueryExecutionError,
+    BigQueryParameter,
+    execute_query,
+)
+
+
+def _install_fake_bigquery(monkeypatch, *, client_class) -> None:
+    google_module = ModuleType("google")
+    cloud_module = ModuleType("google.cloud")
+    bigquery_module = ModuleType("google.cloud.bigquery")
+
+    class FakeScalarQueryParameter:
+        def __init__(self, name, type_, value):
+            self.name = name
+            self.type_ = type_
+            self.value = value
+
+    class FakeQueryJobConfig:
+        def __init__(self, query_parameters):
+            self.query_parameters = query_parameters
+
+    bigquery_module.Client = client_class
+    bigquery_module.QueryJobConfig = FakeQueryJobConfig
+    bigquery_module.ScalarQueryParameter = FakeScalarQueryParameter
+    cloud_module.bigquery = bigquery_module
+    google_module.cloud = cloud_module
+
+    monkeypatch.setitem(sys.modules, "google", google_module)
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_module)
+    monkeypatch.setitem(sys.modules, "google.cloud.bigquery", bigquery_module)
+
+
+def test_execute_query_returns_rows_and_bytes_processed(monkeypatch) -> None:
+    captured = {}
+
+    class FakeJob:
+        total_bytes_processed = 321
+
+        def result(self):
+            return [{"answer": 42}]
+
+    class FakeClient:
+        def query(self, query, job_config):
+            captured["query"] = query
+            captured["query_parameters"] = job_config.query_parameters
+            return FakeJob()
+
+    _install_fake_bigquery(monkeypatch, client_class=FakeClient)
+
+    result = execute_query(
+        "SELECT 42",
+        parameters=(BigQueryParameter("limit", "INT64", 1),),
+    )
+
+    assert result.rows == ({"answer": 42},)
+    assert result.total_bytes_processed == 321
+    assert captured["query"] == "SELECT 42"
+    assert captured["query_parameters"][0].name == "limit"
+    assert captured["query_parameters"][0].type_ == "INT64"
+    assert captured["query_parameters"][0].value == 1
+
+
+def test_execute_query_wraps_client_errors_with_context(monkeypatch) -> None:
+    class FakeClient:
+        def query(self, query, job_config):
+            raise ValueError("boom")
+
+    _install_fake_bigquery(monkeypatch, client_class=FakeClient)
+
+    with pytest.raises(BigQueryExecutionError, match="BigQuery query failed \\(ValueError\\).*boom"):
+        execute_query(
+            "SELECT broken",
+            parameters=(BigQueryParameter("run_date", "DATE", "2026-06-08"),),
+        )

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -81,3 +81,14 @@ def test_run_cleanup_gcs_cache_rejects_non_dry_run_mode() -> None:
             settings=GcsCacheSettings(project_id="pingcap-testing-account"),
             mode="delete",
         )
+
+
+def test_run_cleanup_gcs_cache_propagates_query_failures() -> None:
+    def fake_execute(query, parameters):
+        raise RuntimeError("Query execution failed")
+
+    with pytest.raises(RuntimeError, match="Query execution failed"):
+        run_cleanup_gcs_cache(
+            settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+            execute=fake_execute,
+        )

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from cost_insight.common.bigquery import BigQueryQueryResult
+from cost_insight.common.config import GcsCacheSettings
+from cost_insight.jobs.cleanup_gcs_cache import (
+    build_cleanup_gcs_cache_dry_run_query,
+    run_cleanup_gcs_cache,
+)
+
+
+def test_cleanup_gcs_cache_dry_run_query_targets_current_table() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    query = build_cleanup_gcs_cache_dry_run_query(settings)
+
+    assert "`pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`" in query
+    assert "ARRAY_AGG(" in query
+    assert "object_kind = 'ac'" in query
+    assert "object_kind = 'cas'" in query
+
+
+def test_run_cleanup_gcs_cache_returns_summary_with_samples() -> None:
+    captured = {}
+
+    def fake_execute(query, parameters):
+        captured["query"] = query
+        captured["parameters"] = {param.name: param.value for param in parameters}
+        return BigQueryQueryResult(
+            rows=(
+                {
+                    "candidate_object_count": 20,
+                    "ac_candidate_count": 5,
+                    "cas_candidate_count": 15,
+                    "oldest_last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc),
+                    "newest_last_seen_at": datetime(2026, 5, 10, 0, 0, tzinfo=timezone.utc),
+                    "sample_candidates": [
+                        {
+                            "object_name": "ac/foo",
+                            "object_kind": "ac",
+                            "last_seen_at": "2026-05-01T00:00:00+00:00",
+                            "idle_days": 39,
+                        },
+                        {
+                            "object_name": "cas/bar",
+                            "object_kind": "cas",
+                            "last_seen_at": "2026-05-02T00:00:00+00:00",
+                            "idle_days": 38,
+                        },
+                    ],
+                },
+            ),
+            total_bytes_processed=12345,
+        )
+
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="dry-run",
+        ac_retention_days=21,
+        cas_retention_days=35,
+        sample_limit=2,
+        execute=fake_execute,
+    )
+
+    assert captured["parameters"] == {
+        "ac_retention_days": 21,
+        "cas_retention_days": 35,
+        "sample_limit": 2,
+    }
+    assert summary.candidate_object_count == 20
+    assert summary.ac_candidate_count == 5
+    assert summary.cas_candidate_count == 15
+    assert len(summary.sample_candidates) == 2
+    assert summary.sample_candidates[0].object_name == "ac/foo"
+    assert summary.bytes_processed == 12345
+
+
+def test_run_cleanup_gcs_cache_rejects_non_dry_run_mode() -> None:
+    with pytest.raises(ValueError, match="only supports --mode dry-run"):
+        run_cleanup_gcs_cache(
+            settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+            mode="delete",
+        )

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -88,6 +88,37 @@ def test_load_settings_reads_aws_billing_settings() -> None:
     assert settings.aws_billing.page_size == 1000
 
 
+def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
+    settings = load_settings(
+        {
+            "GOOGLE_CLOUD_PROJECT": "override-project",
+            "COST_INSIGHT_GCS_CACHE_BUCKET_NAME": "custom-bucket",
+            "COST_INSIGHT_GCS_CACHE_DATASET": "custom_dataset",
+            "COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE": "raw_table",
+            "COST_INSIGHT_GCS_CACHE_LAST_SEEN_DAILY_TABLE": "daily_table",
+            "COST_INSIGHT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE": "current_table",
+            "COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS": "21",
+            "COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS": "35",
+            "COST_INSIGHT_GCS_CACHE_CLEANUP_SAMPLE_LIMIT": "25",
+            "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS": "500",
+            "COST_INSIGHT_GCS_CACHE_CLEANUP_BATCH_SIZE": "50",
+        },
+        require_database=False,
+    )
+
+    assert settings.gcs_cache.project_id == "override-project"
+    assert settings.gcs_cache.bucket_name == "custom-bucket"
+    assert settings.gcs_cache.dataset == "custom_dataset"
+    assert settings.gcs_cache.audit_log_table == "raw_table"
+    assert settings.gcs_cache.last_seen_daily_table == "daily_table"
+    assert settings.gcs_cache.last_seen_current_table == "current_table"
+    assert settings.gcs_cache.ac_retention_days == 21
+    assert settings.gcs_cache.cas_retention_days == 35
+    assert settings.gcs_cache.cleanup_sample_limit == 25
+    assert settings.gcs_cache.cleanup_max_delete_objects == 500
+    assert settings.gcs_cache.cleanup_batch_size == 50
+
+
 def test_load_settings_requires_database_when_not_skipped() -> None:
     with pytest.raises(ValueError, match="Missing required environment variable"):
         load_settings({})
@@ -99,6 +130,16 @@ def test_load_settings_rejects_invalid_positive_int() -> None:
             {
                 "COST_INSIGHT_DB_URL": "mysql+pymysql://user:pass@127.0.0.1:4000/cost",
                 "COST_INSIGHT_SYNC_PAGE_SIZE": "0",
+            }
+        )
+
+
+def test_load_settings_rejects_invalid_gcs_cache_positive_int() -> None:
+    with pytest.raises(ValueError, match="COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS must be positive"):
+        load_settings(
+            {
+                "COST_INSIGHT_DB_URL": "mysql+pymysql://user:pass@127.0.0.1:4000/cost",
+                "COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS": "-1",
             }
         )
 

--- a/cost-insight/tests/test_db_and_cli.py
+++ b/cost-insight/tests/test_db_and_cli.py
@@ -1,6 +1,7 @@
 from datetime import date
 from types import SimpleNamespace
 
+import pytest
 from sqlalchemy import create_engine, text
 
 from cost_insight.common import db
@@ -8,7 +9,9 @@ from cost_insight.common.config import AwsBillingSettings, DatabaseSettings, Gcp
 from cost_insight.common.logging import configure_logging
 from cost_insight.jobs import cli
 from cost_insight.jobs.backfill_cost_refine_from_raw import BackfillCostRefineFromRawSummary
+from cost_insight.jobs.cleanup_gcs_cache import CleanupGcsCacheSummary
 from cost_insight.jobs.refresh_attribution_daily import CostAttributionSource, RefreshAttributionSummary
+from cost_insight.jobs.sync_gcs_cache_last_seen import SyncGcsCacheLastSeenResult
 from cost_insight.jobs.sync_gcp_billing_summary import SyncGcpBillingSummaryResult
 from cost_insight.jobs.sync_gcp_billing_export import SyncGcpBillingSummary
 from cost_insight.jobs.sync_gcp_unmatched_resources import SyncGcpUnmatchedResourcesSummary
@@ -210,6 +213,99 @@ def test_cli_split_by_day_runs_each_date(monkeypatch, capsys) -> None:
         (date(2026, 5, 12), date(2026, 5, 12), False, None),
     ]
     assert '"start_date": "2026-05-10"' in capsys.readouterr().out
+
+
+def test_cli_runs_sync_gcs_cache_last_seen_without_database(monkeypatch, capsys) -> None:
+    calls = []
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
+        gcs_cache=SimpleNamespace(),
+        log_level="INFO",
+    )
+
+    def fake_get_settings(require_database=True):
+        calls.append(require_database)
+        return settings
+
+    monkeypatch.setattr(cli, "get_settings", fake_get_settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(
+        cli,
+        "run_sync_gcs_cache_last_seen",
+        lambda **kwargs: SyncGcsCacheLastSeenResult(
+            account_id="pingcap-testing-account",
+            bucket_name="pingcap-ci-bazel-remote-cache-us-central1",
+            run_date=date(2026, 6, 8),
+            source_rows_seen=123,
+            distinct_objects=45,
+            dry_run=True,
+            bytes_processed=678,
+        ),
+    )
+
+    exit_code = cli.main(["sync-gcs-cache-last-seen", "--run-date", "2026-06-08", "--dry-run"])
+
+    assert exit_code == 0
+    assert calls == [False]
+    assert '"distinct_objects": 45' in capsys.readouterr().out
+
+
+def test_cli_runs_cleanup_gcs_cache_without_database(monkeypatch, capsys) -> None:
+    calls = []
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
+        gcs_cache=SimpleNamespace(),
+        log_level="INFO",
+    )
+
+    def fake_get_settings(require_database=True):
+        calls.append(require_database)
+        return settings
+
+    monkeypatch.setattr(cli, "get_settings", fake_get_settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(
+        cli,
+        "run_cleanup_gcs_cache",
+        lambda **kwargs: CleanupGcsCacheSummary(
+            account_id="pingcap-testing-account",
+            bucket_name="pingcap-ci-bazel-remote-cache-us-central1",
+            mode="dry-run",
+            dry_run=True,
+            ac_retention_days=28,
+            cas_retention_days=42,
+            candidate_object_count=99,
+            ac_candidate_count=10,
+            cas_candidate_count=89,
+            oldest_last_seen_at=None,
+            newest_last_seen_at=None,
+            sample_candidates=(),
+            bytes_processed=456,
+        ),
+    )
+
+    exit_code = cli.main(["cleanup-gcs-cache", "--mode", "dry-run"])
+
+    assert exit_code == 0
+    assert calls == [False]
+    assert '"candidate_object_count": 99' in capsys.readouterr().out
+
+
+def test_cli_surfaces_cleanup_gcs_cache_mode_error(monkeypatch) -> None:
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
+        gcs_cache=SimpleNamespace(),
+        log_level="INFO",
+    )
+
+    monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+
+    with pytest.raises(ValueError, match="only supports --mode dry-run"):
+        cli.main(["cleanup-gcs-cache", "--mode", "delete"])
 
 
 def test_cli_runs_refresh_attribution_command(monkeypatch, capsys) -> None:

--- a/cost-insight/tests/test_db_and_cli.py
+++ b/cost-insight/tests/test_db_and_cli.py
@@ -308,6 +308,24 @@ def test_cli_surfaces_cleanup_gcs_cache_mode_error(monkeypatch) -> None:
         cli.main(["cleanup-gcs-cache", "--mode", "delete"])
 
 
+def test_cli_rejects_non_positive_cleanup_retention_days(capsys) -> None:
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit, match="2"):
+        parser.parse_args(["cleanup-gcs-cache", "--ac-retention-days", "0"])
+
+    assert "expected a positive integer" in capsys.readouterr().err
+
+
+def test_cli_rejects_non_positive_cleanup_sample_limit(capsys) -> None:
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit, match="2"):
+        parser.parse_args(["cleanup-gcs-cache", "--sample-limit", "-1"])
+
+    assert "expected a positive integer" in capsys.readouterr().err
+
+
 def test_cli_runs_refresh_attribution_command(monkeypatch, capsys) -> None:
     disposed = []
     captured = {}

--- a/cost-insight/tests/test_sync_gcs_cache_last_seen.py
+++ b/cost-insight/tests/test_sync_gcs_cache_last_seen.py
@@ -1,0 +1,101 @@
+from datetime import date, datetime, timezone
+
+import cost_insight.jobs.sync_gcs_cache_last_seen as sync_gcs_cache_last_seen
+from cost_insight.common.bigquery import BigQueryQueryResult
+from cost_insight.common.config import GcsCacheSettings
+from cost_insight.jobs.sync_gcs_cache_last_seen import (
+    build_sync_gcs_cache_last_seen_dry_run_query,
+    build_sync_gcs_cache_last_seen_query,
+    run_sync_gcs_cache_last_seen,
+)
+
+
+def test_sync_gcs_cache_last_seen_dry_run_uses_expected_query_shape() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    query = build_sync_gcs_cache_last_seen_dry_run_query(settings)
+
+    assert "storage.objects.get" in query
+    assert "storage.objects.create" in query
+    assert "WITH extracted AS (" in query
+    assert "COUNT(*) AS distinct_objects" in query
+    assert "COALESCE(SUM(event_count_in_day), 0) AS source_rows_seen" in query
+    assert "COUNTIF(method_name = \"storage.objects.get\") AS get_count_in_day" in query
+    assert "resource.labels.bucket_name = @bucket_name" in query
+
+
+def test_sync_gcs_cache_last_seen_query_creates_and_merges_tables() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    query = build_sync_gcs_cache_last_seen_query(settings)
+
+    assert (
+        "CREATE TABLE IF NOT EXISTS `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_daily`"
+        in query
+    )
+    assert "first_seen_at TIMESTAMP NOT NULL" in query
+    assert (
+        "CREATE TABLE IF NOT EXISTS `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`"
+        in query
+    )
+    assert (
+        "MERGE `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current` AS target"
+        in query
+    )
+    assert "DELETE FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_daily`" in query
+    assert "event_count_in_day" not in query.partition("INSERT INTO")[2].partition("FROM daily_rollup")[0]
+
+
+def test_run_sync_gcs_cache_last_seen_returns_summary_from_executor() -> None:
+    captured = {}
+
+    def fake_execute(query, parameters):
+        captured["query"] = query
+        captured["parameters"] = {param.name: param.value for param in parameters}
+        return BigQueryQueryResult(
+            rows=({"distinct_objects": 12, "source_rows_seen": 345},),
+            total_bytes_processed=987654321,
+        )
+
+    summary = run_sync_gcs_cache_last_seen(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        run_date=date(2026, 6, 8),
+        dry_run=True,
+        execute=fake_execute,
+    )
+
+    assert captured["parameters"] == {
+        "run_date": date(2026, 6, 8),
+        "bucket_name": "pingcap-ci-bazel-remote-cache-us-central1",
+    }
+    assert summary.account_id == "pingcap-testing-account"
+    assert summary.run_date == date(2026, 6, 8)
+    assert summary.distinct_objects == 12
+    assert summary.source_rows_seen == 345
+    assert summary.bytes_processed == 987654321
+    assert summary.dry_run is True
+
+
+def test_run_sync_gcs_cache_last_seen_defaults_to_yesterday_utc(monkeypatch) -> None:
+    captured = {}
+
+    class FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 6, 10, 12, 0, 0, tzinfo=tz or timezone.utc)
+
+    def fake_execute(query, parameters):
+        captured["parameters"] = {param.name: param.value for param in parameters}
+        return BigQueryQueryResult(
+            rows=({"distinct_objects": 0, "source_rows_seen": 0},),
+            total_bytes_processed=None,
+        )
+
+    monkeypatch.setattr(sync_gcs_cache_last_seen, "datetime", FrozenDatetime)
+
+    summary = run_sync_gcs_cache_last_seen(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        dry_run=True,
+        execute=fake_execute,
+    )
+
+    assert captured["parameters"]["run_date"] == date(2026, 6, 9)
+    assert summary.run_date == date(2026, 6, 9)


### PR DESCRIPTION
## Summary
- add the first GCS Bazel cache cleanup slice in cost-insight with BigQuery-backed last-seen sync and cleanup dry-run commands
- document the design, including create-event seeding, historical-object limitations, and the inventory requirement before delete
- add config, CLI wiring, and tests for the new jobs and BigQuery helper

## Testing
- python -m ruff check cost-insight/src/cost_insight/common/bigquery.py cost-insight/src/cost_insight/common/config.py cost-insight/src/cost_insight/jobs/cli.py cost-insight/src/cost_insight/jobs/sync_gcs_cache_last_seen.py cost-insight/tests/test_bigquery.py cost-insight/tests/test_sync_gcs_cache_last_seen.py cost-insight/tests/test_cleanup_gcs_cache.py cost-insight/tests/test_config.py cost-insight/tests/test_db_and_cli.py
- python -m pytest cost-insight/tests