### PR TITLE
feat(dl): add HEAD request support for oci-file endpoint

### DIFF
--- a/dl/cmd/server/http.go
+++ b/dl/cmd/server/http.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,11 +21,18 @@ import (
 	ocisvr "github.com/PingCAP-QE/ee-apps/dl/gen/http/oci/server"
 	ks3 "github.com/PingCAP-QE/ee-apps/dl/gen/ks3"
 	oci "github.com/PingCAP-QE/ee-apps/dl/gen/oci"
+	pkgoci "github.com/PingCAP-QE/ee-apps/dl/pkg/oci"
+	"oras.land/oras-go/v2/registry/remote"
 )
+
+// ociRepoProvider is implemented by OCI service types that can create authenticated repository clients.
+type ociRepoProvider interface {
+	GetTargetRepo(repo string) (*remote.Repository, error)
+}
 
 // handleHTTPServer starts configures and starts a HTTP server on the given
 // URL. It shuts down the server if any error is received in the error channel.
-func handleHTTPServer(ctx context.Context, u *url.URL, ociEndpoints *oci.Endpoints, ks3Endpoints *ks3.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {
+func handleHTTPServer(ctx context.Context, u *url.URL, ociEndpoints *oci.Endpoints, ks3Endpoints *ks3.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool, ociSvc oci.Service) {
 
 	// Setup goa log adapter.
 	var (
@@ -81,6 +91,9 @@ func handleHTTPServer(ctx context.Context, u *url.URL, ociEndpoints *oci.Endpoin
 	// here apply to all the service endpoints.
 	var handler http.Handler = mux
 	{
+		if provider, ok := ociSvc.(ociRepoProvider); ok {
+			handler = headOCIMiddleware(provider, logger)(handler)
+		}
 		handler = httpmdlwr.Log(adapter)(handler)
 		handler = httpmdlwr.RequestID()(handler)
 	}
@@ -127,5 +140,93 @@ func errorHandler(logger *log.Logger) func(context.Context, http.ResponseWriter,
 		id := ctx.Value(middleware.RequestIDKey).(string)
 		_, _ = w.Write([]byte("[" + id + "] encoding: " + err.Error()))
 		logger.Printf("[%s] ERROR: %s", id, err.Error())
+	}
+}
+
+// headOCIMiddleware intercepts HEAD requests to /oci-file/{*repository} and
+// checks file existence without downloading the blob, enabling wget --spider.
+func headOCIMiddleware(provider ociRepoProvider, logger *log.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodHead {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if !strings.HasPrefix(r.URL.Path, "/oci-file/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			repository := strings.TrimPrefix(r.URL.Path, "/oci-file/")
+			if repository == "" {
+				http.Error(w, "missing repository", http.StatusBadRequest)
+				return
+			}
+
+			qp := r.URL.Query()
+			tag := qp.Get("tag")
+			if tag == "" {
+				http.Error(w, "missing tag query parameter", http.StatusBadRequest)
+				return
+			}
+
+			file := qp.Get("file")
+			fileRegex := qp.Get("file_regex")
+
+			repo, err := provider.GetTargetRepo(repository)
+			if err != nil {
+				logger.Printf("HEAD oci-file: getTargetRepo: %v", err)
+				http.Error(w, "failed to resolve repository", http.StatusInternalServerError)
+				return
+			}
+
+			ctx := r.Context()
+			var targetFile string
+
+			if file != "" {
+				targetFile = file
+			} else if fileRegex != "" {
+				pattern, err := regexp.Compile(fileRegex)
+				if err != nil {
+					http.Error(w, "invalid file_regex", http.StatusBadRequest)
+					return
+				}
+
+				files, err := pkgoci.ListFiles(ctx, repo, tag)
+				if err != nil {
+					logger.Printf("HEAD oci-file: ListFiles: %v", err)
+					http.Error(w, "failed to list files", http.StatusInternalServerError)
+					return
+				}
+
+				for _, f := range files {
+					if pattern.MatchString(f) {
+						targetFile = f
+						break
+					}
+				}
+
+				if targetFile == "" {
+					http.Error(w, "file not found", http.StatusNotFound)
+					return
+				}
+			} else {
+				http.Error(w, "missing file or file_regex parameter", http.StatusBadRequest)
+				return
+			}
+
+			descriptor, err := pkgoci.FetchFileDescriptor(ctx, repo, tag, targetFile)
+			if err != nil {
+				logger.Printf("HEAD oci-file: FetchFileDescriptor: %v", err)
+				http.Error(w, "file not found", http.StatusNotFound)
+				return
+			}
+
+			w.Header().Set("Content-Disposition", `attachment; filename*=UTF-8''`+url.QueryEscape(targetFile))
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", descriptor.Size))
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+		})
 	}
 }

--- a/dl/cmd/server/main.go
+++ b/dl/cmd/server/main.go
@@ -99,7 +99,7 @@ func main() {
 			} else if u.Port() == "" {
 				u.Host = net.JoinHostPort(u.Host, "80")
 			}
-			handleHTTPServer(ctx, u, ociEndpoints, ks3Endpoints, &wg, errc, logger, *dbgF)
+			handleHTTPServer(ctx, u, ociEndpoints, ks3Endpoints, &wg, errc, logger, *dbgF, ociSvc)
 		}
 
 	default:

--- a/dl/oci.go
+++ b/dl/oci.go
@@ -51,7 +51,7 @@ func NewOci(logger *log.Logger, cfgFile *string) oci.Service {
 func (s *ocisrvc) ListFiles(ctx context.Context, p *oci.ListFilesPayload) (res []string, err error) {
 	s.logger.Print("oci.list-files")
 
-	repository, err := s.getTargetRepo(p.Repository)
+	repository, err := s.GetTargetRepo(p.Repository)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,8 @@ func (s *ocisrvc) ListFiles(ctx context.Context, p *oci.ListFilesPayload) (res [
 	return files, nil
 }
 
-func (s *ocisrvc) getTargetRepo(repo string) (*remote.Repository, error) {
+// GetTargetRepo creates a remote.Repository with auth configured for the given repo string.
+func (s *ocisrvc) GetTargetRepo(repo string) (*remote.Repository, error) {
 	repository, err := remote.NewRepository(repo)
 	if err != nil {
 		return nil, err
@@ -84,7 +85,7 @@ func (s *ocisrvc) getTargetRepo(repo string) (*remote.Repository, error) {
 func (s *ocisrvc) DownloadFile(ctx context.Context, p *oci.DownloadFilePayload) (res *oci.DownloadFileResult, resp io.ReadCloser, err error) {
 	s.logger.Print("oci.download-file")
 
-	repository, err := s.getTargetRepo(p.Repository)
+	repository, err := s.GetTargetRepo(p.Repository)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,7 +134,7 @@ func (s *ocisrvc) downloadFile(ctx context.Context, repo *remote.Repository, tag
 func (s *ocisrvc) DownloadFileSha256(ctx context.Context, p *oci.DownloadFileSha256Payload) (res *oci.DownloadFileSha256Result, resp io.ReadCloser, err error) {
 	s.logger.Print("oci.download-file-sha256")
 
-	repository, err := s.getTargetRepo(p.Repository)
+	repository, err := s.GetTargetRepo(p.Repository)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/dl/pkg/oci/download.go
+++ b/dl/pkg/oci/download.go
@@ -30,7 +30,7 @@ func ListFiles(ctx context.Context, repository *remote.Repository, tag string) (
 func NewFileReadCloser(ctx context.Context, repository *remote.Repository, tag, filename string) (io.ReadCloser, int64, error) {
 	// 1. get desired file descriptor in the artifact.
 	// destination := strings.Join([]string{repo, tag}, ":")
-	desiredFileDescriptor, err := fetchFileDescriptor(ctx, repository, tag, filename)
+	desiredFileDescriptor, err := FetchFileDescriptor(ctx, repository, tag, filename)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -48,7 +48,7 @@ func NewFileReadCloser(ctx context.Context, repository *remote.Repository, tag, 
 func GetFileSHA256(ctx context.Context, repository oras.ReadOnlyTarget, tag, filename string) (string, error) {
 	// 1. get desired file descriptor in the artifact.
 	// destination := strings.Join([]string{repo, tag}, ":")
-	desiredFileDescriptor, err := fetchFileDescriptor(ctx, repository, tag, filename)
+	desiredFileDescriptor, err := FetchFileDescriptor(ctx, repository, tag, filename)
 	if err != nil {
 		return "", err
 	}
@@ -70,7 +70,8 @@ func listArtifactLayers(ctx context.Context, target oras.ReadOnlyTarget, ref str
 	return manifest.Layers, nil
 }
 
-func fetchFileDescriptor(ctx context.Context, target oras.ReadOnlyTarget, ref, filename string) (*ocispec.Descriptor, error) {
+// FetchFileDescriptor finds the descriptor for a specific file in an OCI artifact.
+func FetchFileDescriptor(ctx context.Context, target oras.ReadOnlyTarget, ref, filename string) (*ocispec.Descriptor, error) {
 	layers, err := listArtifactLayers(ctx, target, ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
Add HEAD request support for the `/oci-file/{repository}` endpoint to enable `wget --spider` file existence checks.

## Changes
- **Export `FetchFileDescriptor`** in `dl/pkg/oci/download.go` — allows HEAD middleware to check file existence without downloading blob
- **Export `GetTargetRepo`** on `ocisrvc` in `dl/oci.go` — provides middleware access to authenticated OCI repository client
- **Add `headOCIMiddleware`** in `dl/cmd/server/http.go` — intercepts `HEAD /oci-file/{*repository}` requests, validates file existence via OCI registry, returns 200+headers or 404
- **Wire middleware** into `handleHTTPServer` handler chain
- **Pass `ociSvc`** from `main.go` to `handleHTTPServer`

## Testing
- `curl -I /oci-file/<repo>?tag=<tag>&file=<f>` should return 200 with `Content-Disposition` + `Content-Length` headers (file exists) or 404 (not found)
- `wget --spider` should succeed for existing files
- Existing GET download functionality is unaffected (middleware only intercepts HEAD method)

## Risk
- **Low**: Middleware only intercepts `HEAD` method on `/oci-file/` path prefix. GET requests pass through unchanged.
- **Rollback**: Remove `headOCIMiddleware` wrapper from handler chain.

Ref: FLA-204 PR1