### PR TITLE
fix(cost-insight): ignore transfer service gcs get events

### DIFF
--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -18,6 +18,7 @@ DEFAULT_GCS_CACHE_DATASET = "ci_bazel_cache_logs"
 DEFAULT_GCS_CACHE_AUDIT_LOG_TABLE = "cloudaudit_googleapis_com_data_access"
 DEFAULT_GCS_CACHE_LAST_SEEN_DAILY_TABLE = "gcs_cache_object_last_seen_daily"
 DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE = "gcs_cache_object_last_seen_current"
+DEFAULT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT = "TransferService"
 DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET = "pingcap-ci-console-logs-us-central1"
 DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX = "gcs-cache-steady-state-delete"
 
@@ -64,6 +65,8 @@ class GcsCacheSettings:
     audit_log_table: str = DEFAULT_GCS_CACHE_AUDIT_LOG_TABLE
     last_seen_daily_table: str = DEFAULT_GCS_CACHE_LAST_SEEN_DAILY_TABLE
     last_seen_current_table: str = DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE
+    last_seen_excluded_get_user_agent: str = DEFAULT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT
+    last_seen_excluded_get_principal_email: str | None = None
     ac_retention_days: int = 14
     cas_retention_days: int = 21
     cleanup_safety_buffer_days: int = 1
@@ -222,6 +225,17 @@ def load_settings(
                 DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE,
                 "COST_INSIGHT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE",
                 "COST_GCS_CACHE_LAST_SEEN_CURRENT_TABLE",
+            ),
+            last_seen_excluded_get_user_agent=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT,
+                "COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT",
+                "COST_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT",
+            ),
+            last_seen_excluded_get_principal_email=_read_optional_any(
+                env,
+                "COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_PRINCIPAL_EMAIL",
+                "COST_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_PRINCIPAL_EMAIL",
             ),
             ac_retention_days=_read_positive_int_any(
                 env,

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -198,6 +198,9 @@ def run_cleanup_gcs_cache(
             bucket_name=settings.bucket_name,
             manifest_uri=manifest_uri,
             dry_run=False,
+            # sync-gcs-cache-last-seen filters TransferService GET audit events
+            # emitted by Storage Batch Operations. If delete execution changes to a
+            # different service/user-agent path, keep that filter in sync.
             description=(
                 "Steady-state GCS cache cleanup "
                 f"{execute_kind} run {run_id} "

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_last_seen.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_last_seen.py
@@ -32,6 +32,16 @@ def run_sync_gcs_cache_last_seen(
     parameters = [
         BigQueryParameter("run_date", "DATE", resolved_run_date),
         BigQueryParameter("bucket_name", "STRING", settings.bucket_name),
+        BigQueryParameter(
+            "excluded_get_user_agent",
+            "STRING",
+            settings.last_seen_excluded_get_user_agent,
+        ),
+        BigQueryParameter(
+            "excluded_get_principal_email",
+            "STRING",
+            settings.last_seen_excluded_get_principal_email or "",
+        ),
     ]
     query = (
         build_sync_gcs_cache_last_seen_dry_run_query(settings)
@@ -182,6 +192,14 @@ WITH extracted AS (
   WHERE DATE(timestamp) = @run_date
     AND resource.labels.bucket_name = @bucket_name
     AND protopayload_auditlog.methodName IN ("storage.objects.get", "storage.objects.create")
+    AND NOT (
+      protopayload_auditlog.methodName = "storage.objects.get"
+      AND COALESCE(protopayload_auditlog.requestMetadata.callerSuppliedUserAgent, "") = @excluded_get_user_agent
+      AND (
+        @excluded_get_principal_email = ""
+        OR COALESCE(protopayload_auditlog.authenticationInfo.principalEmail, "") = @excluded_get_principal_email
+      )
+    )
 )
 SELECT
   ds,

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_last_seen.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_last_seen.py
@@ -29,25 +29,30 @@ def run_sync_gcs_cache_last_seen(
     execute: QueryExecutor = execute_query,
 ) -> SyncGcsCacheLastSeenResult:
     resolved_run_date = run_date or (datetime.now(timezone.utc).date() - timedelta(days=1))
-    parameters = [
-        BigQueryParameter("run_date", "DATE", resolved_run_date),
-        BigQueryParameter("bucket_name", "STRING", settings.bucket_name),
-        BigQueryParameter(
-            "excluded_get_user_agent",
-            "STRING",
-            settings.last_seen_excluded_get_user_agent,
-        ),
-        BigQueryParameter(
-            "excluded_get_principal_email",
-            "STRING",
-            settings.last_seen_excluded_get_principal_email or "",
-        ),
-    ]
     query = (
         build_sync_gcs_cache_last_seen_dry_run_query(settings)
         if dry_run
         else build_sync_gcs_cache_last_seen_query(settings)
     )
+    parameters = [
+        BigQueryParameter("run_date", "DATE", resolved_run_date),
+        BigQueryParameter("bucket_name", "STRING", settings.bucket_name),
+    ]
+    if settings.last_seen_excluded_get_user_agent.strip():
+        parameters.extend(
+            [
+                BigQueryParameter(
+                    "excluded_get_user_agent",
+                    "STRING",
+                    settings.last_seen_excluded_get_user_agent.strip(),
+                ),
+                BigQueryParameter(
+                    "excluded_get_principal_email",
+                    "STRING",
+                    settings.last_seen_excluded_get_principal_email or "",
+                ),
+            ]
+        )
     result = execute(query, parameters=parameters)
     row = result.rows[0] if result.rows else {}
     return SyncGcsCacheLastSeenResult(
@@ -181,6 +186,18 @@ def _build_daily_rollup_select(settings: GcsCacheSettings) -> str:
         settings.dataset,
         settings.audit_log_table,
     )
+    excluded_get_user_agent = settings.last_seen_excluded_get_user_agent.strip()
+    excluded_get_clause = ""
+    if excluded_get_user_agent:
+        excluded_get_clause = f"""
+    AND NOT (
+      protopayload_auditlog.methodName = "storage.objects.get"
+      AND COALESCE(protopayload_auditlog.requestMetadata.callerSuppliedUserAgent, "") = @excluded_get_user_agent
+      AND (
+        @excluded_get_principal_email = ""
+        OR COALESCE(protopayload_auditlog.authenticationInfo.principalEmail, "") = @excluded_get_principal_email
+      )
+    )"""
     return f"""
 WITH extracted AS (
   SELECT
@@ -192,14 +209,7 @@ WITH extracted AS (
   WHERE DATE(timestamp) = @run_date
     AND resource.labels.bucket_name = @bucket_name
     AND protopayload_auditlog.methodName IN ("storage.objects.get", "storage.objects.create")
-    AND NOT (
-      protopayload_auditlog.methodName = "storage.objects.get"
-      AND COALESCE(protopayload_auditlog.requestMetadata.callerSuppliedUserAgent, "") = @excluded_get_user_agent
-      AND (
-        @excluded_get_principal_email = ""
-        OR COALESCE(protopayload_auditlog.authenticationInfo.principalEmail, "") = @excluded_get_principal_email
-      )
-    )
+{excluded_get_clause}
 )
 SELECT
   ds,

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -45,6 +45,8 @@ def test_load_settings_can_skip_database_for_validation() -> None:
     assert settings.gcs_cache.ac_retention_days == 14
     assert settings.gcs_cache.cas_retention_days == 21
     assert settings.gcs_cache.cleanup_safety_buffer_days == 1
+    assert settings.gcs_cache.last_seen_excluded_get_user_agent == "TransferService"
+    assert settings.gcs_cache.last_seen_excluded_get_principal_email is None
 
 
 def test_load_settings_falls_back_to_tidb_parts() -> None:
@@ -100,6 +102,8 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
             "COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE": "raw_table",
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_DAILY_TABLE": "daily_table",
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE": "current_table",
+            "COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT": "CustomTransferService",
+            "COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_PRINCIPAL_EMAIL": "cleanup@example.com",
             "COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS": "21",
             "COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS": "35",
             "COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS": "2",
@@ -119,6 +123,8 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
     assert settings.gcs_cache.audit_log_table == "raw_table"
     assert settings.gcs_cache.last_seen_daily_table == "daily_table"
     assert settings.gcs_cache.last_seen_current_table == "current_table"
+    assert settings.gcs_cache.last_seen_excluded_get_user_agent == "CustomTransferService"
+    assert settings.gcs_cache.last_seen_excluded_get_principal_email == "cleanup@example.com"
     assert settings.gcs_cache.ac_retention_days == 21
     assert settings.gcs_cache.cas_retention_days == 35
     assert settings.gcs_cache.cleanup_safety_buffer_days == 2

--- a/cost-insight/tests/test_sync_gcs_cache_last_seen.py
+++ b/cost-insight/tests/test_sync_gcs_cache_last_seen.py
@@ -21,6 +21,9 @@ def test_sync_gcs_cache_last_seen_dry_run_uses_expected_query_shape() -> None:
     assert "COALESCE(SUM(event_count_in_day), 0) AS source_rows_seen" in query
     assert "COUNTIF(method_name = \"storage.objects.get\") AS get_count_in_day" in query
     assert "resource.labels.bucket_name = @bucket_name" in query
+    assert "callerSuppliedUserAgent" in query
+    assert "@excluded_get_user_agent" in query
+    assert "@excluded_get_principal_email" in query
 
 
 def test_sync_gcs_cache_last_seen_query_creates_and_merges_tables() -> None:
@@ -65,6 +68,8 @@ def test_run_sync_gcs_cache_last_seen_returns_summary_from_executor() -> None:
     assert captured["parameters"] == {
         "run_date": date(2026, 6, 8),
         "bucket_name": "pingcap-ci-bazel-remote-cache-us-central1",
+        "excluded_get_user_agent": "TransferService",
+        "excluded_get_principal_email": "",
     }
     assert summary.account_id == "pingcap-testing-account"
     assert summary.run_date == date(2026, 6, 8)
@@ -99,3 +104,32 @@ def test_run_sync_gcs_cache_last_seen_defaults_to_yesterday_utc(monkeypatch) -> 
 
     assert captured["parameters"]["run_date"] == date(2026, 6, 9)
     assert summary.run_date == date(2026, 6, 9)
+
+
+def test_run_sync_gcs_cache_last_seen_passes_optional_principal_email_filter() -> None:
+    captured = {}
+
+    def fake_execute(query, parameters):
+        captured["parameters"] = {param.name: param.value for param in parameters}
+        return BigQueryQueryResult(
+            rows=({"distinct_objects": 0, "source_rows_seen": 0},),
+            total_bytes_processed=None,
+        )
+
+    run_sync_gcs_cache_last_seen(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            last_seen_excluded_get_principal_email=(
+                "ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com"
+            ),
+        ),
+        run_date=date(2026, 6, 16),
+        dry_run=True,
+        execute=fake_execute,
+    )
+
+    assert captured["parameters"]["excluded_get_user_agent"] == "TransferService"
+    assert (
+        captured["parameters"]["excluded_get_principal_email"]
+        == "ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com"
+    )

--- a/cost-insight/tests/test_sync_gcs_cache_last_seen.py
+++ b/cost-insight/tests/test_sync_gcs_cache_last_seen.py
@@ -22,8 +22,11 @@ def test_sync_gcs_cache_last_seen_dry_run_uses_expected_query_shape() -> None:
     assert "COUNTIF(method_name = \"storage.objects.get\") AS get_count_in_day" in query
     assert "resource.labels.bucket_name = @bucket_name" in query
     assert "callerSuppliedUserAgent" in query
-    assert "@excluded_get_user_agent" in query
-    assert "@excluded_get_principal_email" in query
+    where_section = query.partition("WHERE DATE(timestamp) = @run_date")[2].partition(")\nSELECT")[0]
+    assert "callerSuppliedUserAgent" in where_section
+    assert "@excluded_get_user_agent" in where_section
+    assert "@excluded_get_principal_email" in where_section
+    assert "authenticationInfo.principalEmail" in where_section
 
 
 def test_sync_gcs_cache_last_seen_query_creates_and_merges_tables() -> None:
@@ -133,3 +136,48 @@ def test_run_sync_gcs_cache_last_seen_passes_optional_principal_email_filter() -
         captured["parameters"]["excluded_get_principal_email"]
         == "ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com"
     )
+
+
+def test_sync_gcs_cache_last_seen_skips_exclusion_clause_for_blank_user_agent() -> None:
+    query = build_sync_gcs_cache_last_seen_dry_run_query(
+        GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            last_seen_excluded_get_user_agent="   ",
+            last_seen_excluded_get_principal_email=(
+                "ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com"
+            ),
+        )
+    )
+
+    where_section = query.partition("WHERE DATE(timestamp) = @run_date")[2].partition(")\nSELECT")[0]
+    assert "callerSuppliedUserAgent" not in where_section
+    assert "authenticationInfo.principalEmail" not in where_section
+
+
+def test_run_sync_gcs_cache_last_seen_skips_exclusion_parameters_for_blank_user_agent() -> None:
+    captured = {}
+
+    def fake_execute(query, parameters):
+        captured["parameters"] = {param.name: param.value for param in parameters}
+        return BigQueryQueryResult(
+            rows=({"distinct_objects": 0, "source_rows_seen": 0},),
+            total_bytes_processed=None,
+        )
+
+    run_sync_gcs_cache_last_seen(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            last_seen_excluded_get_user_agent="",
+            last_seen_excluded_get_principal_email=(
+                "ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com"
+            ),
+        ),
+        run_date=date(2026, 6, 16),
+        dry_run=True,
+        execute=fake_execute,
+    )
+
+    assert captured["parameters"] == {
+        "run_date": date(2026, 6, 16),
+        "bucket_name": "pingcap-ci-bazel-remote-cache-us-central1",
+    }


### PR DESCRIPTION
## Summary
- exclude Storage Batch Operations `TransferService` GET audit events from `sync-gcs-cache-last-seen`
- make the exclusion configurable in `GcsCacheSettings`, with `TransferService` as the default excluded user agent
- add tests for the new query filter and settings wiring

## Why
During the historical and steady-state GCS cache deletes, Storage Batch Operations emitted `storage.objects.get` audit log events with:
- principal: `ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com`
- user agent: `TransferService`

Those GET events were being ingested as normal cache accesses and written back into `gcs_cache_object_last_seen_current`, which makes recently deleted objects look hot again.

This change filters those self-generated delete-side GET events out of the daily last-seen sync.

## Testing
- `pytest`
- Total coverage: `93.96%`
