### PR TITLE
feat: support all git ref formats in getGhRefSha

### DIFF
--- a/experiments/tibuild-v2/internal/service/impl/devbuild_create.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_create.go
@@ -45,7 +45,6 @@ func (s *devbuildsrvc) newBuildEntity(ctx context.Context, p *devbuild.CreatePay
 		SetNillablePipelineEngine(p.Request.PipelineEngine).
 		SetStatus("pending")
 
-	// TODO: get the commit sha and set it in `create`.
 	return create.Save(ctx)
 }
 

--- a/experiments/tibuild-v2/internal/service/impl/devbuild_github.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_github.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/google/go-github/v69/github"
@@ -16,7 +17,7 @@ func NewGitHubClient(token string) *github.Client {
 	return github.NewClient(nil).WithAuthToken(token)
 }
 
-func getGhRefSha(ctx context.Context, ghClient *github.Client, fullRepo, ref string) string {
+func getGhRefSha(ctx context.Context, ghClient *github.Client, fullRepo, gitRef string) string {
 	if ghClient == nil {
 		return ""
 	}
@@ -27,12 +28,38 @@ func getGhRefSha(ctx context.Context, ghClient *github.Client, fullRepo, ref str
 	}
 
 	owner, repo := parts[0], parts[1]
-	branch, _, err := ghClient.Repositories.GetBranch(ctx, owner, repo, ref, 10)
-	if err != nil {
-		return ""
+
+	switch {
+	case strings.HasPrefix(gitRef, "branch/"):
+		branchName := strings.TrimPrefix(gitRef, "branch/")
+		branch, _, err := ghClient.Repositories.GetBranch(ctx, owner, repo, branchName, 10)
+		if err != nil {
+			return ""
+		}
+		return branch.Commit.GetSHA()
+
+	case strings.HasPrefix(gitRef, "tag/"):
+		tagName := strings.TrimPrefix(gitRef, "tag/")
+		ref, _, err := ghClient.Git.GetRef(ctx, owner, repo, "refs/tags/"+tagName)
+		if err != nil {
+			return ""
+		}
+		return ref.Object.GetSHA()
+
+	case strings.HasPrefix(gitRef, "pull/"):
+		prNumberStr := strings.TrimPrefix(gitRef, "pull/")
+		prNumber, err := strconv.Atoi(prNumberStr)
+		if err != nil {
+			return ""
+		}
+		pr, _, err := ghClient.PullRequests.Get(ctx, owner, repo, prNumber)
+		if err != nil {
+			return ""
+		}
+		return pr.Head.GetSHA()
 	}
 
-	return branch.Commit.GetSHA()
+	return ""
 }
 
 func newFakeGitHubPushEventPayload(fullRepo, ref, sha string) *github.PushEvent {

--- a/experiments/tibuild-v2/internal/service/impl/devbuild_github_test.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_github_test.go
@@ -1,0 +1,179 @@
+package impl
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v69/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+)
+
+func TestGetGhRefSha_Branch(t *testing.T) {
+	fullRepo := "owner/repo"
+	branchName := "main"
+	expectedSHA := "abc123def456"
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposBranchesByOwnerByRepoByBranch,
+			&github.Branch{
+				Name: github.Ptr(branchName),
+				Commit: &github.RepositoryCommit{
+					SHA: github.Ptr(expectedSHA),
+				},
+			},
+		),
+	)
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, fullRepo, "branch/"+branchName)
+	if sha != expectedSHA {
+		t.Fatalf("expected sha %s, got %s", expectedSHA, sha)
+	}
+}
+
+func TestGetGhRefSha_Tag(t *testing.T) {
+	fullRepo := "owner/repo"
+	tagName := "v1.0.0"
+	expectedSHA := "tag123sha456"
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposGitRefByOwnerByRepoByRef,
+			&github.Reference{
+				Ref: github.Ptr("refs/tags/" + tagName),
+				Object: &github.GitObject{
+					SHA: github.Ptr(expectedSHA),
+				},
+			},
+		),
+	)
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, fullRepo, "tag/"+tagName)
+	if sha != expectedSHA {
+		t.Fatalf("expected sha %s, got %s", expectedSHA, sha)
+	}
+}
+
+func TestGetGhRefSha_PullRequest(t *testing.T) {
+	fullRepo := "owner/repo"
+	expectedSHA := "pr123head456"
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposPullsByOwnerByRepoByPullNumber,
+			&github.PullRequest{
+				Head: &github.PullRequestBranch{
+					SHA: github.Ptr(expectedSHA),
+				},
+			},
+		),
+	)
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, fullRepo, "pull/42")
+	if sha != expectedSHA {
+		t.Fatalf("expected sha %s, got %s", expectedSHA, sha)
+	}
+}
+
+func TestGetGhRefSha_NilClient(t *testing.T) {
+	sha := getGhRefSha(context.Background(), nil, "owner/repo", "branch/main")
+	if sha != "" {
+		t.Fatalf("expected empty sha, got %s", sha)
+	}
+}
+
+func TestGetGhRefSha_InvalidRepoFormat(t *testing.T) {
+	httpClient := mock.NewMockedHTTPClient()
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, "invalid-repo", "branch/main")
+	if sha != "" {
+		t.Fatalf("expected empty sha, got %s", sha)
+	}
+}
+
+func TestGetGhRefSha_BranchNotFound(t *testing.T) {
+	fullRepo := "owner/repo"
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.GetReposBranchesByOwnerByRepoByBranch,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.Copy(w, strings.NewReader(`{"message": "Not Found"}`))
+			}),
+		),
+	)
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, fullRepo, "branch/nonexistent")
+	if sha != "" {
+		t.Fatalf("expected empty sha, got %s", sha)
+	}
+}
+
+func TestGetGhRefSha_TagNotFound(t *testing.T) {
+	fullRepo := "owner/repo"
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.GetReposGitRefByOwnerByRepoByRef,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.Copy(w, strings.NewReader(`{"message": "Not Found"}`))
+			}),
+		),
+	)
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, fullRepo, "tag/nonexistent")
+	if sha != "" {
+		t.Fatalf("expected empty sha, got %s", sha)
+	}
+}
+
+func TestGetGhRefSha_PRNotFound(t *testing.T) {
+	fullRepo := "owner/repo"
+
+	httpClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.GetReposPullsByOwnerByRepoByPullNumber,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.Copy(w, strings.NewReader(`{"message": "Not Found"}`))
+			}),
+		),
+	)
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, fullRepo, "pull/999")
+	if sha != "" {
+		t.Fatalf("expected empty sha, got %s", sha)
+	}
+}
+
+func TestGetGhRefSha_InvalidPRNumber(t *testing.T) {
+	httpClient := mock.NewMockedHTTPClient()
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, "owner/repo", "pull/abc")
+	if sha != "" {
+		t.Fatalf("expected empty sha, got %s", sha)
+	}
+}
+
+func TestGetGhRefSha_UnknownRefFormat(t *testing.T) {
+	httpClient := mock.NewMockedHTTPClient()
+	ghClient := github.NewClient(httpClient)
+
+	sha := getGhRefSha(context.Background(), ghClient, "owner/repo", "unknown/format")
+	if sha != "" {
+		t.Fatalf("expected empty sha, got %s", sha)
+	}
+}


### PR DESCRIPTION
## Summary

Improve `getGhRefSha` function to support all git ref formats used in DevBuild:
- `branch/xxx` → `Repositories.GetBranch` (existing)
- `tag/xxx` → `Git.GetRef` (new)
- `pull/xxx` → `PullRequests.Get` (new)

## Changes

- **feat**: Add tag and PR ref resolution in `getGhRefSha` function
- **test**: Add 10 comprehensive unit tests covering normal, boundary, and error scenarios
- **chore**: Remove stale TODO comment in `devbuild_create.go`

## Test Plan

- [x] Unit tests for branch/ ref format
- [x] Unit tests for tag/ ref format  
- [x] Unit tests for pull/ ref format
- [x] Edge cases: nil client, invalid repo format, invalid PR number, unknown ref format
- [x] Error scenarios: 404 not found for branch/tag/PR