### PR TITLE
feat(cost): cover raw prow target branch label

### DIFF
--- a/cost-insight/docs/target-branch-cost-dimension-design.md
+++ b/cost-insight/docs/target-branch-cost-dimension-design.md
@@ -12,14 +12,16 @@ Prow already places the target branch on Kubernetes pods as:
 prow.k8s.io/refs.base_ref
 ```
 
-In GCP Cloud Billing detailed export, Kubernetes labels are exposed with the
-`k8s-label/` prefix. The normalized billing label key is:
+In GCP Cloud Billing detailed export, Kubernetes labels are usually exposed with
+the `k8s-label/` prefix. Some rows may also carry the raw Prow label key. Treat
+both as equivalent source labels:
 
 ```text
 k8s-label/prow.k8s.io/refs.base_ref
+prow.k8s.io/refs.base_ref
 ```
 
-The cost pipeline should map that source label to a product-facing
+The cost pipeline should map either source label to a product-facing
 `target_branch` column instead of leaking the Prow label key into dashboard
 queries.
 
@@ -212,7 +214,8 @@ without replacement can leave old branchless rows next to new branch-aware rows.
 
 ## Pipeline Flow
 
-1. GCP billing export query reads `k8s-label/prow.k8s.io/refs.base_ref`.
+1. GCP billing export query reads `k8s-label/prow.k8s.io/refs.base_ref` and
+   `prow.k8s.io/refs.base_ref`.
 2. Collector normalizes it into `target_branch`.
 3. Summary/raw/unmatched upserts persist the column.
 4. Attribution refresh copies `target_branch` from source rows to

--- a/cost-insight/tests/test_gcp_billing_export.py
+++ b/cost-insight/tests/test_gcp_billing_export.py
@@ -19,6 +19,7 @@ def test_build_gcp_billing_query_keeps_expected_dimensions() -> None:
     assert "k8s-label/author" in query
     assert "k8s-label/repo" in query
     assert "k8s-label/prow.k8s.io/refs.base_ref" in query
+    assert "prow.k8s.io/refs.base_ref" in query
     assert "target_branch" in query
     assert "k8s-workload-name" in query
     assert "cost_at_list" in query
@@ -47,6 +48,7 @@ def test_build_gcp_billing_summary_query_uses_partition_pruning() -> None:
     assert "k8s-label/author" in query
     assert "k8s-label/repo" in query
     assert "k8s-label/prow.k8s.io/refs.base_ref" in query
+    assert "prow.k8s.io/refs.base_ref" in query
     assert "target_branch" in query
     assert "resource_name" not in query
     assert "service.description AS service_name" in query
@@ -65,6 +67,7 @@ def test_build_gcp_unmatched_resource_query_keeps_resource_context() -> None:
     assert "DATE(usage_start_time) BETWEEN @usage_start_date AND @usage_end_date" in query
     assert "k8s-workload-name" in query
     assert "k8s-label/prow.k8s.io/refs.base_ref" in query
+    assert "prow.k8s.io/refs.base_ref" in query
     assert "target_branch" in query
     assert "resource.global_name" in query
     assert "usage_seconds" in query


### PR DESCRIPTION
## Summary
- assert GCP billing query builders include both target branch label keys: k8s-label/prow.k8s.io/refs.base_ref and prow.k8s.io/refs.base_ref
- update the target branch design doc to document both equivalent source labels

## Notes
The collector code merged in #508 already reads both keys, so this is a test/docs follow-up and does not require another backfill.

## Validation
- python -m pytest cost-insight/tests/test_gcp_billing_export.py -q --no-cov
- python -m compileall -q cost-insight/src