### PR TITLE
feat(dashboard): Add dashboard breakdown controls

### DIFF
--- a/ci-dashboard/pyproject.toml
+++ b/ci-dashboard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-dashboard"
-version = "0.4.1"
+version = "0.4.2"
 description = "CI dashboard jobs and API scaffold"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
+++ b/ci-dashboard/src/ci_dashboard.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: ci-dashboard
-Version: 0.4.1
+Version: 0.4.2
 Summary: CI dashboard jobs and API scaffold
 Requires-Python: >=3.11
 Description-Content-Type: text/markdown

--- a/ci-dashboard/src/ci_dashboard/__init__.py
+++ b/ci-dashboard/src/ci_dashboard/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/ci-dashboard/src/ci_dashboard/api/queries/builds.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/builds.py
@@ -25,6 +25,7 @@ MIGRATION_MIN_SUCCESS_RUNS = 5
 MIGRATION_IMPROVED_LIMIT = 10
 MIGRATION_REGRESSED_LIMIT = 10
 BUILD_TREND_JOB_RANKING_LIMIT = 10
+BUILD_COUNT_BREAKDOWN_LIMIT = 8
 MIGRATION_FIXED_BASELINE_START = date(2025, 12, 15)
 MIGRATION_FIXED_BASELINE_END = date(2026, 1, 14)
 MIGRATION_FIXED_RECENT_START = date(2026, 4, 15)
@@ -355,6 +356,163 @@ def get_cloud_migration_summary(engine: Engine, filters: CommonFilters) -> dict[
         "total_duration_s": total_duration_s,
         "gcp_duration_share_pct": rate_pct(gcp_total_duration_s, total_duration_s),
         "meta": filters.meta(),
+    }
+
+
+def get_build_count_breakdown_trend(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+    return {
+        "repo": _get_build_count_dimension_trend(
+            engine,
+            filters,
+            dimension_key="repo",
+            dimension_expr="COALESCE(NULLIF(b.repo_full_name, ''), '(unknown repo)')",
+            empty_label="(unknown repo)",
+        ),
+        "branch": _get_build_count_dimension_trend(
+            engine,
+            filters,
+            dimension_key="branch",
+            dimension_expr=f"COALESCE(NULLIF({branch_expr('b')}, ''), '(unknown branch)')",
+            empty_label="(unknown branch)",
+        ),
+        "author": _get_build_count_dimension_trend(
+            engine,
+            filters,
+            dimension_key="author",
+            dimension_expr="COALESCE(NULLIF(b.author, ''), '(unknown author)')",
+            empty_label="(unknown author)",
+        ),
+        "meta": {
+            **filters.meta(),
+            "limit": BUILD_COUNT_BREAKDOWN_LIMIT,
+        },
+    }
+
+
+def _get_build_count_dimension_trend(
+    engine: Engine,
+    filters: CommonFilters,
+    *,
+    dimension_key: str,
+    dimension_expr: str,
+    empty_label: str,
+) -> dict[str, Any]:
+    with engine.begin() as connection:
+        where_clause, params = build_common_where(filters, table_alias="b")
+        builds_table = builds_table_expr(connection, filters, alias="b")
+        bucket = bucket_expr(connection, "b.start_time", filters.granularity)
+        rows = connection.execute(
+            text(
+                f"""
+                SELECT
+                  {bucket} AS bucket_start,
+                  {dimension_expr} AS dimension_name,
+                  COUNT(*) AS build_count
+                FROM {builds_table}
+                WHERE {where_clause}
+                GROUP BY bucket_start, {dimension_expr}
+                ORDER BY bucket_start, build_count DESC, dimension_name ASC
+                """
+            ),
+            params,
+        ).mappings()
+        data_rows = [dict(row) for row in rows]
+        if filters.granularity == "week":
+            data_rows = filter_complete_week_rows(
+                data_rows,
+                start_date=filters.start_date,
+                end_date=filters.end_date,
+            )
+
+    totals: dict[str, int] = {}
+    buckets: set[str] = set()
+    counts_by_dimension: dict[str, dict[str, int]] = {}
+    for row in data_rows:
+        bucket_start = str(row["bucket_start"])
+        dimension_name = str(row["dimension_name"] or empty_label)
+        build_count = int(row["build_count"] or 0)
+        buckets.add(bucket_start)
+        totals[dimension_name] = totals.get(dimension_name, 0) + build_count
+        counts_by_dimension.setdefault(dimension_name, {})[bucket_start] = build_count
+
+    ordered_buckets = sorted(buckets)
+    if not ordered_buckets:
+        return {
+            "items": [],
+            "series": [],
+            "meta": {
+                **filters.meta(),
+                "dimension": dimension_key,
+                "limit": BUILD_COUNT_BREAKDOWN_LIMIT,
+            },
+        }
+
+    total_builds = sum(totals.values())
+    ordered_dimensions = sorted(
+        totals,
+        key=lambda name: (-totals[name], name),
+    )
+    visible_dimensions = ordered_dimensions[:BUILD_COUNT_BREAKDOWN_LIMIT]
+    overflow_dimensions = ordered_dimensions[BUILD_COUNT_BREAKDOWN_LIMIT:]
+
+    items = [
+        {
+            "name": dimension_name,
+            "value": totals[dimension_name],
+            "share_pct": rate_pct(totals[dimension_name], total_builds),
+        }
+        for dimension_name in visible_dimensions
+    ]
+    if overflow_dimensions:
+        other_total = sum(totals[dimension_name] for dimension_name in overflow_dimensions)
+        items.append(
+            {
+                "name": "Others",
+                "value": other_total,
+                "share_pct": rate_pct(other_total, total_builds),
+            }
+        )
+
+    series = [
+        {
+            "key": f"{dimension_key}:{dimension_name}",
+            "label": dimension_name,
+            "type": "bar",
+            "points": [
+                [bucket_start, counts_by_dimension.get(dimension_name, {}).get(bucket_start, 0)]
+                for bucket_start in ordered_buckets
+            ],
+        }
+        for dimension_name in visible_dimensions
+    ]
+    if overflow_dimensions:
+        series.append(
+            {
+                "key": f"{dimension_key}:Others",
+                "label": "Others",
+                "type": "bar",
+                "points": [
+                    [
+                        bucket_start,
+                        sum(
+                            counts_by_dimension.get(dimension_name, {}).get(bucket_start, 0)
+                            for dimension_name in overflow_dimensions
+                        ),
+                    ]
+                    for bucket_start in ordered_buckets
+                ],
+            }
+        )
+
+    return {
+        "items": items,
+        "series": series,
+        "meta": {
+            **filters.meta(),
+            "dimension": dimension_key,
+            "limit": BUILD_COUNT_BREAKDOWN_LIMIT,
+            "total_builds": total_builds,
+        },
     }
 
 

--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -12,6 +12,7 @@ from sqlalchemy.engine import Connection, Engine
 from ci_dashboard.api.queries.base import CommonFilters, bucket_expr, rate_pct, to_number
 
 COST_STACK_LIMIT = 8
+VALID_COST_STACK_GROUPS = frozenset({"repo", "author", "team"})
 UNMATCHED_RESOURCE_LIMIT = 20
 UNMATCHED_RESOURCE_MAX_WINDOW_DAYS = 31
 ENGINEERING_GROUP_NAME = "Engineering Group"
@@ -255,76 +256,85 @@ def _get_engineering_share_by_level_threshold(
         )
 
 
-def get_repo_group_cost_stack(engine: Engine, filters: CommonFilters) -> dict[str, Any]:
+def get_repo_group_cost_stack(
+    engine: Engine,
+    filters: CommonFilters,
+    *,
+    group_by: str = "repo",
+) -> dict[str, Any]:
+    if group_by not in VALID_COST_STACK_GROUPS:
+        group_by = "repo"
+
     with engine.begin() as connection:
         where_clause, params = _build_cost_where(filters, table_alias="c")
         bucket = bucket_expr(connection, "c.usage_date", filters.granularity)
+        dimension = _cost_stack_dimension(connection, group_by)
         top_rows = connection.execute(
             text(
                 f"""
                 SELECT
-                  COALESCE(NULLIF(c.repo, ''), '(no repo)') AS repo_name,
+                  {dimension["expr"]} AS dimension_name,
                   SUM(c.list_cost) AS list_cost
-                FROM cost_attribution_daily c
+                FROM {dimension["from_clause"]}
                 WHERE {where_clause}
-                GROUP BY repo_name
-                ORDER BY list_cost DESC, repo_name
+                GROUP BY dimension_name
+                ORDER BY list_cost DESC, dimension_name
                 LIMIT :limit
                 """
             ),
-            {**params, "limit": COST_STACK_LIMIT},
+            {**params, **dimension["params"], "limit": COST_STACK_LIMIT},
         ).mappings()
-        top_repos = [str(row["repo_name"]) for row in top_rows]
-        if not top_repos:
+        top_dimensions = [str(row["dimension_name"] or dimension["empty_label"]) for row in top_rows]
+        if not top_dimensions:
             return {
                 "series": [],
                 "items": [],
-                "meta": {**filters.meta(), "limit": COST_STACK_LIMIT},
+                "meta": {**filters.meta(), "limit": COST_STACK_LIMIT, "group_by": group_by},
             }
 
         dimension_conditions = []
         dimension_params: dict[str, Any] = {}
-        for index, repo_name in enumerate(top_repos):
-            repo_key = f"repo_{index}"
+        for index, dimension_name in enumerate(top_dimensions):
+            dimension_key = f"dimension_{index}"
             dimension_conditions.append(
-                f"COALESCE(NULLIF(c.repo, ''), '(no repo)') = :{repo_key}"
+                f"{dimension['expr']} = :{dimension_key}"
             )
-            dimension_params[repo_key] = repo_name
+            dimension_params[dimension_key] = dimension_name
 
         rows = connection.execute(
             text(
                 f"""
                 SELECT
                   {bucket} AS bucket_start,
-                  COALESCE(NULLIF(c.repo, ''), '(no repo)') AS repo_name,
+                  {dimension["expr"]} AS dimension_name,
                   SUM(c.list_cost) AS list_cost
-                FROM cost_attribution_daily c
+                FROM {dimension["from_clause"]}
                 WHERE {where_clause}
                   AND ({" OR ".join(dimension_conditions)})
-                GROUP BY bucket_start, repo_name
-                ORDER BY bucket_start, repo_name
+                GROUP BY bucket_start, dimension_name
+                ORDER BY bucket_start, dimension_name
                 """
             ),
-            {**params, **dimension_params},
+            {**params, **dimension["params"], **dimension_params},
         ).mappings()
         data_rows = [dict(row) for row in rows]
 
     buckets = _bucket_starts(filters, data_rows)
     values_by_key = {
-        _repo_key(repo_name, index): {bucket: 0.0 for bucket in buckets}
-        for index, repo_name in enumerate(top_repos)
+        _cost_stack_key(group_by, dimension_name, index): {bucket: 0.0 for bucket in buckets}
+        for index, dimension_name in enumerate(top_dimensions)
     }
     labels_by_key = {
-        _repo_key(repo_name, index): repo_name
-        for index, repo_name in enumerate(top_repos)
+        _cost_stack_key(group_by, dimension_name, index): dimension_name
+        for index, dimension_name in enumerate(top_dimensions)
     }
-    repo_key_by_name = {
-        repo_name: _repo_key(repo_name, index)
-        for index, repo_name in enumerate(top_repos)
+    key_by_name = {
+        dimension_name: _cost_stack_key(group_by, dimension_name, index)
+        for index, dimension_name in enumerate(top_dimensions)
     }
     for row in data_rows:
-        repo_name = str(row["repo_name"])
-        key = repo_key_by_name[repo_name]
+        dimension_name = str(row["dimension_name"] or dimension["empty_label"])
+        key = key_by_name[dimension_name]
         values_by_key[key][str(row["bucket_start"])] = _money(row["list_cost"])
 
     return {
@@ -344,7 +354,7 @@ def get_repo_group_cost_stack(engine: Engine, filters: CommonFilters) -> dict[st
             }
             for key in values_by_key
         ],
-        "meta": {**filters.meta(), "limit": COST_STACK_LIMIT},
+        "meta": {**filters.meta(), "limit": COST_STACK_LIMIT, "group_by": group_by},
     }
 
 
@@ -1157,10 +1167,61 @@ def _null_safe_eq(connection: Connection, left_expr: str, right_expr: str) -> st
     return f"{left_expr} <=> {right_expr}"
 
 
-def _repo_key(repo_name: str, index: int) -> str:
-    if repo_name == "(no repo)":
+def _cost_stack_dimension(connection: Connection, group_by: str) -> dict[str, Any]:
+    if group_by not in VALID_COST_STACK_GROUPS:
+        group_by = "repo"
+
+    if group_by == "author":
+        return {
+            "expr": "COALESCE(NULLIF(c.author, ''), '(unknown author)')",
+            "from_clause": "cost_attribution_daily c",
+            "params": {},
+            "empty_label": "(unknown author)",
+        }
+    if group_by == "team":
+        team_match = _like_prefix_expr(connection, "c_group.path", "target_group.path")
+        return {
+            "expr": "COALESCE(NULLIF(target_group.name, ''), '(no team)')",
+            "from_clause": f"""
+                cost_attribution_daily c
+                LEFT JOIN roster_groups c_group
+                  ON c_group.id = c.group_id
+                LEFT JOIN (
+                  SELECT id, path
+                  FROM roster_groups
+                  WHERE name = :cost_stack_root_group_name
+                    AND is_active = 1
+                  ORDER BY id
+                  LIMIT 1
+                ) root_group
+                  ON 1=1
+                LEFT JOIN roster_groups target_parent
+                  ON target_parent.is_active = 1
+                 AND target_parent.parent_id = root_group.id
+                LEFT JOIN roster_groups target_group
+                  ON target_group.is_active = 1
+                 AND target_group.parent_id = target_parent.id
+                 AND {team_match}
+            """,
+            "params": {"cost_stack_root_group_name": ENGINEERING_GROUP_NAME},
+            "empty_label": "(no team)",
+        }
+    return {
+        "expr": "COALESCE(NULLIF(c.repo, ''), '(no repo)')",
+        "from_clause": "cost_attribution_daily c",
+        "params": {},
+        "empty_label": "(no repo)",
+    }
+
+
+def _cost_stack_key(group_by: str, dimension_name: str, index: int) -> str:
+    if group_by == "repo" and dimension_name == "(no repo)":
         return "repo__no_repo"
-    return f"repo__{index}"
+    if group_by == "author" and dimension_name == "(unknown author)":
+        return "author__unknown_author"
+    if group_by == "team" and dimension_name == "(no team)":
+        return "team__no_team"
+    return f"{group_by}__{index}"
 
 
 def _cost_source_value(vendor: str, account_id: str) -> str:

--- a/ci-dashboard/src/ci_dashboard/api/queries/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/pages.py
@@ -8,6 +8,7 @@ from sqlalchemy.engine import Engine
 
 from ci_dashboard.api.queries.base import CommonFilters
 from ci_dashboard.api.queries.builds import (
+    get_build_count_breakdown_trend,
     get_cloud_comparison,
     get_cloud_migration_summary,
     get_cloud_posture_trend,
@@ -112,6 +113,10 @@ def get_build_trend_page(engine: Engine, filters: CommonFilters) -> dict[str, An
             "outcome_trend": lambda: get_outcome_trend(engine, filters),
             "duration_trend": lambda: get_duration_trend(engine, filters),
             "cloud_migration_summary": lambda: get_cloud_migration_summary(engine, filters),
+            "build_count_breakdown_trend": lambda: get_build_count_breakdown_trend(
+                engine,
+                filters,
+            ),
             "cloud_posture_trend": lambda: get_cloud_posture_trend(engine, filters),
             "longest_avg_success_jobs": lambda: get_longest_avg_success_jobs(engine, filters),
             "lowest_success_rate_jobs": lambda: get_lowest_success_rate_jobs(engine, filters),
@@ -260,8 +265,14 @@ def get_cost_weekly_account_summaries_page(
 def get_cost_repo_group_stack_page(
     engine: Engine,
     filters: CommonFilters,
+    *,
+    group_by: str = "repo",
 ) -> dict[str, Any]:
-    return get_repo_group_cost_stack(engine, _normalize_cost_filters(filters))
+    return get_repo_group_cost_stack(
+        engine,
+        _normalize_cost_filters(filters),
+        group_by=group_by,
+    )
 
 
 def get_cost_engineering_group_share_page(

--- a/ci-dashboard/src/ci_dashboard/api/routes/pages.py
+++ b/ci-dashboard/src/ci_dashboard/api/routes/pages.py
@@ -98,10 +98,11 @@ def cost_weekly_account_summaries_page(
 
 @router.get("/cost-repo-group-stack")
 def cost_repo_group_stack_page(
+    group_by: str = Query("repo", pattern="^(repo|author|team)$"),
     filters: CommonFilters = Depends(get_common_filters),
     engine: Engine = Depends(get_engine),
 ) -> dict[str, object]:
-    return get_cost_repo_group_stack_page(engine, filters)
+    return get_cost_repo_group_stack_page(engine, filters, group_by=group_by)
 
 
 @router.get("/cost-engineering-group-share")

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -67,6 +67,7 @@ def _insert_build(
     pr_number: int = 100,
     normalized_build_url: str | None = None,
     build_id: str = "1",
+    author: str = "alice",
     error_l1_category: str | None = None,
     error_l2_subcategory: str | None = None,
 ) -> None:
@@ -89,7 +90,7 @@ def _insert_build(
                   :source_prow_row_id, :source_prow_job_id, 'prow', :job_name, 'presubmit', :state,
                   0, 1, :org, :repo, :repo_full_name, :base_ref, :pr_number, 1,
                   'unit-test', :url,
-                  :normalized_build_url, 'alice', 0, 'guid', :build_id, NULL, NULL, :start_time,
+                  :normalized_build_url, :author, 0, 'guid', :build_id, NULL, NULL, :start_time,
                   :start_time, :queue_wait_seconds, :run_seconds, :total_seconds, 'sha', :target_branch, :cloud_phase, :is_flaky,
                   :is_retry_loop, 0, :failure_category, NULL, :error_l1_category, :error_l2_subcategory
                 )
@@ -108,6 +109,7 @@ def _insert_build(
                 "url": f"{build_url}display/redirect",
                 "normalized_build_url": build_url,
                 "build_id": build_id,
+                "author": author,
                 "start_time": start_time,
                 "queue_wait_seconds": queue_wait_seconds,
                 "run_seconds": run_seconds,
@@ -782,6 +784,7 @@ def api_client(sqlite_engine, monkeypatch):
         run_seconds=200,
         total_seconds=225,
         pr_number=200,
+        author="bob",
         error_l1_category="OTHERS",
         error_l2_subcategory="UNCLASSIFIED",
     )
@@ -803,6 +806,7 @@ def api_client(sqlite_engine, monkeypatch):
         run_seconds=450,
         total_seconds=540,
         pr_number=103,
+        author="carol",
     )
     _insert_success_run_series(
         sqlite_engine,
@@ -1971,6 +1975,41 @@ def test_page_routes(api_client: TestClient) -> None:
     )
     assert build_trend_all.status_code == 200
     build_trend_all_body = build_trend_all.json()
+    build_count_breakdown = build_trend_all_body["build_count_breakdown_trend"]
+    assert build_count_breakdown["repo"]["items"] == [
+        {"name": "pingcap/tidb", "value": 6, "share_pct": 85.71},
+        {"name": "pingcap/tiflash", "value": 1, "share_pct": 14.29},
+    ]
+    repo_series = {
+        item["label"]: item["points"]
+        for item in build_count_breakdown["repo"]["series"]
+    }
+    assert repo_series["pingcap/tidb"] == [["2026-04-10", 3], ["2026-04-11", 3]]
+    assert repo_series["pingcap/tiflash"] == [["2026-04-10", 0], ["2026-04-11", 1]]
+    assert build_count_breakdown["branch"]["items"] == [
+        {"name": "master", "value": 5, "share_pct": 71.43},
+        {"name": "main", "value": 1, "share_pct": 14.29},
+        {"name": "release-8.5", "value": 1, "share_pct": 14.29},
+    ]
+    branch_series = {
+        item["label"]: item["points"]
+        for item in build_count_breakdown["branch"]["series"]
+    }
+    assert branch_series["master"] == [["2026-04-10", 3], ["2026-04-11", 2]]
+    assert branch_series["main"] == [["2026-04-10", 0], ["2026-04-11", 1]]
+    assert branch_series["release-8.5"] == [["2026-04-10", 0], ["2026-04-11", 1]]
+    assert build_count_breakdown["author"]["items"] == [
+        {"name": "alice", "value": 5, "share_pct": 71.43},
+        {"name": "bob", "value": 1, "share_pct": 14.29},
+        {"name": "carol", "value": 1, "share_pct": 14.29},
+    ]
+    author_series = {
+        item["label"]: item["points"]
+        for item in build_count_breakdown["author"]["series"]
+    }
+    assert author_series["alice"] == [["2026-04-10", 3], ["2026-04-11", 2]]
+    assert author_series["bob"] == [["2026-04-10", 0], ["2026-04-11", 1]]
+    assert author_series["carol"] == [["2026-04-10", 0], ["2026-04-11", 1]]
     cloud_repo_share = {
         item["cloud_phase"]: item for item in build_trend_all_body["cloud_repo_share"]["clouds"]
     }
@@ -2483,6 +2522,7 @@ def test_cost_page_supporting_routes(sqlite_engine, api_client: TestClient) -> N
     assert stack_response.status_code == 200
     stack_body = stack_response.json()
     assert stack_body["meta"]["granularity"] == "week"
+    assert stack_body["meta"]["group_by"] == "repo"
     assert stack_body["items"] == [{"name": "(no repo)", "value": 10.0}]
     assert stack_body["series"] == [
         {
@@ -2497,6 +2537,42 @@ def test_cost_page_supporting_routes(sqlite_engine, api_client: TestClient) -> N
                 ["2026-05-25", 0.0],
             ],
         }
+    ]
+
+    author_stack_response = api_client.get(
+        "/api/v1/pages/cost-repo-group-stack",
+        params={**params, "group_by": "author"},
+    )
+    assert author_stack_response.status_code == 200
+    author_stack_body = author_stack_response.json()
+    assert author_stack_body["meta"]["group_by"] == "author"
+    assert author_stack_body["items"] == [{"name": "alice", "value": 10.0}]
+    assert author_stack_body["series"][0]["key"] == "author__0"
+    assert author_stack_body["series"][0]["label"] == "alice"
+    assert author_stack_body["series"][0]["points"] == [
+        ["2026-04-27", 10.0],
+        ["2026-05-04", 0.0],
+        ["2026-05-11", 0.0],
+        ["2026-05-18", 0.0],
+        ["2026-05-25", 0.0],
+    ]
+
+    team_stack_response = api_client.get(
+        "/api/v1/pages/cost-repo-group-stack",
+        params={**params, "group_by": "team"},
+    )
+    assert team_stack_response.status_code == 200
+    team_stack_body = team_stack_response.json()
+    assert team_stack_body["meta"]["group_by"] == "team"
+    assert team_stack_body["items"] == [{"name": "TiDB", "value": 10.0}]
+    assert team_stack_body["series"][0]["key"] == "team__0"
+    assert team_stack_body["series"][0]["label"] == "TiDB"
+    assert team_stack_body["series"][0]["points"] == [
+        ["2026-04-27", 10.0],
+        ["2026-05-04", 0.0],
+        ["2026-05-11", 0.0],
+        ["2026-05-18", 0.0],
+        ["2026-05-25", 0.0],
     ]
 
     share_response = api_client.get("/api/v1/pages/cost-engineering-group-share", params=params)
@@ -3179,8 +3255,14 @@ def test_cost_query_helpers_cover_edge_cases(sqlite_engine) -> None:
         "2026-06-01",
         "2026-07-01",
     ]
-    assert cost_queries._repo_key("(no repo)", 0) == "repo__no_repo"
-    assert cost_queries._repo_key("repo-1", 0) != cost_queries._repo_key("repo.1", 1)
+    assert cost_queries._cost_stack_key("repo", "(no repo)", 0) == "repo__no_repo"
+    assert cost_queries._cost_stack_key("repo", "repo-1", 0) != cost_queries._cost_stack_key(
+        "repo",
+        "repo.1",
+        1,
+    )
+    assert cost_queries._cost_stack_key("author", "(unknown author)", 0) == "author__unknown_author"
+    assert cost_queries._cost_stack_key("team", "(no team)", 0) == "team__no_team"
 
 
 def test_budget_health_snapshot_marks_warning_when_over_pace(

--- a/ci-dashboard/web/package-lock.json
+++ b/ci-dashboard/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-dashboard-web",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/ci-dashboard/web/package.json
+++ b/ci-dashboard/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-dashboard-web",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ci-dashboard/web/src/components/controls.jsx
+++ b/ci-dashboard/web/src/components/controls.jsx
@@ -1,0 +1,34 @@
+export function SegmentedControl({ ariaLabel, options, value, onChange }) {
+  return (
+    <div className="segmented-control" aria-label={ariaLabel}>
+      {options.map((option) => (
+        <button
+          key={option.key}
+          type="button"
+          className={buildSegmentedButtonClassName(value === option.key)}
+          onClick={() => onChange(option.key)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function buildSegmentedButtonClassName(active) {
+  return [
+    "segmented-control__button",
+    active ? "segmented-control__button--active" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function buildDimensionChipClassName(active) {
+  return [
+    "dimension-chip",
+    active ? "dimension-chip--active" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}

--- a/ci-dashboard/web/src/pages/BuildTrendPage.jsx
+++ b/ci-dashboard/web/src/pages/BuildTrendPage.jsx
@@ -17,11 +17,14 @@ import {
   StatCard,
   TrendChart,
 } from "../components/charts";
+import { SegmentedControl, buildDimensionChipClassName } from "../components/controls";
 
 export default function BuildTrendPage({ filters }) {
   const page = useApiData("/api/v1/pages/ci-status", filters);
   const [selectedRepoSlice, setSelectedRepoSlice] = useState(null);
   const [selectedErrorCatalog, setSelectedErrorCatalog] = useState("");
+  const [buildCountDimension, setBuildCountDimension] = useState("repo");
+  const [selectedBuildCountTrend, setSelectedBuildCountTrend] = useState("");
 
   const outcomeSummary = page.data?.outcome_trend?.meta?.summary || {};
   const totalBuilds = Number(
@@ -72,6 +75,11 @@ export default function BuildTrendPage({ filters }) {
   const errorDetailsTitle = selectedErrorCatalog
     ? `${formatErrorCatalogName(selectedErrorCatalog)} Error Details`
     : "Top Error Details";
+  const buildCountBreakdownTrend = page.data?.build_count_breakdown_trend || {};
+  const activeBuildCountTrend = buildCountBreakdownTrend[buildCountDimension];
+  const activeBuildCountDimension = BUILD_COUNT_DIMENSIONS.find(
+    (dimension) => dimension.key === buildCountDimension,
+  ) || BUILD_COUNT_DIMENSIONS[0];
 
   useEffect(() => {
     function handleKeyDown(event) {
@@ -96,6 +104,15 @@ export default function BuildTrendPage({ filters }) {
       setSelectedErrorCatalog("");
     }
   }, [errorCatalogItems, selectedErrorCatalog]);
+
+  useEffect(() => {
+    if (!selectedBuildCountTrend) {
+      return;
+    }
+    if (!hasDimensionItem(activeBuildCountTrend?.items, selectedBuildCountTrend)) {
+      setSelectedBuildCountTrend("");
+    }
+  }, [activeBuildCountTrend?.items, selectedBuildCountTrend]);
 
   return (
     <div className="page-stack">
@@ -195,6 +212,30 @@ export default function BuildTrendPage({ filters }) {
         >
           <TrendChart series={page.data?.duration_trend?.series} yFormatter={formatSeconds} />
         </Panel>
+
+        <Panel
+          title={`Build count by ${activeBuildCountDimension.label.toLowerCase()}`}
+          subtitle={`Bucketed build-count trend split by ${activeBuildCountDimension.description} in the current CI scope.`}
+          loading={page.loading}
+          error={page.error}
+          actions={
+            <DimensionModeSelector
+              value={buildCountDimension}
+              onChange={(nextDimension) => {
+                setBuildCountDimension(nextDimension);
+                setSelectedBuildCountTrend("");
+              }}
+            />
+          }
+        >
+          <BuildCountDimensionTrend
+            dimension={activeBuildCountTrend}
+            selectedName={selectedBuildCountTrend}
+            onSelect={setSelectedBuildCountTrend}
+            emptyMessage={`No ${activeBuildCountDimension.label.toLowerCase()} build-count trend data for the current filters.`}
+          />
+        </Panel>
+
         <Panel
           title="Longest avg success time jobs"
           subtitle="Success-only average run time ranked inside the current repo, branch, cloud, and date scope."
@@ -311,6 +352,77 @@ export default function BuildTrendPage({ filters }) {
       ) : null}
     </div>
   );
+}
+
+const BUILD_COUNT_DIMENSIONS = [
+  { key: "repo", label: "Repo", description: "repo" },
+  { key: "branch", label: "Branch", description: "target branch" },
+  { key: "author", label: "Author", description: "author" },
+];
+
+function DimensionModeSelector({ value, onChange }) {
+  return (
+    <SegmentedControl
+      ariaLabel="Build count grouping"
+      options={BUILD_COUNT_DIMENSIONS}
+      value={value}
+      onChange={onChange}
+    />
+  );
+}
+
+function BuildCountDimensionTrend({
+  dimension,
+  selectedName,
+  onSelect,
+  emptyMessage,
+}) {
+  const items = dimension?.items || [];
+  const series = selectedName
+    ? (dimension?.series || []).filter((item) => item.label === selectedName)
+    : dimension?.series;
+
+  if (!items.length || !series?.length) {
+    return <div className="empty-state">{emptyMessage}</div>;
+  }
+
+  return (
+    <div className="build-count-breakdown">
+      <TrendChart
+        series={series}
+        yFormatter={formatCompact}
+        stackBars={!selectedName}
+        yTickMode="integer"
+        height={320}
+        barMaxWidth={38}
+      />
+      <div className="dimension-selector" aria-label="Build count trend dimension selector">
+        <button
+          type="button"
+          className={buildDimensionChipClassName(!selectedName)}
+          onClick={() => onSelect("")}
+        >
+          All
+        </button>
+        {items.map((item) => (
+          <button
+            key={item.name}
+            type="button"
+            className={buildDimensionChipClassName(selectedName === item.name)}
+            title={`${item.name}: ${formatCompact(item.value)} builds`}
+            onClick={() => onSelect(selectedName === item.name ? "" : item.name)}
+          >
+            <span>{item.name}</span>
+            <strong>{formatCompact(item.value)}</strong>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function hasDimensionItem(items, name) {
+  return (items || []).some((item) => item.name === name);
 }
 
 function limitRepoShareItems(cloudShare, maxItems = 10, minSharePct = 1) {

--- a/ci-dashboard/web/src/pages/CostPage.jsx
+++ b/ci-dashboard/web/src/pages/CostPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   formatCostSourceLabel,
@@ -19,12 +19,15 @@ import {
   TrendChart,
   UnmatchedResourceTable,
 } from "../components/charts";
+import { SegmentedControl, buildDimensionChipClassName } from "../components/controls";
 
 const SHARED_COST_GROUP = "Efficiency & Quality";
 
 export default function CostPage({ filters }) {
   const [isWeeklyLevel2Shared, setIsWeeklyLevel2Shared] = useState(false);
   const [isSelectedLevel2Shared, setIsSelectedLevel2Shared] = useState(false);
+  const [costStackGroupBy, setCostStackGroupBy] = useState("repo");
+  const [selectedCostStackName, setSelectedCostStackName] = useState("");
   const weeklyOverviewRange = getLaggedTrailingDateRange();
   const selectedCostSource = filters.cost_source || DEFAULT_COST_SOURCE;
   const selectedCostSourceLabel = formatCostSourceLabel(selectedCostSource);
@@ -42,25 +45,26 @@ export default function CostPage({ filters }) {
     granularity: filters.granularity === "month" ? "month" : "week",
     cost_source: selectedCostSourceValue,
   };
+  const costStackFilters = {
+    ...costFilters,
+    group_by: costStackGroupBy,
+  };
   const weeklyOverview = useApiData("/api/v1/pages/cost-weekly-overview", weeklyOverviewFilters);
   const trend = useApiData("/api/v1/pages/cost-trend", costFilters);
-  const repoGroupStack = useApiData("/api/v1/pages/cost-repo-group-stack", costFilters);
+  const repoGroupStack = useApiData("/api/v1/pages/cost-repo-group-stack", costStackFilters);
   const engineeringGroupShare = useApiData("/api/v1/pages/cost-engineering-group-share", costFilters);
   const unmatchedResources = useApiData("/api/v1/pages/cost-unmatched-resources", costFilters);
   const summary = trend.data?.meta?.summary || {};
   const configuredAnnualBudget = Number(weeklyOverview.data?.budget_health?.annual_budget || 0);
   const hasConfiguredBudget = configuredAnnualBudget > 0;
-  const stackTotal = (repoGroupStack.data?.items || []).reduce(
-    (sum, item) => sum + Number(item.value || 0),
-    0,
-  );
-  const level1Total = engineeringGroupShare.data?.level1?.meta?.total_list_cost || 0;
-  const level2Total = engineeringGroupShare.data?.level2?.meta?.total_list_cost || 0;
   const costTrendSeries = withBudgetSeries(
     trend.data?.series,
     costFilters.granularity,
     trend.data?.meta?.annual_budgets,
   );
+  const activeCostStackGroup = COST_STACK_GROUPS.find(
+    (group) => group.key === costStackGroupBy,
+  ) || COST_STACK_GROUPS[0];
   const weeklyLevel2Items = withSharedCostAllocation(
     weeklyOverview.data?.level2_share?.items,
     isWeeklyLevel2Shared,
@@ -69,6 +73,15 @@ export default function CostPage({ filters }) {
     engineeringGroupShare.data?.level2?.items,
     isSelectedLevel2Shared,
   );
+
+  useEffect(() => {
+    if (!selectedCostStackName) {
+      return;
+    }
+    if (!hasCostStackItem(repoGroupStack.data?.items, selectedCostStackName)) {
+      setSelectedCostStackName("");
+    }
+  }, [repoGroupStack.data?.items, selectedCostStackName]);
 
   return (
     <div className="page-stack">
@@ -199,21 +212,24 @@ export default function CostPage({ filters }) {
         </Panel>
 
         <Panel
-          title="Repo cost stack"
-          subtitle="Top repos stacked by list cost bucket."
+          title={`${activeCostStackGroup.label} cost stack`}
+          subtitle={`Top ${activeCostStackGroup.description} stacked by list cost bucket.`}
           loading={repoGroupStack.loading}
           error={repoGroupStack.error}
+          actions={
+            <CostStackGroupSelector
+              value={costStackGroupBy}
+              onChange={(nextGroup) => {
+                setCostStackGroupBy(nextGroup);
+                setSelectedCostStackName("");
+              }}
+            />
+          }
         >
-          <TrendChart
-            series={repoGroupStack.data?.series}
-            yFormatter={formatCompactCurrency}
-            height={300}
-            compactY
-            stackBars
-            yTickMode="thousands-rounded"
-            yTickSegments={5}
-            barGroupWidthFactor={0.56}
-            barMaxWidth={58}
+          <CostStackTrend
+            data={repoGroupStack.data}
+            selectedName={selectedCostStackName}
+            onSelect={setSelectedCostStackName}
           />
         </Panel>
       </div>
@@ -272,6 +288,75 @@ export default function CostPage({ filters }) {
       </Panel>
     </div>
   );
+}
+
+const COST_STACK_GROUPS = [
+  { key: "repo", label: "Repo", description: "repos" },
+  { key: "author", label: "Author", description: "authors" },
+  { key: "team", label: "Team", description: "teams" },
+];
+
+function CostStackGroupSelector({ value, onChange }) {
+  return (
+    <SegmentedControl
+      ariaLabel="Cost stack grouping"
+      options={COST_STACK_GROUPS}
+      value={value}
+      onChange={onChange}
+    />
+  );
+}
+
+function CostStackTrend({ data, selectedName, onSelect }) {
+  const items = data?.items || [];
+  const series = selectedName
+    ? (data?.series || []).filter((item) => item.label === selectedName)
+    : data?.series;
+
+  if (!items.length || !series?.length) {
+    return <div className="empty-state">No cost stack data for the current filters.</div>;
+  }
+
+  return (
+    <div className="build-count-breakdown">
+      <TrendChart
+        series={series}
+        yFormatter={formatCompactCurrency}
+        height={300}
+        compactY
+        stackBars={!selectedName}
+        yTickMode="thousands-rounded"
+        yTickSegments={5}
+        barGroupWidthFactor={0.56}
+        barMaxWidth={58}
+      />
+      <div className="dimension-selector" aria-label="Cost stack value selector">
+        <button
+          type="button"
+          className={buildDimensionChipClassName(!selectedName)}
+          onClick={() => onSelect("")}
+        >
+          All
+        </button>
+        {items.map((item) => (
+          <button
+            key={item.name}
+            type="button"
+            className={buildDimensionChipClassName(selectedName === item.name)}
+            title={`${item.name}: ${formatCurrency(item.value)}`}
+            onClick={() => onSelect(selectedName === item.name ? "" : item.name)}
+          >
+            <span>{item.name}</span>
+            <strong>{formatCompactCurrency(item.value)}</strong>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function hasCostStackItem(items, name) {
+  return (items || []).some((item) => item.name === name);
 }
 
 function withSharedCostAllocation(items, enabled) {

--- a/ci-dashboard/web/src/styles.css
+++ b/ci-dashboard/web/src/styles.css
@@ -964,6 +964,85 @@ select {
   height: auto;
 }
 
+.build-count-breakdown {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.segmented-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border: 1px solid rgba(114, 129, 143, 0.22);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.segmented-control__button {
+  min-width: 4.5rem;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.45rem 0.75rem;
+  background: transparent;
+  color: #647380;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.segmented-control__button--active {
+  background: #172431;
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(23, 36, 49, 0.16);
+}
+
+.dimension-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.dimension-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+  max-width: 100%;
+  border: 1px solid rgba(49, 87, 114, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+  cursor: pointer;
+  padding: 0.45rem 0.7rem;
+  font: inherit;
+  font-size: 0.84rem;
+}
+
+.dimension-chip span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dimension-chip strong {
+  flex: none;
+  color: #526b76;
+  font-size: 0.78rem;
+}
+
+.dimension-chip--active {
+  border-color: rgba(42, 157, 143, 0.42);
+  background: rgba(42, 157, 143, 0.12);
+}
+
+.dimension-chip--active strong {
+  color: #0f7c82;
+}
+
 .chart-grid {
   stroke: rgba(49, 87, 114, 0.1);
   stroke-width: 1;


### PR DESCRIPTION
## Summary
- add CI build-count breakdown charts with selectable repo, branch, and author grouping
- add cost stack grouping by repo, author, and team, with chip-based focus for one selected value
- bump CI Dashboard version to 0.4.2

## Validation
- `uv run --extra dev coverage run -m pytest`
- `uv run --extra dev coverage report --fail-under=90` (TOTAL 91%)
- `uv run --extra dev ruff check src tests`
- `npm test`
- `npm run build`

## Notes
- Cost stack grouping is requested on demand through `group_by=repo|author|team` instead of fetching every grouping at once.