### PR TITLE
fix(dl): add both filename and filename* to Content-Disposition header

### DIFF
--- a/dl/cmd/server/http.go
+++ b/dl/cmd/server/http.go
@@ -17,6 +17,7 @@ import (
 	httpmdlwr "goa.design/goa/v3/http/middleware"
 	"goa.design/goa/v3/middleware"
 
+	dl "github.com/PingCAP-QE/ee-apps/dl"
 	ks3svr "github.com/PingCAP-QE/ee-apps/dl/gen/http/ks3/server"
 	ocisvr "github.com/PingCAP-QE/ee-apps/dl/gen/http/oci/server"
 	ks3 "github.com/PingCAP-QE/ee-apps/dl/gen/ks3"
@@ -223,7 +224,7 @@ func headOCIMiddleware(provider ociRepoProvider, logger *log.Logger) func(http.H
 				return
 			}
 
-			w.Header().Set("Content-Disposition", `attachment; filename*=UTF-8''`+url.QueryEscape(targetFile))
+			w.Header().Set("Content-Disposition", dl.ContentDisposition(targetFile))
 			w.Header().Set("Content-Length", fmt.Sprintf("%d", descriptor.Size))
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)

--- a/dl/content_disposition.go
+++ b/dl/content_disposition.go
@@ -1,0 +1,33 @@
+package dl
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ContentDisposition returns a Content-Disposition header value with both
+// filename (ASCII fallback) and filename* (UTF-8 encoded) per RFC 6266.
+// This ensures compatibility with wget, curl, and modern browsers.
+func ContentDisposition(filename string) string {
+	escaped := url.QueryEscape(filename)
+	// For ASCII-only filenames, filename and filename* can be the same.
+	// For non-ASCII filenames, filename uses ASCII approximation.
+	asciiFilename := toASCIIFilename(filename)
+	return fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, asciiFilename, escaped)
+}
+
+// toASCIIFilename converts a filename to ASCII-safe version.
+// For pure ASCII filenames, returns as-is.
+// For non-ASCII, replaces non-ASCII chars with underscores.
+func toASCIIFilename(filename string) string {
+	var buf strings.Builder
+	for _, r := range filename {
+		if r > 127 {
+			buf.WriteByte('_')
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
+}

--- a/dl/content_disposition_test.go
+++ b/dl/content_disposition_test.go
@@ -1,0 +1,143 @@
+package dl
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestContentDisposition verifies that the Content-Disposition header
+// includes both filename (ASCII fallback) and filename* (UTF-8 encoded).
+func TestContentDisposition(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "ASCII filename",
+			filename: "cdc-v8.5.5-linux-amd64.tar.gz",
+			want:     `attachment; filename="cdc-v8.5.5-linux-amd64.tar.gz"; filename*=UTF-8''cdc-v8.5.5-linux-amd64.tar.gz`,
+		},
+		{
+			name:     "ASCII filename with spaces",
+			filename: "my file.tar.gz",
+			want:     `attachment; filename="my file.tar.gz"; filename*=UTF-8''my+file.tar.gz`,
+		},
+		{
+			name:     "Chinese filename",
+			filename: "测试文件.tar.gz",
+			want:     `attachment; filename="____.tar.gz"; filename*=UTF-8''%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6.tar.gz`,
+		},
+		{
+			name:     "filename with special chars",
+			filename: "file+with+plus.tar.gz",
+			want:     `attachment; filename="file+with+plus.tar.gz"; filename*=UTF-8''file%2Bwith%2Bplus.tar.gz`,
+		},
+		{
+			name:     "SHA256 filename",
+			filename: "cdc-v8.5.5-linux-amd64.tar.gz.sha256",
+			want:     `attachment; filename="cdc-v8.5.5-linux-amd64.tar.gz.sha256"; filename*=UTF-8''cdc-v8.5.5-linux-amd64.tar.gz.sha256`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ContentDisposition(tt.filename)
+			if got != tt.want {
+				t.Errorf("ContentDisposition(%q)\n  got:  %q\n  want: %q", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestContentDispositionHTTPResponse verifies that the HTTP response
+// includes the correct Content-Disposition header format.
+func TestContentDispositionHTTPResponse(t *testing.T) {
+	// Create a test server that uses our ContentDisposition function
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		filename := r.URL.Query().Get("file")
+		w.Header().Set("Content-Disposition", ContentDisposition(filename))
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "ASCII filename",
+			filename: "test.tar.gz",
+		},
+		{
+			name:     "filename with special chars",
+			filename: "file+with+plus.tar.gz",
+		},
+		{
+			name:     "SHA256 filename",
+			filename: "test.tar.gz.sha256",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(server.URL + "/test?file=" + url.QueryEscape(tt.filename))
+			if err != nil {
+				t.Fatalf("failed to make request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			cd := resp.Header.Get("Content-Disposition")
+			t.Logf("Content-Disposition: %s", cd)
+
+			// Verify the header contains both filename and filename*
+			if !strings.Contains(cd, "filename=") {
+				t.Error("Content-Disposition missing 'filename=' parameter")
+			}
+			if !strings.Contains(cd, "filename*=") {
+				t.Error("Content-Disposition missing 'filename*=' parameter")
+			}
+
+			// Verify the filename* parameter uses UTF-8 encoding
+			expectedFilenameStar := "filename*=UTF-8''" + url.QueryEscape(tt.filename)
+			if !strings.Contains(cd, expectedFilenameStar) {
+				t.Errorf("Content-Disposition missing expected filename*=%q, got: %s",
+					expectedFilenameStar, cd)
+			}
+
+			// Verify the filename parameter is ASCII-safe (quoted)
+			expectedFilename := `filename="` + tt.filename + `"`
+			if !strings.Contains(cd, expectedFilename) {
+				t.Errorf("Content-Disposition missing expected %q, got: %s",
+					expectedFilename, cd)
+			}
+		})
+	}
+}
+
+// TestContentDispositionWgetCompatibility verifies that the Content-Disposition
+// header format is compatible with wget --content-disposition.
+// This test documents the expected behavior that wget will use the filename
+// parameter (not filename*) when --content-disposition is used.
+func TestContentDispositionWgetCompatibility(t *testing.T) {
+	filename := "cdc-v8.5.5-release.3-20260127-69f3866-linux-amd64.tar.gz"
+	cd := ContentDisposition(filename)
+
+	// The filename parameter should be present and ASCII-safe
+	// This is what wget --content-disposition will use
+	if !strings.Contains(cd, `filename="`+filename+`"`) {
+		t.Errorf("Content-Disposition should contain ASCII-safe filename for wget compatibility, got: %s", cd)
+	}
+
+	// The filename* parameter should also be present for modern clients
+	if !strings.Contains(cd, "filename*=UTF-8''"+url.QueryEscape(filename)) {
+		t.Errorf("Content-Disposition should contain UTF-8 encoded filename*, got: %s", cd)
+	}
+}

--- a/dl/ks3.go
+++ b/dl/ks3.go
@@ -78,7 +78,7 @@ func (s *ks3srvc) DownloadObject(ctx context.Context, p *ks3.DownloadObjectPaylo
 		if getObjectOutput.ContentDisposition != nil {
 			res.ContentDisposition = *getObjectOutput.ContentDisposition
 		} else {
-			res.ContentDisposition = `attachment; filename*=UTF-8''` + url.QueryEscape(filepath.Base(p.Key))
+			res.ContentDisposition = ContentDisposition(filepath.Base(p.Key))
 		}
 	}
 

--- a/dl/ks3.go
+++ b/dl/ks3.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"log"
-	"net/url"
 	"os"
 	"path/filepath"
 

--- a/dl/oci.go
+++ b/dl/oci.go
@@ -106,7 +106,7 @@ func (s *ocisrvc) downloadFile(ctx context.Context, repo *remote.Repository, tag
 
 	res = &oci.DownloadFileResult{
 		Length:             length,
-		ContentDisposition: `attachment; filename*=UTF-8''` + url.QueryEscape(file),
+		ContentDisposition: ContentDisposition(file),
 	}
 	return res, rc, nil
 }
@@ -132,7 +132,7 @@ func (s *ocisrvc) HeadFile(ctx context.Context, p *oci.HeadFilePayload) (*oci.He
 
 	return &oci.HeadFileResult{
 		Length:             descriptor.Size,
-		ContentDisposition: `attachment; filename*=UTF-8''` + url.QueryEscape(targetFile),
+		ContentDisposition: ContentDisposition(targetFile),
 	}, nil
 }
 
@@ -179,7 +179,7 @@ func (s *ocisrvc) DownloadFileSha256(ctx context.Context, p *oci.DownloadFileSha
 
 	res = &oci.DownloadFileSha256Result{
 		Length:             int64(len(value)),
-		ContentDisposition: `attachment; filename*=UTF-8''` + url.QueryEscape(p.File) + ".sha256",
+		ContentDisposition: ContentDisposition(p.File + ".sha256"),
 	}
 	return res, io.NopCloser(strings.NewReader(value)), nil
 }

--- a/dl/oci.go
+++ b/dl/oci.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/url"
 	"os"
 	"regexp"
 	"strings"


### PR DESCRIPTION
## Summary
Fix Content-Disposition header to include both `filename` (ASCII fallback) and `filename*` (UTF-8 encoded) per RFC 6266. This ensures wget compatibility with `--content-disposition` flag.

## Problem
wget downloads were saving files with URL-derived names (e.g., `package?tag=...&file=...`) instead of the OCI layer title. Root cause: only `filename*` was set, but wget doesn't respect it by default.

## Solution
- Add `ContentDisposition()` helper function that generates RFC 6266 compliant headers
- Use it in all download handlers (OCI + KS3)
- Add unit tests for header format

## Changes
- `dl/content_disposition.go`: new helper function `ContentDisposition()`
- `dl/content_disposition_test.go`: unit tests for header format
- `dl/oci.go`: use `ContentDisposition()` for DownloadFile, HeadFile, DownloadFileSha256
- `dl/ks3.go`: use `ContentDisposition()` for DownloadObject
- `dl/cmd/server/http.go`: use `ContentDisposition()` in HEAD middleware

## Testing
- Unit tests verify header format includes both `filename` and `filename*`
- Tests cover ASCII, UTF-8, and special character filenames
- CI will verify Docker build

## Risk
- Low: only changes header format, no functional change
- Rollback: revert to previous header format

Fixes: wget filename issue reported by Flare
Ref: FLA-204