### PR TITLE
test(cost): assert exact target branch label keys

### DIFF
--- a/cost-insight/tests/test_gcp_billing_export.py
+++ b/cost-insight/tests/test_gcp_billing_export.py
@@ -12,14 +12,18 @@ from cost_insight.sources.gcp_billing_export import (
 )
 
 
+def _assert_target_branch_label_keys(query: str) -> None:
+    assert "'k8s-label/prow.k8s.io/refs.base_ref'" in query
+    assert "'prow.k8s.io/refs.base_ref'" in query
+
+
 def test_build_gcp_billing_query_keeps_expected_dimensions() -> None:
     query = build_gcp_billing_query(billing_table="project.dataset.table", limit=10)
 
     assert "`project.dataset.table`" in query
     assert "k8s-label/author" in query
     assert "k8s-label/repo" in query
-    assert "k8s-label/prow.k8s.io/refs.base_ref" in query
-    assert "prow.k8s.io/refs.base_ref" in query
+    _assert_target_branch_label_keys(query)
     assert "target_branch" in query
     assert "k8s-workload-name" in query
     assert "cost_at_list" in query
@@ -47,8 +51,7 @@ def test_build_gcp_billing_summary_query_uses_partition_pruning() -> None:
     assert "DATE(usage_start_time) >= @earliest_usage_date" in query
     assert "k8s-label/author" in query
     assert "k8s-label/repo" in query
-    assert "k8s-label/prow.k8s.io/refs.base_ref" in query
-    assert "prow.k8s.io/refs.base_ref" in query
+    _assert_target_branch_label_keys(query)
     assert "target_branch" in query
     assert "resource_name" not in query
     assert "service.description AS service_name" in query
@@ -66,8 +69,7 @@ def test_build_gcp_unmatched_resource_query_keeps_resource_context() -> None:
     assert "_PARTITIONDATE BETWEEN @export_partition_start AND @export_partition_end" in query
     assert "DATE(usage_start_time) BETWEEN @usage_start_date AND @usage_end_date" in query
     assert "k8s-workload-name" in query
-    assert "k8s-label/prow.k8s.io/refs.base_ref" in query
-    assert "prow.k8s.io/refs.base_ref" in query
+    _assert_target_branch_label_keys(query)
     assert "target_branch" in query
     assert "resource.global_name" in query
     assert "usage_seconds" in query


### PR DESCRIPTION
## Summary
- tighten target_branch label key assertions so the raw Prow key is matched as its own quoted label, not as a substring of the k8s-label key

## Validation
- python -m pytest cost-insight/tests/test_gcp_billing_export.py -q --no-cov
- python -m compileall -q cost-insight/src