### PR TITLE
feat: implement event-driven build status update via IngestEvent

### DIFF
--- a/experiments/tibuild-v2/internal/service/impl/devbuild.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -217,14 +218,14 @@ func (s *devbuildsrvc) Rerun(ctx context.Context, p *devbuild.RerunPayload) (res
 func (s *devbuildsrvc) IngestEvent(ctx context.Context, p *devbuild.CloudEventIngestEventPayload) (res *devbuild.CloudEventResponse, err error) {
 	s.logger.Info().Msgf("devbuild.ingestEvent")
 
-	// Extract DevBuild ID from subject
-	if p.Subject == nil {
-		return nil, &devbuild.HTTPError{Code: http.StatusBadRequest, Message: "missing subject"}
-	}
-
-	buildID, err := strconv.Atoi(*p.Subject)
+	// Extract DevBuild ID from PipelineRun annotations
+	buildID, err := s.extractDevBuildID(p.Data, p.Source)
 	if err != nil {
-		return nil, &devbuild.HTTPError{Code: http.StatusBadRequest, Message: "invalid subject format"}
+		s.logger.Err(err).Msg("failed to extract devbuild id from event")
+		return nil, &devbuild.HTTPError{Code: http.StatusBadRequest, Message: err.Error()}
+	}
+	if buildID == 0 {
+		return nil, &devbuild.HTTPError{Code: http.StatusBadRequest, Message: "not a devbuild event"}
 	}
 
 	// Get the existing build
@@ -236,8 +237,8 @@ func (s *devbuildsrvc) IngestEvent(ctx context.Context, p *devbuild.CloudEventIn
 		return nil, err
 	}
 
-	// Extract status from event data
-	status := s.extractBuildStatus(p.Data)
+	// Extract status from event type
+	status := s.extractBuildStatusFromEventType(p.Type)
 
 	// Update build status
 	updater := s.dbClient.DevBuild.UpdateOneID(build.ID)
@@ -263,30 +264,51 @@ func (s *devbuildsrvc) IngestEvent(ctx context.Context, p *devbuild.CloudEventIn
 	}, nil
 }
 
-func (s *devbuildsrvc) extractBuildStatus(data any) string {
-	if data == nil {
-		return ""
+func (s *devbuildsrvc) extractDevBuildID(data any, source string) (int, error) {
+	// First try to extract from PipelineRun annotations (Tekton callback)
+	if data != nil {
+		if dataMap, ok := data.(map[string]any); ok {
+			if pipelineRun, ok := dataMap["pipelineRun"].(map[string]any); ok {
+				if metadata, ok := pipelineRun["metadata"].(map[string]any); ok {
+					if annotations, ok := metadata["annotations"].(map[string]any); ok {
+						if ceContext, ok := annotations["tekton.dev/ce-context"].(string); ok {
+							var context struct {
+								Source  string `json:"source"`
+								Subject string `json:"subject"`
+							}
+							if err := json.Unmarshal([]byte(ceContext), &context); err == nil {
+								if strings.Contains(context.Source, "tibuild.pingcap.net/api/devbuild") {
+									return strconv.Atoi(context.Subject)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
-	dataMap, ok := data.(map[string]any)
-	if !ok {
-		return ""
+	// Fallback: try to extract from event source
+	if strings.Contains(source, "tibuild.pingcap.net/api/devbuilds/") {
+		parts := strings.Split(source, "/")
+		if len(parts) > 0 {
+			return strconv.Atoi(parts[len(parts)-1])
+		}
 	}
 
-	status, ok := dataMap["status"].(string)
-	if !ok {
-		return ""
-	}
+	return 0, nil
+}
 
-	switch strings.ToLower(status) {
-	case "success", "succeeded", "completed":
-		return "success"
-	case "failure", "failed", "error":
-		return "failure"
-	case "running", "in_progress":
+func (s *devbuildsrvc) extractBuildStatusFromEventType(eventType string) string {
+	switch eventType {
+	case "dev.tekton.event.pipelinerun.started.v1":
 		return "running"
+	case "dev.tekton.event.pipelinerun.successful.v1":
+		return "success"
+	case "dev.tekton.event.pipelinerun.failed.v1":
+		return "failure"
 	default:
-		return status
+		return ""
 	}
 }
 

--- a/experiments/tibuild-v2/internal/service/impl/devbuild_ingest_test.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_ingest_test.go
@@ -4,81 +4,138 @@ import (
 	"testing"
 )
 
-func TestExtractBuildStatus(t *testing.T) {
+func TestExtractBuildStatusFromEventType(t *testing.T) {
 	srvc := &devbuildsrvc{}
 
 	tests := []struct {
-		name     string
-		data     any
-		expected string
+		name      string
+		eventType string
+		expected  string
 	}{
 		{
-			name:     "nil data",
-			data:     nil,
-			expected: "",
+			name:      "started event",
+			eventType: "dev.tekton.event.pipelinerun.started.v1",
+			expected:  "running",
 		},
 		{
-			name:     "non-map data",
-			data:     "invalid",
-			expected: "",
+			name:      "successful event",
+			eventType: "dev.tekton.event.pipelinerun.successful.v1",
+			expected:  "success",
 		},
 		{
-			name:     "success status",
-			data:     map[string]any{"status": "success"},
-			expected: "success",
+			name:      "failed event",
+			eventType: "dev.tekton.event.pipelinerun.failed.v1",
+			expected:  "failure",
 		},
 		{
-			name:     "succeeded status",
-			data:     map[string]any{"status": "Succeeded"},
-			expected: "success",
+			name:      "unknown event type",
+			eventType: "unknown.event.type",
+			expected:  "",
 		},
 		{
-			name:     "completed status",
-			data:     map[string]any{"status": "completed"},
-			expected: "success",
-		},
-		{
-			name:     "failure status",
-			data:     map[string]any{"status": "failure"},
-			expected: "failure",
-		},
-		{
-			name:     "failed status",
-			data:     map[string]any{"status": "Failed"},
-			expected: "failure",
-		},
-		{
-			name:     "error status",
-			data:     map[string]any{"status": "error"},
-			expected: "failure",
-		},
-		{
-			name:     "running status",
-			data:     map[string]any{"status": "running"},
-			expected: "running",
-		},
-		{
-			name:     "in_progress status",
-			data:     map[string]any{"status": "in_progress"},
-			expected: "running",
-		},
-		{
-			name:     "unknown status",
-			data:     map[string]any{"status": "pending"},
-			expected: "pending",
-		},
-		{
-			name:     "missing status field",
-			data:     map[string]any{"other": "value"},
-			expected: "",
+			name:      "empty event type",
+			eventType: "",
+			expected:  "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := srvc.extractBuildStatus(tt.data)
+			result := srvc.extractBuildStatusFromEventType(tt.eventType)
 			if result != tt.expected {
 				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestExtractDevBuildID_FromAnnotations(t *testing.T) {
+	srvc := &devbuildsrvc{}
+
+	tests := []struct {
+		name      string
+		data      any
+		source    string
+		expected  int
+		expectErr bool
+	}{
+		{
+			name: "valid ce-context annotation",
+			data: map[string]any{
+				"pipelineRun": map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							"tekton.dev/ce-context": `{"source":"tibuild.pingcap.net/api/devbuilds/123","subject":"123"}`,
+						},
+					},
+				},
+			},
+			source:   "tekton",
+			expected: 123,
+		},
+		{
+			name: "non-devbuild source in ce-context",
+			data: map[string]any{
+				"pipelineRun": map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							"tekton.dev/ce-context": `{"source":"other.source","subject":"456"}`,
+						},
+					},
+				},
+			},
+			source:   "tekton",
+			expected: 0,
+		},
+		{
+			name: "fallback to event source",
+			data:   nil,
+			source: "tibuild.pingcap.net/api/devbuilds/789",
+			expected: 789,
+		},
+		{
+			name:      "nil data and non-devbuild source",
+			data:      nil,
+			source:    "other.source",
+			expected:  0,
+		},
+		{
+			name: "invalid ce-context json",
+			data: map[string]any{
+				"pipelineRun": map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							"tekton.dev/ce-context": "invalid json",
+						},
+					},
+				},
+			},
+			source:   "tekton",
+			expected: 0,
+		},
+		{
+			name: "missing annotations",
+			data: map[string]any{
+				"pipelineRun": map[string]any{
+					"metadata": map[string]any{},
+				},
+			},
+			source:   "tekton",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := srvc.extractDevBuildID(tt.data, tt.source)
+			if tt.expectErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Fatalf("expected %d, got %d", tt.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Implement event-driven build status update using Tekton CloudEvent callbacks, following the same pattern as tibuild v1.

## Changes

### Core Implementation
- **IngestEvent**: Process CloudEvent callbacks from Tekton
  - Extract DevBuild ID from PipelineRun annotations (tekton.dev/ce-context)
  - Map Tekton event types to build status
  - Update build status and tekton_status in database

### Cleanup
- Remove proactive sync code (tekton_client.go, syncBuildStatus)
- Remove Tekton Dashboard API config (DashboardURL, Namespace)

### Tests
- TestExtractBuildStatusFromEventType - 5 test cases
- TestExtractDevBuildID_FromAnnotations - 6 test cases
- TestExtractTektonStatus - 4 test cases

## Event Flow

1. Trigger Build: Set subject and source with DevBuild ID
2. Tekton saves to PipelineRun annotations: tekton.dev/ce-context
3. Tekton callback to IngestEvent: Parse ce-context to extract DevBuild ID

## Event Type Mapping
- dev.tekton.event.pipelinerun.started.v1 -> running
- dev.tekton.event.pipelinerun.successful.v1 -> success
- dev.tekton.event.pipelinerun.failed.v1 -> failure