### PR TITLE
fix(cost-insight): reconcile gcs cache current table after delete

### DIFF
--- a/cost-insight/src/cost_insight/common/datetime_utils.py
+++ b/cost-insight/src/cost_insight/common/datetime_utils.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def coerce_optional_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    return coerce_datetime(value)
+
+
+def coerce_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    raise ValueError(f"Unsupported datetime value: {value!r}")

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import datetime
+from time import sleep
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -11,6 +13,17 @@ from urllib.request import Request, urlopen
 class StorageBatchOperationsJob:
     job_name: str
     operation_name: str | None
+
+
+@dataclass(frozen=True)
+class StorageBatchOperationsJobStatus:
+    job_name: str
+    state: str
+    total_object_count: int
+    succeeded_object_count: int
+    failed_object_count: int
+    total_bytes_transformed: int
+    complete_time: datetime | None
 
 
 def create_delete_job(
@@ -82,3 +95,88 @@ def create_delete_job(
         job_name=f"projects/{project_id}/locations/global/jobs/{job_id}",
         operation_name=payload.get("name"),
     )
+
+
+def wait_for_delete_job(
+    *,
+    job_name: str,
+    timeout_seconds: int = 7200,
+    poll_interval_seconds: int = 10,
+) -> StorageBatchOperationsJobStatus:
+    from google.auth import default
+    from google.auth.transport.requests import Request as GoogleAuthRequest
+
+    credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    if not credentials.valid:
+        credentials.refresh(GoogleAuthRequest())
+
+    request_url = f"https://storagebatchoperations.googleapis.com/v1/{job_name}"
+    deadline = timeout_seconds
+    elapsed = 0
+    while True:
+        payload = _get_job_payload(request_url=request_url, token=credentials.token)
+        state = str(payload.get("state") or "STATE_UNSPECIFIED")
+        if state not in {"RUNNING", "QUEUED", "STATE_UNSPECIFIED"}:
+            return _coerce_job_status(job_name=job_name, payload=payload)
+        if elapsed >= timeout_seconds:
+            raise RuntimeError(
+                f"Storage Batch Operations job timed out after {timeout_seconds}s: {job_name}"
+            )
+        sleep(poll_interval_seconds)
+        elapsed += poll_interval_seconds
+        deadline -= poll_interval_seconds
+
+
+def _get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
+    request = Request(
+        request_url,
+        headers={
+            "Authorization": f"Bearer {token}",
+        },
+        method="GET",
+    )
+    try:
+        with urlopen(request, timeout=120) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Storage Batch Operations get job failed ({exc.code}): {detail}") from exc
+    except URLError as exc:
+        raise RuntimeError(
+            f"Storage Batch Operations get job failed: {str(exc.reason)}"
+        ) from exc
+
+
+def _coerce_job_status(
+    *,
+    job_name: str,
+    payload: dict[str, object],
+) -> StorageBatchOperationsJobStatus:
+    counters = payload.get("counters") or {}
+    if not isinstance(counters, dict):
+        counters = {}
+    return StorageBatchOperationsJobStatus(
+        job_name=job_name,
+        state=str(payload.get("state") or "STATE_UNSPECIFIED"),
+        total_object_count=_coerce_counter(counters.get("totalObjectCount")),
+        succeeded_object_count=_coerce_counter(counters.get("succeededObjectCount")),
+        failed_object_count=_coerce_counter(counters.get("failedObjectCount")),
+        total_bytes_transformed=_coerce_counter(counters.get("totalBytesTransformed")),
+        complete_time=_coerce_optional_datetime(payload.get("completeTime")),
+    )
+
+
+def _coerce_counter(value: object) -> int:
+    if value is None:
+        return 0
+    return int(str(value))
+
+
+def _coerce_optional_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    raise ValueError(f"Unsupported datetime value: {value!r}")

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -26,6 +26,10 @@ class StorageBatchOperationsJobStatus:
     complete_time: datetime | None
 
 
+class StorageBatchOperationsTransientError(RuntimeError):
+    """Raised when polling should retry after a transient API failure."""
+
+
 def create_delete_job(
     *,
     project_id: str,
@@ -111,20 +115,27 @@ def wait_for_delete_job(
         credentials.refresh(GoogleAuthRequest())
 
     request_url = f"https://storagebatchoperations.googleapis.com/v1/{job_name}"
-    deadline = timeout_seconds
     elapsed = 0
     while True:
-        payload = _get_job_payload(request_url=request_url, token=credentials.token)
+        try:
+            payload = _get_job_payload(request_url=request_url, token=credentials.token)
+        except StorageBatchOperationsTransientError:
+            elapsed = _sleep_or_raise_timeout(
+                job_name=job_name,
+                timeout_seconds=timeout_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                elapsed=elapsed,
+            )
+            continue
         state = str(payload.get("state") or "STATE_UNSPECIFIED")
         if state not in {"RUNNING", "QUEUED", "STATE_UNSPECIFIED"}:
             return _coerce_job_status(job_name=job_name, payload=payload)
-        if elapsed >= timeout_seconds:
-            raise RuntimeError(
-                f"Storage Batch Operations job timed out after {timeout_seconds}s: {job_name}"
-            )
-        sleep(poll_interval_seconds)
-        elapsed += poll_interval_seconds
-        deadline -= poll_interval_seconds
+        elapsed = _sleep_or_raise_timeout(
+            job_name=job_name,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+            elapsed=elapsed,
+        )
 
 
 def _get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
@@ -140,10 +151,14 @@ def _get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
             return json.loads(response.read().decode("utf-8"))
     except HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
+        if exc.code in {429, 500, 502, 503, 504}:
+            raise StorageBatchOperationsTransientError(
+                f"Storage Batch Operations get job transient failure ({exc.code}): {detail}"
+            ) from exc
         raise RuntimeError(f"Storage Batch Operations get job failed ({exc.code}): {detail}") from exc
     except URLError as exc:
-        raise RuntimeError(
-            f"Storage Batch Operations get job failed: {str(exc.reason)}"
+        raise StorageBatchOperationsTransientError(
+            f"Storage Batch Operations get job transient failure: {str(exc.reason)}"
         ) from exc
 
 
@@ -180,3 +195,18 @@ def _coerce_optional_datetime(value: object) -> datetime | None:
     if isinstance(value, str):
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     raise ValueError(f"Unsupported datetime value: {value!r}")
+
+
+def _sleep_or_raise_timeout(
+    *,
+    job_name: str,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    elapsed: int,
+) -> int:
+    if elapsed >= timeout_seconds:
+        raise RuntimeError(
+            f"Storage Batch Operations job timed out after {timeout_seconds}s: {job_name}"
+        )
+    sleep(poll_interval_seconds)
+    return elapsed + poll_interval_seconds

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from time import sleep
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
+
+from cost_insight.common.datetime_utils import coerce_optional_datetime
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -120,6 +125,12 @@ def wait_for_delete_job(
         try:
             payload = _get_job_payload(request_url=request_url, token=credentials.token)
         except StorageBatchOperationsTransientError:
+            logger.debug(
+                "Polling Storage Batch Operations job %s hit transient error after %ss",
+                job_name,
+                elapsed,
+                exc_info=True,
+            )
             elapsed = _sleep_or_raise_timeout(
                 job_name=job_name,
                 timeout_seconds=timeout_seconds,
@@ -128,6 +139,12 @@ def wait_for_delete_job(
             )
             continue
         state = str(payload.get("state") or "STATE_UNSPECIFIED")
+        logger.debug(
+            "Polling Storage Batch Operations job %s: state=%s elapsed=%ss",
+            job_name,
+            state,
+            elapsed,
+        )
         if state not in {"RUNNING", "QUEUED", "STATE_UNSPECIFIED"}:
             return _coerce_job_status(job_name=job_name, payload=payload)
         elapsed = _sleep_or_raise_timeout(
@@ -177,7 +194,7 @@ def _coerce_job_status(
         succeeded_object_count=_coerce_counter(counters.get("succeededObjectCount")),
         failed_object_count=_coerce_counter(counters.get("failedObjectCount")),
         total_bytes_transformed=_coerce_counter(counters.get("totalBytesTransformed")),
-        complete_time=_coerce_optional_datetime(payload.get("completeTime")),
+        complete_time=coerce_optional_datetime(payload.get("completeTime")),
     )
 
 
@@ -185,16 +202,6 @@ def _coerce_counter(value: object) -> int:
     if value is None:
         return 0
     return int(str(value))
-
-
-def _coerce_optional_datetime(value: object) -> datetime | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    raise ValueError(f"Unsupported datetime value: {value!r}")
 
 
 def _sleep_or_raise_timeout(

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -7,10 +7,16 @@ from uuid import uuid4
 
 from cost_insight.common.bigquery import BigQueryParameter, BigQueryQueryResult, execute_query
 from cost_insight.common.config import GcsCacheSettings
-from cost_insight.common.storage_batch_operations import StorageBatchOperationsJob, create_delete_job
+from cost_insight.common.storage_batch_operations import (
+    StorageBatchOperationsJob,
+    StorageBatchOperationsJobStatus,
+    create_delete_job,
+    wait_for_delete_job,
+)
 
 QueryExecutor = Callable[[str, list[BigQueryParameter]], BigQueryQueryResult]
 BatchJobCreator = Callable[..., StorageBatchOperationsJob]
+BatchJobWaiter = Callable[..., StorageBatchOperationsJobStatus]
 
 VALID_EXECUTE_KINDS = ("all", "ac", "cas", "mixed-canary")
 
@@ -60,6 +66,7 @@ def run_cleanup_gcs_cache(
     sample_limit: int | None = None,
     execute: QueryExecutor = execute_query,
     create_batch_job: BatchJobCreator = create_delete_job,
+    wait_for_batch_job: BatchJobWaiter = wait_for_delete_job,
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
     run_id_factory: Callable[[], str] = lambda: str(uuid4()),
 ) -> CleanupGcsCacheSummary:
@@ -197,6 +204,27 @@ def run_cleanup_gcs_cache(
             ),
         )
         batch_job_name = batch_job.job_name
+        batch_status = wait_for_batch_job(job_name=batch_job.job_name)
+        if batch_status.state != "SUCCEEDED":
+            raise RuntimeError(
+                f"Storage Batch Operations job did not succeed for {batch_job.job_name}: "
+                f"state={batch_status.state}"
+            )
+        if batch_status.failed_object_count > 0:
+            raise RuntimeError(
+                f"Storage Batch Operations job reported failed objects for {batch_job.job_name}: "
+                f"{batch_status.failed_object_count}"
+            )
+        reconcile_result = execute(
+            build_cleanup_gcs_cache_reconcile_current_table_query(
+                settings,
+                candidate_table=candidate_table,
+            ),
+            parameters=[],
+        )
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total, reconcile_result.total_bytes_processed
+        )
 
     run_finished_at = now()
     return CleanupGcsCacheSummary(
@@ -350,6 +378,21 @@ SELECT
   object_name AS name
 FROM {candidate_table}
 ORDER BY last_seen_at ASC, object_name ASC
+""".strip()
+
+
+def build_cleanup_gcs_cache_reconcile_current_table_query(
+    settings: GcsCacheSettings,
+    *,
+    candidate_table: str,
+) -> str:
+    current_table = _table_ref(settings.project_id, settings.dataset, settings.last_seen_current_table)
+    return f"""
+DELETE FROM {current_table}
+WHERE STRUCT(object_name, last_seen_at) IN (
+  SELECT AS STRUCT object_name, last_seen_at
+  FROM {candidate_table}
+)
 """.strip()
 
 

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from cost_insight.common.bigquery import BigQueryParameter, BigQueryQueryResult, execute_query
 from cost_insight.common.config import GcsCacheSettings
+from cost_insight.common.datetime_utils import coerce_datetime, coerce_optional_datetime
 from cost_insight.common.storage_batch_operations import (
     StorageBatchOperationsJob,
     StorageBatchOperationsJobStatus,
@@ -99,7 +100,7 @@ def run_cleanup_gcs_cache(
         CleanupGcsCacheSample(
             object_name=str(item["object_name"]),
             object_kind=str(item["object_kind"]),
-            last_seen_at=_coerce_datetime(item["last_seen_at"]),
+            last_seen_at=coerce_datetime(item["last_seen_at"]),
             idle_days=int(item["idle_days"]),
         )
         for item in (row.get("sample_candidates") or [])
@@ -108,8 +109,8 @@ def run_cleanup_gcs_cache(
     candidate_object_count = int(row.get("candidate_object_count", 0) or 0)
     ac_candidate_count = int(row.get("ac_candidate_count", 0) or 0)
     cas_candidate_count = int(row.get("cas_candidate_count", 0) or 0)
-    oldest_last_seen_at = _coerce_optional_datetime(row.get("oldest_last_seen_at"))
-    newest_last_seen_at = _coerce_optional_datetime(row.get("newest_last_seen_at"))
+    oldest_last_seen_at = coerce_optional_datetime(row.get("oldest_last_seen_at"))
+    newest_last_seen_at = coerce_optional_datetime(row.get("newest_last_seen_at"))
 
     if mode == "dry-run":
         run_finished_at = now()
@@ -513,17 +514,3 @@ def _validate_mode_and_execute_kind(*, mode: str, execute_kind: str) -> None:
         )
     if mode == "delete" and execute_kind == "all":
         raise ValueError("cleanup-gcs-cache --mode delete requires --execute-kind ac, cas, or mixed-canary")
-
-
-def _coerce_optional_datetime(value: object) -> datetime | None:
-    if value is None:
-        return None
-    return _coerce_datetime(value)
-
-
-def _coerce_datetime(value: object) -> datetime:
-    if isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    raise ValueError(f"Unsupported datetime value: {value!r}")

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -4,10 +4,14 @@ import pytest
 
 from cost_insight.common.bigquery import BigQueryQueryResult
 from cost_insight.common.config import GcsCacheSettings
-from cost_insight.common.storage_batch_operations import StorageBatchOperationsJob
+from cost_insight.common.storage_batch_operations import (
+    StorageBatchOperationsJob,
+    StorageBatchOperationsJobStatus,
+)
 from cost_insight.jobs.cleanup_gcs_cache import (
     build_cleanup_gcs_cache_candidate_table_query,
     build_cleanup_gcs_cache_manifest_export_query,
+    build_cleanup_gcs_cache_reconcile_current_table_query,
     build_cleanup_gcs_cache_summary_query,
     run_cleanup_gcs_cache,
 )
@@ -51,6 +55,17 @@ def test_cleanup_gcs_cache_manifest_export_query_uses_bucket_and_name_columns() 
     assert "manifest-*.csv" in query
     assert "'pingcap-ci-bazel-remote-cache-us-central1' AS bucket" in query
     assert "object_name AS name" in query
+
+
+def test_cleanup_gcs_cache_reconcile_query_matches_object_name_and_last_seen_at() -> None:
+    query = build_cleanup_gcs_cache_reconcile_current_table_query(
+        GcsCacheSettings(project_id="pingcap-testing-account"),
+        candidate_table="`project.dataset.candidates`",
+    )
+
+    assert "DELETE FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`" in query
+    assert "STRUCT(object_name, last_seen_at)" in query
+    assert "FROM `project.dataset.candidates`" in query
 
 
 def test_run_cleanup_gcs_cache_returns_dry_run_summary_with_samples() -> None:
@@ -157,6 +172,7 @@ def test_run_cleanup_gcs_cache_dry_run_ac_only_passes_only_used_parameters() -> 
 def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> None:
     captured_queries = []
     created_jobs = []
+    waited_jobs = []
 
     def fake_execute(query, parameters):
         captured_queries.append((query, {param.name: param.value for param in parameters}))
@@ -183,6 +199,8 @@ def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> Non
             )
         if "EXPORT DATA OPTIONS" in query:
             return BigQueryQueryResult(rows=(), total_bytes_processed=50)
+        if query.startswith("DELETE FROM "):
+            return BigQueryQueryResult(rows=(), total_bytes_processed=30)
         raise AssertionError(f"Unexpected query: {query}")
 
     def fake_create_batch_job(**kwargs):
@@ -190,6 +208,18 @@ def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> Non
         return StorageBatchOperationsJob(
             job_name="projects/pingcap-testing-account/locations/global/jobs/job-1",
             operation_name="operations/op-1",
+        )
+
+    def fake_wait_for_batch_job(**kwargs):
+        waited_jobs.append(kwargs)
+        return StorageBatchOperationsJobStatus(
+            job_name="projects/pingcap-testing-account/locations/global/jobs/job-1",
+            state="SUCCEEDED",
+            total_object_count=7,
+            succeeded_object_count=7,
+            failed_object_count=0,
+            total_bytes_transformed=123,
+            complete_time=datetime(2026, 6, 15, 10, 31, tzinfo=UTC),
         )
 
     run_started_at = datetime(2026, 6, 15, 10, 30, tzinfo=UTC)
@@ -203,6 +233,7 @@ def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> Non
         max_delete_objects=10000000,
         execute=fake_execute,
         create_batch_job=fake_create_batch_job,
+        wait_for_batch_job=fake_wait_for_batch_job,
         now=lambda: run_started_at,
         run_id_factory=lambda: "steady-run-001",
     )
@@ -215,8 +246,8 @@ def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> Non
         "gcs-cache-steady-state-delete/2026-06-15/ac/steady-run-001/manifest-*.csv"
     )
     assert summary.batch_job_name == "projects/pingcap-testing-account/locations/global/jobs/job-1"
-    assert summary.bytes_processed == 375
-    assert len(captured_queries) == 4
+    assert summary.bytes_processed == 405
+    assert len(captured_queries) == 5
     assert captured_queries[0][1] == {
         "ac_cutoff_days": 15,
         "sample_limit": 10,
@@ -227,9 +258,13 @@ def test_run_cleanup_gcs_cache_delete_ac_creates_manifest_and_batch_job() -> Non
         "ac_cutoff_days": 15,
         "limit": 7,
     }
+    assert captured_queries[4][0].startswith(
+        "DELETE FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`"
+    )
     assert created_jobs[0]["manifest_uri"] == summary.manifest_uri
     assert created_jobs[0]["dry_run"] is False
     assert created_jobs[0]["bucket_name"] == "pingcap-ci-bazel-remote-cache-us-central1"
+    assert waited_jobs == [{"job_name": "projects/pingcap-testing-account/locations/global/jobs/job-1"}]
 
 
 def test_run_cleanup_gcs_cache_delete_mixed_canary_uses_fixed_500_per_kind() -> None:
@@ -257,6 +292,8 @@ def test_run_cleanup_gcs_cache_delete_mixed_canary_uses_fixed_500_per_kind() -> 
             return BigQueryQueryResult(rows=({"selected_object_count": 1000},), total_bytes_processed=5)
         if "EXPORT DATA OPTIONS" in query:
             return BigQueryQueryResult(rows=(), total_bytes_processed=3)
+        if query.startswith("DELETE FROM "):
+            return BigQueryQueryResult(rows=(), total_bytes_processed=2)
         raise AssertionError(f"Unexpected query: {query}")
 
     summary = run_cleanup_gcs_cache(
@@ -267,6 +304,15 @@ def test_run_cleanup_gcs_cache_delete_mixed_canary_uses_fixed_500_per_kind() -> 
         create_batch_job=lambda **_: StorageBatchOperationsJob(
             job_name="projects/pingcap-testing-account/locations/global/jobs/job-canary",
             operation_name="operations/op-canary",
+        ),
+        wait_for_batch_job=lambda **_: StorageBatchOperationsJobStatus(
+            job_name="projects/pingcap-testing-account/locations/global/jobs/job-canary",
+            state="SUCCEEDED",
+            total_object_count=1000,
+            succeeded_object_count=1000,
+            failed_object_count=0,
+            total_bytes_transformed=321,
+            complete_time=datetime(2026, 6, 15, 8, 1, tzinfo=UTC),
         ),
         now=lambda: datetime(2026, 6, 15, 8, 0, tzinfo=UTC),
         run_id_factory=lambda: "steady-canary-001",
@@ -285,6 +331,9 @@ def test_run_cleanup_gcs_cache_delete_mixed_canary_uses_fixed_500_per_kind() -> 
         "ac_cutoff_days": 15,
         "cas_cutoff_days": 22,
     }
+    assert captured_queries[4][0].startswith(
+        "DELETE FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`"
+    )
     assert summary.selected_object_count == 1000
 
 
@@ -313,6 +362,8 @@ def test_run_cleanup_gcs_cache_delete_cas_passes_only_used_parameters() -> None:
             return BigQueryQueryResult(rows=({"selected_object_count": 9},), total_bytes_processed=5)
         if "EXPORT DATA OPTIONS" in query:
             return BigQueryQueryResult(rows=(), total_bytes_processed=3)
+        if query.startswith("DELETE FROM "):
+            return BigQueryQueryResult(rows=(), total_bytes_processed=2)
         raise AssertionError(f"Unexpected query: {query}")
 
     run_cleanup_gcs_cache(
@@ -323,6 +374,15 @@ def test_run_cleanup_gcs_cache_delete_cas_passes_only_used_parameters() -> None:
         create_batch_job=lambda **_: StorageBatchOperationsJob(
             job_name="projects/pingcap-testing-account/locations/global/jobs/job-cas",
             operation_name="operations/op-cas",
+        ),
+        wait_for_batch_job=lambda **_: StorageBatchOperationsJobStatus(
+            job_name="projects/pingcap-testing-account/locations/global/jobs/job-cas",
+            state="SUCCEEDED",
+            total_object_count=9,
+            succeeded_object_count=9,
+            failed_object_count=0,
+            total_bytes_transformed=123,
+            complete_time=datetime(2026, 6, 15, 8, 1, tzinfo=UTC),
         ),
         now=lambda: datetime(2026, 6, 15, 8, 0, tzinfo=UTC),
         run_id_factory=lambda: "steady-cas-001",
@@ -338,6 +398,59 @@ def test_run_cleanup_gcs_cache_delete_cas_passes_only_used_parameters() -> None:
         "cas_cutoff_days": 22,
         "limit": 9,
     }
+
+
+def test_run_cleanup_gcs_cache_delete_does_not_reconcile_when_batch_job_has_failures() -> None:
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append((query, {param.name: param.value for param in parameters}))
+        if "ARRAY_AGG(" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_object_count": 7,
+                        "ac_candidate_count": 7,
+                        "cas_candidate_count": 0,
+                        "oldest_last_seen_at": None,
+                        "newest_last_seen_at": None,
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=10,
+            )
+        if "CREATE OR REPLACE TABLE" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=20)
+        if "selected_object_count" in query:
+            return BigQueryQueryResult(rows=({"selected_object_count": 7},), total_bytes_processed=5)
+        if "EXPORT DATA OPTIONS" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=3)
+        if query.startswith("DELETE FROM "):
+            raise AssertionError("Reconcile query should not run when batch delete has failures")
+        raise AssertionError(f"Unexpected query: {query}")
+
+    with pytest.raises(RuntimeError, match="reported failed objects"):
+        run_cleanup_gcs_cache(
+            settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+            mode="delete",
+            execute_kind="ac",
+            execute=fake_execute,
+            create_batch_job=lambda **_: StorageBatchOperationsJob(
+                job_name="projects/pingcap-testing-account/locations/global/jobs/job-failed",
+                operation_name="operations/op-failed",
+            ),
+            wait_for_batch_job=lambda **_: StorageBatchOperationsJobStatus(
+                job_name="projects/pingcap-testing-account/locations/global/jobs/job-failed",
+                state="SUCCEEDED",
+                total_object_count=7,
+                succeeded_object_count=6,
+                failed_object_count=1,
+                total_bytes_transformed=100,
+                complete_time=datetime(2026, 6, 15, 8, 1, tzinfo=UTC),
+            ),
+            now=lambda: datetime(2026, 6, 15, 8, 0, tzinfo=UTC),
+            run_id_factory=lambda: "steady-failed-001",
+        )
 
 
 def test_run_cleanup_gcs_cache_rejects_delete_without_specific_execute_kind() -> None:

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -453,6 +453,59 @@ def test_run_cleanup_gcs_cache_delete_does_not_reconcile_when_batch_job_has_fail
         )
 
 
+def test_run_cleanup_gcs_cache_delete_raises_when_batch_job_state_is_not_succeeded() -> None:
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append((query, {param.name: param.value for param in parameters}))
+        if "ARRAY_AGG(" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_object_count": 7,
+                        "ac_candidate_count": 7,
+                        "cas_candidate_count": 0,
+                        "oldest_last_seen_at": None,
+                        "newest_last_seen_at": None,
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=10,
+            )
+        if "CREATE OR REPLACE TABLE" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=20)
+        if "selected_object_count" in query:
+            return BigQueryQueryResult(rows=({"selected_object_count": 7},), total_bytes_processed=5)
+        if "EXPORT DATA OPTIONS" in query:
+            return BigQueryQueryResult(rows=(), total_bytes_processed=3)
+        if query.startswith("DELETE FROM "):
+            raise AssertionError("Reconcile query should not run when batch job is not succeeded")
+        raise AssertionError(f"Unexpected query: {query}")
+
+    with pytest.raises(RuntimeError, match="did not succeed"):
+        run_cleanup_gcs_cache(
+            settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+            mode="delete",
+            execute_kind="ac",
+            execute=fake_execute,
+            create_batch_job=lambda **_: StorageBatchOperationsJob(
+                job_name="projects/pingcap-testing-account/locations/global/jobs/job-failed",
+                operation_name="operations/op-failed",
+            ),
+            wait_for_batch_job=lambda **_: StorageBatchOperationsJobStatus(
+                job_name="projects/pingcap-testing-account/locations/global/jobs/job-failed",
+                state="FAILED",
+                total_object_count=7,
+                succeeded_object_count=0,
+                failed_object_count=7,
+                total_bytes_transformed=100,
+                complete_time=datetime(2026, 6, 15, 8, 1, tzinfo=UTC),
+            ),
+            now=lambda: datetime(2026, 6, 15, 8, 0, tzinfo=UTC),
+            run_id_factory=lambda: "steady-failed-state-001",
+        )
+
+
 def test_run_cleanup_gcs_cache_rejects_delete_without_specific_execute_kind() -> None:
     with pytest.raises(
         ValueError,

--- a/cost-insight/tests/test_storage_batch_operations.py
+++ b/cost-insight/tests/test_storage_batch_operations.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from cost_insight.common import storage_batch_operations
+
+
+class _FakeCredentials:
+    def __init__(self) -> None:
+        self.valid = True
+        self.token = "test-token"
+
+    def refresh(self, _request) -> None:
+        self.valid = True
+
+
+def _install_fake_google_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    import google.auth
+    from google.auth.transport import requests
+
+    monkeypatch.setattr(google.auth, "default", lambda scopes=None: (_FakeCredentials(), "test"))
+    monkeypatch.setattr(requests, "Request", lambda: object())
+
+
+def test_wait_for_delete_job_retries_transient_errors_and_state_unspecified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_google_auth(monkeypatch)
+
+    responses = iter(
+        [
+            storage_batch_operations.StorageBatchOperationsTransientError("retry later"),
+            {"state": "STATE_UNSPECIFIED"},
+            {"state": "RUNNING"},
+            {
+                "state": "SUCCEEDED",
+                "counters": {
+                    "totalObjectCount": "7",
+                    "succeededObjectCount": "7",
+                    "failedObjectCount": "0",
+                    "totalBytesTransformed": "123",
+                },
+                "completeTime": "2026-06-15T08:01:00Z",
+            },
+        ]
+    )
+    sleeps: list[int] = []
+
+    def fake_get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
+        assert request_url.endswith("/projects/test/locations/global/jobs/job-1")
+        assert token == "test-token"
+        response = next(responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(storage_batch_operations, "_get_job_payload", fake_get_job_payload)
+    monkeypatch.setattr(storage_batch_operations, "sleep", lambda seconds: sleeps.append(seconds))
+
+    status = storage_batch_operations.wait_for_delete_job(
+        job_name="projects/test/locations/global/jobs/job-1",
+        timeout_seconds=60,
+        poll_interval_seconds=5,
+    )
+
+    assert status == storage_batch_operations.StorageBatchOperationsJobStatus(
+        job_name="projects/test/locations/global/jobs/job-1",
+        state="SUCCEEDED",
+        total_object_count=7,
+        succeeded_object_count=7,
+        failed_object_count=0,
+        total_bytes_transformed=123,
+        complete_time=datetime(2026, 6, 15, 8, 1, tzinfo=UTC),
+    )
+    assert sleeps == [5, 5, 5]
+
+
+def test_wait_for_delete_job_times_out_for_non_terminal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_google_auth(monkeypatch)
+
+    monkeypatch.setattr(
+        storage_batch_operations,
+        "_get_job_payload",
+        lambda **_: {"state": "RUNNING"},
+    )
+    sleeps: list[int] = []
+    monkeypatch.setattr(storage_batch_operations, "sleep", lambda seconds: sleeps.append(seconds))
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Storage Batch Operations job timed out after 20s: "
+            "projects/test/locations/global/jobs/job-2"
+        ),
+    ):
+        storage_batch_operations.wait_for_delete_job(
+            job_name="projects/test/locations/global/jobs/job-2",
+            timeout_seconds=20,
+            poll_interval_seconds=10,
+        )
+
+    assert sleeps == [10, 10]

--- a/cost-insight/tests/test_storage_batch_operations.py
+++ b/cost-insight/tests/test_storage_batch_operations.py
@@ -104,3 +104,31 @@ def test_wait_for_delete_job_times_out_for_non_terminal_state(
         )
 
     assert sleeps == [10, 10]
+
+
+def test_wait_for_delete_job_returns_terminal_failure_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_google_auth(monkeypatch)
+
+    monkeypatch.setattr(
+        storage_batch_operations,
+        "_get_job_payload",
+        lambda **_: {"state": "FAILED"},
+    )
+
+    status = storage_batch_operations.wait_for_delete_job(
+        job_name="projects/test/locations/global/jobs/job-3",
+        timeout_seconds=20,
+        poll_interval_seconds=10,
+    )
+
+    assert status == storage_batch_operations.StorageBatchOperationsJobStatus(
+        job_name="projects/test/locations/global/jobs/job-3",
+        state="FAILED",
+        total_object_count=0,
+        succeeded_object_count=0,
+        failed_object_count=0,
+        total_bytes_transformed=0,
+        complete_time=None,
+    )


### PR DESCRIPTION
## Summary
- wait for Storage Batch Operations delete jobs to complete before treating a cleanup run as successful
- reconcile `gcs_cache_object_last_seen_current` after a fully successful delete so already-removed objects stop reappearing in later dry-runs/deletes
- add coverage for the success path and the failure path where reconcile must not run

## Why
The first steady-state real delete removed objects from GCS successfully, but the corresponding rows remained in `gcs_cache_object_last_seen_current`. That means later daily dry-runs and delete jobs would keep selecting the same already-deleted objects again.

This change keeps the current-table source of truth aligned with successful delete results without introducing a separate runs table.

## Testing
- `pytest`
- Total coverage: `92.24%`
