### PR TITLE
fix(cost-insight): gate cas cleanup on fresh ac index

### DIFF
--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -74,6 +74,7 @@ class GcsCacheSettings:
     ac_reference_shard_count: int = 256
     ac_reference_batch_size: int = 500
     ac_reference_download_workers: int = 64
+    ac_reference_max_index_staleness_hours: int = 12
     ac_retention_days: int = 14
     cas_retention_days: int = 21
     cleanup_safety_buffer_days: int = 1
@@ -279,6 +280,14 @@ def load_settings(
                     "COST_GCS_CACHE_AC_REFERENCE_DOWNLOAD_WORKERS",
                 ),
                 64,
+            ),
+            ac_reference_max_index_staleness_hours=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS",
+                    "COST_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS",
+                ),
+                12,
             ),
             ac_retention_days=_read_positive_int_any(
                 env,

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -461,7 +461,10 @@ def _read_int_any(environ: Mapping[str, str], keys: tuple[str, ...], default: in
 
 
 def _read_positive_int_any(environ: Mapping[str, str], keys: tuple[str, ...], default: int) -> int:
-    return _read_int_any(environ, keys, default)
+    value = _read_int_any(environ, keys, default)
+    if value <= 0:
+        raise ValueError(f"{keys[0]} must be positive, got {value!r}")
+    return value
 
 
 def _read_non_negative_int(

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -816,14 +816,20 @@ def _assert_cleanup_index_fresh(
 ) -> None:
     row = rows[0] if rows else {}
     oldest_indexed_through = coerce_optional_datetime(row.get("oldest_indexed_through"))
+    newest_indexed_through = coerce_optional_datetime(row.get("newest_indexed_through"))
     if oldest_indexed_through is None:
         raise RuntimeError("AC reference index has no indexed_through watermark for CAS cleanup")
 
     cutoff = run_started_at - timedelta(hours=max_index_staleness_hours)
     if oldest_indexed_through < cutoff:
+        spread = (
+            f"index_spread={oldest_indexed_through.isoformat()}..{newest_indexed_through.isoformat()}"
+            if newest_indexed_through is not None
+            else f"oldest_indexed_through={oldest_indexed_through.isoformat()}"
+        )
         raise RuntimeError(
             "AC reference index is too stale for CAS cleanup: "
-            f"oldest_indexed_through={oldest_indexed_through.isoformat()}, "
+            f"{spread}, "
             f"required_at_or_after={cutoff.isoformat()}, "
             f"max_staleness_hours={max_index_staleness_hours}"
         )

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from itertools import islice
 from uuid import uuid4
 
@@ -106,6 +106,11 @@ def run_cleanup_gcs_cache(
     )
     bytes_processed_total = _add_bytes(bytes_processed_total, index_ready_result.total_bytes_processed)
     _assert_cleanup_index_ready(index_ready_result.rows)
+    _assert_cleanup_index_fresh(
+        index_ready_result.rows,
+        run_started_at=run_started_at,
+        max_index_staleness_hours=settings.ac_reference_max_index_staleness_hours,
+    )
 
     summary_result = execute(
         build_cleanup_gcs_cache_summary_query(settings),
@@ -410,7 +415,9 @@ def build_cleanup_gcs_cache_index_ready_query(settings: GcsCacheSettings) -> str
     return f"""
 SELECT
   COUNT(*) AS total_shards,
-  COUNTIF(indexed_through IS NOT NULL) AS ready_shards
+  COUNTIF(indexed_through IS NOT NULL) AS ready_shards,
+  MIN(indexed_through) AS oldest_indexed_through,
+  MAX(indexed_through) AS newest_indexed_through
 FROM {state_table}
 """.strip()
 
@@ -798,6 +805,27 @@ def _assert_cleanup_index_ready(rows: Sequence[dict[str, object]]) -> None:
         raise RuntimeError(
             "AC reference index is not ready for CAS cleanup: "
             f"ready_shards={ready_shards}, total_shards={total_shards}"
+        )
+
+
+def _assert_cleanup_index_fresh(
+    rows: Sequence[dict[str, object]],
+    *,
+    run_started_at: datetime,
+    max_index_staleness_hours: int,
+) -> None:
+    row = rows[0] if rows else {}
+    oldest_indexed_through = coerce_optional_datetime(row.get("oldest_indexed_through"))
+    if oldest_indexed_through is None:
+        raise RuntimeError("AC reference index has no indexed_through watermark for CAS cleanup")
+
+    cutoff = run_started_at - timedelta(hours=max_index_staleness_hours)
+    if oldest_indexed_through < cutoff:
+        raise RuntimeError(
+            "AC reference index is too stale for CAS cleanup: "
+            f"oldest_indexed_through={oldest_indexed_through.isoformat()}, "
+            f"required_at_or_after={cutoff.isoformat()}, "
+            f"max_staleness_hours={max_index_staleness_hours}"
         )
 
 

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -297,13 +297,99 @@ def test_run_cleanup_gcs_cache_fails_closed_when_index_is_stale() -> None:
             )
         return BigQueryQueryResult(rows=(), total_bytes_processed=1)
 
-    with pytest.raises(RuntimeError, match="AC reference index is too stale"):
+    with pytest.raises(RuntimeError, match="index_spread="):
         run_cleanup_gcs_cache(
             settings=GcsCacheSettings(
                 project_id="pingcap-testing-account",
                 ac_reference_max_index_staleness_hours=12,
             ),
             mode="dry-run",
+            execute=fake_execute,
+            now=lambda: datetime(2026, 6, 15, 12, 0, tzinfo=UTC),
+        )
+
+
+@pytest.mark.parametrize(
+    ("oldest_indexed_through", "should_raise"),
+    [
+        (datetime(2026, 6, 15, 0, 1, tzinfo=UTC), False),
+        (datetime(2026, 6, 14, 23, 59, tzinfo=UTC), True),
+    ],
+)
+def test_run_cleanup_gcs_cache_index_freshness_boundary(
+    oldest_indexed_through: datetime,
+    should_raise: bool,
+) -> None:
+    def fake_execute(query, parameters):
+        if "COUNT(*) AS total_shards" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "total_shards": 256,
+                        "ready_shards": 256,
+                        "oldest_indexed_through": oldest_indexed_through,
+                        "newest_indexed_through": datetime(2026, 6, 15, 11, 50, tzinfo=UTC),
+                    },
+                ),
+                total_bytes_processed=1,
+            )
+        if "candidate_cas_object_count" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_cas_object_count": 0,
+                        "candidate_ac_object_count": 0,
+                        "candidate_cas_delete_object_count": 0,
+                        "oldest_last_seen_at": None,
+                        "newest_last_seen_at": None,
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=1,
+            )
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    kwargs = dict(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            ac_reference_max_index_staleness_hours=12,
+        ),
+        mode="dry-run",
+        execute=fake_execute,
+        now=lambda: datetime(2026, 6, 15, 12, 0, tzinfo=UTC),
+    )
+    if should_raise:
+        with pytest.raises(RuntimeError, match="AC reference index is too stale"):
+            run_cleanup_gcs_cache(**kwargs)
+    else:
+        summary = run_cleanup_gcs_cache(**kwargs)
+        assert summary.candidate_cas_object_count == 0
+
+
+def test_run_cleanup_gcs_cache_delete_fails_closed_when_index_is_stale() -> None:
+    def fake_execute(query, parameters):
+        if "COUNT(*) AS total_shards" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "total_shards": 256,
+                        "ready_shards": 256,
+                        "oldest_indexed_through": datetime(2026, 6, 14, 22, 0, tzinfo=UTC),
+                        "newest_indexed_through": datetime(2026, 6, 15, 11, 59, tzinfo=UTC),
+                    },
+                ),
+                total_bytes_processed=1,
+            )
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    with pytest.raises(RuntimeError, match="AC reference index is too stale"):
+        run_cleanup_gcs_cache(
+            settings=GcsCacheSettings(
+                project_id="pingcap-testing-account",
+                ac_reference_max_index_staleness_hours=12,
+            ),
+            mode="delete",
+            execute_kind="cas",
             execute=fake_execute,
             now=lambda: datetime(2026, 6, 15, 12, 0, tzinfo=UTC),
         )

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -35,6 +35,7 @@ def test_cleanup_gcs_cache_index_ready_query_targets_state_table() -> None:
 
     assert "`pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_ac_reference_index_state`" in query
     assert "COUNTIF(indexed_through IS NOT NULL)" in query
+    assert "MIN(indexed_through)" in query
 
 
 def test_cleanup_gcs_cache_manifest_export_query_uses_generation() -> None:
@@ -67,7 +68,14 @@ def test_run_cleanup_gcs_cache_returns_dry_run_summary_with_samples() -> None:
         captured.setdefault("queries", []).append((query, {param.name: param.value for param in parameters}))
         if "COUNT(*) AS total_shards" in query:
             return BigQueryQueryResult(
-                rows=({"total_shards": 256, "ready_shards": 256},),
+                rows=(
+                    {
+                        "total_shards": 256,
+                        "ready_shards": 256,
+                        "oldest_indexed_through": datetime(2026, 6, 15, 11, 30, tzinfo=UTC),
+                        "newest_indexed_through": datetime(2026, 6, 15, 11, 55, tzinfo=UTC),
+                    },
+                ),
                 total_bytes_processed=5,
             )
         if "candidate_cas_object_count" in query:
@@ -130,7 +138,14 @@ def test_run_cleanup_gcs_cache_delete_cascades_ac_then_cas() -> None:
         captured_queries.append((query, rendered))
         if "COUNT(*) AS total_shards" in query:
             return BigQueryQueryResult(
-                rows=({"total_shards": 256, "ready_shards": 256},),
+                rows=(
+                    {
+                        "total_shards": 256,
+                        "ready_shards": 256,
+                        "oldest_indexed_through": datetime(2026, 6, 15, 9, 30, tzinfo=UTC),
+                        "newest_indexed_through": datetime(2026, 6, 15, 10, 20, tzinfo=UTC),
+                    },
+                ),
                 total_bytes_processed=1,
             )
         if "candidate_cas_object_count" in query:
@@ -246,7 +261,14 @@ def test_run_cleanup_gcs_cache_fails_closed_when_index_not_ready() -> None:
     def fake_execute(query, parameters):
         if "COUNT(*) AS total_shards" in query:
             return BigQueryQueryResult(
-                rows=({"total_shards": 256, "ready_shards": 255},),
+                rows=(
+                    {
+                        "total_shards": 256,
+                        "ready_shards": 255,
+                        "oldest_indexed_through": datetime(2026, 6, 15, 11, 0, tzinfo=UTC),
+                        "newest_indexed_through": datetime(2026, 6, 15, 11, 0, tzinfo=UTC),
+                    },
+                ),
                 total_bytes_processed=1,
             )
         return BigQueryQueryResult(rows=(), total_bytes_processed=1)
@@ -256,4 +278,32 @@ def test_run_cleanup_gcs_cache_fails_closed_when_index_not_ready() -> None:
             settings=GcsCacheSettings(project_id="pingcap-testing-account"),
             mode="dry-run",
             execute=fake_execute,
+        )
+
+
+def test_run_cleanup_gcs_cache_fails_closed_when_index_is_stale() -> None:
+    def fake_execute(query, parameters):
+        if "COUNT(*) AS total_shards" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "total_shards": 256,
+                        "ready_shards": 256,
+                        "oldest_indexed_through": datetime(2026, 6, 14, 22, 59, tzinfo=UTC),
+                        "newest_indexed_through": datetime(2026, 6, 15, 11, 50, tzinfo=UTC),
+                    },
+                ),
+                total_bytes_processed=1,
+            )
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    with pytest.raises(RuntimeError, match="AC reference index is too stale"):
+        run_cleanup_gcs_cache(
+            settings=GcsCacheSettings(
+                project_id="pingcap-testing-account",
+                ac_reference_max_index_staleness_hours=12,
+            ),
+            mode="dry-run",
+            execute=fake_execute,
+            now=lambda: datetime(2026, 6, 15, 12, 0, tzinfo=UTC),
         )

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -163,6 +163,17 @@ def test_load_settings_rejects_invalid_gcs_cache_positive_int() -> None:
             }
         )
 
+    with pytest.raises(
+        ValueError,
+        match="COST_INSIGHT_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS must be positive",
+    ):
+        load_settings(
+            {
+                "COST_INSIGHT_DB_URL": "mysql+pymysql://user:pass@127.0.0.1:4000/cost",
+                "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS": "0",
+            }
+        )
+
 
 def test_load_settings_rejects_invalid_int() -> None:
     with pytest.raises(ValueError, match="COST_INSIGHT_SYNC_OVERLAP_DAYS must be an integer"):

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -47,6 +47,7 @@ def test_load_settings_can_skip_database_for_validation() -> None:
     assert settings.gcs_cache.cleanup_safety_buffer_days == 1
     assert settings.gcs_cache.last_seen_excluded_get_user_agent == "TransferService"
     assert settings.gcs_cache.last_seen_excluded_get_principal_email is None
+    assert settings.gcs_cache.ac_reference_max_index_staleness_hours == 12
 
 
 def test_load_settings_falls_back_to_tidb_parts() -> None:
@@ -104,6 +105,7 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE": "current_table",
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT": "CustomTransferService",
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_PRINCIPAL_EMAIL": "cleanup@example.com",
+            "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS": "6",
             "COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS": "21",
             "COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS": "35",
             "COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS": "2",
@@ -125,6 +127,7 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
     assert settings.gcs_cache.last_seen_current_table == "current_table"
     assert settings.gcs_cache.last_seen_excluded_get_user_agent == "CustomTransferService"
     assert settings.gcs_cache.last_seen_excluded_get_principal_email == "cleanup@example.com"
+    assert settings.gcs_cache.ac_reference_max_index_staleness_hours == 6
     assert settings.gcs_cache.ac_retention_days == 21
     assert settings.gcs_cache.cas_retention_days == 35
     assert settings.gcs_cache.cleanup_safety_buffer_days == 2


### PR DESCRIPTION
## Summary
- fail closed when the AC reference index is too stale for CAS cleanup
- keep the existing bootstrap readiness check and add an index freshness check
- make the freshness window configurable in GCS cache settings

## Details
- extend the cleanup index readiness query to return oldest/newest `indexed_through`
- require `oldest_indexed_through` to be within the configured max staleness window
- default `COST_INSIGHT_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS` to `12`
- add coverage for stale-index failure and config loading

## Testing
- `pytest -q` in `cost-insight/`
  - total coverage: `92.22%`
