### PR TITLE
fix(cost-insight): ignore cleanup metadata gets in CAS audit check

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -675,6 +675,7 @@ def build_cleanup_gcs_cache_final_cas_delete_table_query(
         settings.project_id, settings.dataset, settings.last_seen_current_table
     )
     audit_table = _table_ref(settings.project_id, settings.dataset, settings.audit_log_table)
+    ignored_cleanup_get_filter = _ignored_cleanup_get_filter(settings)
     return f"""
 CREATE OR REPLACE TABLE {candidate_table}
 OPTIONS (
@@ -702,6 +703,7 @@ WHERE NOT EXISTS (
     )
     AND REGEXP_EXTRACT(audit.protopayload_auditlog.resourceName, r"/objects/(.+)$") = source.object_name
     AND audit.timestamp > source.last_seen_at
+    {ignored_cleanup_get_filter}
 )
 ORDER BY source.last_seen_at ASC, source.object_name ASC
 """.strip()
@@ -1104,6 +1106,21 @@ def _batched_values(values: Iterable[str], batch_size: int) -> Iterator[tuple[st
 
 def _table_ref(project_id: str, dataset: str, table: str) -> str:
     return f"`{project_id}.{dataset}.{table}`"
+
+
+def _ignored_cleanup_get_filter(settings: GcsCacheSettings) -> str:
+    principal_email = (settings.last_seen_excluded_get_principal_email or "").strip()
+    if not principal_email:
+        return ""
+    return f"""
+    AND NOT (
+      audit.protopayload_auditlog.methodName = 'storage.objects.get'
+      AND audit.protopayload_auditlog.authenticationInfo.principalEmail = {_sql_string_literal(principal_email)}
+    )""".rstrip()
+
+
+def _sql_string_literal(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
 
 
 def _add_bytes(total: int, value: int | None) -> int:

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -129,6 +129,43 @@ def test_cleanup_gcs_cache_cas_queries_avoid_current_reserved_alias() -> None:
         assert " AS current_obj\n" in query
 
 
+def test_cleanup_gcs_cache_final_cas_delete_ignores_cleanup_metadata_gets() -> None:
+    query = build_cleanup_gcs_cache_final_cas_delete_table_query(
+        GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            last_seen_excluded_get_principal_email=(
+                "ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com"
+            ),
+        ),
+        source_table="`project.dataset.candidate_cas`",
+        live_metadata_table="`project.dataset.cas_live`",
+        candidate_table="`project.dataset.delete_cas`",
+        ttl_days=7,
+    )
+
+    assert "FROM `pingcap-testing-account.ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access` AS audit" in query
+    assert "audit.protopayload_auditlog.methodName IN" in query
+    assert "audit.timestamp > source.last_seen_at" in query
+    assert "AND NOT (" in query
+    assert "audit.protopayload_auditlog.methodName = 'storage.objects.get'" in query
+    assert (
+        "audit.protopayload_auditlog.authenticationInfo.principalEmail = "
+        "'ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com'"
+    ) in query
+
+
+def test_cleanup_gcs_cache_final_cas_delete_keeps_all_audit_events_without_exclusion() -> None:
+    query = build_cleanup_gcs_cache_final_cas_delete_table_query(
+        GcsCacheSettings(project_id="pingcap-testing-account"),
+        source_table="`project.dataset.candidate_cas`",
+        live_metadata_table="`project.dataset.cas_live`",
+        candidate_table="`project.dataset.delete_cas`",
+        ttl_days=7,
+    )
+
+    assert "authenticationInfo.principalEmail" not in query
+
+
 def test_populate_ac_stage_tables_skips_parse_failed_ac_from_delete_inputs() -> None:
     loaded_rows = []
 


### PR DESCRIPTION
## Summary

- ignore the cleanup job service account's own `storage.objects.get` events in the final CAS raw-audit recheck
- keep real external `storage.objects.get` / `storage.objects.create` events as CAS deletion blockers
- add SQL-shape tests for both configured and unconfigured exclusion paths

## Why

The v3 canary on 2026-06-23 selected 500 cold AC objects and parsed 659 distinct CAS references. 63 CAS passed coldness and live metadata checks, but final CAS delete selected 0 objects. Raw audit inspection showed all 63 were blocked only by `ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com` `storage.objects.get` events emitted during the cleanup job metadata/generation check itself. Non-cleanup raw audit blockers were 0.

## Validation

- `python -m ruff check cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py cost-insight/tests/test_cleanup_gcs_cache.py`
- `python -m pytest cost-insight/tests -q` -> coverage 93.10%
- generated the fixed final CAS delete SQL from the app code and ran it against the canary intermediate tables into a scratch table; result: `would_delete_cas_count = 63`
