### PR TITLE
fix(cost-insight): avoid reserved alias in CAS cleanup SQL

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -585,14 +585,14 @@ WITH cas_from_deleted_ac AS (
 ),
 cas_after_extra_idle AS (
   SELECT DISTINCT
-    current.object_name,
-    current.last_seen_at,
-    TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), current.last_seen_at, DAY) AS idle_days
+    current_obj.object_name,
+    current_obj.last_seen_at,
+    TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), current_obj.last_seen_at, DAY) AS idle_days
   FROM cas_from_deleted_ac AS candidate
-  JOIN {current_table} AS current
-    ON current.object_name = candidate.cas_object_name
-   AND current.object_kind = 'cas'
-   AND current.last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_cutoff_days DAY)
+  JOIN {current_table} AS current_obj
+    ON current_obj.object_name = candidate.cas_object_name
+   AND current_obj.object_kind = 'cas'
+   AND current_obj.last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @cas_cutoff_days DAY)
 )
 SELECT
   cas.object_name,
@@ -688,10 +688,10 @@ SELECT
 FROM {source_table} AS source
 JOIN {live_metadata_table} AS live
   USING (object_name)
-JOIN {current_table} AS current
-  ON current.object_name = source.object_name
- AND current.object_kind = 'cas'
- AND current.last_seen_at = source.last_seen_at
+JOIN {current_table} AS current_obj
+  ON current_obj.object_name = source.object_name
+ AND current_obj.object_kind = 'cas'
+ AND current_obj.last_seen_at = source.last_seen_at
 WHERE NOT EXISTS (
   SELECT 1
   FROM {audit_table} AS audit

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -13,6 +13,8 @@ from cost_insight.common.storage_batch_operations import (
 )
 from cost_insight.jobs.cleanup_gcs_cache import (
     _populate_ac_stage_tables,
+    build_cleanup_gcs_cache_cas_candidate_table_query,
+    build_cleanup_gcs_cache_final_cas_delete_table_query,
     build_cleanup_gcs_cache_final_ac_delete_table_query,
     build_cleanup_gcs_cache_manifest_export_query,
     build_cleanup_gcs_cache_metadata_stage_tables_query,
@@ -102,6 +104,29 @@ def test_cleanup_gcs_cache_run_references_table_query_uses_nullable_load_schema(
     assert "ac_object_name STRING," in query
     assert "cas_object_name STRING" in query
     assert "NOT NULL" not in query
+
+
+def test_cleanup_gcs_cache_cas_queries_avoid_current_reserved_alias() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    queries = (
+        build_cleanup_gcs_cache_cas_candidate_table_query(
+            settings,
+            run_references_table="`project.dataset.run_refs`",
+            candidate_table="`project.dataset.candidate_cas`",
+            ttl_days=7,
+        ),
+        build_cleanup_gcs_cache_final_cas_delete_table_query(
+            settings,
+            source_table="`project.dataset.candidate_cas`",
+            live_metadata_table="`project.dataset.cas_live`",
+            candidate_table="`project.dataset.delete_cas`",
+            ttl_days=7,
+        ),
+    )
+
+    for query in queries:
+        assert " AS current\n" not in query
+        assert " AS current_obj\n" in query
 
 
 def test_populate_ac_stage_tables_skips_parse_failed_ac_from_delete_inputs() -> None:


### PR DESCRIPTION
## Summary

Fix the next CAS GC v3 canary blocker:

```text
Syntax error: Unexpected keyword CURRENT at [11:5]
```

The CAS cleanup SQL used `current` as a table alias. BigQuery parses `CURRENT` as a reserved keyword in this position. This blocked the canary before manifest export / Storage Batch Operations creation, so no objects were deleted.

## Changes

- Rename the `current` table alias to `current_obj` in:
  - CAS candidate table query
  - final CAS delete table query
- Add a regression test to ensure CAS cleanup queries no longer emit `AS current`.

## Validation

Local unit/lint validation:

```bash
cd cost-insight
python -m pytest -q
python -m ruff check .
python -m ruff format --check ../cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py ../cost-insight/tests/test_cleanup_gcs_cache.py
```

Full test coverage: `93.07%`.

Real BigQuery parser validation:

I also ran a full CAS GC v3 delete-path BigQuery dry-run using short-TTL scratch tables in `pingcap-testing-account.ci_bazel_cache_logs`. This validates parser/schema coverage for every query/script in the delete path, not just the failed query.

Validated dry-run steps:

- summary
- AC seed table
- run references DDL
- metadata stage DDL script
- count distinct run refs
- reconcile missing AC
- final AC delete table
- count AC delete table
- AC manifest export
- reconcile deleted AC
- CAS candidate table
- reconcile missing CAS
- final CAS delete table
- count CAS delete table
- CAS manifest export
- reconcile deleted CAS

Result: all 16 BigQuery dry-runs succeeded.

The two CAS SQLs that previously would have been parser-sensitive were also validated explicitly with `bq query --dry_run`.
