### PR TITLE
fix(cost-insight): separate GCS cleanup metadata DDL statements

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -612,7 +612,7 @@ def build_cleanup_gcs_cache_metadata_stage_tables_query(
     cas_live_metadata_table: str,
     cas_missing_metadata_table: str,
 ) -> str:
-    return "\n\n".join(
+    return ";\n\n".join(
         [
             _create_table_query(
                 ac_live_metadata_table,

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -14,6 +14,7 @@ from cost_insight.jobs.cleanup_gcs_cache import (
     _populate_ac_stage_tables,
     build_cleanup_gcs_cache_final_ac_delete_table_query,
     build_cleanup_gcs_cache_manifest_export_query,
+    build_cleanup_gcs_cache_metadata_stage_tables_query,
     build_cleanup_gcs_cache_reconcile_deleted_cas_query,
     build_cleanup_gcs_cache_summary_query,
     run_cleanup_gcs_cache,
@@ -74,6 +75,20 @@ def test_cleanup_gcs_cache_final_ac_delete_table_excludes_missing_metadata() -> 
     assert "WHERE NOT EXISTS" in query
     assert "FROM `project.dataset.ac_missing` AS missing" in query
     assert "missing.object_name = live.object_name" in query
+
+
+def test_cleanup_gcs_cache_metadata_stage_tables_query_separates_ddl_statements() -> None:
+    query = build_cleanup_gcs_cache_metadata_stage_tables_query(
+        ttl_days=7,
+        ac_live_metadata_table="`project.dataset.ac_live`",
+        ac_missing_metadata_table="`project.dataset.ac_missing`",
+        cas_live_metadata_table="`project.dataset.cas_live`",
+        cas_missing_metadata_table="`project.dataset.cas_missing`",
+    )
+
+    assert query.count("CREATE OR REPLACE TABLE") == 4
+    assert query.count(";\n\nCREATE OR REPLACE TABLE") == 3
+    assert "INTERVAL 7 DAY" in query
 
 
 def test_populate_ac_stage_tables_skips_parse_failed_ac_from_delete_inputs() -> None:


### PR DESCRIPTION
## Summary

Fix the CAS GC v3 canary blocker where the metadata stage table setup generated multiple `CREATE OR REPLACE TABLE` statements without semicolon separators.

BigQuery rejected the query as:

```text
Syntax error: Expected end of input but got keyword CREATE
```

## Changes

- Separate the metadata stage DDL statements with `;\n\n` so BigQuery can execute them as a script.
- Add a regression test that verifies all four metadata stage `CREATE TABLE` statements are separated.

## Validation

```bash
cd cost-insight
python -m pytest -q
python -m ruff check .
python -m ruff format --check ../cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py ../cost-insight/tests/test_cleanup_gcs_cache.py
```

Notes:

- Full `python -m pytest -q` passes with total coverage `92.92%`.
- Full-directory `ruff format --check .` still reports pre-existing formatting differences in unrelated files, so I verified the two changed files directly.
