### PR TITLE
feat(cost-insight): add gcs cache cleanup workflows

### DIFF
--- a/cost-insight/README.md
+++ b/cost-insight/README.md
@@ -180,13 +180,25 @@ Summarize one day of access logs into BigQuery object last-seen tables:
 cost-insight sync-gcs-cache-last-seen --run-date 2026-06-08
 ```
 
+Bootstrap the current last-seen table from the historical audit-log window in
+one scan:
+
+```bash
+cost-insight bootstrap-gcs-cache-last-seen --start-date 2026-05-25 --end-date 2026-06-09
+```
+
+This command rebuilds `gcs_cache_object_last_seen_current` directly from the
+raw audit-log window. It is intended for one-time historical seeding before the
+daily incremental sync continues.
+
 Validate the query shape without writing BigQuery summary tables:
 
 ```bash
 cost-insight sync-gcs-cache-last-seen --run-date 2026-06-08 --dry-run
 ```
 
-Build a weekly dry-run candidate report from the current last-seen table:
+Build a daily steady-state dry-run candidate report from the current last-seen
+table:
 
 ```bash
 cost-insight cleanup-gcs-cache --mode dry-run
@@ -195,5 +207,24 @@ cost-insight cleanup-gcs-cache --mode dry-run
 Override retention windows during validation:
 
 ```bash
-cost-insight cleanup-gcs-cache --mode dry-run --ac-retention-days 21 --cas-retention-days 35
+cost-insight cleanup-gcs-cache \
+  --mode dry-run \
+  --ac-retention-days 14 \
+  --cas-retention-days 21 \
+  --safety-buffer-days 1
+```
+
+Run a real-delete steady-state canary with `500 ac + 500 cas`:
+
+```bash
+cost-insight cleanup-gcs-cache --mode delete --execute-kind mixed-canary
+```
+
+Run a real-delete `ac` cleanup wave with an explicit hard cap:
+
+```bash
+cost-insight cleanup-gcs-cache \
+  --mode delete \
+  --execute-kind ac \
+  --max-delete-objects 10000000
 ```

--- a/cost-insight/docs/gcs-bazel-cache-cleanup-design.md
+++ b/cost-insight/docs/gcs-bazel-cache-cleanup-design.md
@@ -1,685 +1,585 @@
-# GCS Bazel Cache Cleanup Design
+# GCS Bazel Cache Historical Silent Object Evaluation Design
 
 ## Context
 
 CI Bazel jobs use the GCS bucket
 `pingcap-ci-bazel-remote-cache-us-central1` as a remote cache backend.
 
-As of 2026-06-09, this bucket is the dominant storage consumer in the
-`pingcap-testing-account` project:
+As of 2026-06-14:
 
-- bucket size: about `589.97 TiB`
-- lifecycle: none
-- access log source: `pingcap-testing-account.ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access`
-- log sink: `ci-bazel-cache-gcs-data-access-to-bq`
+- access-log source:
+  `pingcap-testing-account.ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access`
+- access-log window:
+  `2026-05-25 07:01:34 UTC` to `2026-06-14 08:49:38 UTC`
+- current `last_seen` object set:
+  `80,725,633` objects in
+  `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`
+- inventory snapshot:
+  `gs://pingcap-ci-console-logs-us-central1/gcs-cache-inventory/2026-06-10/`
+- inventory manifest row count:
+  `248,734,953`
+- inventory snapshot time:
+  `2026-06-11T00:28:58.390558Z`
 
-The bucket is already exporting Cloud Storage Data Access audit logs into
-BigQuery. The next step is to turn that access history into a safe cleanup
-workflow based on `last_seen_at`, not object age.
+The daily BigQuery summary job is already running and maintaining
+`gcs_cache_object_last_seen_current` from `storage.objects.get` and
+`storage.objects.create` logs. That solves the steady-state access-history
+problem for the post-log window, but it still leaves a large historical blind
+spot:
 
-One important caveat is that the access log was enabled recently, not at
-bucket inception. This bucket already contains a large historical object set,
-and many older objects may have produced neither `storage.objects.create` nor
-`storage.objects.get` events during the current audit-log window.
+- objects that already existed before `2026-05-25 07:01:34 UTC`
+- were never read or recreated after the log window began
+- still occupy space in the bucket today
 
-This design keeps the implementation in `cost-insight`, because the project
-already owns:
+Those objects are visible in inventory, but absent from `last_seen`.
 
-- BigQuery-backed cost and usage jobs
-- recurring batch jobs packaged into `cost-insight-jobs`
-- the `ee-apps` to `ee-ops` CronJob rollout flow
+## Goal
 
-## Goals
+Perform a one-time evaluation of the current bucket population to answer:
 
-1. Compute object-level `last_seen_at` for the Bazel remote cache with low
-   recurring BigQuery cost.
-2. Support a weekly dry-run and delete workflow based on "N days without
-   access".
-3. Keep the logic versioned in `ee-apps`, with deployment through `ee-ops`
-   CronJobs.
-4. Make the first slice conservative enough to observe safely before enabling
-   deletes.
-5. Cover the full current bucket object set before enabling delete, including
-   historical objects that predate the audit-log window.
+1. how many current objects were already present before
+   `2026-05-25 07:01:34 UTC` and still have no post-window access record
+2. what percentage of the current bucket object count they represent
+3. what percentage of the current bucket bytes they represent
+4. how that population splits across `ac/`, `cas/`, and `other`
+
+This design deliberately stops at evaluation and delete preparation. It does
+not define the production delete execution yet.
 
 ## Non-goals
 
-- Adding a dashboard page in the first slice.
-- Building a general GCS janitor for arbitrary buckets.
-- Exact deleted-byte accounting in the first slice.
-- Replacing GCS lifecycle rules for buckets whose retention can be expressed by
-  object age alone.
-- Enabling production delete from a logs-only view of the bucket.
+- Adding a long-lived inventory sync pipeline.
+- Adding a new CronJob or CLI command for this one-time evaluation.
+- Mirroring object-level cache state into TiDB.
+- Enabling delete directly from this document.
+- Replacing the existing `last_seen` daily job.
 
 ## Live Findings
 
-### Access window maturity
+### What `last_seen` already covers
 
-As of 2026-06-09, the access-log table covers:
+`gcs_cache_object_last_seen_current` is built from both
+`storage.objects.get` and `storage.objects.create`.
 
-- `first_ts = 2026-05-25 07:01:34 UTC`
-- `last_ts = 2026-06-09 06:35:08 UTC`
+That means an object is present in `last_seen` if it has had any observed
+read or create activity during the current log window. The table is therefore
+the correct post-window visibility surface for this one-time evaluation.
 
-That is enough to evaluate short-term reuse and to start a dry-run workflow,
-but not enough to claim that a `28-day no access` deletion policy is already
-validated by a full 28-day window. The earliest date when a full 28-day policy
-can be judged from this log stream is approximately 2026-06-22.
+### The historical silent gap
 
-### Read activity shape
+For this task, the target population is:
 
-Recent log shape from the live table:
+- object is present in the current inventory snapshot
+- `time_created < 2026-05-25 07:01:34 UTC`
+- `object_name` does not exist in
+  `gcs_cache_object_last_seen_current`
 
-- total rows in current window: about `659.7M`
-- `storage.objects.get`: about `575.0M`
-- `storage.objects.create`: about `84.7M`
-- one sampled day (`2026-06-08`) had about `39.6M` gets and about `7.24M`
-  creates
+Operationally, these are "inventory-only historical objects":
 
-### Reuse sample
+- they existed before the audit-log window began
+- they have no observed `get` or `create` since that moment
+- they still exist in the bucket now
 
-A deterministic `0.1%` sample of objects created between 2026-05-26 and
-2026-06-01 was checked against subsequent reads through 2026-06-09.
+This is the exact population that a logs-only cleanup design cannot see.
 
-Key findings:
+### Measured historical silent population
 
-- sampled cohort size: `23,199` objects
-- `75.1%` were never read again after create
-- only `0.35%` were still read on or after day 7
-- only `0.14%` were still read on or after day 10
-- only `0.02%` were still read on or after day 14
+The one-time evaluation was executed on 2026-06-14 against:
 
-Split by kind:
+- inventory snapshot time: `2026-06-11T00:28:58.390558Z`
+- current `last_seen` table as of the same working session
 
-- `ac/` cools slightly faster than `cas/`
-- both prefixes become very cold after the first few days
+Measured result:
 
-This supports a future LRU cleanup policy, but the first delete threshold
-should still be conservative because the available observation window is short.
+- `historical_silent_object_count = 178,554,492`
+- `historical_silent_object_ratio_vs_all_inventory = 71.79%`
+- `historical_silent_object_ratio_vs_pre_20260525_inventory = 99.30%`
+- `historical_silent_size_bytes = 495,343,299,908,013`
+- `historical_silent_size_ratio_vs_all_inventory_bytes = 69.78%`
+- `historical_silent_size_ratio_vs_pre_20260525_inventory_bytes = 99.68%`
 
-### Historical object gap
+Split by prefix:
 
-Objects that were created before `2026-05-25` and have not produced any
-`storage.objects.get` or `storage.objects.create` event since that date will
-not be visible to the first-slice summary tables. This is not a small edge
-case. Because the access log was enabled after the bucket had already been in
-use, there may be a large historical population of still-existing objects that
-are completely invisible to the log-derived tables.
+- `ac`: `55,790,841` objects, `29,486,820,553` bytes
+- `cas`: `122,763,651` objects, `495,313,813,087,460` bytes
+- `other`: `0`
 
-That means:
+This result changes the practical rollout order:
 
-1. the current `last_seen` tables are accurate only for the log-visible subset
-   of objects
-2. a logs-only dry-run can help validate query shape and recent reuse behavior,
-   but it is not a complete candidate view for the whole bucket
-3. production delete must not rely only on the log-derived tables
+1. first handle the one-time historical silent population
+2. then design recurring steady-state cleanup for post-window objects
 
-The design correction is to add a full object inventory source before delete.
-The recommended approach is GCS Inventory or Storage Insights exported into
-BigQuery, then joined with the log-derived `last_seen` state.
+### Delete-related operational constraints
 
-After inventory is added, historical silent objects can still participate in a
-conservative LRU policy:
+Current live bucket state relevant to delete:
 
-- if an object existed before `2026-05-25` and no read has been observed since
-  `2026-05-25 07:01:34 UTC`, then by `2026-06-22 07:01:34 UTC` it is provably
-  at least 28 days cold
-- the same logic makes `42-day` silence provable on
-  `2026-07-06 07:01:34 UTC`
+- soft delete is disabled:
+  `soft_delete_policy.retentionDurationSeconds = 0`
+- no lifecycle rule is present
+- `storagebatchoperations.googleapis.com` was not enabled as of
+  2026-06-14
+- Storage batch operations additionally requires Storage Intelligence to be
+  enabled for the bucket's project scope
+- local `gcloud` version used for this work is `565.0.0`
 
-So the real missing piece is not only `last_seen_at`, but full object
-enumeration.
+Because soft delete is disabled, any object delete is permanent. That raises
+the bar for the first deletion slice:
 
-## Why Keep Object State in BigQuery
+- no direct full-scale delete
+- no best-effort high-concurrency custom script
+- all first-pass deletion inputs must be auditable and generation-safe
 
-The canonical object-access state should live in BigQuery, not TiDB.
+## Why Keep This Evaluation In BigQuery
+
+This one-time analysis should stay entirely in BigQuery.
 
 Reasons:
 
-1. The source of truth already lives in BigQuery.
-2. Object cardinality is high enough that daily object-level upserts would make
-   TiDB a poor fit for the first slice.
-3. The primary consumer is the cleanup job, not a latency-sensitive product
-   API.
-4. Keeping object state close to the source avoids an extra BigQuery -> app ->
-   TiDB transport step for millions of objects per day.
+1. the source of truth is already in BigQuery and GCS
+2. object cardinality is too high for a temporary TiDB mirror to be worth it
+3. the result is an offline operational analysis, not a latency-sensitive API
+4. BigQuery already holds the post-window `last_seen` table we need for the
+   join
 
-TiDB may still be useful later for small control-plane or reporting tables, but
-the first slice should not mirror object-level cache state into TiDB.
+## One-Time Evaluation Approach
 
-## Proposed Architecture
+### Input A: current `last_seen` state
 
-```text
-GCS Data Access logs
-  -> BigQuery raw table
-  -> cost-insight daily summary job
-  -> BigQuery object_last_seen tables
-
-GCS Inventory / Storage Insights
-  -> BigQuery inventory snapshot table
-
-object_last_seen + inventory snapshot
-  -> cleanup state / candidate query
-  -> cost-insight weekly cleanup job
-  -> GCS delete operations
-```
-
-Implementation ownership:
-
-- `ee-apps/cost-insight`
-  - Python job code
-  - SQL templates
-  - design docs
-- `ee-ops/apps/gcp/cost-insight`
-  - CronJob manifests
-  - service account wiring
-  - rollout sequencing
-
-## BigQuery Data Model
-
-Use the existing dataset `ci_bazel_cache_logs` in project
-`pingcap-testing-account`, because it is already in the same region as the raw
-audit-log table.
-
-### `gcs_cache_object_last_seen_daily`
-
-Daily object-level aggregation from both `storage.objects.get` and
-`storage.objects.create`.
-
-Suggested schema:
-
-```sql
-CREATE TABLE IF NOT EXISTS `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_daily` (
-  ds DATE NOT NULL,
-  object_name STRING NOT NULL,
-  object_kind STRING NOT NULL,
-  first_seen_at TIMESTAMP NOT NULL,
-  last_seen_at TIMESTAMP NOT NULL,
-  get_count_in_day INT64 NOT NULL,
-  updated_at TIMESTAMP NOT NULL
-)
-PARTITION BY ds
-CLUSTER BY object_kind, object_name;
-```
-
-Column meanings:
-
-- `ds`: logical source day from `DATE(timestamp)`
-- `object_name`: extracted from
-  `protopayload_auditlog.resourceName`
-- `object_kind`: `cas`, `ac`, or `other`
-- `first_seen_at`: earliest event timestamp for that object in that day
-- `last_seen_at`: latest create-or-read timestamp for that object in that day
-- `get_count_in_day`: daily read count for that object
-- `updated_at`: job write timestamp
-
-### `gcs_cache_object_last_seen_current`
-
-Current object state, one row per object.
-
-Suggested schema:
-
-```sql
-CREATE TABLE IF NOT EXISTS `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current` (
-  object_name STRING NOT NULL,
-  object_kind STRING NOT NULL,
-  first_seen_at TIMESTAMP,
-  last_seen_at TIMESTAMP NOT NULL,
-  last_seen_date DATE NOT NULL,
-  total_get_count INT64 NOT NULL,
-  updated_at TIMESTAMP NOT NULL
-)
-CLUSTER BY object_kind, last_seen_date;
-```
-
-This table is one input to the weekly cleanup job, but it is not sufficient by
-itself for full-bucket cleanup decisions.
-
-By itself, this table is not a full-bucket inventory. It only tracks objects
-that are visible in the current audit-log window.
-
-### Required second-source table: `gcs_cache_object_inventory_current`
-
-Current object inventory, one row per object currently present in the bucket.
-
-Suggested schema:
-
-```sql
-CREATE TABLE IF NOT EXISTS `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_inventory_current` (
-  snapshot_date DATE NOT NULL,
-  object_name STRING NOT NULL,
-  object_kind STRING NOT NULL,
-  time_created TIMESTAMP,
-  size_bytes INT64,
-  updated_at TIMESTAMP NOT NULL
-)
-PARTITION BY snapshot_date
-CLUSTER BY object_kind, object_name;
-```
-
-Expected source:
-
-- preferred: GCS Inventory or Storage Insights export into BigQuery
-- fallback: a one-time bootstrap listing job plus periodic refresh, if the
-  platform path for inventory is blocked
-
-Purpose:
-
-- enumerate the whole current bucket object set
-- provide size metadata for better dry-run reporting
-- expose historical silent objects that do not appear in audit logs
-
-### Derived cleanup view: `gcs_cache_object_cleanup_state_current`
-
-This can be a table or a query-level CTE. It joins current inventory with
-log-derived `last_seen` state.
-
-Suggested fields:
-
-- `object_name`
-- `object_kind`
-- `time_created`
-- `size_bytes`
-- `log_first_seen_at`
-- `log_last_seen_at`
-- `has_log_activity`
-- `is_pre_window_inventory_only`
-- `no_access_observed_since`
-
-Semantics:
-
-- for log-visible objects, `log_last_seen_at` is the cleanup decision input
-- for inventory-only historical objects, `log_last_seen_at` is unknown, but
-  `no_access_observed_since = 2026-05-25 07:01:34 UTC` is still provable if the
-  object exists in inventory and has no post-window log activity
-- delete eligibility for inventory-only historical objects must be based on
-  provable silence since log start, not guessed last access time
-
-### Optional future table: `gcs_cache_cleanup_run_reports`
-
-The first slice can log run summaries to stdout and Cloud Logging only.
-If later we want durable run history in BigQuery, add a small report table such
-as:
-
-- `run_ts`
-- `mode`
-- `ac_retention_days`
-- `cas_retention_days`
-- `candidate_object_count`
-- `deleted_object_count`
-- `error_count`
-
-No object-level candidate archive is required in the first slice.
-
-## Job Design
-
-### 1. Daily summary job
-
-CLI shape:
-
-```bash
-cost-insight sync-gcs-cache-last-seen --run-date 2026-06-08
-```
-
-Responsibilities:
-
-1. Read one source day from
-   `ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access`
-2. Filter to:
-   - `resource.labels.bucket_name = "pingcap-ci-bazel-remote-cache-us-central1"`
-   - `protopayload_auditlog.methodName IN ("storage.objects.get", "storage.objects.create")`
-3. Extract `object_name`
-4. Classify `object_kind`
-5. Seed newly created objects into the summary even if they were never read
-6. Aggregate into `gcs_cache_object_last_seen_daily`
-7. `MERGE` daily results into `gcs_cache_object_last_seen_current`
-8. Emit a JSON summary with:
-   - source rows scanned
-   - distinct objects touched
-   - BigQuery bytes processed
-   - run date
-
-Important behavior:
-
-- rerunnable for the same `run-date`
-- one source day per run
-- no GCS delete behavior
-- not a complete bucket inventory on its own
-
-Suggested merge behavior:
-
-- `first_seen_at`: keep the earliest known timestamp
-- `last_seen_at`: keep the greatest value
-- `total_get_count`: add only `storage.objects.get` counts
-- `updated_at`: set to current run time
-
-### 2. Weekly cleanup job
-
-CLI shape:
-
-```bash
-cost-insight cleanup-gcs-cache --mode dry-run
-cost-insight cleanup-gcs-cache --mode delete
-```
-
-Responsibilities:
-
-1. Read the inventory-backed cleanup state
-2. Join with `gcs_cache_object_inventory_current` so the job sees the full
-   current bucket object set
-3. Build candidates with separate retention windows for `ac` and `cas`
-4. Exclude `other`
-5. In `dry-run` mode:
-   - print summary
-   - split counts into `log-visible` and `inventory-only historical`
-   - print example candidate samples
-   - exit without deleting
-6. In `delete` mode:
-   - delete candidates in batches
-   - collect success and error counts
-   - stop if safety thresholds are exceeded
-
-Suggested first-slice flags:
+Use the existing table:
 
 ```text
---mode dry-run|delete
---ac-retention-days 28
---cas-retention-days 42
---max-delete-objects 50000
---batch-size 1000
---sample-limit 100
+pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current
 ```
 
-Deletion should use the Python GCS client rather than shelling out to
-`gcloud storage rm`, so retries and per-object error handling stay in one
-process.
+This is the authoritative view of all objects that had any observed
+`storage.objects.get` or `storage.objects.create` activity during the current
+log window.
 
-## Query Shapes
+### Input B: one-time inventory snapshot
 
-### Daily summary query
+Use the existing Storage Insights inventory export:
 
-Core aggregation shape:
+```text
+gs://pingcap-ci-console-logs-us-central1/gcs-cache-inventory/2026-06-10/
+```
+
+The report is not productized into a recurring pipeline. Instead, we import it
+once into a temporary BigQuery table for this evaluation and for the first
+delete-preparation pass next week.
+
+### Temporary BigQuery tables
+
+Use two one-time tables in dataset `ci_bazel_cache_logs`:
+
+1. raw staging table loaded from parquet
+2. normalized analysis table with only the fields we actually need
+
+Suggested names:
+
+```text
+pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_raw_20260611
+pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611
+```
+
+The raw staging table exists only because the parquet schema uses source field
+names such as `name`, `size`, and `timeCreated`. The normalized table is the
+one used for analysis.
+
+Normalized table schema:
 
 ```sql
+CREATE OR REPLACE TABLE `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611` AS
 SELECT
-  DATE(timestamp) AS ds,
-  REGEXP_EXTRACT(protopayload_auditlog.resourceName, r"/objects/(.+)$") AS object_name,
-  CASE
-    WHEN STARTS_WITH(REGEXP_EXTRACT(protopayload_auditlog.resourceName, r"/objects/(.+)$"), "cas/") THEN "cas"
-    WHEN STARTS_WITH(REGEXP_EXTRACT(protopayload_auditlog.resourceName, r"/objects/(.+)$"), "ac/") THEN "ac"
-    ELSE "other"
-  END AS object_kind,
-  MIN(timestamp) AS first_seen_at,
-  MAX(timestamp) AS last_seen_at,
-  COUNTIF(protopayload_auditlog.methodName = "storage.objects.get") AS get_count_in_day,
-  CURRENT_TIMESTAMP() AS updated_at
-FROM `pingcap-testing-account.ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access`
-WHERE DATE(timestamp) = @run_date
-  AND resource.labels.bucket_name = "pingcap-ci-bazel-remote-cache-us-central1"
-  AND protopayload_auditlog.methodName IN ("storage.objects.get", "storage.objects.create")
-GROUP BY ds, object_name, object_kind;
+  name AS object_name,
+  timeCreated AS time_created,
+  size AS size_bytes
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_raw_20260611`
+WHERE bucket = "pingcap-ci-bazel-remote-cache-us-central1";
 ```
 
-Measured dry-run cost for one daily source partition:
+Only these fields are retained:
 
-- bytes processed: `9,885,639,778` bytes
-- about `9.89 GB`
+- `object_name STRING`
+- `time_created TIMESTAMP`
+- `size_bytes INT64`
 
-### Weekly cleanup query
+These fields are intentionally not retained in the normalized table:
 
-The weekly cleanup job should not read the raw audit-log table. It should read
-the inventory-backed cleanup state built from
-`gcs_cache_object_last_seen_current` plus
-`gcs_cache_object_inventory_current`.
+- `snapshot_date`
+- `snapshot_time`
+- `storage_class`
+- `object_kind`
+- `generation`
 
-Example candidate query:
+`snapshot_time` still matters, but only as run metadata in the runbook and
+operator notes. It does not need to be stored per row.
+
+## Core Analysis Definition
+
+The historical silent object population is defined as:
+
+1. object exists in the normalized inventory table
+2. `time_created < TIMESTAMP("2026-05-25 07:01:34 UTC")`
+3. `LEFT JOIN` to `gcs_cache_object_last_seen_current` by `object_name`
+4. `WHERE last_seen.object_name IS NULL`
+
+That yields the exact one-time cohort we want:
+
+- existed before the log window
+- still exists today
+- no observed `storage.objects.get` or `storage.objects.create` in the current
+  log window
+
+`ac/`, `cas/`, and `other` are not stored in the temporary table. They are
+derived at query time from `object_name`:
 
 ```sql
-SELECT object_name, object_kind, size_bytes, effective_last_seen_at
-FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_cleanup_state_current`
-WHERE (
-    object_kind = 'ac'
-    AND (
-      (
-        has_log_activity
-        AND effective_last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_retention_days DAY)
-      ) OR (
-        is_pre_window_inventory_only
-        AND no_access_observed_since <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_retention_days DAY)
-      )
-    )
-  ) OR (
-    object_kind = 'cas'
-    AND (
-      (
-        has_log_activity
-        AND effective_last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_retention_days DAY)
-      ) OR (
-        is_pre_window_inventory_only
-        AND no_access_observed_since <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_retention_days DAY)
-      )
-    )
-  )
-ORDER BY object_kind, effective_last_seen_at
-LIMIT @max_delete_objects;
+CASE
+  WHEN STARTS_WITH(object_name, "ac/") THEN "ac"
+  WHEN STARTS_WITH(object_name, "cas/") THEN "cas"
+  ELSE "other"
+END
 ```
 
-## Cost Model
+## Output Metrics
 
-BigQuery scheduled queries and manual queries are priced the same. The first
-slice will run from a CronJob in `ee-ops`, but the underlying pricing model is
-still regular BigQuery query processing.
+The one-time evaluation must produce these metrics:
 
-At the current documented on-demand US rate:
+### Object-count metrics
 
-- first `1 TiB` per month per billing account: free
-- above that: `US $6.25 / TiB`
+- `historical_silent_object_count`
+- `historical_silent_object_ratio_vs_all_inventory`
+- `historical_silent_object_ratio_vs_pre_20260525_inventory`
 
-Reference:
+### Byte metrics
 
-- [BigQuery pricing](https://cloud.google.com/bigquery/pricing?hl=en_US)
-- [Scheduling queries](https://docs.cloud.google.com/bigquery/docs/scheduling-queries)
+- `historical_silent_size_bytes`
+- `historical_silent_size_ratio_vs_all_inventory_bytes`
+- `historical_silent_size_ratio_vs_pre_20260525_inventory_bytes`
 
-### Estimated recurring scan cost
+### Prefix split
 
-Measured daily summary query:
+Each of the above should also be split by:
 
-- about `9.89 GB/day`
-- about `69.2 GB/week`
-- about `0.0629 TiB/week`
-- about `US $0.39/week` at on-demand pricing before free-tier effects
+- `ac`
+- `cas`
+- `other`
 
-This means the recurring summary pipeline is cheap enough to run daily.
+### Spot-check sample
 
-### Why daily instead of weekly summary
+The evaluation should also produce a small object-name sample for manual
+verification before any delete design is finalized.
 
-Daily summary is not chosen because it is dramatically cheaper than an ideal
-weekly incremental summary. If both scan each source day exactly once, total
-scan volume is similar.
+## Cost Estimate
 
-Daily summary is chosen because it gives:
+This section is intentionally approximate and is based on the current report
+size and current BigQuery pricing as checked on 2026-06-14.
 
-1. smaller failure domains
-2. simpler reruns
-3. a stable object-state table for weekly cleanup
-4. no need for the weekly cleaner to rescan raw access logs
+Official pricing references:
 
-### Ad hoc analysis cost
+- query: `US $6.25 / TiB scanned`
+- first `1 TiB / month` of on-demand query usage: free
+- load data: free
+- active logical storage: about `US $0.02 / GiB-month`
 
-Measured sample query cost for a 14-day cohort study:
+References:
 
-- bytes processed: `128,657,528,203`
-- about `128.7 GB`
-- about `US $0.73/run`
+- [BigQuery pricing](https://cloud.google.com/bigquery/pricing)
+- [External tables pricing](https://docs.cloud.google.com/bigquery/docs/external-tables)
+- [Estimate query costs](https://docs.cloud.google.com/bigquery/docs/best-practices-costs)
+- [BigQuery data type sizes](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-types)
 
-A similar 28-day access-pattern study would be expected to cost on the order of
-`~US $1.46/run`, assuming roughly linear growth in scanned days.
+Inventory-report scale used for the estimate:
 
-This is acceptable for one-off validation, but it is not the right shape for a
-recurring weekly cleanup decision path.
+- parquet files total size: about `25.3 GB`
+- manifest rows: `248,734,953`
+- observed average `object_name` length in current `last_seen` table:
+  about `67.7` bytes
 
-## What the First Slice Will Not Measure Exactly
+Approximate cost envelope for the one-time workflow:
 
-The current access-log table is strong on access recency, but weak on object
-size and whole-bucket coverage:
+- load parquet into raw staging table: `US $0`
+- normalized inventory table logical size: about `19.8 GiB`
+- temporary-table storage:
+  - about `US $0.013 / day`
+  - about `US $0.09 / week`
+  - about `US $0.40 / month`
+- one query that scans only the normalized inventory table:
+  about `US $0.12`
+- one query that scans normalized inventory plus
+  `gcs_cache_object_last_seen_current` for the join:
+  about `US $0.15`
 
-- `storage.objects.get` rows often contain `metadataJson.requested_bytes`
-- `storage.objects.create` rows do not reliably expose full object size
-- historical silent objects may have no log rows in the current window
+Important notes:
 
-Therefore, the first slice should report:
+- if the billing account has not exhausted the monthly free `1 TiB` on-demand
+  query allowance, the actual billed query cost can be lower or zero
+- these are logical-byte estimates, not billing-export-confirmed charges
+- the `US $0` statement applies to the parquet `load` step itself; the later
+  SQL projection and join analysis are normal BigQuery queries
 
-- candidate object count
-- candidate split by `ac` and `cas`
-- oldest and newest candidate `last_seen_at`
-- example candidate names
+## Validation
 
-The first slice should not promise exact reclaimable TiB per run.
+Before using the result for delete planning, all of the following checks should
+pass:
 
-If exact deleted-byte accounting and full-bucket coverage are required, add a
-second source such as GCS Inventory or Storage Insights and join it by
-`object_name`.
+1. normalized inventory row count matches manifest `recordsProcessed`
+2. `historical_silent_object_count <= pre_20260525_inventory_object_count <= all_inventory_object_count`
+3. `historical_silent_size_bytes <= pre_20260525_inventory_size_bytes <= all_inventory_size_bytes`
+4. `ac + cas + other = total`
+5. at least 10 sample objects are manually checked to confirm:
+   - they exist in inventory
+   - `time_created` is earlier than `2026-05-25 07:01:34 UTC`
+   - they do not exist in `gcs_cache_object_last_seen_current`
 
-## Recommended Retention Policy
+## Delete Execution Design
 
-### Dry-run phase
+This section defines the first production delete design for the historical
+silent population only.
 
-Start immediately with weekly dry-runs:
+It intentionally does not merge that work with the later recurring LRU cleanup
+for post-window objects.
 
-- `ac`: `28 days no access`
-- `cas`: `42 days no access`
+### Why not use a custom delete script first
 
-Reasoning:
+For this first slice, a custom script that issues individual delete requests is
+not the preferred path.
 
-- the sample shows very fast cooling
-- `cas` is the dominant storage consumer, but it is safer to retain longer in
-  the first delete slice
-- `ac` can be more aggressive because cache misses on action metadata are less
-  risky than a broken reference chain to missing content blobs
+Reasons:
 
-### Delete phase
+1. the target set is extremely large: `178,554,492` objects
+2. the bucket has no soft delete protection
+3. the initial object-write guideline for a flat bucket is on the order of
+   `~1000` write or delete requests per second, and Google recommends gradual
+   ramp-up
+4. Cloud Storage now provides a managed bulk-delete path specifically for
+   millions or billions of objects
 
-Do not enable recurring delete until both conditions are true:
+Preferred path:
 
-1. the access-log window has matured far enough for the chosen retention
-2. inventory has been added so historical silent objects are not invisible
+- use Cloud Storage Storage batch operations with manifest files
+- include object `generation` in every manifest row
+- enable Cloud Logging for both `succeeded` and `failed` transforms
 
-Earliest possible dates after the current log start are:
+### Candidate materialization
 
-- `ac = 28 days`: approximately `2026-06-22 07:01:34 UTC`
-- `cas = 42 days`: approximately `2026-07-06 07:01:34 UTC`
+The temporary normalized inventory table is sufficient for evaluation, but not
+for safe delete execution because it dropped `generation`.
 
-These dates are necessary but not sufficient. Delete should still remain
-blocked until the inventory join is in place.
+Delete execution should therefore build a one-time candidate table from the raw
+staging inventory table plus `gcs_cache_object_last_seen_current`.
 
-Even after that date, the first production step should be:
-
-1. keep the delete CronJob present but suspended
-2. run dry-run for at least 2-3 consecutive weeks
-3. inspect candidate volume and job health
-4. unsuspend delete with conservative per-run limits
-
-## Safety Guards
-
-The weekly delete job should include the following guards:
-
-1. `dry-run` as the default mode
-2. separate retention windows for `ac` and `cas`
-3. exclude `other`
-4. `concurrencyPolicy: Forbid`
-5. `suspend: true` for delete CronJob at initial rollout
-6. per-run maximum object limit
-7. batch delete limit
-8. stop the run if error rate exceeds a threshold
-9. idempotent handling for already-missing objects
-10. inventory snapshot freshness check before any delete run
-
-Suggested first values:
-
-- `max-delete-objects = 50,000`
-- `batch-size = 1,000`
-- stop if delete errors exceed `1%` or a fixed small absolute threshold
-
-Because exact object bytes are not available in the first slice, a strict
-`max-delete-bytes` guard should be deferred until inventory is added.
-
-## Rollout Shape
-
-### Code placement
-
-Add new code under:
+Suggested one-time table:
 
 ```text
-cost-insight/
-  docs/gcs-bazel-cache-cleanup-design.md
-  src/cost_insight/jobs/sync_gcs_cache_last_seen.py
-  src/cost_insight/jobs/cleanup_gcs_cache.py
+pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_delete_candidates_20260614
 ```
 
-CLI additions in:
+Suggested schema:
+
+- `bucket STRING`
+- `object_name STRING`
+- `generation INT64`
+- `object_kind STRING`
+- `time_created TIMESTAMP`
+- `size_bytes INT64`
+- `shard_id INT64`
+- `candidate_reason STRING`
+- `candidate_generated_at TIMESTAMP`
+
+`shard_id` should be deterministic:
+
+```sql
+MOD(ABS(FARM_FINGERPRINT(object_name)), 256)
+```
+
+`candidate_reason` for this slice is fixed to:
 
 ```text
-cost-insight/src/cost_insight/jobs/cli.py
+historical_silent_pre_20260525_no_post_window_activity
 ```
 
-### CronJob placement
+### Why generation is required
 
-Add new manifests beside the existing cost-insight CronJobs in:
+The manifest format used by Storage batch operations allows an optional
+`generation` column.
+
+This must be included for the first slice.
+
+Reason:
+
+- if a manifest contains only `bucket` and `name`, Cloud Storage deletes the
+  current live object for that name
+- some objects may have been recreated after the inventory snapshot
+- using `generation` pins deletion to the exact snapshot generation and avoids
+  deleting a newer live object that reused the same name
+
+### Delete phases
+
+The delete rollout should be split into four phases.
+
+#### Phase 0: final freeze and refresh
+
+Before any delete job is created:
+
+1. refresh `gcs_cache_object_last_seen_current` through the latest complete UTC
+   day
+2. rebuild the delete candidate table from the inventory snapshot plus the
+   refreshed `last_seen`
+3. export immutable manifests from that candidate table
+4. do not modify the candidate table after manifest export
+
+This phase exists to make the delete input auditable and reproducible.
+
+#### Phase 1: `ac` canary
+
+Create one small canary manifest for `ac` only.
+
+Suggested size:
+
+- `10,000` objects
+
+Suggested ordering:
+
+- oldest `time_created` first
+
+After the canary batch job completes:
+
+- wait `12-24` hours
+- inspect Cloud Logging job results
+- inspect CI behavior for unexpected cache-miss amplification
+
+#### Phase 2: remaining `ac`
+
+If the canary is clean:
+
+- delete the remaining `ac` historical silent objects
+
+This is still meaningful as a safety gate even though `ac` bytes are tiny,
+because it validates:
+
+- manifest generation handling
+- batch-operation observability
+- operator workflow
+
+#### Phase 3: `cas` main cleanup
+
+Delete `cas` candidates in shard groups.
+
+Suggested shard plan:
+
+- total shards: `256`
+- one batch job per `8` shards
+- initial concurrency: `1` batch job
+- if the first jobs are healthy, raise to `2-4` concurrent jobs
+
+This keeps rollout pressure deliberate without inventing custom client-side
+rate control.
+
+#### Phase 4: post-delete re-measurement
+
+After the historical silent sweep completes:
+
+1. generate a fresh inventory report
+2. rerun the one-time evaluation query shape
+3. confirm that the historical silent population collapsed as expected
+4. only then move on to recurring steady-state LRU delete design
+
+### Storage batch operations requirements
+
+Prerequisites for the first delete slice:
+
+1. enable `storagebatchoperations.googleapis.com`
+2. enable Storage Intelligence for the project scope that contains the bucket
+   and make an explicit edition decision
+3. use a principal with `roles/storage.admin` on the project or bucket
+4. store manifests in a Cloud Storage bucket path that the operator can read
+5. enable job logging with:
+   - `--log-actions=transform`
+   - `--log-action-states=succeeded,failed`
+
+Because the bucket already has Storage Insights inventory configured, the
+remaining missing prerequisite is Storage Intelligence enrollment for batch
+operations.
+
+### Manifest strategy
+
+Manifests should be created as CSV files with header:
 
 ```text
-ee-ops/apps/gcp/cost-insight/cronjobs.yaml
+bucket,name,generation
 ```
 
-Suggested CronJobs:
+Each manifest should contain objects from only one source bucket:
 
-1. `cost-insight-sync-gcs-cache-last-seen`
-   - daily
-   - BQ read + BQ merge only
-2. `cost-insight-sync-gcs-cache-inventory`
-   - daily or weekly, depending on inventory export frequency
-   - refresh inventory-backed current table
-3. `cost-insight-cleanup-gcs-cache-dry-run`
-   - weekly
-   - full-bucket dry-run only
-4. `cost-insight-cleanup-gcs-cache-delete`
-   - weekly
-   - initially `suspend: true`
+```text
+pingcap-ci-bazel-remote-cache-us-central1
+```
 
-The same `cost-insight-jobs` image can own all three commands.
+Suggested manifest layout:
 
-### IAM and runtime
+```text
+gs://pingcap-ci-console-logs-us-central1/gcs-cache-delete-manifests/2026-06-14/
+  ac-canary.csv
+  ac-rest.csv
+  cas-shards-000-007.csv
+  cas-shards-008-015.csv
+  ...
+```
 
-The CronJob service account needs:
+### Stop conditions
 
-- BigQuery job execution
-- read/write access to dataset `ci_bazel_cache_logs`
-- GCS object delete permission on
-  `pingcap-ci-bazel-remote-cache-us-central1`
+The delete rollout should stop immediately if any of the following occurs:
 
-If the existing `ci-dashboard` workload identity path is reused, add only the
-minimum incremental GCS permission needed for delete.
+1. unexpected failed transforms exceed `0.1%`
+2. unexpected failed transforms exceed `1000` objects for a job
+3. CI cache behavior shows clear regression after the `ac` canary
+4. operator validation reveals manifest-generation mismatch or candidate drift
 
-## Concurrency and Recovery
+Expected non-fatal outcomes:
 
-Only one active instance of each cleanup job type should run at a time.
+- `not found`
+- generation mismatch against newer objects
 
-Recommended rules:
+These should be recorded and reviewed, but they are not by themselves a reason
+to treat the whole job as unsafe.
 
-- summary job may rerun safely for the same day
-- inventory sync may rerun safely for the same snapshot day
-- dry-run and delete must never overlap
-- a failed delete run should be rerunnable without manual cleanup of partially
-  processed object lists
+### Separation from future steady-state cleanup
 
-If later we need stronger operator visibility, add a small run-state table in
-TiDB or a BigQuery run-report table. That is not required for the first slice.
+This delete design is only for the historical silent population identified by
+the inventory snapshot.
 
-## Open Questions
+The later recurring cleanup design should remain separate:
 
-1. Do we want to use GCS Inventory or Storage Insights as the full object
-   inventory source?
-2. If inventory export is not immediately available, do we want a one-time
-   bootstrap listing job as an interim fallback?
-3. Should the first delete slice remove only `ac`, or is `ac=28d` and
-   `cas=42d` acceptable immediately after the dry-run period?
-4. Do we want a small API or SQL report later for cleanup history, or are
-   CronJob logs enough?
+- input: post-window `last_seen` candidates
+- cadence: weekly
+- retention: still expected to start from `ac=28d`, `cas=42d`
+- implementation home: existing `cost-insight` plus `ee-ops` CronJob path
+
+Do not combine the first historical cleanup with that steady-state workflow in
+the same initial rollout.
+
+## Relationship To The Existing `last_seen` Pipeline
+
+The current daily job remains unchanged:
+
+- `sync-gcs-cache-last-seen` continues to summarize one UTC day of access logs
+- `gcs_cache_object_last_seen_current` continues to be the steady-state
+  post-window access table
+
+This one-time inventory-based analysis is additive. It closes the pre-log blind
+spot without introducing a new recurring pipeline yet.
+
+## Next Step After This Evaluation
+
+After the historical silent population is quantified, the next delete design
+discussion can decide:
+
+1. the exact manifest export queries and batch-job commands
+2. the canary timing and approval checkpoint
+3. the shard grouping for `cas`
+4. whether the ongoing steady-state cleanup should continue to rely on
+   `last_seen` plus future inventory refreshes
+
+That delete execution design is intentionally deferred until the one-time
+evaluation result is in hand.

--- a/cost-insight/docs/gcs-bazel-cache-historical-silent-objects-delete-runbook.md
+++ b/cost-insight/docs/gcs-bazel-cache-historical-silent-objects-delete-runbook.md
@@ -1,0 +1,367 @@
+# GCS Bazel Cache Historical Silent Objects Delete Runbook
+
+## Purpose
+
+This runbook defines the first production delete workflow for the historical
+silent population in `pingcap-ci-bazel-remote-cache-us-central1`.
+
+This runbook only covers the one-time historical silent sweep. It does not
+cover the later recurring steady-state LRU cleanup.
+
+## Safety Summary
+
+Current live constraints as of 2026-06-14:
+
+- bucket soft delete is disabled
+- bucket lifecycle is not configured
+- delete is therefore permanent
+- historical silent candidates are extremely large in count and bytes
+
+Because of that, this runbook uses:
+
+- immutable BigQuery candidate tables
+- manifest files that include `generation`
+- Cloud Storage Storage batch operations
+- a staged rollout: `ac` canary, `ac` full, then `cas` shard groups
+
+## Prerequisites
+
+### Required APIs
+
+Enable the batch-operations API:
+
+```bash
+gcloud services enable storagebatchoperations.googleapis.com \
+  --project=pingcap-testing-account
+```
+
+### Required Storage Intelligence enrollment
+
+Storage batch operations is not available until Storage Intelligence is enabled
+for the bucket's project scope.
+
+CLI entrypoint:
+
+```bash
+gcloud storage intelligence-configs enable \
+  --project=pingcap-testing-account \
+  --trial-edition
+```
+
+Important note:
+
+- the `TRIAL` tier enables batch operations immediately
+- according to the current product documentation, the 30-day trial
+  automatically upgrades to `STANDARD` if it is not disabled before the trial
+  ends
+
+Do not run this command casually. Treat it as a billing-affecting change that
+should be explicitly approved by the bucket owner.
+
+### Required permissions
+
+The operator should have:
+
+- `roles/storage.admin`
+- enough permission to read and write objects in
+  `gs://pingcap-ci-console-logs-us-central1/`
+- enough permission to run BigQuery queries and export results in
+  `pingcap-testing-account.ci_bazel_cache_logs`
+
+### Local tooling
+
+Validated during this work:
+
+- `gcloud` version: `565.0.0`
+
+## Inputs
+
+### Raw staging inventory table
+
+```text
+pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_raw_20260611
+```
+
+This table must exist and must contain at least:
+
+- `bucket`
+- `name`
+- `size`
+- `timeCreated`
+- `generation`
+
+### Current `last_seen` table
+
+```text
+pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current
+```
+
+## Step 1: Build The Immutable Delete Candidate Table
+
+Create the delete candidate table directly from raw inventory plus current
+`last_seen`.
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+CREATE OR REPLACE TABLE `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_delete_candidates_20260614` AS
+SELECT
+  raw.bucket AS bucket,
+  raw.name AS object_name,
+  raw.generation AS generation,
+  CASE
+    WHEN STARTS_WITH(raw.name, "ac/") THEN "ac"
+    WHEN STARTS_WITH(raw.name, "cas/") THEN "cas"
+    ELSE "other"
+  END AS object_kind,
+  raw.timeCreated AS time_created,
+  raw.size AS size_bytes,
+  MOD(ABS(FARM_FINGERPRINT(raw.name)), 256) AS shard_id,
+  "historical_silent_pre_20260525_no_post_window_activity" AS candidate_reason,
+  CURRENT_TIMESTAMP() AS candidate_generated_at
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_raw_20260611` AS raw
+LEFT JOIN `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current` AS last
+  ON raw.name = last.object_name
+WHERE raw.bucket = "pingcap-ci-bazel-remote-cache-us-central1"
+  AND raw.timeCreated < TIMESTAMP("2026-05-25 07:01:34 UTC")
+  AND last.object_name IS NULL
+'
+```
+
+## Step 2: Validate Candidate Totals
+
+Verify the candidate totals before any manifest export:
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+SELECT
+  object_kind,
+  COUNT(*) AS object_count,
+  COALESCE(SUM(size_bytes), 0) AS size_bytes
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_delete_candidates_20260614`
+GROUP BY object_kind
+ORDER BY object_kind
+'
+```
+
+Expected baseline from the current analysis:
+
+- `ac`: `55,790,841` objects
+- `cas`: `122,763,651` objects
+- `other`: `0`
+
+## Step 3: Export The `ac` Canary Manifest
+
+Export a single small canary manifest with header `bucket,name,generation`.
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+EXPORT DATA OPTIONS (
+  uri = "gs://pingcap-ci-console-logs-us-central1/gcs-cache-delete-manifests/2026-06-14/ac-canary.csv",
+  format = "CSV",
+  overwrite = true,
+  header = true
+) AS
+SELECT
+  bucket,
+  object_name AS name,
+  generation
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_delete_candidates_20260614`
+WHERE object_kind = "ac"
+ORDER BY time_created, object_name
+LIMIT 10000
+'
+```
+
+## Step 4: Dry-Run The `ac` Canary Batch Job
+
+Create a dry-run batch job first.
+
+```bash
+gcloud storage batch-operations jobs create gcs-cache-ac-canary-dry-run-20260614 \
+  --bucket=gs://pingcap-ci-bazel-remote-cache-us-central1 \
+  --manifest-location=gs://pingcap-ci-console-logs-us-central1/gcs-cache-delete-manifests/2026-06-14/ac-canary.csv \
+  --delete-object \
+  --dry-run \
+  --log-actions=transform \
+  --log-action-states=succeeded,failed \
+  --description='Dry run for historical silent AC canary delete'
+```
+
+Confirm the dry-run object count matches the manifest expectation.
+
+If the command returns a permission error stating that Storage Intelligence is
+not enabled for the bucket's project, stop here and complete the prerequisite
+in the previous section first.
+
+## Step 5: Execute The `ac` Canary
+
+If the dry run is correct, create the real canary job:
+
+```bash
+gcloud storage batch-operations jobs create gcs-cache-ac-canary-20260614 \
+  --bucket=gs://pingcap-ci-bazel-remote-cache-us-central1 \
+  --manifest-location=gs://pingcap-ci-console-logs-us-central1/gcs-cache-delete-manifests/2026-06-14/ac-canary.csv \
+  --delete-object \
+  --log-actions=transform \
+  --log-action-states=succeeded,failed \
+  --description='Historical silent AC canary delete'
+```
+
+After completion:
+
+- wait `12-24` hours
+- inspect batch-operation logs
+- inspect CI behavior for unexpected cache regression
+
+## Step 6: Export And Delete Remaining `ac`
+
+If the canary is clean, export the remaining `ac` manifest.
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+EXPORT DATA OPTIONS (
+  uri = "gs://pingcap-ci-console-logs-us-central1/gcs-cache-delete-manifests/2026-06-14/ac-rest.csv",
+  format = "CSV",
+  overwrite = true,
+  header = true
+) AS
+SELECT
+  bucket,
+  object_name AS name,
+  generation
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_delete_candidates_20260614`
+WHERE object_kind = "ac"
+QUALIFY ROW_NUMBER() OVER (ORDER BY time_created, object_name) > 10000
+'
+```
+
+Then create the delete job:
+
+```bash
+gcloud storage batch-operations jobs create gcs-cache-ac-rest-20260614 \
+  --bucket=gs://pingcap-ci-bazel-remote-cache-us-central1 \
+  --manifest-location=gs://pingcap-ci-console-logs-us-central1/gcs-cache-delete-manifests/2026-06-14/ac-rest.csv \
+  --delete-object \
+  --log-actions=transform \
+  --log-action-states=succeeded,failed \
+  --description='Historical silent AC full delete after canary'
+```
+
+## Step 7: Export `cas` Manifests By Shard Group
+
+Export one manifest per eight shards.
+
+Example for shards `0-7`:
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+EXPORT DATA OPTIONS (
+  uri = "gs://pingcap-ci-console-logs-us-central1/gcs-cache-delete-manifests/2026-06-14/cas-shards-000-007.csv",
+  format = "CSV",
+  overwrite = true,
+  header = true
+) AS
+SELECT
+  bucket,
+  object_name AS name,
+  generation
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_delete_candidates_20260614`
+WHERE object_kind = "cas"
+  AND shard_id BETWEEN 0 AND 7
+ORDER BY shard_id, object_name
+'
+```
+
+Repeat for:
+
+- `008-015`
+- `016-023`
+- ...
+- `248-255`
+
+## Step 8: Delete `cas` In Controlled Concurrency
+
+Start with a single batch job:
+
+```bash
+gcloud storage batch-operations jobs create gcs-cache-cas-shards-000-007-20260614 \
+  --bucket=gs://pingcap-ci-bazel-remote-cache-us-central1 \
+  --manifest-location=gs://pingcap-ci-console-logs-us-central1/gcs-cache-delete-manifests/2026-06-14/cas-shards-000-007.csv \
+  --delete-object \
+  --log-actions=transform \
+  --log-action-states=succeeded,failed \
+  --description='Historical silent CAS delete shards 000-007'
+```
+
+Recommended rollout:
+
+1. run `1` `cas` job
+2. inspect logs and completion behavior
+3. if healthy, increase to `2`
+4. if still healthy, increase to `4`
+
+Do not start with all manifests at once.
+
+## Step 9: Monitor Jobs And Logs
+
+List jobs:
+
+```bash
+gcloud storage batch-operations jobs list
+```
+
+Describe a job:
+
+```bash
+gcloud storage batch-operations jobs describe gcs-cache-ac-canary-20260614
+```
+
+Read logs:
+
+```bash
+gcloud logging read \
+  'resource.type="storagebatchoperations.googleapis.com/Job"' \
+  --limit=50
+```
+
+## Step 10: Stop Conditions
+
+Stop the rollout immediately if any of the following occurs:
+
+- unexpected failed transforms exceed `0.1%`
+- unexpected failed transforms exceed `1000` objects in one job
+- CI cache behavior clearly regresses after the `ac` canary
+- manifest-generation mismatch or candidate drift is discovered
+
+Expected non-fatal outcomes:
+
+- object already missing
+- generation mismatch against a newer object
+
+Record those separately, but do not automatically treat them as catastrophic.
+
+## Step 11: Post-Delete Verification
+
+After all historical silent manifests finish:
+
+1. request a fresh inventory snapshot
+2. rerun the evaluation query against the new snapshot
+3. compare:
+   - total objects
+   - total bytes
+   - residual historical silent objects
+
+The expected result is that the historical silent population falls close to
+zero, aside from objects that changed after the original snapshot or were
+intentionally excluded.
+
+## Optional Cleanup
+
+After verification, remove no-longer-needed temporary tables:
+
+```bash
+bq --location=US rm -f -t \
+  pingcap-testing-account:ci_bazel_cache_logs._tmp_gcs_cache_delete_candidates_20260614
+```
+
+Keep manifest files until the rollout is fully accepted and audited.

--- a/cost-insight/docs/gcs-bazel-cache-historical-silent-objects-runbook.md
+++ b/cost-insight/docs/gcs-bazel-cache-historical-silent-objects-runbook.md
@@ -1,0 +1,312 @@
+# GCS Bazel Cache Historical Silent Objects Runbook
+
+## Purpose
+
+This runbook executes a one-time evaluation of historical silent objects in
+`pingcap-ci-bazel-remote-cache-us-central1`.
+
+A historical silent object is defined as an object that:
+
+- exists in the current inventory snapshot
+- has `time_created < 2026-05-25 07:01:34 UTC`
+- does not exist in
+  `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`
+
+In plain terms, it already existed before the GCS Data Access audit-log window
+began and has had no observed `storage.objects.get` or `storage.objects.create`
+activity since then.
+
+## Inputs
+
+### Audit-log-backed current state
+
+```text
+pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current
+```
+
+### Inventory snapshot
+
+```text
+gs://pingcap-ci-console-logs-us-central1/gcs-cache-inventory/2026-06-10/
+```
+
+Snapshot metadata:
+
+- manifest rows: `248,734,953`
+- snapshot time: `2026-06-11T00:28:58.390558Z`
+- target datetime: `2026-06-11`
+
+### One-time BigQuery tables
+
+```text
+pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_raw_20260611
+pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611
+```
+
+## Step 1: Confirm Inventory Report Completeness
+
+Check that the manifest exists and the parquet shards are present:
+
+```bash
+gcloud storage cat \
+  gs://pingcap-ci-console-logs-us-central1/gcs-cache-inventory/2026-06-10/5183fd89-65d6-4067-b511-fc91f0ddea71_2026-06-11T00:00_manifest.json
+
+gcloud storage ls \
+  gs://pingcap-ci-console-logs-us-central1/gcs-cache-inventory/2026-06-10/*_2026-06-11T00:28_*.parquet \
+  | wc -l
+```
+
+Expected outcome:
+
+- manifest shows `recordsProcessed = 248734953`
+- parquet shard count should match the report's shard count
+
+## Step 2: Load Parquet Into A Raw BigQuery Staging Table
+
+Load the parquet shards directly into BigQuery. This step is a BigQuery load
+job, so the load itself is free.
+
+Note: for this report layout, the direct wildcard form was not accepted by
+`bq load` during execution on 2026-06-14. The reliable approach is to expand
+the shard list first and then pass the comma-separated URI list to `bq load`.
+
+```bash
+uris=$(
+  gcloud storage ls \
+    'gs://pingcap-ci-console-logs-us-central1/gcs-cache-inventory/2026-06-10/*_2026-06-11T00:28_*.parquet' \
+    | paste -sd, -
+)
+
+bq --location=US load \
+  --replace \
+  --source_format=PARQUET \
+  pingcap-testing-account:ci_bazel_cache_logs._tmp_gcs_cache_inventory_raw_20260611 \
+  "$uris"
+```
+
+The expected raw schema includes at least:
+
+- `bucket`
+- `name`
+- `size`
+- `timeCreated`
+
+## Step 3: Project Into The Normalized Analysis Table
+
+Create the one-time normalized table with only the fields needed for the
+evaluation.
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+CREATE OR REPLACE TABLE `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611` AS
+SELECT
+  name AS object_name,
+  timeCreated AS time_created,
+  size AS size_bytes
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_raw_20260611`
+WHERE bucket = "pingcap-ci-bazel-remote-cache-us-central1"
+'
+```
+
+Normalized schema:
+
+- `object_name STRING`
+- `time_created TIMESTAMP`
+- `size_bytes INT64`
+
+## Step 4: Validate Imported Row Count
+
+Check that the normalized table row count matches the manifest:
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+SELECT COUNT(*) AS object_count
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611`
+'
+```
+
+Expected result:
+
+- `248734953`
+
+If the row count does not match, stop and investigate before running the join
+analysis.
+
+## Step 5: Run The Main Summary Query
+
+This query produces the primary output metrics for the historical silent
+population.
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+WITH inventory AS (
+  SELECT
+    object_name,
+    time_created,
+    size_bytes
+  FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611`
+),
+pre_20260525 AS (
+  SELECT
+    object_name,
+    time_created,
+    size_bytes
+  FROM inventory
+  WHERE time_created < TIMESTAMP("2026-05-25 07:01:34 UTC")
+),
+historical_silent AS (
+  SELECT
+    inv.object_name,
+    inv.time_created,
+    inv.size_bytes
+  FROM pre_20260525 AS inv
+  LEFT JOIN `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current` AS last
+    USING (object_name)
+  WHERE last.object_name IS NULL
+),
+all_inventory_totals AS (
+  SELECT
+    COUNT(*) AS all_inventory_object_count,
+    COALESCE(SUM(size_bytes), 0) AS all_inventory_size_bytes
+  FROM inventory
+),
+pre_window_totals AS (
+  SELECT
+    COUNT(*) AS pre_20260525_inventory_object_count,
+    COALESCE(SUM(size_bytes), 0) AS pre_20260525_inventory_size_bytes
+  FROM pre_20260525
+),
+historical_silent_totals AS (
+  SELECT
+    COUNT(*) AS historical_silent_object_count,
+    COALESCE(SUM(size_bytes), 0) AS historical_silent_size_bytes
+  FROM historical_silent
+)
+SELECT
+  historical_silent_object_count,
+  SAFE_DIVIDE(
+    historical_silent_object_count,
+    all_inventory_object_count
+  ) AS historical_silent_object_ratio_vs_all_inventory,
+  SAFE_DIVIDE(
+    historical_silent_object_count,
+    pre_20260525_inventory_object_count
+  ) AS historical_silent_object_ratio_vs_pre_20260525_inventory,
+  historical_silent_size_bytes,
+  SAFE_DIVIDE(
+    historical_silent_size_bytes,
+    all_inventory_size_bytes
+  ) AS historical_silent_size_ratio_vs_all_inventory_bytes,
+  SAFE_DIVIDE(
+    historical_silent_size_bytes,
+    pre_20260525_inventory_size_bytes
+  ) AS historical_silent_size_ratio_vs_pre_20260525_inventory_bytes,
+  all_inventory_object_count,
+  pre_20260525_inventory_object_count,
+  all_inventory_size_bytes,
+  pre_20260525_inventory_size_bytes
+FROM historical_silent_totals
+CROSS JOIN all_inventory_totals
+CROSS JOIN pre_window_totals
+'
+```
+
+Required outputs:
+
+- `historical_silent_object_count`
+- `historical_silent_object_ratio_vs_all_inventory`
+- `historical_silent_object_ratio_vs_pre_20260525_inventory`
+- `historical_silent_size_bytes`
+- `historical_silent_size_ratio_vs_all_inventory_bytes`
+- `historical_silent_size_ratio_vs_pre_20260525_inventory_bytes`
+
+## Step 6: Split The Result By `ac`, `cas`, And `other`
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+WITH historical_silent AS (
+  SELECT
+    inv.object_name,
+    inv.time_created,
+    inv.size_bytes
+  FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611` AS inv
+  LEFT JOIN `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current` AS last
+    USING (object_name)
+  WHERE inv.time_created < TIMESTAMP("2026-05-25 07:01:34 UTC")
+    AND last.object_name IS NULL
+)
+SELECT
+  CASE
+    WHEN STARTS_WITH(object_name, "ac/") THEN "ac"
+    WHEN STARTS_WITH(object_name, "cas/") THEN "cas"
+    ELSE "other"
+  END AS object_kind,
+  COUNT(*) AS object_count,
+  COALESCE(SUM(size_bytes), 0) AS size_bytes
+FROM historical_silent
+GROUP BY object_kind
+ORDER BY object_kind
+'
+```
+
+Validation rule:
+
+- `ac + cas + other = total`
+
+## Step 7: Produce Spot-Check Samples
+
+Export a small sample list for manual review:
+
+```bash
+bq --location=US query --nouse_legacy_sql '
+SELECT
+  inv.object_name,
+  inv.time_created,
+  inv.size_bytes
+FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611` AS inv
+LEFT JOIN `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current` AS last
+  USING (object_name)
+WHERE inv.time_created < TIMESTAMP("2026-05-25 07:01:34 UTC")
+  AND last.object_name IS NULL
+ORDER BY inv.time_created, inv.object_name
+LIMIT 10
+'
+```
+
+Each sampled object should satisfy all of the following:
+
+- exists in inventory
+- `time_created < 2026-05-25 07:01:34 UTC`
+- absent from `gcs_cache_object_last_seen_current`
+
+## Step 8: Optional Cleanup After Analysis
+
+If the tables are no longer needed after the delete-planning discussion, drop
+them to stop storage charges.
+
+```bash
+bq --location=US rm -f -t \
+  pingcap-testing-account:ci_bazel_cache_logs._tmp_gcs_cache_inventory_20260611
+
+bq --location=US rm -f -t \
+  pingcap-testing-account:ci_bazel_cache_logs._tmp_gcs_cache_inventory_raw_20260611
+```
+
+## Validation Checklist
+
+Do not use the output for delete planning unless all checks pass:
+
+- normalized row count matches manifest `248734953`
+- `historical_silent_object_count <= pre_20260525_inventory_object_count <= all_inventory_object_count`
+- `historical_silent_size_bytes <= pre_20260525_inventory_size_bytes <= all_inventory_size_bytes`
+- `ac + cas + other = total`
+- at least 10 samples are manually verified
+
+## What This Runbook Does Not Do
+
+- It does not delete any object.
+- It does not create a recurring inventory pipeline.
+- It does not modify the daily `last_seen` job.
+- It does not decide the final delete batching strategy.
+
+Those are follow-up steps after the historical silent population size is known.

--- a/cost-insight/pyproject.toml
+++ b/cost-insight/pyproject.toml
@@ -9,6 +9,7 @@ description = "Cloud cost collection, attribution, and budget jobs"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+  "google-auth>=2.0.0",
   "google-cloud-bigquery>=3.25.0",
   "PyMySQL>=1.1.0",
   "SQLAlchemy>=2.0.0",

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -229,7 +229,7 @@ def load_settings(
                     "COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS",
                     "COST_GCS_CACHE_AC_RETENTION_DAYS",
                 ),
-                28,
+                14,
             ),
             cas_retention_days=_read_positive_int_any(
                 env,

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -18,6 +18,8 @@ DEFAULT_GCS_CACHE_DATASET = "ci_bazel_cache_logs"
 DEFAULT_GCS_CACHE_AUDIT_LOG_TABLE = "cloudaudit_googleapis_com_data_access"
 DEFAULT_GCS_CACHE_LAST_SEEN_DAILY_TABLE = "gcs_cache_object_last_seen_daily"
 DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE = "gcs_cache_object_last_seen_current"
+DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET = "pingcap-ci-console-logs-us-central1"
+DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX = "gcs-cache-steady-state-delete"
 
 
 @dataclass(frozen=True)
@@ -62,11 +64,15 @@ class GcsCacheSettings:
     audit_log_table: str = DEFAULT_GCS_CACHE_AUDIT_LOG_TABLE
     last_seen_daily_table: str = DEFAULT_GCS_CACHE_LAST_SEEN_DAILY_TABLE
     last_seen_current_table: str = DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE
-    ac_retention_days: int = 28
-    cas_retention_days: int = 42
-    cleanup_sample_limit: int = 100
-    cleanup_max_delete_objects: int = 50000
+    ac_retention_days: int = 14
+    cas_retention_days: int = 21
+    cleanup_safety_buffer_days: int = 1
+    cleanup_sample_limit: int = 10
+    cleanup_max_delete_objects: int = 10000000
     cleanup_batch_size: int = 1000
+    cleanup_manifest_bucket: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
+    cleanup_manifest_prefix: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX
+    cleanup_candidate_ttl_days: int = 7
 
 
 @dataclass(frozen=True)
@@ -231,7 +237,15 @@ def load_settings(
                     "COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS",
                     "COST_GCS_CACHE_CAS_RETENTION_DAYS",
                 ),
-                42,
+                21,
+            ),
+            cleanup_safety_buffer_days=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS",
+                    "COST_GCS_CACHE_SAFETY_BUFFER_DAYS",
+                ),
+                1,
             ),
             cleanup_sample_limit=_read_positive_int_any(
                 env,
@@ -239,7 +253,7 @@ def load_settings(
                     "COST_INSIGHT_GCS_CACHE_CLEANUP_SAMPLE_LIMIT",
                     "COST_GCS_CACHE_CLEANUP_SAMPLE_LIMIT",
                 ),
-                100,
+                10,
             ),
             cleanup_max_delete_objects=_read_positive_int_any(
                 env,
@@ -247,7 +261,7 @@ def load_settings(
                     "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS",
                     "COST_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS",
                 ),
-                50000,
+                10000000,
             ),
             cleanup_batch_size=_read_positive_int_any(
                 env,
@@ -256,6 +270,26 @@ def load_settings(
                     "COST_GCS_CACHE_CLEANUP_BATCH_SIZE",
                 ),
                 1000,
+            ),
+            cleanup_manifest_bucket=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET,
+                "COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET",
+                "COST_GCS_CACHE_CLEANUP_MANIFEST_BUCKET",
+            ),
+            cleanup_manifest_prefix=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX,
+                "COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX",
+                "COST_GCS_CACHE_CLEANUP_MANIFEST_PREFIX",
+            ),
+            cleanup_candidate_ttl_days=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_CANDIDATE_TTL_DAYS",
+                    "COST_GCS_CACHE_CLEANUP_CANDIDATE_TTL_DAYS",
+                ),
+                7,
             ),
         ),
         log_level=_read_any(env, "INFO", "COST_INSIGHT_LOG_LEVEL", "COST_LOG_LEVEL").upper(),

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class StorageBatchOperationsJob:
+    job_name: str
+    operation_name: str | None
+
+
+def create_delete_job(
+    *,
+    project_id: str,
+    job_id: str,
+    bucket_name: str,
+    manifest_uri: str,
+    dry_run: bool,
+    description: str | None = None,
+) -> StorageBatchOperationsJob:
+    from google.auth import default
+    from google.auth.transport.requests import Request as GoogleAuthRequest
+
+    credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    if not credentials.valid:
+        credentials.refresh(GoogleAuthRequest())
+
+    request_url = (
+        "https://storagebatchoperations.googleapis.com/v1/"
+        f"projects/{project_id}/locations/global/jobs?{urlencode({'jobId': job_id})}"
+    )
+    body = {
+        "bucketList": {
+            "buckets": [
+                {
+                    "bucket": bucket_name,
+                    "manifest": {
+                        "manifestLocation": manifest_uri,
+                    },
+                }
+            ]
+        },
+        "deleteObject": {
+            "permanentObjectDeletionEnabled": True,
+        },
+        "dryRun": dry_run,
+        "loggingConfig": {
+            "logActions": ["TRANSFORM"],
+            "logActionStates": ["SUCCEEDED", "FAILED"],
+        },
+    }
+    if description:
+        body["description"] = description
+
+    request = Request(
+        request_url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {credentials.token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=120) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"Storage Batch Operations create job failed ({exc.code}) for {job_id}: {detail}"
+        ) from exc
+    except URLError as exc:
+        raise RuntimeError(
+            f"Storage Batch Operations create job failed for {job_id}: {exc.reason}"
+        ) from exc
+
+    return StorageBatchOperationsJob(
+        job_name=f"projects/{project_id}/locations/global/jobs/{job_id}",
+        operation_name=payload.get("name"),
+    )

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -75,7 +75,7 @@ def create_delete_job(
         ) from exc
     except URLError as exc:
         raise RuntimeError(
-            f"Storage Batch Operations create job failed for {job_id}: {exc.reason}"
+            f"Storage Batch Operations create job failed for {job_id}: {str(exc.reason)}"
         ) from exc
 
     return StorageBatchOperationsJob(

--- a/cost-insight/src/cost_insight/jobs/bootstrap_gcs_cache_last_seen.py
+++ b/cost-insight/src/cost_insight/jobs/bootstrap_gcs_cache_last_seen.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+
+from cost_insight.common.bigquery import BigQueryParameter, BigQueryQueryResult, execute_query
+from cost_insight.common.config import GcsCacheSettings
+
+QueryExecutor = Callable[[str, list[BigQueryParameter]], BigQueryQueryResult]
+
+
+@dataclass(frozen=True)
+class BootstrapGcsCacheLastSeenResult:
+    account_id: str
+    bucket_name: str
+    start_date: date
+    end_date: date
+    source_rows_seen: int
+    distinct_objects: int
+    dry_run: bool
+    bytes_processed: int | None
+
+
+def run_bootstrap_gcs_cache_last_seen(
+    *,
+    settings: GcsCacheSettings,
+    start_date: date,
+    end_date: date | None = None,
+    dry_run: bool = False,
+    execute: QueryExecutor = execute_query,
+) -> BootstrapGcsCacheLastSeenResult:
+    resolved_end_date = end_date or (datetime.now(timezone.utc).date() - timedelta(days=1))
+    if start_date > resolved_end_date:
+        raise ValueError("--start-date must be before or equal to --end-date")
+
+    parameters = [
+        BigQueryParameter("start_date", "DATE", start_date),
+        BigQueryParameter("end_date", "DATE", resolved_end_date),
+        BigQueryParameter("bucket_name", "STRING", settings.bucket_name),
+    ]
+    query = (
+        build_bootstrap_gcs_cache_last_seen_dry_run_query(settings)
+        if dry_run
+        else build_bootstrap_gcs_cache_last_seen_query(settings)
+    )
+    result = execute(query, parameters=parameters)
+    row = result.rows[0] if result.rows else {}
+    return BootstrapGcsCacheLastSeenResult(
+        account_id=settings.project_id,
+        bucket_name=settings.bucket_name,
+        start_date=start_date,
+        end_date=resolved_end_date,
+        source_rows_seen=int(row.get("source_rows_seen", 0) or 0),
+        distinct_objects=int(row.get("distinct_objects", 0) or 0),
+        dry_run=dry_run,
+        bytes_processed=result.total_bytes_processed,
+    )
+
+
+def build_bootstrap_gcs_cache_last_seen_dry_run_query(settings: GcsCacheSettings) -> str:
+    return f"""
+WITH bootstrap_rollup AS (
+  {_build_bootstrap_rollup_select(settings)}
+)
+SELECT
+  COUNT(*) AS distinct_objects,
+  COALESCE(SUM(source_event_count), 0) AS source_rows_seen
+FROM bootstrap_rollup
+""".strip()
+
+
+def build_bootstrap_gcs_cache_last_seen_query(settings: GcsCacheSettings) -> str:
+    current_table = _table_ref(
+        settings.project_id,
+        settings.dataset,
+        settings.last_seen_current_table,
+    )
+    return f"""
+CREATE TEMP TABLE bootstrap_rollup AS
+{_build_bootstrap_rollup_select(settings)};
+
+CREATE OR REPLACE TABLE {current_table}
+CLUSTER BY object_kind, last_seen_date AS
+SELECT
+  object_name,
+  object_kind,
+  first_seen_at,
+  last_seen_at,
+  DATE(last_seen_at) AS last_seen_date,
+  total_get_count,
+  CURRENT_TIMESTAMP() AS updated_at
+FROM bootstrap_rollup;
+
+SELECT
+  COUNT(*) AS distinct_objects,
+  COALESCE(SUM(source_event_count), 0) AS source_rows_seen
+FROM bootstrap_rollup
+""".strip()
+
+
+def _build_bootstrap_rollup_select(settings: GcsCacheSettings) -> str:
+    audit_log_table = _table_ref(
+        settings.project_id,
+        settings.dataset,
+        settings.audit_log_table,
+    )
+    return f"""
+WITH extracted AS (
+  SELECT
+    REGEXP_EXTRACT(protopayload_auditlog.resourceName, r"/objects/(.+)$") AS object_name,
+    timestamp,
+    protopayload_auditlog.methodName AS method_name
+  FROM {audit_log_table}
+  WHERE DATE(timestamp) BETWEEN @start_date AND @end_date
+    AND resource.labels.bucket_name = @bucket_name
+    AND protopayload_auditlog.methodName IN ("storage.objects.get", "storage.objects.create")
+)
+SELECT
+  object_name,
+  CASE
+    WHEN STARTS_WITH(object_name, "cas/") THEN "cas"
+    WHEN STARTS_WITH(object_name, "ac/") THEN "ac"
+    ELSE "other"
+  END AS object_kind,
+  MIN(timestamp) AS first_seen_at,
+  MAX(timestamp) AS last_seen_at,
+  COUNTIF(method_name = "storage.objects.get") AS total_get_count,
+  COUNT(*) AS source_event_count
+FROM extracted
+GROUP BY object_name, object_kind
+""".strip()
+
+
+def _table_ref(project_id: str, dataset: str, table: str) -> str:
+    return f"`{project_id}.{dataset}.{table}`"

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
+from uuid import uuid4
 
 from cost_insight.common.bigquery import BigQueryParameter, BigQueryQueryResult, execute_query
 from cost_insight.common.config import GcsCacheSettings
+from cost_insight.common.storage_batch_operations import StorageBatchOperationsJob, create_delete_job
 
 QueryExecutor = Callable[[str, list[BigQueryParameter]], BigQueryQueryResult]
+BatchJobCreator = Callable[..., StorageBatchOperationsJob]
+
+VALID_EXECUTE_KINDS = ("all", "ac", "cas", "mixed-canary")
 
 
 @dataclass(frozen=True)
@@ -22,40 +27,65 @@ class CleanupGcsCacheSample:
 class CleanupGcsCacheSummary:
     account_id: str
     bucket_name: str
+    run_id: str
     mode: str
+    execute_kind: str
     dry_run: bool
     ac_retention_days: int
     cas_retention_days: int
+    safety_buffer_days: int
     candidate_object_count: int
+    selected_object_count: int
     ac_candidate_count: int
     cas_candidate_count: int
     oldest_last_seen_at: datetime | None
     newest_last_seen_at: datetime | None
     sample_candidates: tuple[CleanupGcsCacheSample, ...]
     bytes_processed: int | None
+    run_started_at: datetime
+    run_finished_at: datetime
+    manifest_uri: str | None = None
+    batch_job_name: str | None = None
 
 
 def run_cleanup_gcs_cache(
     *,
     settings: GcsCacheSettings,
     mode: str = "dry-run",
+    execute_kind: str = "all",
     ac_retention_days: int | None = None,
     cas_retention_days: int | None = None,
+    safety_buffer_days: int | None = None,
+    max_delete_objects: int | None = None,
     sample_limit: int | None = None,
     execute: QueryExecutor = execute_query,
+    create_batch_job: BatchJobCreator = create_delete_job,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    run_id_factory: Callable[[], str] = lambda: str(uuid4()),
 ) -> CleanupGcsCacheSummary:
-    if mode != "dry-run":
-        raise ValueError("cleanup-gcs-cache only supports --mode dry-run in the first slice")
+    run_started_at = now()
+    _validate_mode_and_execute_kind(mode=mode, execute_kind=execute_kind)
+
     resolved_ac_days = ac_retention_days or settings.ac_retention_days
     resolved_cas_days = cas_retention_days or settings.cas_retention_days
+    resolved_safety_buffer_days = safety_buffer_days or settings.cleanup_safety_buffer_days
     resolved_sample_limit = sample_limit or settings.cleanup_sample_limit
-    parameters = [
-        BigQueryParameter("ac_retention_days", "INT64", resolved_ac_days),
-        BigQueryParameter("cas_retention_days", "INT64", resolved_cas_days),
-        BigQueryParameter("sample_limit", "INT64", resolved_sample_limit),
-    ]
-    result = execute(build_cleanup_gcs_cache_dry_run_query(settings), parameters=parameters)
-    row = result.rows[0] if result.rows else {}
+    resolved_max_delete_objects = max_delete_objects or settings.cleanup_max_delete_objects
+    ac_cutoff_days = resolved_ac_days + resolved_safety_buffer_days
+    cas_cutoff_days = resolved_cas_days + resolved_safety_buffer_days
+
+    bytes_processed_total = 0
+    summary_result = execute(
+        build_cleanup_gcs_cache_summary_query(settings, execute_kind=execute_kind),
+        parameters=[
+            BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days),
+            BigQueryParameter("cas_cutoff_days", "INT64", cas_cutoff_days),
+            BigQueryParameter("sample_limit", "INT64", resolved_sample_limit),
+        ],
+    )
+    bytes_processed_total = _add_bytes(bytes_processed_total, summary_result.total_bytes_processed)
+    row = summary_result.rows[0] if summary_result.rows else {}
+
     sample_candidates = tuple(
         CleanupGcsCacheSample(
             object_name=str(item["object_name"]),
@@ -65,29 +95,134 @@ def run_cleanup_gcs_cache(
         )
         for item in (row.get("sample_candidates") or [])
     )
+
+    candidate_object_count = int(row.get("candidate_object_count", 0) or 0)
+    ac_candidate_count = int(row.get("ac_candidate_count", 0) or 0)
+    cas_candidate_count = int(row.get("cas_candidate_count", 0) or 0)
+    oldest_last_seen_at = _coerce_optional_datetime(row.get("oldest_last_seen_at"))
+    newest_last_seen_at = _coerce_optional_datetime(row.get("newest_last_seen_at"))
+
+    if mode == "dry-run":
+        run_finished_at = now()
+        return CleanupGcsCacheSummary(
+            account_id=settings.project_id,
+            bucket_name=settings.bucket_name,
+            run_id=run_id_factory(),
+            mode=mode,
+            execute_kind=execute_kind,
+            dry_run=True,
+            ac_retention_days=resolved_ac_days,
+            cas_retention_days=resolved_cas_days,
+            safety_buffer_days=resolved_safety_buffer_days,
+            candidate_object_count=candidate_object_count,
+            selected_object_count=0,
+            ac_candidate_count=ac_candidate_count,
+            cas_candidate_count=cas_candidate_count,
+            oldest_last_seen_at=oldest_last_seen_at,
+            newest_last_seen_at=newest_last_seen_at,
+            sample_candidates=sample_candidates,
+            bytes_processed=bytes_processed_total,
+            run_started_at=run_started_at,
+            run_finished_at=run_finished_at,
+        )
+
+    run_id = run_id_factory()
+    candidate_table = _candidate_table_name(settings, execute_kind=execute_kind, run_id=run_id)
+    limit = _selected_limit(
+        execute_kind=execute_kind,
+        candidate_object_count=candidate_object_count,
+        ac_candidate_count=ac_candidate_count,
+        cas_candidate_count=cas_candidate_count,
+        max_delete_objects=resolved_max_delete_objects,
+    )
+    create_candidate_result = execute(
+        build_cleanup_gcs_cache_candidate_table_query(
+            settings,
+            execute_kind=execute_kind,
+            candidate_table=candidate_table,
+        ),
+        parameters=[
+            BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days),
+            BigQueryParameter("cas_cutoff_days", "INT64", cas_cutoff_days),
+            BigQueryParameter("run_id", "STRING", run_id),
+            BigQueryParameter("limit", "INT64", limit),
+            BigQueryParameter("ttl_days", "INT64", settings.cleanup_candidate_ttl_days),
+        ],
+    )
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total, create_candidate_result.total_bytes_processed
+    )
+
+    count_result = execute(
+        f"SELECT COUNT(*) AS selected_object_count FROM {candidate_table}",
+        parameters=[],
+    )
+    bytes_processed_total = _add_bytes(bytes_processed_total, count_result.total_bytes_processed)
+    selected_object_count = int(
+        (count_result.rows[0] if count_result.rows else {}).get("selected_object_count", 0) or 0
+    )
+
+    manifest_uri = None
+    batch_job_name = None
+    if selected_object_count > 0:
+        manifest_uri = _manifest_uri(
+            settings,
+            execute_kind=execute_kind,
+            run_started_at=run_started_at,
+            run_id=run_id,
+        )
+        export_result = execute(
+            build_cleanup_gcs_cache_manifest_export_query(
+                candidate_table=candidate_table,
+                manifest_uri=manifest_uri,
+                bucket_name=settings.bucket_name,
+            ),
+            parameters=[],
+        )
+        bytes_processed_total = _add_bytes(bytes_processed_total, export_result.total_bytes_processed)
+
+        batch_job = create_batch_job(
+            project_id=settings.project_id,
+            job_id=_batch_job_id(execute_kind=execute_kind, run_started_at=run_started_at, run_id=run_id),
+            bucket_name=settings.bucket_name,
+            manifest_uri=manifest_uri,
+            dry_run=False,
+            description=(
+                "Steady-state GCS cache cleanup "
+                f"{execute_kind} run {run_id} "
+                f"(ac={resolved_ac_days}, cas={resolved_cas_days}, buffer={resolved_safety_buffer_days})"
+            ),
+        )
+        batch_job_name = batch_job.job_name
+
+    run_finished_at = now()
     return CleanupGcsCacheSummary(
         account_id=settings.project_id,
         bucket_name=settings.bucket_name,
+        run_id=run_id,
         mode=mode,
-        dry_run=True,
+        execute_kind=execute_kind,
+        dry_run=False,
         ac_retention_days=resolved_ac_days,
         cas_retention_days=resolved_cas_days,
-        candidate_object_count=int(row.get("candidate_object_count", 0) or 0),
-        ac_candidate_count=int(row.get("ac_candidate_count", 0) or 0),
-        cas_candidate_count=int(row.get("cas_candidate_count", 0) or 0),
-        oldest_last_seen_at=_coerce_optional_datetime(row.get("oldest_last_seen_at")),
-        newest_last_seen_at=_coerce_optional_datetime(row.get("newest_last_seen_at")),
-        sample_candidates=sample_candidates,
-        bytes_processed=result.total_bytes_processed,
+        safety_buffer_days=resolved_safety_buffer_days,
+        candidate_object_count=candidate_object_count,
+        selected_object_count=selected_object_count,
+        ac_candidate_count=ac_candidate_count,
+        cas_candidate_count=cas_candidate_count,
+        oldest_last_seen_at=oldest_last_seen_at,
+        newest_last_seen_at=newest_last_seen_at,
+        sample_candidates=(),
+        bytes_processed=bytes_processed_total,
+        run_started_at=run_started_at,
+        run_finished_at=run_finished_at,
+        manifest_uri=manifest_uri,
+        batch_job_name=batch_job_name,
     )
 
 
-def build_cleanup_gcs_cache_dry_run_query(settings: GcsCacheSettings) -> str:
-    current_table = _table_ref(
-        settings.project_id,
-        settings.dataset,
-        settings.last_seen_current_table,
-    )
+def build_cleanup_gcs_cache_summary_query(settings: GcsCacheSettings, *, execute_kind: str) -> str:
+    current_table = _table_ref(settings.project_id, settings.dataset, settings.last_seen_current_table)
     return f"""
 WITH candidates AS (
   SELECT
@@ -96,13 +231,7 @@ WITH candidates AS (
     last_seen_at,
     TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), last_seen_at, DAY) AS idle_days
   FROM {current_table}
-  WHERE (
-      object_kind = 'ac'
-      AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_retention_days DAY)
-    ) OR (
-      object_kind = 'cas'
-      AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_retention_days DAY)
-    )
+  WHERE {_candidate_filter_clause(execute_kind=execute_kind)}
 )
 SELECT
   COUNT(*) AS candidate_object_count,
@@ -117,15 +246,190 @@ SELECT
       last_seen_at AS last_seen_at,
       idle_days AS idle_days
     )
-    ORDER BY last_seen_at
+    ORDER BY last_seen_at ASC, object_name ASC
     LIMIT @sample_limit
   ) AS sample_candidates
 FROM candidates
 """.strip()
 
 
+def build_cleanup_gcs_cache_candidate_table_query(
+    settings: GcsCacheSettings,
+    *,
+    execute_kind: str,
+    candidate_table: str,
+) -> str:
+    current_table = _table_ref(settings.project_id, settings.dataset, settings.last_seen_current_table)
+    if execute_kind == "mixed-canary":
+        return f"""
+CREATE OR REPLACE TABLE {candidate_table}
+OPTIONS (
+  expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL @ttl_days DAY)
+) AS
+WITH ac_candidates AS (
+  SELECT
+    object_name,
+    last_seen_at,
+    TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), last_seen_at, DAY) AS idle_days
+  FROM {current_table}
+  WHERE object_kind = 'ac'
+    AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_cutoff_days DAY)
+  ORDER BY last_seen_at ASC, object_name ASC
+  LIMIT 500
+),
+cas_candidates AS (
+  SELECT
+    object_name,
+    last_seen_at,
+    TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), last_seen_at, DAY) AS idle_days
+  FROM {current_table}
+  WHERE object_kind = 'cas'
+    AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_cutoff_days DAY)
+  ORDER BY last_seen_at ASC, object_name ASC
+  LIMIT 500
+)
+SELECT
+  @run_id AS run_id,
+  object_name,
+  last_seen_at,
+  idle_days,
+  CURRENT_TIMESTAMP() AS selected_at
+FROM (
+  SELECT * FROM ac_candidates
+  UNION ALL
+  SELECT * FROM cas_candidates
+)
+""".strip()
+    object_kind = execute_kind
+    cutoff_parameter = "@ac_cutoff_days" if execute_kind == "ac" else "@cas_cutoff_days"
+    return f"""
+CREATE OR REPLACE TABLE {candidate_table}
+OPTIONS (
+  expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL @ttl_days DAY)
+) AS
+WITH candidates AS (
+  SELECT
+    object_name,
+    last_seen_at,
+    TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), last_seen_at, DAY) AS idle_days
+  FROM {current_table}
+  WHERE object_kind = '{object_kind}'
+    AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {cutoff_parameter} DAY)
+)
+SELECT
+  @run_id AS run_id,
+  object_name,
+  last_seen_at,
+  idle_days,
+  CURRENT_TIMESTAMP() AS selected_at
+FROM candidates
+ORDER BY last_seen_at ASC, object_name ASC
+LIMIT @limit
+""".strip()
+
+
+def build_cleanup_gcs_cache_manifest_export_query(
+    *,
+    candidate_table: str,
+    manifest_uri: str,
+    bucket_name: str,
+) -> str:
+    return f"""
+EXPORT DATA OPTIONS (
+  uri = '{manifest_uri}',
+  format = 'CSV',
+  overwrite = true,
+  header = true,
+  field_delimiter = ','
+) AS
+SELECT
+  '{bucket_name}' AS bucket,
+  object_name AS name
+FROM {candidate_table}
+ORDER BY last_seen_at ASC, object_name ASC
+""".strip()
+
+
+def _candidate_filter_clause(*, execute_kind: str) -> str:
+    if execute_kind == "ac":
+        return (
+            "object_kind = 'ac' "
+            "AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_cutoff_days DAY)"
+        )
+    if execute_kind == "cas":
+        return (
+            "object_kind = 'cas' "
+            "AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_cutoff_days DAY)"
+        )
+    return """
+(
+  object_kind = 'ac'
+  AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_cutoff_days DAY)
+) OR (
+  object_kind = 'cas'
+  AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_cutoff_days DAY)
+)
+""".strip()
+
+
 def _table_ref(project_id: str, dataset: str, table: str) -> str:
     return f"`{project_id}.{dataset}.{table}`"
+
+
+def _candidate_table_name(settings: GcsCacheSettings, *, execute_kind: str, run_id: str) -> str:
+    suffix = run_id.replace("-", "")
+    table_name = f"_tmp_gcs_cache_cleanup_candidates_{execute_kind.replace('-', '_')}_{suffix}"
+    return _table_ref(settings.project_id, settings.dataset, table_name)
+
+
+def _manifest_uri(
+    settings: GcsCacheSettings,
+    *,
+    execute_kind: str,
+    run_started_at: datetime,
+    run_id: str,
+) -> str:
+    date_prefix = run_started_at.strftime("%Y-%m-%d")
+    return (
+        f"gs://{settings.cleanup_manifest_bucket}/"
+        f"{settings.cleanup_manifest_prefix}/{date_prefix}/{execute_kind}/{run_id}/manifest-*.csv"
+    )
+
+
+def _batch_job_id(*, execute_kind: str, run_started_at: datetime, run_id: str) -> str:
+    timestamp = run_started_at.strftime("%Y%m%dt%H%M%S")
+    suffix = run_id.replace("-", "")[:12]
+    return f"gcs-cache-cleanup-{execute_kind}-{timestamp}-{suffix}".lower()
+
+
+def _selected_limit(
+    *,
+    execute_kind: str,
+    candidate_object_count: int,
+    ac_candidate_count: int,
+    cas_candidate_count: int,
+    max_delete_objects: int,
+) -> int:
+    if execute_kind == "mixed-canary":
+        return min(ac_candidate_count, 500) + min(cas_candidate_count, 500)
+    return min(candidate_object_count, max_delete_objects)
+
+
+def _add_bytes(total: int, value: int | None) -> int:
+    if value is None:
+        return total
+    return total + int(value)
+
+
+def _validate_mode_and_execute_kind(*, mode: str, execute_kind: str) -> None:
+    if mode not in {"dry-run", "delete"}:
+        raise ValueError(f"Unsupported cleanup mode: {mode}")
+    if execute_kind not in VALID_EXECUTE_KINDS:
+        raise ValueError(
+            f"Unsupported cleanup execute kind: {execute_kind} (expected one of {VALID_EXECUTE_KINDS})"
+        )
+    if mode == "delete" and execute_kind == "all":
+        raise ValueError("cleanup-gcs-cache --mode delete requires --execute-kind ac, cas, or mixed-canary")
 
 
 def _coerce_optional_datetime(value: object) -> datetime | None:

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -75,13 +75,15 @@ def run_cleanup_gcs_cache(
     cas_cutoff_days = resolved_cas_days + resolved_safety_buffer_days
 
     bytes_processed_total = 0
+    summary_parameters = _summary_query_parameters(
+        execute_kind=execute_kind,
+        ac_cutoff_days=ac_cutoff_days,
+        cas_cutoff_days=cas_cutoff_days,
+        sample_limit=resolved_sample_limit,
+    )
     summary_result = execute(
         build_cleanup_gcs_cache_summary_query(settings, execute_kind=execute_kind),
-        parameters=[
-            BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days),
-            BigQueryParameter("cas_cutoff_days", "INT64", cas_cutoff_days),
-            BigQueryParameter("sample_limit", "INT64", resolved_sample_limit),
-        ],
+        parameters=summary_parameters,
     )
     bytes_processed_total = _add_bytes(bytes_processed_total, summary_result.total_bytes_processed)
     row = summary_result.rows[0] if summary_result.rows else {}
@@ -141,13 +143,14 @@ def run_cleanup_gcs_cache(
             execute_kind=execute_kind,
             candidate_table=candidate_table,
         ),
-        parameters=[
-            BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days),
-            BigQueryParameter("cas_cutoff_days", "INT64", cas_cutoff_days),
-            BigQueryParameter("run_id", "STRING", run_id),
-            BigQueryParameter("limit", "INT64", limit),
-            BigQueryParameter("ttl_days", "INT64", settings.cleanup_candidate_ttl_days),
-        ],
+        parameters=_candidate_table_query_parameters(
+            execute_kind=execute_kind,
+            ac_cutoff_days=ac_cutoff_days,
+            cas_cutoff_days=cas_cutoff_days,
+            run_id=run_id,
+            limit=limit,
+            ttl_days=settings.cleanup_candidate_ttl_days,
+        ),
     )
     bytes_processed_total = _add_bytes(
         bytes_processed_total, create_candidate_result.total_bytes_processed
@@ -413,6 +416,43 @@ def _selected_limit(
     if execute_kind == "mixed-canary":
         return min(ac_candidate_count, 500) + min(cas_candidate_count, 500)
     return min(candidate_object_count, max_delete_objects)
+
+
+def _summary_query_parameters(
+    *,
+    execute_kind: str,
+    ac_cutoff_days: int,
+    cas_cutoff_days: int,
+    sample_limit: int,
+) -> list[BigQueryParameter]:
+    parameters = [BigQueryParameter("sample_limit", "INT64", sample_limit)]
+    if execute_kind in {"all", "ac", "mixed-canary"}:
+        parameters.insert(0, BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days))
+    if execute_kind in {"all", "cas", "mixed-canary"}:
+        parameters.insert(0, BigQueryParameter("cas_cutoff_days", "INT64", cas_cutoff_days))
+    return parameters
+
+
+def _candidate_table_query_parameters(
+    *,
+    execute_kind: str,
+    ac_cutoff_days: int,
+    cas_cutoff_days: int,
+    run_id: str,
+    limit: int,
+    ttl_days: int,
+) -> list[BigQueryParameter]:
+    parameters = [
+        BigQueryParameter("run_id", "STRING", run_id),
+        BigQueryParameter("ttl_days", "INT64", ttl_days),
+    ]
+    if execute_kind in {"ac", "mixed-canary"}:
+        parameters.append(BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days))
+    if execute_kind in {"cas", "mixed-canary"}:
+        parameters.append(BigQueryParameter("cas_cutoff_days", "INT64", cas_cutoff_days))
+    if execute_kind != "mixed-canary":
+        parameters.append(BigQueryParameter("limit", "INT64", limit))
+    return parameters
 
 
 def _add_bytes(total: int, value: int | None) -> int:

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -11,6 +11,7 @@ from cost_insight.common.config import AwsBillingSettings, GcpBillingSettings, g
 from cost_insight.common.db import build_engine
 from cost_insight.common.logging import configure_logging
 from cost_insight.jobs.backfill_cost_refine_from_raw import run_backfill_cost_refine_from_raw
+from cost_insight.jobs.bootstrap_gcs_cache_last_seen import run_bootstrap_gcs_cache_last_seen
 from cost_insight.jobs.cleanup_gcs_cache import run_cleanup_gcs_cache
 from cost_insight.jobs.cost_sources import list_active_cost_sources
 from cost_insight.jobs.refresh_attribution_daily import (
@@ -138,9 +139,18 @@ def build_parser() -> argparse.ArgumentParser:
     sync_gcs_cache.add_argument("--run-date", type=_parse_date, default=None)
     sync_gcs_cache.add_argument("--dry-run", action="store_true")
 
+    bootstrap_gcs_cache = subparsers.add_parser(
+        "bootstrap-gcs-cache-last-seen",
+        help="Bootstrap GCS Bazel cache last-seen state from a historical BigQuery log window",
+    )
+    bootstrap_gcs_cache.set_defaults(require_database=False)
+    bootstrap_gcs_cache.add_argument("--start-date", type=_parse_date, required=True)
+    bootstrap_gcs_cache.add_argument("--end-date", type=_parse_date, default=None)
+    bootstrap_gcs_cache.add_argument("--dry-run", action="store_true")
+
     cleanup_gcs_cache = subparsers.add_parser(
         "cleanup-gcs-cache",
-        help="Build dry-run cleanup candidates from GCS cache last-seen summaries",
+        help="Build steady-state cleanup candidates from GCS cache last-seen summaries",
     )
     cleanup_gcs_cache.set_defaults(require_database=False)
     cleanup_gcs_cache.add_argument(
@@ -148,8 +158,15 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("dry-run", "delete"),
         default="dry-run",
     )
+    cleanup_gcs_cache.add_argument(
+        "--execute-kind",
+        choices=("all", "ac", "cas", "mixed-canary"),
+        default="all",
+    )
     cleanup_gcs_cache.add_argument("--ac-retention-days", type=_parse_positive_int, default=None)
     cleanup_gcs_cache.add_argument("--cas-retention-days", type=_parse_positive_int, default=None)
+    cleanup_gcs_cache.add_argument("--safety-buffer-days", type=_parse_positive_int, default=None)
+    cleanup_gcs_cache.add_argument("--max-delete-objects", type=_parse_positive_int, default=None)
     cleanup_gcs_cache.add_argument("--sample-limit", type=_parse_positive_int, default=None)
 
     return parser
@@ -322,12 +339,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(json.dumps(_summaries_to_json([summary]), indent=2, sort_keys=True))
         return 0
 
+    if args.command == "bootstrap-gcs-cache-last-seen":
+        summary = run_bootstrap_gcs_cache_last_seen(
+            settings=settings.gcs_cache,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            dry_run=args.dry_run,
+        )
+        print(json.dumps(_summaries_to_json([summary]), indent=2, sort_keys=True))
+        return 0
+
     if args.command == "cleanup-gcs-cache":
         summary = run_cleanup_gcs_cache(
             settings=settings.gcs_cache,
             mode=args.mode,
+            execute_kind=args.execute_kind,
             ac_retention_days=args.ac_retention_days,
             cas_retention_days=args.cas_retention_days,
+            safety_buffer_days=args.safety_buffer_days,
+            max_delete_objects=args.max_delete_objects,
             sample_limit=args.sample_limit,
         )
         print(json.dumps(_summaries_to_json([summary]), indent=2, sort_keys=True))

--- a/cost-insight/tests/test_bootstrap_gcs_cache_last_seen.py
+++ b/cost-insight/tests/test_bootstrap_gcs_cache_last_seen.py
@@ -1,0 +1,113 @@
+from datetime import date, datetime, timezone
+
+import pytest
+
+import cost_insight.jobs.bootstrap_gcs_cache_last_seen as bootstrap_gcs_cache_last_seen
+from cost_insight.common.bigquery import BigQueryQueryResult
+from cost_insight.common.config import GcsCacheSettings
+from cost_insight.jobs.bootstrap_gcs_cache_last_seen import (
+    build_bootstrap_gcs_cache_last_seen_dry_run_query,
+    build_bootstrap_gcs_cache_last_seen_query,
+    run_bootstrap_gcs_cache_last_seen,
+)
+
+
+def test_bootstrap_gcs_cache_last_seen_dry_run_uses_expected_query_shape() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    query = build_bootstrap_gcs_cache_last_seen_dry_run_query(settings)
+
+    assert "storage.objects.get" in query
+    assert "storage.objects.create" in query
+    assert "DATE(timestamp) BETWEEN @start_date AND @end_date" in query
+    assert "WITH extracted AS (" in query
+    assert "COUNT(*) AS distinct_objects" in query
+    assert "COALESCE(SUM(source_event_count), 0) AS source_rows_seen" in query
+    assert "COUNTIF(method_name = \"storage.objects.get\") AS total_get_count" in query
+    assert "resource.labels.bucket_name = @bucket_name" in query
+
+
+def test_bootstrap_gcs_cache_last_seen_query_replaces_current_table() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    query = build_bootstrap_gcs_cache_last_seen_query(settings)
+    replace_select = query.partition("CREATE OR REPLACE TABLE")[2].partition("FROM bootstrap_rollup")[0]
+
+    assert "CREATE TEMP TABLE bootstrap_rollup AS" in query
+    assert (
+        "CREATE OR REPLACE TABLE `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`"
+        in query
+    )
+    assert "CLUSTER BY object_kind, last_seen_date AS" in query
+    assert "DATE(last_seen_at) AS last_seen_date" in query
+    assert "source_event_count" not in replace_select
+
+
+def test_run_bootstrap_gcs_cache_last_seen_returns_summary_from_executor() -> None:
+    captured = {}
+
+    def fake_execute(query, parameters):
+        captured["query"] = query
+        captured["parameters"] = {param.name: param.value for param in parameters}
+        return BigQueryQueryResult(
+            rows=({"distinct_objects": 12, "source_rows_seen": 345},),
+            total_bytes_processed=987654321,
+        )
+
+    summary = run_bootstrap_gcs_cache_last_seen(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        start_date=date(2026, 5, 25),
+        end_date=date(2026, 6, 9),
+        dry_run=True,
+        execute=fake_execute,
+    )
+
+    assert captured["parameters"] == {
+        "start_date": date(2026, 5, 25),
+        "end_date": date(2026, 6, 9),
+        "bucket_name": "pingcap-ci-bazel-remote-cache-us-central1",
+    }
+    assert summary.account_id == "pingcap-testing-account"
+    assert summary.start_date == date(2026, 5, 25)
+    assert summary.end_date == date(2026, 6, 9)
+    assert summary.distinct_objects == 12
+    assert summary.source_rows_seen == 345
+    assert summary.bytes_processed == 987654321
+    assert summary.dry_run is True
+
+
+def test_run_bootstrap_gcs_cache_last_seen_defaults_end_date_to_yesterday_utc(monkeypatch) -> None:
+    captured = {}
+
+    class FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 6, 10, 12, 0, 0, tzinfo=tz or timezone.utc)
+
+    def fake_execute(query, parameters):
+        captured["parameters"] = {param.name: param.value for param in parameters}
+        return BigQueryQueryResult(
+            rows=({"distinct_objects": 0, "source_rows_seen": 0},),
+            total_bytes_processed=None,
+        )
+
+    monkeypatch.setattr(bootstrap_gcs_cache_last_seen, "datetime", FrozenDatetime)
+
+    summary = run_bootstrap_gcs_cache_last_seen(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        start_date=date(2026, 5, 25),
+        dry_run=True,
+        execute=fake_execute,
+    )
+
+    assert captured["parameters"]["end_date"] == date(2026, 6, 9)
+    assert summary.end_date == date(2026, 6, 9)
+
+
+def test_run_bootstrap_gcs_cache_last_seen_rejects_invalid_date_range() -> None:
+    with pytest.raises(ValueError, match="--start-date must be before or equal to --end-date"):
+        run_bootstrap_gcs_cache_last_seen(
+            settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+            start_date=date(2026, 6, 10),
+            end_date=date(2026, 6, 9),
+            dry_run=True,
+            execute=lambda *_args, **_kwargs: BigQueryQueryResult(rows=(), total_bytes_processed=None),
+        )

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -1,26 +1,59 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
 from cost_insight.common.bigquery import BigQueryQueryResult
 from cost_insight.common.config import GcsCacheSettings
+from cost_insight.common.storage_batch_operations import StorageBatchOperationsJob
 from cost_insight.jobs.cleanup_gcs_cache import (
-    build_cleanup_gcs_cache_dry_run_query,
+    build_cleanup_gcs_cache_candidate_table_query,
+    build_cleanup_gcs_cache_manifest_export_query,
+    build_cleanup_gcs_cache_summary_query,
     run_cleanup_gcs_cache,
 )
 
 
-def test_cleanup_gcs_cache_dry_run_query_targets_current_table() -> None:
+def test_cleanup_gcs_cache_summary_query_targets_current_table() -> None:
     settings = GcsCacheSettings(project_id="pingcap-testing-account")
-    query = build_cleanup_gcs_cache_dry_run_query(settings)
+    query = build_cleanup_gcs_cache_summary_query(settings, execute_kind="all")
 
     assert "`pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`" in query
     assert "ARRAY_AGG(" in query
+    assert "@ac_cutoff_days" in query
+    assert "@cas_cutoff_days" in query
     assert "object_kind = 'ac'" in query
     assert "object_kind = 'cas'" in query
 
 
-def test_run_cleanup_gcs_cache_returns_summary_with_samples() -> None:
+def test_cleanup_gcs_cache_candidate_query_limits_mixed_canary_to_500_each() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    query = build_cleanup_gcs_cache_candidate_table_query(
+        settings,
+        execute_kind="mixed-canary",
+        candidate_table="`project.dataset.table`",
+    )
+
+    assert "LIMIT 500" in query
+    assert query.count("LIMIT 500") == 2
+    assert "UNION ALL" in query
+    assert "object_kind = 'ac'" in query
+    assert "object_kind = 'cas'" in query
+
+
+def test_cleanup_gcs_cache_manifest_export_query_uses_bucket_and_name_columns() -> None:
+    query = build_cleanup_gcs_cache_manifest_export_query(
+        candidate_table="`project.dataset.table`",
+        manifest_uri="gs://manifest-bucket/prefix/manifest-*.csv",
+        bucket_name="pingcap-ci-bazel-remote-cache-us-central1",
+    )
+
+    assert "EXPORT DATA OPTIONS" in query
+    assert "manifest-*.csv" in query
+    assert "'pingcap-ci-bazel-remote-cache-us-central1' AS bucket" in query
+    assert "object_name AS name" in query
+
+
+def test_run_cleanup_gcs_cache_returns_dry_run_summary_with_samples() -> None:
     captured = {}
 
     def fake_execute(query, parameters):
@@ -32,8 +65,8 @@ def test_run_cleanup_gcs_cache_returns_summary_with_samples() -> None:
                     "candidate_object_count": 20,
                     "ac_candidate_count": 5,
                     "cas_candidate_count": 15,
-                    "oldest_last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc),
-                    "newest_last_seen_at": datetime(2026, 5, 10, 0, 0, tzinfo=timezone.utc),
+                    "oldest_last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+                    "newest_last_seen_at": datetime(2026, 5, 10, 0, 0, tzinfo=UTC),
                     "sample_candidates": [
                         {
                             "object_name": "ac/foo",
@@ -53,33 +86,160 @@ def test_run_cleanup_gcs_cache_returns_summary_with_samples() -> None:
             total_bytes_processed=12345,
         )
 
+    now = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
     summary = run_cleanup_gcs_cache(
         settings=GcsCacheSettings(project_id="pingcap-testing-account"),
         mode="dry-run",
-        ac_retention_days=21,
-        cas_retention_days=35,
+        execute_kind="all",
+        ac_retention_days=14,
+        cas_retention_days=21,
+        safety_buffer_days=1,
         sample_limit=2,
         execute=fake_execute,
+        now=lambda: now,
+        run_id_factory=lambda: "run-dry-001",
     )
 
     assert captured["parameters"] == {
-        "ac_retention_days": 21,
-        "cas_retention_days": 35,
+        "ac_cutoff_days": 15,
+        "cas_cutoff_days": 22,
         "sample_limit": 2,
     }
+    assert summary.run_id == "run-dry-001"
     assert summary.candidate_object_count == 20
+    assert summary.selected_object_count == 0
     assert summary.ac_candidate_count == 5
     assert summary.cas_candidate_count == 15
     assert len(summary.sample_candidates) == 2
     assert summary.sample_candidates[0].object_name == "ac/foo"
     assert summary.bytes_processed == 12345
+    assert summary.run_started_at == now
+    assert summary.run_finished_at == now
 
 
-def test_run_cleanup_gcs_cache_rejects_non_dry_run_mode() -> None:
-    with pytest.raises(ValueError, match="only supports --mode dry-run"):
+def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> None:
+    captured_queries = []
+    created_jobs = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append((query, {param.name: param.value for param in parameters}))
+        if "ARRAY_AGG(" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_object_count": 7,
+                        "ac_candidate_count": 7,
+                        "cas_candidate_count": 0,
+                        "oldest_last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+                        "newest_last_seen_at": datetime(2026, 5, 8, 0, 0, tzinfo=UTC),
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=100,
+            )
+        if "CREATE OR REPLACE TABLE" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=200)
+        if "selected_object_count" in query:
+            return BigQueryQueryResult(
+                rows=({"selected_object_count": 7},),
+                total_bytes_processed=25,
+            )
+        if "EXPORT DATA OPTIONS" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=50)
+        raise AssertionError(f"Unexpected query: {query}")
+
+    def fake_create_batch_job(**kwargs):
+        created_jobs.append(kwargs)
+        return StorageBatchOperationsJob(
+            job_name="projects/pingcap-testing-account/locations/global/jobs/job-1",
+            operation_name="operations/op-1",
+        )
+
+    run_started_at = datetime(2026, 6, 15, 10, 30, tzinfo=UTC)
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="delete",
+        execute_kind="ac",
+        ac_retention_days=14,
+        cas_retention_days=21,
+        safety_buffer_days=1,
+        max_delete_objects=10000000,
+        execute=fake_execute,
+        create_batch_job=fake_create_batch_job,
+        now=lambda: run_started_at,
+        run_id_factory=lambda: "steady-run-001",
+    )
+
+    assert summary.candidate_object_count == 7
+    assert summary.selected_object_count == 7
+    assert summary.sample_candidates == ()
+    assert summary.manifest_uri == (
+        "gs://pingcap-ci-console-logs-us-central1/"
+        "gcs-cache-steady-state-delete/2026-06-15/ac/steady-run-001/manifest-*.csv"
+    )
+    assert summary.batch_job_name == "projects/pingcap-testing-account/locations/global/jobs/job-1"
+    assert summary.bytes_processed == 375
+    assert len(captured_queries) == 4
+    assert created_jobs[0]["manifest_uri"] == summary.manifest_uri
+    assert created_jobs[0]["dry_run"] is False
+    assert created_jobs[0]["bucket_name"] == "pingcap-ci-bazel-remote-cache-us-central1"
+
+
+def test_run_cleanup_gcs_cache_delete_mixed_canary_uses_fixed_500_per_kind() -> None:
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append((query, {param.name: param.value for param in parameters}))
+        if "ARRAY_AGG(" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_object_count": 5000,
+                        "ac_candidate_count": 1200,
+                        "cas_candidate_count": 3800,
+                        "oldest_last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+                        "newest_last_seen_at": datetime(2026, 5, 20, 0, 0, tzinfo=UTC),
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=10,
+            )
+        if "CREATE OR REPLACE TABLE" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=20)
+        if "selected_object_count" in query:
+            return BigQueryQueryResult(rows=({"selected_object_count": 1000},), total_bytes_processed=5)
+        if "EXPORT DATA OPTIONS" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=3)
+        raise AssertionError(f"Unexpected query: {query}")
+
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="delete",
+        execute_kind="mixed-canary",
+        execute=fake_execute,
+        create_batch_job=lambda **_: StorageBatchOperationsJob(
+            job_name="projects/pingcap-testing-account/locations/global/jobs/job-canary",
+            operation_name="operations/op-canary",
+        ),
+        now=lambda: datetime(2026, 6, 15, 8, 0, tzinfo=UTC),
+        run_id_factory=lambda: "steady-canary-001",
+    )
+
+    create_query, create_params = captured_queries[1]
+    assert create_query.count("LIMIT 500") == 2
+    assert create_params["limit"] == 1000
+    assert summary.selected_object_count == 1000
+
+
+def test_run_cleanup_gcs_cache_rejects_delete_without_specific_execute_kind() -> None:
+    with pytest.raises(
+        ValueError,
+        match="requires --execute-kind ac, cas, or mixed-canary",
+    ):
         run_cleanup_gcs_cache(
             settings=GcsCacheSettings(project_id="pingcap-testing-account"),
             mode="delete",
+            execute_kind="all",
         )
 
 

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -117,6 +117,43 @@ def test_run_cleanup_gcs_cache_returns_dry_run_summary_with_samples() -> None:
     assert summary.run_finished_at == now
 
 
+def test_run_cleanup_gcs_cache_dry_run_ac_only_passes_only_used_parameters() -> None:
+    captured = {}
+
+    def fake_execute(query, parameters):
+        captured["parameters"] = {param.name: param.value for param in parameters}
+        return BigQueryQueryResult(
+            rows=(
+                {
+                    "candidate_object_count": 2,
+                    "ac_candidate_count": 2,
+                    "cas_candidate_count": 0,
+                    "oldest_last_seen_at": None,
+                    "newest_last_seen_at": None,
+                    "sample_candidates": [],
+                },
+            ),
+            total_bytes_processed=1,
+        )
+
+    run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="dry-run",
+        execute_kind="ac",
+        ac_retention_days=14,
+        cas_retention_days=21,
+        safety_buffer_days=1,
+        sample_limit=3,
+        execute=fake_execute,
+        now=lambda: datetime(2026, 6, 15, 12, 0, tzinfo=UTC),
+    )
+
+    assert captured["parameters"] == {
+        "ac_cutoff_days": 15,
+        "sample_limit": 3,
+    }
+
+
 def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> None:
     captured_queries = []
     created_jobs = []
@@ -180,6 +217,16 @@ def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> Non
     assert summary.batch_job_name == "projects/pingcap-testing-account/locations/global/jobs/job-1"
     assert summary.bytes_processed == 375
     assert len(captured_queries) == 4
+    assert captured_queries[0][1] == {
+        "ac_cutoff_days": 15,
+        "sample_limit": 10,
+    }
+    assert captured_queries[1][1] == {
+        "run_id": "steady-run-001",
+        "ttl_days": 7,
+        "ac_cutoff_days": 15,
+        "limit": 7,
+    }
     assert created_jobs[0]["manifest_uri"] == summary.manifest_uri
     assert created_jobs[0]["dry_run"] is False
     assert created_jobs[0]["bucket_name"] == "pingcap-ci-bazel-remote-cache-us-central1"
@@ -227,8 +274,70 @@ def test_run_cleanup_gcs_cache_delete_mixed_canary_uses_fixed_500_per_kind() -> 
 
     create_query, create_params = captured_queries[1]
     assert create_query.count("LIMIT 500") == 2
-    assert create_params["limit"] == 1000
+    assert captured_queries[0][1] == {
+        "ac_cutoff_days": 15,
+        "cas_cutoff_days": 22,
+        "sample_limit": 10,
+    }
+    assert create_params == {
+        "run_id": "steady-canary-001",
+        "ttl_days": 7,
+        "ac_cutoff_days": 15,
+        "cas_cutoff_days": 22,
+    }
     assert summary.selected_object_count == 1000
+
+
+def test_run_cleanup_gcs_cache_delete_cas_passes_only_used_parameters() -> None:
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append((query, {param.name: param.value for param in parameters}))
+        if "ARRAY_AGG(" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_object_count": 9,
+                        "ac_candidate_count": 0,
+                        "cas_candidate_count": 9,
+                        "oldest_last_seen_at": None,
+                        "newest_last_seen_at": None,
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=10,
+            )
+        if "CREATE OR REPLACE TABLE" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=20)
+        if "selected_object_count" in query:
+            return BigQueryQueryResult(rows=({"selected_object_count": 9},), total_bytes_processed=5)
+        if "EXPORT DATA OPTIONS" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=3)
+        raise AssertionError(f"Unexpected query: {query}")
+
+    run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="delete",
+        execute_kind="cas",
+        execute=fake_execute,
+        create_batch_job=lambda **_: StorageBatchOperationsJob(
+            job_name="projects/pingcap-testing-account/locations/global/jobs/job-cas",
+            operation_name="operations/op-cas",
+        ),
+        now=lambda: datetime(2026, 6, 15, 8, 0, tzinfo=UTC),
+        run_id_factory=lambda: "steady-cas-001",
+    )
+
+    assert captured_queries[0][1] == {
+        "cas_cutoff_days": 22,
+        "sample_limit": 10,
+    }
+    assert captured_queries[1][1] == {
+        "run_id": "steady-cas-001",
+        "ttl_days": 7,
+        "cas_cutoff_days": 22,
+        "limit": 9,
+    }
 
 
 def test_run_cleanup_gcs_cache_rejects_delete_without_specific_execute_kind() -> None:

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -42,6 +42,9 @@ def test_load_settings_can_skip_database_for_validation() -> None:
     assert settings.gcp_billing.billing_table == DEFAULT_GCP_BILLING_TABLE
     assert settings.aws_billing.billing_table == DEFAULT_AWS_BILLING_TABLE
     assert settings.aws_billing.account_id is None
+    assert settings.gcs_cache.ac_retention_days == 14
+    assert settings.gcs_cache.cas_retention_days == 21
+    assert settings.gcs_cache.cleanup_safety_buffer_days == 1
 
 
 def test_load_settings_falls_back_to_tidb_parts() -> None:

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -99,9 +99,13 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE": "current_table",
             "COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS": "21",
             "COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS": "35",
+            "COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS": "2",
             "COST_INSIGHT_GCS_CACHE_CLEANUP_SAMPLE_LIMIT": "25",
             "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS": "500",
             "COST_INSIGHT_GCS_CACHE_CLEANUP_BATCH_SIZE": "50",
+            "COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET": "manifest-bucket",
+            "COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX": "manifest-prefix",
+            "COST_INSIGHT_GCS_CACHE_CLEANUP_CANDIDATE_TTL_DAYS": "9",
         },
         require_database=False,
     )
@@ -114,9 +118,13 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
     assert settings.gcs_cache.last_seen_current_table == "current_table"
     assert settings.gcs_cache.ac_retention_days == 21
     assert settings.gcs_cache.cas_retention_days == 35
+    assert settings.gcs_cache.cleanup_safety_buffer_days == 2
     assert settings.gcs_cache.cleanup_sample_limit == 25
     assert settings.gcs_cache.cleanup_max_delete_objects == 500
     assert settings.gcs_cache.cleanup_batch_size == 50
+    assert settings.gcs_cache.cleanup_manifest_bucket == "manifest-bucket"
+    assert settings.gcs_cache.cleanup_manifest_prefix == "manifest-prefix"
+    assert settings.gcs_cache.cleanup_candidate_ttl_days == 9
 
 
 def test_load_settings_requires_database_when_not_skipped() -> None:

--- a/cost-insight/tests/test_db_and_cli.py
+++ b/cost-insight/tests/test_db_and_cli.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import UTC, date, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +9,7 @@ from cost_insight.common.config import AwsBillingSettings, DatabaseSettings, Gcp
 from cost_insight.common.logging import configure_logging
 from cost_insight.jobs import cli
 from cost_insight.jobs.backfill_cost_refine_from_raw import BackfillCostRefineFromRawSummary
+from cost_insight.jobs.bootstrap_gcs_cache_last_seen import BootstrapGcsCacheLastSeenResult
 from cost_insight.jobs.cleanup_gcs_cache import CleanupGcsCacheSummary
 from cost_insight.jobs.refresh_attribution_daily import CostAttributionSource, RefreshAttributionSummary
 from cost_insight.jobs.sync_gcs_cache_last_seen import SyncGcsCacheLastSeenResult
@@ -251,6 +252,52 @@ def test_cli_runs_sync_gcs_cache_last_seen_without_database(monkeypatch, capsys)
     assert '"distinct_objects": 45' in capsys.readouterr().out
 
 
+def test_cli_runs_bootstrap_gcs_cache_last_seen_without_database(monkeypatch, capsys) -> None:
+    calls = []
+    settings = SimpleNamespace(
+        gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
+        aws_billing=AwsBillingSettings(),
+        gcs_cache=SimpleNamespace(),
+        log_level="INFO",
+    )
+
+    def fake_get_settings(require_database=True):
+        calls.append(require_database)
+        return settings
+
+    monkeypatch.setattr(cli, "get_settings", fake_get_settings)
+    monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
+    monkeypatch.setattr(
+        cli,
+        "run_bootstrap_gcs_cache_last_seen",
+        lambda **kwargs: BootstrapGcsCacheLastSeenResult(
+            account_id="pingcap-testing-account",
+            bucket_name="pingcap-ci-bazel-remote-cache-us-central1",
+            start_date=date(2026, 5, 25),
+            end_date=date(2026, 6, 9),
+            source_rows_seen=456,
+            distinct_objects=78,
+            dry_run=True,
+            bytes_processed=910,
+        ),
+    )
+
+    exit_code = cli.main(
+        [
+            "bootstrap-gcs-cache-last-seen",
+            "--start-date",
+            "2026-05-25",
+            "--end-date",
+            "2026-06-09",
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    assert calls == [False]
+    assert '"distinct_objects": 78' in capsys.readouterr().out
+
+
 def test_cli_runs_cleanup_gcs_cache_without_database(monkeypatch, capsys) -> None:
     calls = []
     settings = SimpleNamespace(
@@ -272,17 +319,23 @@ def test_cli_runs_cleanup_gcs_cache_without_database(monkeypatch, capsys) -> Non
         lambda **kwargs: CleanupGcsCacheSummary(
             account_id="pingcap-testing-account",
             bucket_name="pingcap-ci-bazel-remote-cache-us-central1",
+            run_id="run-001",
             mode="dry-run",
+            execute_kind="all",
             dry_run=True,
-            ac_retention_days=28,
-            cas_retention_days=42,
+            ac_retention_days=14,
+            cas_retention_days=21,
+            safety_buffer_days=1,
             candidate_object_count=99,
+            selected_object_count=0,
             ac_candidate_count=10,
             cas_candidate_count=89,
             oldest_last_seen_at=None,
             newest_last_seen_at=None,
             sample_candidates=(),
             bytes_processed=456,
+            run_started_at=datetime(2026, 6, 15, 0, 0, tzinfo=UTC),
+            run_finished_at=datetime(2026, 6, 15, 0, 0, tzinfo=UTC),
         ),
     )
 
@@ -293,7 +346,7 @@ def test_cli_runs_cleanup_gcs_cache_without_database(monkeypatch, capsys) -> Non
     assert '"candidate_object_count": 99' in capsys.readouterr().out
 
 
-def test_cli_surfaces_cleanup_gcs_cache_mode_error(monkeypatch) -> None:
+def test_cli_surfaces_cleanup_gcs_cache_delete_requires_specific_execute_kind(monkeypatch) -> None:
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
         aws_billing=AwsBillingSettings(),
@@ -304,7 +357,7 @@ def test_cli_surfaces_cleanup_gcs_cache_mode_error(monkeypatch) -> None:
     monkeypatch.setattr(cli, "get_settings", lambda require_database=True: settings)
     monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
 
-    with pytest.raises(ValueError, match="only supports --mode dry-run"):
+    with pytest.raises(ValueError, match="requires --execute-kind ac, cas, or mixed-canary"):
         cli.main(["cleanup-gcs-cache", "--mode", "delete"])
 
 
@@ -322,6 +375,15 @@ def test_cli_rejects_non_positive_cleanup_sample_limit(capsys) -> None:
 
     with pytest.raises(SystemExit, match="2"):
         parser.parse_args(["cleanup-gcs-cache", "--sample-limit", "-1"])
+
+    assert "expected a positive integer" in capsys.readouterr().err
+
+
+def test_cli_rejects_non_positive_cleanup_safety_buffer_days(capsys) -> None:
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit, match="2"):
+        parser.parse_args(["cleanup-gcs-cache", "--safety-buffer-days", "0"])
 
     assert "expected a positive integer" in capsys.readouterr().err
 


### PR DESCRIPTION
## Summary
- add a one-time bootstrap command and runbooks for building GCS cache last-seen state from the audit-log window
- add steady-state GCS cache cleanup delete support with manifest export and Storage Batch Operations job creation
- update cleanup defaults and CLI/config wiring for `ac=14d`, `cas=21d`, and `1d` safety buffer

## Testing
- `pytest --override-ini=addopts='' cost-insight/tests/test_bootstrap_gcs_cache_last_seen.py cost-insight/tests/test_cleanup_gcs_cache.py cost-insight/tests/test_config.py cost-insight/tests/test_db_and_cli.py`
- `ruff check cost-insight/src/cost_insight/common/storage_batch_operations.py cost-insight/src/cost_insight/jobs/bootstrap_gcs_cache_last_seen.py cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py cost-insight/src/cost_insight/jobs/cli.py cost-insight/src/cost_insight/common/config.py cost-insight/tests/test_bootstrap_gcs_cache_last_seen.py cost-insight/tests/test_cleanup_gcs_cache.py cost-insight/tests/test_config.py cost-insight/tests/test_db_and_cli.py`
