### PR TITLE
fix(tibuild): use go-github client for branch_commits API call

### DIFF
--- a/tibuild/pkg/rest/service/gh_client.go
+++ b/tibuild/pkg/rest/service/gh_client.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -17,6 +16,9 @@ var sha1regex *regexp.Regexp = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 
 type GitHubClient struct{ *github.Client }
 
+// GetBranchesForCommit implements GHClient.
+// It retrieves all branches that contain the given commit by calling
+// the GitHub web UI internal API with Accept: application/json.
 // define a struct for the json data:
 /*
 {
@@ -63,33 +65,24 @@ func (c GitHubClient) GetBranchesForCommit(ctx context.Context, owner string, re
 		return nil, fmt.Errorf("commit %s is not a valid sha1", commit)
 	}
 
-	rawURL, err := url.JoinPath("https://github.com", owner, repo, "branch_commits", commit)
+	u, err := url.JoinPath("https://github.com", owner, repo, "branch_commits", commit)
 	if err != nil {
 		return nil, err
 	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := c.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
-	req.Header.Add("Accept", "application/json")
-	res, err := c.Client.Client().Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	// parse the res body
 	var data branchesForCommitResponse
-	// read the response body and unmarshal to `data`
-	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+	if _, err := c.Do(ctx, req, &data); err != nil {
 		return nil, err
 	}
 
 	var branches []string
-	for _, branch := range data.Branches {
-		branches = append(branches, branch.Branch)
+	for _, b := range data.Branches {
+		branches = append(branches, b.Branch)
 	}
 	return branches, nil
 }


### PR DESCRIPTION
## Problem

When chatops-lark triggers a devbuild with tekton engine (e.g., `/devbuild trigger --engine tekton --platform linux --product ticdc-newarch --edition nextgen --gitRef commit/<sha>`), tibuild returns:

```
trigger devbuild failed: {"code":500,"message":"invalid character '\u003c' looking for beginning of value"}
```

## Root cause

`GetBranchesForCommit` in `gh_client.go` makes a raw HTTP request to `github.com/{owner}/{repo}/branch_commits/{sha}`:

```go
req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
...
req.Header.Add("Accept", "application/json")
res, err := c.Client.Client().Do(req)
...
json.NewDecoder(res.Body).Decode(&data)
```

Despite setting `Accept: application/json`, the raw HTTP call bypasses the go-github client's auth transport and `CheckResponse` error handling. When authentication is insufficient, GitHub returns an HTML page (starting with `<`), causing JSON decode to fail with a cryptic error.

## Fix

Replace the raw HTTP call with go-github's `NewRequest` + `Do` methods:

- `c.NewRequest("GET", u, nil)` — uses go-github's User-Agent and request construction
- `c.Do(ctx, req, &data)` — handles auth transport, rate limit checking, `CheckResponse` (non-2xx errors), and JSON decoding internally

This aligns with the approach used in `experiments/tibuild-v2/internal/service/impl/hotfix_tidbx.go` (`getBranchesContainingCommit`).

## Changes

`tibuild/pkg/rest/service/gh_client.go` — only the `GetBranchesForCommit` method body is changed; `encoding/json` import is removed; all other methods, data structures, and comments are preserved.

## Notes

- The fix still uses the undocumented `github.com/branch_commits` endpoint; its Bearer token acceptance on `github.com` needs verification after deployment
- For private repo support, a follow-up switch to the GraphQL API may be needed