### PR TITLE
fix(ci-dashboard): track flaky linked PR metadata

### DIFF
--- a/ci-dashboard/sql/028_create_ci_l1_flaky_linked_prs.sql
+++ b/ci-dashboard/sql/028_create_ci_l1_flaky_linked_prs.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS ci_l1_flaky_linked_prs (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  pr_repo VARCHAR(255) NOT NULL,
+  pr_number BIGINT NOT NULL,
+  pr_url VARCHAR(1024) NOT NULL,
+  pr_title VARCHAR(512) NOT NULL,
+  pr_state VARCHAR(32) NOT NULL,
+  pr_created_at DATETIME NOT NULL,
+  pr_closed_at DATETIME NULL,
+  pr_merged_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uk_ci_l1_flaky_linked_prs_repo_pr (pr_repo, pr_number),
+  KEY idx_ci_l1_flaky_linked_prs_state_time (pr_state, pr_merged_at)
+);

--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -736,12 +736,10 @@ def get_issue_fix_progress_snapshot(
         current_pull_rows = _fetch_linked_pull_rows(
             connection,
             [(str(row["repo"]), int(row["issue_number"])) for row in current_issue_rows],
-            branch=filters.branch,
         )
         previous_pull_rows = _fetch_linked_pull_rows(
             connection,
             [(str(row["repo"]), int(row["issue_number"])) for row in previous_issue_rows],
-            branch=filters.branch,
         )
 
     current_fixed_issue_count = sum(
@@ -783,7 +781,7 @@ def get_issue_fix_progress_snapshot(
             "ignores_cloud_phase": True,
             "ignores_issue_status": True,
             "ignores_branch_for_issues": True,
-            "applies_branch_to_prs": bool(filters.branch),
+            "applies_branch_to_prs": False,
         }
     )
 
@@ -1454,8 +1452,6 @@ def _fetch_issue_latest_rows(
 def _fetch_linked_pull_rows(
     connection: Connection,
     issue_keys: list[tuple[str, int]],
-    *,
-    branch: str | None = None,
 ) -> list[dict[str, Any]]:
     if not issue_keys:
         return []
@@ -1469,43 +1465,28 @@ def _fetch_linked_pull_rows(
         params[f"issue_repo_{index}"] = issue_repo
         params[f"issue_number_{index}"] = issue_number
 
-    branch_clause = ""
-    if branch:
-        branch_clause = f" AND {_pull_ticket_branch_expr(connection, 'p')} = :branch"
-        params["branch"] = branch
-
     rows = connection.execute(
         text(
             f"""
             SELECT DISTINCT
-              p.repo,
-              p.number,
-              p.state,
-              p.created_at,
-              p.closed_at,
-              p.merged,
-              p.merged_at
+              p.pr_repo AS repo,
+              p.pr_number AS number,
+              p.pr_state AS state,
+              p.pr_created_at AS created_at,
+              p.pr_closed_at AS closed_at,
+              CASE WHEN p.pr_merged_at IS NOT NULL THEN 1 ELSE 0 END AS merged,
+              p.pr_merged_at AS merged_at
             FROM ci_l1_flaky_issue_pr_links l
-            JOIN github_tickets p
-              ON p.type = 'pull'
-             AND p.repo = l.pr_repo
-             AND p.number = l.pr_number
+            JOIN ci_l1_flaky_linked_prs p
+              ON p.pr_repo = l.pr_repo
+             AND p.pr_number = l.pr_number
             WHERE ({' OR '.join(clauses)})
-            {branch_clause}
-            ORDER BY p.repo, p.number
+            ORDER BY p.pr_repo, p.pr_number
             """
         ),
         params,
     ).mappings()
     return [dict(row) for row in rows]
-
-
-def _pull_ticket_branch_expr(connection: Connection, table_alias: str) -> str:
-    prefix = f"{table_alias}."
-    if connection.dialect.name == "sqlite":
-        return f"json_extract({prefix}branches, '$.base.ref')"
-    return f"JSON_UNQUOTE(JSON_EXTRACT({prefix}branches, '$.base.ref'))"
-
 
 def _latest_complete_week_start(end_date: date | None) -> date | None:
     if end_date is None:

--- a/ci-dashboard/src/ci_dashboard/common/models.py
+++ b/ci-dashboard/src/ci_dashboard/common/models.py
@@ -100,6 +100,9 @@ class SyncFlakyIssuesSummary:
     source_rows_scanned: int = 0
     rows_written: int = 0
     issue_pr_links_written: int = 0
+    linked_pr_rows_written: int = 0
+    linked_pr_fetch_attempted: int = 0
+    linked_pr_fetch_failed: int = 0
     branch_fetch_attempted: int = 0
     branch_fetch_failed: int = 0
     last_ticket_updated_at: str | None = None
@@ -111,6 +114,9 @@ class BackfillFlakyIssuePrLinksSummary:
     source_rows_scanned: int = 0
     issue_rows_touched: int = 0
     issue_pr_links_written: int = 0
+    linked_pr_rows_written: int = 0
+    linked_pr_fetch_attempted: int = 0
+    linked_pr_fetch_failed: int = 0
     last_ticket_updated_at: str | None = None
 
 

--- a/ci-dashboard/src/ci_dashboard/jobs/sync_flaky_issues.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/sync_flaky_issues.py
@@ -74,6 +74,18 @@ class FlakyIssuePrLinkRow:
     source_ticket_updated_at: datetime
 
 
+@dataclass(frozen=True)
+class FlakyLinkedPrRow:
+    pr_repo: str
+    pr_number: int
+    pr_url: str
+    pr_title: str
+    pr_state: str
+    pr_created_at: datetime
+    pr_closed_at: datetime | None
+    pr_merged_at: datetime | None
+
+
 def run_sync_flaky_issues(engine: Engine, settings: Settings) -> SyncFlakyIssuesSummary:
     with engine.begin() as connection:
         watermark = _load_watermark(connection)
@@ -89,6 +101,7 @@ def run_sync_flaky_issues(engine: Engine, settings: Settings) -> SyncFlakyIssues
         summary.source_rows_scanned = len(source_rows)
 
         prepared_batches: list[tuple[FlakyIssueRow, list[FlakyIssuePrLinkRow]]] = []
+        fetched_linked_prs: set[tuple[str, int]] = set()
         latest_updated_at: datetime | None = None
 
         for row in source_rows:
@@ -115,9 +128,12 @@ def run_sync_flaky_issues(engine: Engine, settings: Settings) -> SyncFlakyIssues
             prepared_batches.append((issue_row, link_rows))
 
         for batch in chunked(prepared_batches, settings.jobs.batch_size):
+            link_rows = [link_row for _issue_row, links in batch for link_row in links]
+            linked_pr_rows, linked_pr_attempted, linked_pr_failed = _fetch_linked_pr_metadata_rows(
+                _filter_unseen_link_rows(link_rows, fetched_linked_prs)
+            )
             with engine.begin() as connection:
                 issue_rows = [item[0] for item in batch]
-                link_rows = [link_row for _issue_row, links in batch for link_row in links]
                 issue_keys = [(issue_row.repo, issue_row.issue_number) for issue_row in issue_rows]
 
                 _upsert_flaky_issues(connection, issue_rows)
@@ -126,18 +142,20 @@ def run_sync_flaky_issues(engine: Engine, settings: Settings) -> SyncFlakyIssues
                     issue_keys=issue_keys,
                     rows=link_rows,
                 )
+                _upsert_flaky_linked_prs(connection, linked_pr_rows)
                 summary.rows_written += len(issue_rows)
                 summary.issue_pr_links_written += len(link_rows)
+                summary.linked_pr_rows_written += len(linked_pr_rows)
+                summary.linked_pr_fetch_attempted += linked_pr_attempted
+                summary.linked_pr_fetch_failed += linked_pr_failed
 
-        new_watermark = {
-            "last_ticket_updated_at": latest_updated_at.isoformat().replace("+00:00", "Z")
-            if latest_updated_at
-            else None
-        }
+        last_ticket_updated_at = _format_watermark_datetime(latest_updated_at)
+        new_watermark = {"last_ticket_updated_at": last_ticket_updated_at}
         with engine.begin() as connection:
+            _delete_orphaned_flaky_linked_prs(connection)
             mark_job_succeeded(connection, JOB_NAME, new_watermark)
 
-        summary.last_ticket_updated_at = new_watermark["last_ticket_updated_at"]
+        summary.last_ticket_updated_at = last_ticket_updated_at
         return summary
     except Exception as exc:
         with engine.begin() as connection:
@@ -155,6 +173,7 @@ def run_backfill_flaky_issue_pr_links(
         source_rows = _fetch_source_issue_rows(connection, DEFAULT_FLAKY_ISSUE_REPOS)
 
     summary.source_rows_scanned = len(source_rows)
+    fetched_linked_prs: set[tuple[str, int]] = set()
     latest_updated_at: datetime | None = None
 
     for batch in chunked(source_rows, settings.jobs.batch_size):
@@ -174,22 +193,28 @@ def run_backfill_flaky_issue_pr_links(
                 )
             )
 
+        linked_pr_rows, linked_pr_attempted, linked_pr_failed = _fetch_linked_pr_metadata_rows(
+            _filter_unseen_link_rows(link_rows, fetched_linked_prs)
+        )
         with engine.begin() as connection:
             _replace_flaky_issue_pr_links(
                 connection,
                 issue_keys=issue_keys,
                 rows=link_rows,
             )
+            _upsert_flaky_linked_prs(connection, linked_pr_rows)
 
         summary.batches_processed += 1
         summary.issue_rows_touched += len(issue_keys)
         summary.issue_pr_links_written += len(link_rows)
+        summary.linked_pr_rows_written += len(linked_pr_rows)
+        summary.linked_pr_fetch_attempted += linked_pr_attempted
+        summary.linked_pr_fetch_failed += linked_pr_failed
 
-    summary.last_ticket_updated_at = (
-        latest_updated_at.isoformat().replace("+00:00", "Z")
-        if latest_updated_at
-        else None
-    )
+    with engine.begin() as connection:
+        _delete_orphaned_flaky_linked_prs(connection)
+
+    summary.last_ticket_updated_at = _format_watermark_datetime(latest_updated_at)
     return summary
 
 
@@ -213,6 +238,17 @@ def fetch_issue_details_via_github_api(
         if isinstance(comments_payload, list):
             comments = [item for item in comments_payload if isinstance(item, dict)]
     return body, comments
+
+
+def fetch_pull_details_via_github_api(
+    *,
+    repo: str,
+    pr_number: int,
+) -> dict[str, Any]:
+    payload = _fetch_github_api_json(f"{GITHUB_API_BASE_URL}/repos/{repo}/pulls/{pr_number}")
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub pull payload is not an object")
+    return payload
 
 
 def _fetch_github_api_json(url: str) -> Any:
@@ -501,6 +537,70 @@ def _extract_linked_pr_rows(
     )
 
 
+def _fetch_linked_pr_metadata_rows(
+    link_rows: list[FlakyIssuePrLinkRow],
+) -> tuple[list[FlakyLinkedPrRow], int, int]:
+    unique_prs = sorted({(row.pr_repo, row.pr_number) for row in link_rows})
+    rows: list[FlakyLinkedPrRow] = []
+    failed = 0
+
+    for pr_repo, pr_number in unique_prs:
+        try:
+            payload = fetch_pull_details_via_github_api(repo=pr_repo, pr_number=pr_number)
+            rows.append(
+                _build_flaky_linked_pr_row(
+                    payload,
+                    pr_repo=pr_repo,
+                    pr_number=pr_number,
+                )
+            )
+        except Exception:
+            failed += 1
+            LOG.exception("failed to fetch linked flaky PR %s#%s", pr_repo, pr_number)
+
+    return rows, len(unique_prs), failed
+
+
+def _filter_unseen_link_rows(
+    link_rows: list[FlakyIssuePrLinkRow],
+    seen_prs: set[tuple[str, int]],
+) -> list[FlakyIssuePrLinkRow]:
+    unseen_rows: list[FlakyIssuePrLinkRow] = []
+    for row in link_rows:
+        key = (row.pr_repo, row.pr_number)
+        if key in seen_prs:
+            continue
+        seen_prs.add(key)
+        unseen_rows.append(row)
+    return unseen_rows
+
+
+def _build_flaky_linked_pr_row(
+    payload: dict[str, Any],
+    *,
+    pr_repo: str,
+    pr_number: int,
+) -> FlakyLinkedPrRow:
+    pr_state = str(payload.get("state") or "unknown")
+    if pr_state not in {"open", "closed", "unknown"}:
+        LOG.warning(
+            "unexpected linked flaky PR state %r for %s#%s",
+            pr_state,
+            pr_repo,
+            pr_number,
+        )
+    return FlakyLinkedPrRow(
+        pr_repo=pr_repo,
+        pr_number=pr_number,
+        pr_url=str(payload.get("html_url") or f"https://github.com/{pr_repo}/pull/{pr_number}"),
+        pr_title=str(payload.get("title") or ""),
+        pr_state=pr_state,
+        pr_created_at=_parse_datetime(payload.get("created_at")),
+        pr_closed_at=_parse_optional_datetime(payload.get("closed_at")),
+        pr_merged_at=_parse_optional_datetime(payload.get("merged_at")),
+    )
+
+
 def _parse_timeline(value: Any) -> list[dict[str, Any]]:
     if value is None:
         return []
@@ -537,10 +637,25 @@ def _extract_issue_lifecycle(
 
 def _parse_datetime(value: Any) -> datetime:
     if isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    raise ValueError(f"Unsupported datetime value: {value!r}")
+        parsed = value
+    elif isinstance(value, str):
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    else:
+        raise ValueError(f"Unsupported datetime value: {value!r}")
+    return _normalize_datetime_key(parsed)
+
+
+def _parse_optional_datetime(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    return _parse_datetime(value)
+
+
+def _format_watermark_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    normalized = _normalize_datetime_key(value)
+    return f"{normalized.isoformat()}Z"
 
 
 def _normalize_datetime_key(value: datetime) -> datetime:
@@ -569,6 +684,29 @@ def _replace_flaky_issue_pr_links(
     if rows:
         statement = _build_issue_pr_links_upsert_statement(connection)
         connection.execute(statement, [_issue_pr_link_to_params(row) for row in rows])
+
+
+def _upsert_flaky_linked_prs(connection: Connection, rows: list[FlakyLinkedPrRow]) -> None:
+    if not rows:
+        return
+    statement = _build_flaky_linked_prs_upsert_statement(connection)
+    connection.execute(statement, [_linked_pr_to_params(row) for row in rows])
+
+
+def _delete_orphaned_flaky_linked_prs(connection: Connection) -> None:
+    connection.execute(
+        text(
+            """
+            DELETE FROM ci_l1_flaky_linked_prs
+            WHERE NOT EXISTS (
+              SELECT 1
+              FROM ci_l1_flaky_issue_pr_links l
+              WHERE l.pr_repo = ci_l1_flaky_linked_prs.pr_repo
+                AND l.pr_number = ci_l1_flaky_linked_prs.pr_number
+            )
+            """
+        )
+    )
 
 
 def _row_to_params(row: FlakyIssueRow) -> dict[str, Any]:
@@ -604,6 +742,19 @@ def _issue_pr_link_to_params(row: FlakyIssuePrLinkRow) -> dict[str, Any]:
         "source_event_id": row.source_event_id,
         "linked_at": row.linked_at,
         "source_ticket_updated_at": row.source_ticket_updated_at,
+    }
+
+
+def _linked_pr_to_params(row: FlakyLinkedPrRow) -> dict[str, Any]:
+    return {
+        "pr_repo": row.pr_repo,
+        "pr_number": row.pr_number,
+        "pr_url": row.pr_url,
+        "pr_title": row.pr_title,
+        "pr_state": row.pr_state,
+        "pr_created_at": row.pr_created_at,
+        "pr_closed_at": row.pr_closed_at,
+        "pr_merged_at": row.pr_merged_at,
     }
 
 
@@ -824,6 +975,77 @@ def _build_issue_pr_links_upsert_statement(connection: Connection):
           source_event_id = VALUES(source_event_id),
           linked_at = VALUES(linked_at),
           source_ticket_updated_at = VALUES(source_ticket_updated_at),
+          updated_at = CURRENT_TIMESTAMP
+        """
+    )
+
+
+def _build_flaky_linked_prs_upsert_statement(connection: Connection):
+    if connection.dialect.name == "sqlite":
+        return text(
+            """
+            INSERT INTO ci_l1_flaky_linked_prs (
+              pr_repo,
+              pr_number,
+              pr_url,
+              pr_title,
+              pr_state,
+              pr_created_at,
+              pr_closed_at,
+              pr_merged_at,
+              created_at,
+              updated_at
+            ) VALUES (
+              :pr_repo,
+              :pr_number,
+              :pr_url,
+              :pr_title,
+              :pr_state,
+              :pr_created_at,
+              :pr_closed_at,
+              :pr_merged_at,
+              CURRENT_TIMESTAMP,
+              CURRENT_TIMESTAMP
+            )
+            ON CONFLICT(pr_repo, pr_number) DO UPDATE SET
+              pr_url = excluded.pr_url,
+              pr_title = excluded.pr_title,
+              pr_state = excluded.pr_state,
+              pr_created_at = excluded.pr_created_at,
+              pr_closed_at = excluded.pr_closed_at,
+              pr_merged_at = excluded.pr_merged_at,
+              updated_at = CURRENT_TIMESTAMP
+            """
+        )
+
+    return text(
+        """
+        INSERT INTO ci_l1_flaky_linked_prs (
+          pr_repo,
+          pr_number,
+          pr_url,
+          pr_title,
+          pr_state,
+          pr_created_at,
+          pr_closed_at,
+          pr_merged_at
+        ) VALUES (
+          :pr_repo,
+          :pr_number,
+          :pr_url,
+          :pr_title,
+          :pr_state,
+          :pr_created_at,
+          :pr_closed_at,
+          :pr_merged_at
+        )
+        ON DUPLICATE KEY UPDATE
+          pr_url = VALUES(pr_url),
+          pr_title = VALUES(pr_title),
+          pr_state = VALUES(pr_state),
+          pr_created_at = VALUES(pr_created_at),
+          pr_closed_at = VALUES(pr_closed_at),
+          pr_merged_at = VALUES(pr_merged_at),
           updated_at = CURRENT_TIMESTAMP
         """
     )

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -315,40 +315,32 @@ def _insert_pull_ticket(
     number: int,
     state: str,
     created_at: str,
-    updated_at: str | None = None,
     closed_at: str | None = None,
     merged: int = 0,
     merged_at: str | None = None,
-    target_branch: str | None = "master",
 ) -> None:
     with sqlite_engine.begin() as connection:
         connection.execute(
             text(
                 """
-                INSERT INTO github_tickets (
-                  type, repo, number, title, body, comments, state, created_at, updated_at,
-                  closed_at, merged, merged_at, review, review_comments, timeline, branches
+                INSERT INTO ci_l1_flaky_linked_prs (
+                  pr_repo, pr_number, pr_url, pr_title, pr_state, pr_created_at,
+                  pr_closed_at, pr_merged_at
                 ) VALUES (
-                  'pull', :repo, :number, :title, NULL, '[]', :state, :created_at, :updated_at,
-                  :closed_at, :merged, :merged_at, '[]', '[]', '[]', :branches
+                  :repo, :number, :pr_url, :title, :state, :created_at,
+                  :closed_at, :merged_at
                 )
                 """
             ),
             {
                 "repo": repo,
                 "number": number,
+                "pr_url": f"https://github.com/{repo}/pull/{number}",
                 "title": f"PR {number}",
                 "state": state,
                 "created_at": created_at,
-                "updated_at": updated_at or closed_at or created_at,
                 "closed_at": closed_at,
-                "merged": merged,
-                "merged_at": merged_at,
-                "branches": (
-                    json.dumps({"base": {"ref": target_branch}})
-                    if target_branch is not None
-                    else None
-                ),
+                "merged_at": merged_at if merged else None,
             },
         )
 
@@ -4089,7 +4081,7 @@ def test_flaky_page_issue_fix_progress_snapshot(
     assert progress["meta"]["ignores_cloud_phase"] is True
     assert progress["meta"]["ignores_issue_status"] is True
     assert progress["meta"]["ignores_branch_for_issues"] is True
-    assert progress["meta"]["applies_branch_to_prs"] is True
+    assert progress["meta"]["applies_branch_to_prs"] is False
     assert progress["filed_issue_count"] == 5
     assert progress["filed_issue_delta"] == 1
     assert progress["fixed_issue_count"] == 2
@@ -4142,7 +4134,6 @@ def test_flaky_issue_queries_ignore_branch_filter(sqlite_engine) -> None:
         number=73001,
         state="open",
         created_at="2026-04-10 11:05:00",
-        target_branch="release-8.5",
     )
     _insert_pull_ticket(
         sqlite_engine,
@@ -4185,10 +4176,10 @@ def test_flaky_issue_queries_ignore_branch_filter(sqlite_engine) -> None:
     page_body = page_response.json()
     issue_fix_progress = page_body["issue_fix_progress"]
     assert issue_fix_progress["meta"]["ignores_branch_for_issues"] is True
-    assert issue_fix_progress["meta"]["applies_branch_to_prs"] is True
+    assert issue_fix_progress["meta"]["applies_branch_to_prs"] is False
     assert issue_fix_progress["filed_issue_count"] == 2
     assert issue_fix_progress["fixed_issue_count"] == 1
-    assert issue_fix_progress["in_review_pr_count"] == 0
+    assert issue_fix_progress["in_review_pr_count"] == 1
     assert issue_fix_progress["merged_pr_count"] == 1
 
     issue_lifecycle = page_body["issue_lifecycle"]

--- a/ci-dashboard/tests/conftest.py
+++ b/ci-dashboard/tests/conftest.py
@@ -219,6 +219,26 @@ def _create_test_schema(engine: Engine) -> None:
         )
         """,
         """
+        CREATE TABLE ci_l1_flaky_linked_prs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          pr_repo TEXT NOT NULL,
+          pr_number INTEGER NOT NULL,
+          pr_url TEXT NOT NULL,
+          pr_title TEXT NOT NULL,
+          pr_state TEXT NOT NULL,
+          pr_created_at TEXT NOT NULL,
+          pr_closed_at TEXT NULL,
+          pr_merged_at TEXT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(pr_repo, pr_number)
+        )
+        """,
+        """
+        CREATE INDEX idx_ci_l1_flaky_linked_prs_state_time
+        ON ci_l1_flaky_linked_prs (pr_state, pr_merged_at)
+        """,
+        """
         CREATE TABLE ci_l1_pod_events (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           source_project TEXT NOT NULL,

--- a/ci-dashboard/tests/jobs/test_sync_flaky_issues.py
+++ b/ci-dashboard/tests/jobs/test_sync_flaky_issues.py
@@ -90,6 +90,29 @@ def _insert_issue_ticket(
         )
 
 
+def _pull_payload(
+    *,
+    number: int,
+    state: str = "closed",
+    merged: bool = True,
+    created_at: str = "2026-04-16T10:11:25Z",
+    updated_at: str = "2026-04-23T08:05:41Z",
+    closed_at: str | None = "2026-04-23T08:05:40Z",
+    merged_at: str | None = "2026-04-23T08:05:40Z",
+) -> dict[str, object]:
+    return {
+        "number": number,
+        "html_url": f"https://github.com/pingcap/tidb/pull/{number}",
+        "title": f"stabilize flaky #{number}",
+        "state": state,
+        "merged": merged,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "closed_at": closed_at,
+        "merged_at": merged_at,
+    }
+
+
 def test_sync_flaky_issues_end_to_end_and_idempotent_refresh(sqlite_engine, monkeypatch) -> None:
     _insert_issue_ticket(
         sqlite_engine,
@@ -301,11 +324,18 @@ def test_sync_flaky_issues_writes_and_replaces_issue_pr_links(
             AssertionError("GitHub API should not be called when source ticket has branch")
         ),
     )
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.fetch_pull_details_via_github_api",
+        lambda **kwargs: _pull_payload(number=kwargs["pr_number"]),
+    )
 
     summary = run_sync_flaky_issues(sqlite_engine, _settings(batch_size=10))
 
     assert summary.rows_written == 1
     assert summary.issue_pr_links_written == 1
+    assert summary.linked_pr_rows_written == 1
+    assert summary.linked_pr_fetch_attempted == 1
+    assert summary.linked_pr_fetch_failed == 0
 
     with sqlite_engine.begin() as connection:
         links = connection.execute(
@@ -327,6 +357,22 @@ def test_sync_flaky_issues_writes_and_replaces_issue_pr_links(
                 """
             )
         ).mappings().all()
+        linked_pr = connection.execute(
+            text(
+                """
+                SELECT
+                  pr_number,
+                  pr_url,
+                  pr_title,
+                  pr_state,
+                  pr_created_at,
+                  pr_closed_at,
+                  pr_merged_at
+                FROM ci_l1_flaky_linked_prs
+                WHERE pr_repo = 'pingcap/tidb' AND pr_number = 67822
+                """
+            )
+        ).mappings().one()
 
     assert len(links) == 1
     assert links[0]["pr_repo"] == "pingcap/tidb"
@@ -335,6 +381,13 @@ def test_sync_flaky_issues_writes_and_replaces_issue_pr_links(
     assert links[0]["link_type"] == "linked_pull_request"
     assert links[0]["source_event_type"] == "cross-referenced"
     assert str(links[0]["linked_at"]).startswith("2026-04-16 10:11:26")
+    assert linked_pr["pr_number"] == 67822
+    assert linked_pr["pr_url"] == "https://github.com/pingcap/tidb/pull/67822"
+    assert linked_pr["pr_title"] == "stabilize flaky #67822"
+    assert linked_pr["pr_state"] == "closed"
+    assert str(linked_pr["pr_created_at"]).startswith("2026-04-16 10:11:25")
+    assert str(linked_pr["pr_closed_at"]).startswith("2026-04-23 08:05:40")
+    assert str(linked_pr["pr_merged_at"]).startswith("2026-04-23 08:05:40")
 
     with sqlite_engine.begin() as connection:
         connection.execute(
@@ -370,6 +423,7 @@ def test_sync_flaky_issues_writes_and_replaces_issue_pr_links(
 
     second_summary = run_sync_flaky_issues(sqlite_engine, _settings(batch_size=10))
     assert second_summary.issue_pr_links_written == 1
+    assert second_summary.linked_pr_rows_written == 1
 
     with sqlite_engine.begin() as connection:
         links = connection.execute(
@@ -382,12 +436,100 @@ def test_sync_flaky_issues_writes_and_replaces_issue_pr_links(
                 """
             )
         ).mappings().all()
+        linked_prs = connection.execute(
+            text(
+                """
+                SELECT pr_number
+                FROM ci_l1_flaky_linked_prs
+                ORDER BY pr_number
+                """
+            )
+        ).mappings().all()
 
     assert [row["pr_number"] for row in links] == [67871]
+    assert [row["pr_number"] for row in linked_prs] == [67871]
+
+
+def test_sync_flaky_issues_fetches_linked_pr_metadata_once_across_batches(
+    sqlite_engine,
+    monkeypatch,
+) -> None:
+    timeline = [
+        {
+            "event": "cross-referenced",
+            "created_at": "2026-04-16T10:11:26Z",
+            "source": {
+                "type": "issue",
+                "issue": {
+                    "number": 67822,
+                    "title": "br/pkg/streamhelper: stabilize flaky TestShared",
+                    "repository": {"full_name": "pingcap/tidb"},
+                    "pull_request": {},
+                },
+            },
+        }
+    ]
+    for index, issue_number in enumerate((67740, 67741), start=1):
+        _insert_issue_ticket(
+            sqlite_engine,
+            ticket_id=20 + index,
+            repo="pingcap/tidb",
+            number=issue_number,
+            title=f"Flaky test: TestShared{index} in nightly",
+            body="Automated flaky test report.\n\n- Branch: master\n",
+            state="open",
+            created_at="2026-04-14T00:05:37Z",
+            updated_at=f"2026-04-24T04:09:5{index}Z",
+            timeline=timeline,
+        )
+
+    fetched_pr_numbers: list[int] = []
+
+    def _fetch_pull(**kwargs):
+        fetched_pr_numbers.append(kwargs["pr_number"])
+        return _pull_payload(number=kwargs["pr_number"])
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.fetch_pull_details_via_github_api",
+        _fetch_pull,
+    )
+
+    summary = run_sync_flaky_issues(sqlite_engine, _settings(batch_size=1))
+
+    assert summary.issue_pr_links_written == 2
+    assert summary.linked_pr_rows_written == 1
+    assert summary.linked_pr_fetch_attempted == 1
+    assert fetched_pr_numbers == [67822]
+
+    with sqlite_engine.begin() as connection:
+        links = connection.execute(
+            text(
+                """
+                SELECT issue_number, pr_number
+                FROM ci_l1_flaky_issue_pr_links
+                ORDER BY issue_number
+                """
+            )
+        ).mappings().all()
+        linked_prs = connection.execute(
+            text(
+                """
+                SELECT pr_number
+                FROM ci_l1_flaky_linked_prs
+                """
+            )
+        ).mappings().all()
+
+    assert [(row["issue_number"], row["pr_number"]) for row in links] == [
+        (67740, 67822),
+        (67741, 67822),
+    ]
+    assert [row["pr_number"] for row in linked_prs] == [67822]
 
 
 def test_backfill_flaky_issue_pr_links_rebuilds_links_without_touching_issue_rows(
     sqlite_engine,
+    monkeypatch,
 ) -> None:
     _insert_issue_ticket(
         sqlite_engine,
@@ -507,12 +649,20 @@ def test_backfill_flaky_issue_pr_links_rebuilds_links_without_touching_issue_row
             )
         )
 
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.fetch_pull_details_via_github_api",
+        lambda **kwargs: _pull_payload(number=kwargs["pr_number"]),
+    )
+
     summary = run_backfill_flaky_issue_pr_links(sqlite_engine, _settings(batch_size=1))
 
     assert summary.batches_processed == 1
     assert summary.source_rows_scanned == 1
     assert summary.issue_rows_touched == 1
     assert summary.issue_pr_links_written == 2
+    assert summary.linked_pr_rows_written == 2
+    assert summary.linked_pr_fetch_attempted == 2
+    assert summary.linked_pr_fetch_failed == 0
     assert summary.last_ticket_updated_at == "2026-04-26T09:15:00Z"
 
     with sqlite_engine.begin() as connection:
@@ -535,10 +685,20 @@ def test_backfill_flaky_issue_pr_links_rebuilds_links_without_touching_issue_row
                 """
             )
         ).mappings().all()
+        linked_prs = connection.execute(
+            text(
+                """
+                SELECT pr_number
+                FROM ci_l1_flaky_linked_prs
+                ORDER BY pr_number
+                """
+            )
+        ).mappings().all()
 
     assert issue_row["issue_branch"] == "release-8.4"
     assert issue_row["branch_source"] == "manual_seed"
     assert [row["pr_number"] for row in links] == [67601, 67644]
+    assert [row["pr_number"] for row in linked_prs] == [67601, 67644]
 
 
 def test_sync_flaky_issues_reuses_existing_branch_when_ticket_is_unchanged(
@@ -676,7 +836,7 @@ def test_sync_flaky_issue_helpers_cover_fallbacks_and_payload_shapes(monkeypatch
 
     now = datetime(2026, 4, 15, 9, 0, 0)
     assert _parse_datetime(now) == now
-    assert _parse_datetime("2026-04-15T09:00:00Z") == datetime.fromisoformat("2026-04-15T09:00:00+00:00")
+    assert _parse_datetime("2026-04-15T09:00:00Z") == datetime(2026, 4, 15, 9, 0, 0)
     with pytest.raises(ValueError, match="Unsupported datetime value"):
         _parse_datetime(123)
 


### PR DESCRIPTION
## Summary
- add `ci_l1_flaky_linked_prs` as a dashboard-owned PR metadata table for flaky linked PRs
- sync linked PR metadata from GitHub when processing flaky issue links and during link backfill
- compute flaky issue fix progress from the owned linked PR table instead of `github_tickets(type='pull')`

## Behavior notes
- `github_tickets(type='pull')` is no longer used for Flaky Issue Progress / Fix PR Progress, because that source is not controlled by CI Dashboard and can lag behind linked issue data.
- PR-side branch filtering is intentionally not applied in this PR: the new owned table stores only the PR fields needed for progress counts, and `issue_fix_progress.meta.applies_branch_to_prs` is now `false`. Issue-side branch behavior remains unchanged.
- GitHub PR fetch volume is exposed in job summaries via `linked_pr_fetch_attempted`, `linked_pr_fetch_failed`, and `linked_pr_rows_written`; these fields can be monitored to catch unexpected fetch spikes or API quota pressure.
- Linked PR metadata is fetched once per unique PR per sync/backfill run and orphaned metadata rows are cleaned after the run when no issue link references them anymore.

## Testing
- `PYTHONPATH=ci-dashboard/src pytest ci-dashboard/tests/jobs/test_sync_flaky_issues.py ci-dashboard/tests/api/test_routes.py -q` (`50 passed`)
- `cd ci-dashboard && python -m ruff check src tests`
- `cd ci-dashboard && PYTHONPATH=src python -m pytest --cov=src/ci_dashboard --cov-report=term-missing` (`406 passed`, total coverage `91.29%`)
