### PR TITLE
fix(cost-insight): expand gcs client http pool for ac indexing

### DIFF
--- a/cost-insight/src/cost_insight/common/gcs_cache_references.py
+++ b/cost-insight/src/cost_insight/common/gcs_cache_references.py
@@ -4,6 +4,8 @@ from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
+from cost_insight.common.gcs_client import create_storage_client
+
 
 @dataclass(frozen=True)
 class AcReferenceExtraction:
@@ -38,7 +40,7 @@ def extract_action_cache_references_batch(
     if not names:
         return ()
 
-    client = _create_storage_client(project_id=project_id, pool_maxsize=max_workers)
+    client = create_storage_client(project_id=project_id, pool_maxsize=max_workers)
     bucket = client.bucket(bucket_name)
 
     def extract_one(ac_object_name: str) -> AcReferenceExtraction:
@@ -85,42 +87,6 @@ def extract_action_cache_references_batch(
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         return tuple(executor.map(extract_one, names))
-
-
-def _create_storage_client(*, project_id: str, pool_maxsize: int):
-    from google.cloud import storage
-
-    client = storage.Client(project=project_id)
-    _configure_storage_client_http_pool(client=client, pool_maxsize=pool_maxsize)
-    return client
-
-
-def _configure_storage_client_http_pool(*, client, pool_maxsize: int) -> None:
-    if pool_maxsize <= 0:
-        return
-
-    session = getattr(client, "_http", None)
-    if session is None:
-        return
-
-    adapters = getattr(session, "adapters", None)
-    if not isinstance(adapters, dict):
-        return
-
-    from requests.adapters import HTTPAdapter
-
-    for prefix in ("https://", "http://"):
-        current_adapter = adapters.get(prefix)
-        pool_connections = getattr(current_adapter, "_pool_connections", pool_maxsize)
-        max_retries = getattr(current_adapter, "max_retries", 0)
-        session.mount(
-            prefix,
-            HTTPAdapter(
-                pool_connections=pool_connections,
-                pool_maxsize=pool_maxsize,
-                max_retries=max_retries,
-            ),
-        )
 
 
 def extract_cas_references_from_action_result_bytes(

--- a/cost-insight/src/cost_insight/common/gcs_cache_references.py
+++ b/cost-insight/src/cost_insight/common/gcs_cache_references.py
@@ -33,13 +33,12 @@ def extract_action_cache_references_batch(
     max_workers: int = 64,
 ) -> tuple[AcReferenceExtraction, ...]:
     from google.api_core.exceptions import NotFound
-    from google.cloud import storage
 
     names = tuple(ac_object_names)
     if not names:
         return ()
 
-    client = storage.Client(project=project_id)
+    client = _create_storage_client(project_id=project_id, pool_maxsize=max_workers)
     bucket = client.bucket(bucket_name)
 
     def extract_one(ac_object_name: str) -> AcReferenceExtraction:
@@ -86,6 +85,42 @@ def extract_action_cache_references_batch(
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         return tuple(executor.map(extract_one, names))
+
+
+def _create_storage_client(*, project_id: str, pool_maxsize: int):
+    from google.cloud import storage
+
+    client = storage.Client(project=project_id)
+    _configure_storage_client_http_pool(client=client, pool_maxsize=pool_maxsize)
+    return client
+
+
+def _configure_storage_client_http_pool(*, client, pool_maxsize: int) -> None:
+    if pool_maxsize <= 0:
+        return
+
+    session = getattr(client, "_http", None)
+    if session is None:
+        return
+
+    adapters = getattr(session, "adapters", None)
+    if not isinstance(adapters, dict):
+        return
+
+    from requests.adapters import HTTPAdapter
+
+    for prefix in ("https://", "http://"):
+        current_adapter = adapters.get(prefix)
+        pool_connections = getattr(current_adapter, "_pool_connections", pool_maxsize)
+        max_retries = getattr(current_adapter, "max_retries", 0)
+        session.mount(
+            prefix,
+            HTTPAdapter(
+                pool_connections=pool_connections,
+                pool_maxsize=pool_maxsize,
+                max_retries=max_retries,
+            ),
+        )
 
 
 def extract_cas_references_from_action_result_bytes(

--- a/cost-insight/src/cost_insight/common/gcs_client.py
+++ b/cost-insight/src/cost_insight/common/gcs_client.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+def create_storage_client(*, project_id: str, pool_maxsize: int):
+    from google.cloud import storage
+
+    client = storage.Client(project=project_id)
+    configure_storage_client_http_pool(client=client, pool_maxsize=pool_maxsize)
+    return client
+
+
+def configure_storage_client_http_pool(*, client, pool_maxsize: int) -> None:
+    if pool_maxsize <= 0:
+        return
+
+    session = getattr(client, "_http", None)
+    if session is None:
+        LOG.warning(
+            "GCS client HTTP pool expansion skipped because storage.Client._http is unavailable"
+        )
+        return
+
+    adapters = getattr(session, "adapters", None)
+    if not isinstance(adapters, dict):
+        LOG.warning(
+            "GCS client HTTP pool expansion skipped because storage.Client._http.adapters is unavailable"
+        )
+        return
+
+    from requests.adapters import HTTPAdapter
+
+    for prefix in ("https://", "http://"):
+        current_adapter = adapters.get(prefix)
+        pool_connections = getattr(current_adapter, "_pool_connections", 10)
+        max_retries = getattr(current_adapter, "max_retries", 0)
+        session.mount(
+            prefix,
+            HTTPAdapter(
+                pool_connections=pool_connections,
+                pool_maxsize=pool_maxsize,
+                max_retries=max_retries,
+            ),
+        )

--- a/cost-insight/src/cost_insight/common/gcs_objects.py
+++ b/cost-insight/src/cost_insight/common/gcs_objects.py
@@ -4,6 +4,8 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Iterable
 
+from cost_insight.common.gcs_client import create_storage_client
+
 
 @dataclass(frozen=True)
 class GcsObjectMetadata:
@@ -19,13 +21,11 @@ def fetch_object_metadata_batch(
     object_names: Iterable[str],
     max_workers: int = 64,
 ) -> tuple[GcsObjectMetadata, ...]:
-    from google.cloud import storage
-
     names = tuple(object_names)
     if not names:
         return ()
 
-    client = storage.Client(project=project_id)
+    client = create_storage_client(project_id=project_id, pool_maxsize=max_workers)
     bucket = client.bucket(bucket_name)
 
     def fetch_one(object_name: str) -> GcsObjectMetadata:

--- a/cost-insight/tests/test_gcs_cache_references.py
+++ b/cost-insight/tests/test_gcs_cache_references.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from cost_insight.common import gcs_cache_references
 from cost_insight.common.gcs_cache_references import (
     extract_cas_references_from_action_result_bytes,
     extract_cas_references_from_tree_bytes,
@@ -71,6 +79,125 @@ def test_extract_cas_references_from_tree_bytes_reads_root_and_children() -> Non
         "cas/root-file",
         "cas/child-file",
     }
+
+
+def test_create_storage_client_expands_http_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    mounted: list[tuple[str, object]] = []
+
+    class _FakeAdapter:
+        def __init__(self, *, pool_connections: int = 10, pool_maxsize: int = 10, max_retries: int = 3) -> None:
+            self._pool_connections = pool_connections
+            self._pool_maxsize = pool_maxsize
+            self.max_retries = max_retries
+
+    class _MountedAdapter(_FakeAdapter):
+        pass
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.adapters = {
+                "https://": _FakeAdapter(pool_connections=10, pool_maxsize=10, max_retries=5),
+                "http://": _FakeAdapter(pool_connections=8, pool_maxsize=8, max_retries=2),
+            }
+
+        def mount(self, prefix: str, adapter: object) -> None:
+            mounted.append((prefix, adapter))
+            self.adapters[prefix] = adapter
+
+    class _FakeClient:
+        def __init__(self, *, project: str) -> None:
+            self.project = project
+            self._http = _FakeSession()
+
+    cloud_module = ModuleType("google.cloud")
+    storage_module = ModuleType("google.cloud.storage")
+    requests_module = ModuleType("requests")
+    requests_adapters_module = ModuleType("requests.adapters")
+
+    def _client_factory(project=None):
+        return _FakeClient(project=project)
+
+    def _adapter_factory(*, pool_connections: int, pool_maxsize: int, max_retries):
+        return _MountedAdapter(
+            pool_connections=pool_connections,
+            pool_maxsize=pool_maxsize,
+            max_retries=max_retries,
+        )
+
+    storage_module.Client = _client_factory
+    cloud_module.storage = storage_module
+    requests_adapters_module.HTTPAdapter = _adapter_factory
+    requests_module.adapters = requests_adapters_module
+
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_module)
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_module)
+    monkeypatch.setitem(sys.modules, "requests", requests_module)
+    monkeypatch.setitem(sys.modules, "requests.adapters", requests_adapters_module)
+
+    client = gcs_cache_references._create_storage_client(project_id="test-project", pool_maxsize=32)
+
+    assert client.project == "test-project"
+    assert [prefix for prefix, _ in mounted] == ["https://", "http://"]
+    https_adapter = client._http.adapters["https://"]
+    http_adapter = client._http.adapters["http://"]
+    assert https_adapter._pool_connections == 10
+    assert https_adapter._pool_maxsize == 32
+    assert https_adapter.max_retries == 5
+    assert http_adapter._pool_connections == 8
+    assert http_adapter._pool_maxsize == 32
+    assert http_adapter.max_retries == 2
+
+
+def test_extract_action_cache_references_batch_uses_worker_count_for_http_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_pool_sizes: list[int] = []
+
+    class _FakeBucket:
+        def blob(self, object_name: str):
+            class _FakeBlob:
+                def download_as_bytes(self) -> bytes:
+                    return b""
+
+            return _FakeBlob()
+
+    class _FakeClient:
+        def bucket(self, bucket_name: str) -> _FakeBucket:
+            assert bucket_name == "test-bucket"
+            return _FakeBucket()
+
+    def _fake_create_storage_client(*, project_id: str, pool_maxsize: int):
+        assert project_id == "test-project"
+        observed_pool_sizes.append(pool_maxsize)
+        return _FakeClient()
+
+    monkeypatch.setattr(gcs_cache_references, "_create_storage_client", _fake_create_storage_client)
+    monkeypatch.setattr(
+        gcs_cache_references,
+        "extract_cas_references_from_action_result_bytes",
+        lambda action_result_bytes, *, fetch_cas_blob: {"cas/a", "cas/b"},
+    )
+
+    rows = gcs_cache_references.extract_action_cache_references_batch(
+        project_id="test-project",
+        bucket_name="test-bucket",
+        ac_object_names=("ac/one", "ac/two"),
+        max_workers=32,
+    )
+
+    assert observed_pool_sizes == [32]
+    assert rows == (
+        gcs_cache_references.AcReferenceExtraction(
+            ac_object_name="ac/one",
+            exists=True,
+            cas_object_names=("cas/a", "cas/b"),
+        ),
+        gcs_cache_references.AcReferenceExtraction(
+            ac_object_name="ac/two",
+            exists=True,
+            cas_object_names=("cas/a", "cas/b"),
+        ),
+    )
 
 
 def _action_result(*, output_files=(), output_directories=(), stdout_digest=None, stderr_digest=None) -> bytes:

--- a/cost-insight/tests/test_gcs_cache_references.py
+++ b/cost-insight/tests/test_gcs_cache_references.py
@@ -1,10 +1,3 @@
-from __future__ import annotations
-
-import sys
-from types import ModuleType
-
-import pytest
-
 from cost_insight.common import gcs_cache_references
 from cost_insight.common.gcs_cache_references import (
     extract_cas_references_from_action_result_bytes,
@@ -81,76 +74,7 @@ def test_extract_cas_references_from_tree_bytes_reads_root_and_children() -> Non
     }
 
 
-def test_create_storage_client_expands_http_pool(monkeypatch: pytest.MonkeyPatch) -> None:
-    mounted: list[tuple[str, object]] = []
-
-    class _FakeAdapter:
-        def __init__(self, *, pool_connections: int = 10, pool_maxsize: int = 10, max_retries: int = 3) -> None:
-            self._pool_connections = pool_connections
-            self._pool_maxsize = pool_maxsize
-            self.max_retries = max_retries
-
-    class _MountedAdapter(_FakeAdapter):
-        pass
-
-    class _FakeSession:
-        def __init__(self) -> None:
-            self.adapters = {
-                "https://": _FakeAdapter(pool_connections=10, pool_maxsize=10, max_retries=5),
-                "http://": _FakeAdapter(pool_connections=8, pool_maxsize=8, max_retries=2),
-            }
-
-        def mount(self, prefix: str, adapter: object) -> None:
-            mounted.append((prefix, adapter))
-            self.adapters[prefix] = adapter
-
-    class _FakeClient:
-        def __init__(self, *, project: str) -> None:
-            self.project = project
-            self._http = _FakeSession()
-
-    cloud_module = ModuleType("google.cloud")
-    storage_module = ModuleType("google.cloud.storage")
-    requests_module = ModuleType("requests")
-    requests_adapters_module = ModuleType("requests.adapters")
-
-    def _client_factory(project=None):
-        return _FakeClient(project=project)
-
-    def _adapter_factory(*, pool_connections: int, pool_maxsize: int, max_retries):
-        return _MountedAdapter(
-            pool_connections=pool_connections,
-            pool_maxsize=pool_maxsize,
-            max_retries=max_retries,
-        )
-
-    storage_module.Client = _client_factory
-    cloud_module.storage = storage_module
-    requests_adapters_module.HTTPAdapter = _adapter_factory
-    requests_module.adapters = requests_adapters_module
-
-    monkeypatch.setitem(sys.modules, "google.cloud", cloud_module)
-    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_module)
-    monkeypatch.setitem(sys.modules, "requests", requests_module)
-    monkeypatch.setitem(sys.modules, "requests.adapters", requests_adapters_module)
-
-    client = gcs_cache_references._create_storage_client(project_id="test-project", pool_maxsize=32)
-
-    assert client.project == "test-project"
-    assert [prefix for prefix, _ in mounted] == ["https://", "http://"]
-    https_adapter = client._http.adapters["https://"]
-    http_adapter = client._http.adapters["http://"]
-    assert https_adapter._pool_connections == 10
-    assert https_adapter._pool_maxsize == 32
-    assert https_adapter.max_retries == 5
-    assert http_adapter._pool_connections == 8
-    assert http_adapter._pool_maxsize == 32
-    assert http_adapter.max_retries == 2
-
-
-def test_extract_action_cache_references_batch_uses_worker_count_for_http_pool(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_extract_action_cache_references_batch_uses_worker_count_for_http_pool(monkeypatch) -> None:
     observed_pool_sizes: list[int] = []
 
     class _FakeBucket:
@@ -171,7 +95,7 @@ def test_extract_action_cache_references_batch_uses_worker_count_for_http_pool(
         observed_pool_sizes.append(pool_maxsize)
         return _FakeClient()
 
-    monkeypatch.setattr(gcs_cache_references, "_create_storage_client", _fake_create_storage_client)
+    monkeypatch.setattr(gcs_cache_references, "create_storage_client", _fake_create_storage_client)
     monkeypatch.setattr(
         gcs_cache_references,
         "extract_cas_references_from_action_result_bytes",

--- a/cost-insight/tests/test_gcs_client.py
+++ b/cost-insight/tests/test_gcs_client.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+import sys
+from types import ModuleType
+
+import pytest
+
+from cost_insight.common import gcs_client
+
+
+def test_create_storage_client_expands_http_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    mounted: list[tuple[str, object]] = []
+
+    class _FakeAdapter:
+        def __init__(self, *, pool_connections: int = 10, pool_maxsize: int = 10, max_retries: int = 3) -> None:
+            self._pool_connections = pool_connections
+            self._pool_maxsize = pool_maxsize
+            self.max_retries = max_retries
+
+    class _MountedAdapter(_FakeAdapter):
+        pass
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.adapters = {
+                "https://": _FakeAdapter(pool_connections=10, pool_maxsize=10, max_retries=5),
+                "http://": _FakeAdapter(pool_connections=8, pool_maxsize=8, max_retries=2),
+            }
+
+        def mount(self, prefix: str, adapter: object) -> None:
+            mounted.append((prefix, adapter))
+            self.adapters[prefix] = adapter
+
+    class _FakeClient:
+        def __init__(self, *, project: str) -> None:
+            self.project = project
+            self._http = _FakeSession()
+
+    cloud_module = ModuleType("google.cloud")
+    storage_module = ModuleType("google.cloud.storage")
+    requests_module = ModuleType("requests")
+    requests_adapters_module = ModuleType("requests.adapters")
+
+    def _client_factory(project=None):
+        return _FakeClient(project=project)
+
+    def _adapter_factory(*, pool_connections: int, pool_maxsize: int, max_retries):
+        return _MountedAdapter(
+            pool_connections=pool_connections,
+            pool_maxsize=pool_maxsize,
+            max_retries=max_retries,
+        )
+
+    storage_module.Client = _client_factory
+    cloud_module.storage = storage_module
+    requests_adapters_module.HTTPAdapter = _adapter_factory
+    requests_module.adapters = requests_adapters_module
+
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_module)
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_module)
+    monkeypatch.setitem(sys.modules, "requests", requests_module)
+    monkeypatch.setitem(sys.modules, "requests.adapters", requests_adapters_module)
+
+    client = gcs_client.create_storage_client(project_id="test-project", pool_maxsize=32)
+
+    assert client.project == "test-project"
+    assert [prefix for prefix, _ in mounted] == ["https://", "http://"]
+    https_adapter = client._http.adapters["https://"]
+    http_adapter = client._http.adapters["http://"]
+    assert https_adapter._pool_connections == 10
+    assert https_adapter._pool_maxsize == 32
+    assert https_adapter.max_retries == 5
+    assert http_adapter._pool_connections == 8
+    assert http_adapter._pool_maxsize == 32
+    assert http_adapter.max_retries == 2
+
+
+def test_configure_storage_client_http_pool_warns_when_http_session_unavailable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _FakeClient:
+        pass
+
+    with caplog.at_level(logging.WARNING):
+        gcs_client.configure_storage_client_http_pool(client=_FakeClient(), pool_maxsize=32)
+
+    assert "storage.Client._http is unavailable" in caplog.text

--- a/cost-insight/tests/test_gcs_objects.py
+++ b/cost-insight/tests/test_gcs_objects.py
@@ -1,10 +1,3 @@
-from __future__ import annotations
-
-import sys
-from types import ModuleType
-
-import pytest
-
 from cost_insight.common import gcs_objects
 
 
@@ -33,23 +26,12 @@ class _FakeClient:
         return self._bucket
 
 
-def _install_fake_storage(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    bucket: _FakeBucket,
-) -> None:
-    cloud_module = ModuleType("google.cloud")
-    storage_module = ModuleType("google.cloud.storage")
-    storage_module.Client = lambda project=None: _FakeClient(project=project, bucket=bucket)
-    cloud_module.storage = storage_module
-    monkeypatch.setitem(sys.modules, "google.cloud", cloud_module)
-    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_module)
-
-
-def test_fetch_object_metadata_batch_returns_empty_tuple_for_empty_input(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _install_fake_storage(monkeypatch, bucket=_FakeBucket({}))
+def test_fetch_object_metadata_batch_returns_empty_tuple_for_empty_input(monkeypatch) -> None:
+    monkeypatch.setattr(
+        gcs_objects,
+        "create_storage_client",
+        lambda *, project_id, pool_maxsize: _FakeClient(project=project_id, bucket=_FakeBucket({})),
+    )
 
     assert gcs_objects.fetch_object_metadata_batch(
         project_id="test-project",
@@ -58,16 +40,18 @@ def test_fetch_object_metadata_batch_returns_empty_tuple_for_empty_input(
     ) == ()
 
 
-def test_fetch_object_metadata_batch_reads_objects_sequentially(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_fetch_object_metadata_batch_reads_objects_sequentially(monkeypatch) -> None:
     bucket = _FakeBucket(
         {
             "cas/present": _FakeBlob("123"),
             "cas/no-generation": _FakeBlob(None),
         }
     )
-    _install_fake_storage(monkeypatch, bucket=bucket)
+    monkeypatch.setattr(
+        gcs_objects,
+        "create_storage_client",
+        lambda *, project_id, pool_maxsize: _FakeClient(project=project_id, bucket=bucket),
+    )
 
     metadata = gcs_objects.fetch_object_metadata_batch(
         project_id="test-project",
@@ -96,23 +80,29 @@ def test_fetch_object_metadata_batch_reads_objects_sequentially(
     assert bucket.requested_names == ["cas/present", "cas/missing", "cas/no-generation"]
 
 
-def test_fetch_object_metadata_batch_uses_executor_for_parallel_path(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_fetch_object_metadata_batch_uses_executor_for_parallel_path(monkeypatch) -> None:
     bucket = _FakeBucket(
         {
             "cas/one": _FakeBlob("11"),
             "cas/two": _FakeBlob("22"),
         }
     )
-    _install_fake_storage(monkeypatch, bucket=bucket)
+    observed_pool_sizes: list[int] = []
+    monkeypatch.setattr(
+        gcs_objects,
+        "create_storage_client",
+        lambda *, project_id, pool_maxsize: (
+            observed_pool_sizes.append(pool_maxsize)
+            or _FakeClient(project=project_id, bucket=bucket)
+        ),
+    )
     used_max_workers: list[int] = []
 
     class _FakeExecutor:
         def __init__(self, *, max_workers: int) -> None:
             used_max_workers.append(max_workers)
 
-        def __enter__(self) -> _FakeExecutor:
+        def __enter__(self):
             return self
 
         def __exit__(self, exc_type, exc, tb) -> None:
@@ -131,6 +121,7 @@ def test_fetch_object_metadata_batch_uses_executor_for_parallel_path(
     )
 
     assert used_max_workers == [4]
+    assert observed_pool_sizes == [4]
     assert metadata == (
         gcs_objects.GcsObjectMetadata(object_name="cas/one", exists=True, generation=11),
         gcs_objects.GcsObjectMetadata(object_name="cas/two", exists=True, generation=22),


### PR DESCRIPTION
## Summary
- expand the GCS storage client HTTP pool used by AC reference indexing
- size the pool from `ac_reference_download_workers` so bootstrap/incremental runs stop bottlenecking on the default pool size of 10
- add focused tests for pool expansion and worker-to-pool propagation

## Context
During the CAS GC v2 bootstrap canary, the AC reference indexer completed successfully but emitted a large number of warnings like:

```text
urllib3.connectionpool Connection pool is full, discarding connection: storage.googleapis.com. Connection pool size: 10
```

The job uses concurrent GCS downloads, but `google-cloud-storage` still starts with the default requests/urllib3 pool size. This PR keeps the existing worker count behavior and aligns the underlying HTTP pool with that concurrency.

## Validation
- `python -m pytest tests/test_gcs_cache_references.py --no-cov -q`
- `python -m ruff check src/cost_insight/common/gcs_cache_references.py tests/test_gcs_cache_references.py`
- `python -m pytest -q`
  - total coverage: `92.89%`
