### PR TITLE
feat(ci-dashboard): daily data freshness check, flaky table sticky column + build key fix

### DIFF
--- a/ci-dashboard/docs/daily-data-freshness-check-design.md
+++ b/ci-dashboard/docs/daily-data-freshness-check-design.md
@@ -1,0 +1,263 @@
+# Daily Data Freshness Check & Alert Design
+
+## 目标
+
+每天运行一次检查 Job，验证 ci-dashboard 和 cost-insight 各核心数据表的新鲜度是否在容忍范围内。超过阈值则通过飞书发送告警。
+
+## 检查范围
+
+跳过 raw 表（如 `cost_raw_details`、`ci_l1_pod_events`），只检查汇总层和直接消费的表。上游外部表（`prow_jobs`、`github_tickets`）作为独立检查项纳入，因为它们的数据新鲜度直接影响下游所有表。
+
+## 检查项总览
+
+| # | 检查对象 | 数据来源 | 新鲜度指标 | 容忍 Lag | 告警级别 |
+|---|---------|---------|-----------|---------|---------|
+| 1 | `ci_l1_builds` | Kafka Jenkins CDEvents + prow_jobs sync | `MAX(start_time)` vs NOW | **4 小时** | HIGH |
+| 2 | `ci_l1_pod_lifecycle` | K8s Watch + GCP Cloud Logging sync | `MAX(last_event_at)` vs NOW | **4 小时** | HIGH |
+| 3 | Archive Error Logs 积压 | Jenkins API → GCS | 近 4 小时内未归档的失败 build 数量 | **4 小时** 窗口内积压 ≤ 动态阈值 | MEDIUM |
+| 4 | `prow_jobs` | 外部 Prow Reporter（Prow SQL 同步） | `MAX(startTime)` vs NOW | **4 小时** | HIGH |
+| 5 | `github_tickets` | 外部 GitHub 数据同步（tibuild） | `MAX(updated_at)` vs NOW | **30 小时** | MEDIUM |
+| 6 | `ci_l1_flaky_issues` | GitHub Issues API (daily) | `ci_job_state` 中 `ci-sync-flaky-issues` 的 `last_succeeded_at` | **30 小时** | MEDIUM |
+| 7 | `ci_l1_pr_events` | github_tickets → sync-pr-events | `MAX(event_time)` vs NOW | **4 小时** | MEDIUM |
+| 8 | `problem_case_runs` | cloudevents-server CloudEvents | `MAX(report_time)` vs NOW | **4 小时** | MEDIUM |
+| 9 | `ci_l1_builds` 派生列 | refresh-build-derived | `ci_job_state` 中 `ci-refresh-build-derived` 的 `last_succeeded_at` | **4 小时** | MEDIUM |
+| 10 | `cost_bq_export_summary_daily` | GCP/AWS Billing Export（daily） | `MAX(usage_date)` vs NOW（GCP 源） | **4 天** | MEDIUM |
+| 11 | `cost_attribution_daily` | cost_raw_details + roster（daily） | `MAX(usage_date)` vs NOW | **4 天** | MEDIUM |
+| 12 | `cost_unmatched_resource_daily` | GCP/AWS Unmatched Detection（weekly） | `MAX(usage_date)` vs NOW | **10 天** | LOW |
+| 13 | `sync-gcs-cache-last-seen` | BigQuery GCS Audit Logs → BigQuery last-seen 表 | `cost_job_state` 中 `sync-gcs-cache-last-seen` 的 `last_succeeded_at` | **30 小时** | LOW |
+| 14 | `roster_employees` | Lark 飞书通讯录 API（daily） | `MAX(updated_at)` vs NOW | **30 小时** | MEDIUM |
+
+## 详细检查逻辑
+
+### 1. `ci_l1_builds` — 最新 Build 时间
+
+```sql
+SELECT MAX(start_time) AS latest_build_time
+FROM ci_l1_builds
+WHERE start_time IS NOT NULL;
+```
+
+如果 `latest_build_time < NOW() - INTERVAL 4 HOUR` → 告警。
+
+> **注意：** 夜间/周末可能没有 CI 活动，告警需要配合工作时段判断（例如只在 08:00-22:00 UTC+8 触发 HIGH 级别，其余时段降级为 LOW 或忽略）。先实现为全天 4 小时检查，后续根据误报频率调整。
+
+### 2. `ci_l1_pod_lifecycle` — 最新 Pod 事件时间
+
+```sql
+SELECT MAX(last_event_at) AS latest_pod_event
+FROM ci_l1_pod_lifecycle
+WHERE last_event_at IS NOT NULL;
+```
+
+如果 `latest_pod_event < NOW() - INTERVAL 4 HOUR` → 告警。
+
+> 注意：与 #1 相同，需要考虑夜间低活跃期。
+
+### 3. Archive Error Logs — 积压检查
+
+```sql
+SELECT COUNT(*) AS pending_count
+FROM ci_l1_builds
+WHERE state IN ('failure', 'error', 'timeout', 'aborted')
+  AND log_gcs_uri IS NULL
+  AND completion_time > NOW() - INTERVAL 4 HOUR;
+```
+
+如果 `pending_count > 0`（近 4 小时内产生的失败 build 都还没有被归档）→ 告警。
+
+> **阈值说明：** `archive-error-logs` 每小时跑一次，且只处理未归档的 build。正常情况下，失败 build 产生后最多 1 小时就会被归档。如果 4 小时窗口内积压大于 0，说明归档 job 可能停滞。
+
+### 4. `prow_jobs` — 最新 Prow Job 时间
+
+```sql
+SELECT MAX(startTime) AS latest_prow_job
+FROM prow_jobs
+WHERE startTime IS NOT NULL;
+```
+
+如果 `latest_prow_job < NOW() - INTERVAL 4 HOUR` → 告警。
+
+> `prow_jobs` 由外部 Prow Reporter 写入，是 `ci_l1_builds` 的上游数据源（通过 `sync-builds` job）。如果这个表停滞，`ci_l1_builds` 的 Prow 来源数据就会缺失。夜间/周末与 #1 相同的低活跃期问题。
+
+### 5. `github_tickets` — 最新 GitHub Ticket 更新时间
+
+```sql
+SELECT MAX(updated_at) AS latest_ticket_update
+FROM github_tickets;
+```
+
+如果 `latest_ticket_update < NOW() - INTERVAL 30 HOUR` → 告警。
+
+> `github_tickets` 由外部 GitHub 同步服务（tibuild）写入，是 `ci_l1_pr_events` 和 `ci_l1_flaky_issues` 的源表。GitHub 上每天都有大量 PR/issue 活动，30 小时无更新说明同步可能断了。
+
+### 6. `ci_l1_flaky_issues` — Flaky Issue 同步
+
+```sql
+SELECT last_succeeded_at
+FROM ci_job_state
+WHERE job_name = 'ci-sync-flaky-issues';
+```
+
+如果 `last_succeeded_at < NOW() - INTERVAL 30 HOUR` → 告警。
+
+### 7. `ci_l1_pr_events` — 最新 PR Event 时间
+
+```sql
+SELECT MAX(event_time) AS latest_pr_event
+FROM ci_l1_pr_events
+WHERE event_time IS NOT NULL;
+```
+
+如果 `latest_pr_event < NOW() - INTERVAL 4 HOUR` → 告警。
+
+> 注意：如果 PR 事件写入频率本身就不高（例如夜间），可能误报。后续可根据实际数据调整阈值或增加工作时段判断。
+
+### 8. `problem_case_runs` — 最新 Test Case Run 时间
+
+```sql
+SELECT MAX(report_time) AS latest_report_time
+FROM problem_case_runs
+WHERE report_time IS NOT NULL;
+```
+
+如果 `latest_report_time < NOW() - INTERVAL 4 HOUR` → 告警。
+
+### 9. `ci_l1_builds` 派生列刷新 — 通过 job_state
+
+```sql
+SELECT last_succeeded_at
+FROM ci_job_state
+WHERE job_name = 'ci-refresh-build-derived';
+```
+
+如果 `last_succeeded_at < NOW() - INTERVAL 4 HOUR` → 告警。
+
+### 10. `cost_bq_export_summary_daily` — Billing 汇总最新日期
+
+```sql
+SELECT MAX(usage_date) AS latest_usage_date
+FROM cost_bq_export_summary_daily
+WHERE vendor = 'GCP';
+```
+
+如果 `latest_usage_date < CURDATE() - INTERVAL 4 DAY` → 告警。
+
+> GCP billing export 本身有 1-2 天延迟，加上每日 sync job，4 天容忍度覆盖了 1 次 sync 失败 + billing 数据源延迟的缓冲。AWS 源单独检查需要更长的容忍度（~5 天），可后续按需添加。
+
+### 11. `cost_attribution_daily` — 成本归属最新日期
+
+```sql
+SELECT MAX(usage_date) AS latest_usage_date
+FROM cost_attribution_daily;
+```
+
+如果 `latest_usage_date < CURDATE() - INTERVAL 4 DAY` → 告警。
+
+> 依赖链路：GCP billing export → `cost_raw_details` → `cost_bq_export_summary_daily` → `cost_attribution_daily`。只要 `cost_bq_export_summary_daily` 是新鲜的，`cost_attribution_daily` 也应该新鲜。此项作为确认检查。
+
+### 12. `cost_unmatched_resource_daily` — 未匹配资源最新日期
+
+```sql
+SELECT MAX(usage_date) AS latest_usage_date
+FROM cost_unmatched_resource_daily;
+```
+
+如果 `latest_usage_date < CURDATE() - INTERVAL 10 DAY` → 告警。
+
+> 这是周级 job，且数据本身不频繁变动。10 天容忍 1 次周级失败 + 缓冲。
+
+### 13. `sync-gcs-cache-last-seen` — GCS Cache 访问日志同步
+
+```sql
+SELECT last_succeeded_at
+FROM cost_job_state
+WHERE job_name = 'sync-gcs-cache-last-seen';
+```
+
+如果 `last_succeeded_at < NOW() - INTERVAL 30 HOUR` → 告警。
+
+> `sync-gcs-cache-last-seen` 将 GCS audit log 数据写入 BigQuery last-seen 表（不在 TiDB 中），每日运行。无法直接查询目标表的新鲜度，只能通过 `cost_job_state` 间接检查。此项依赖 cost-insight 数据库连接。
+
+### 14. `roster_employees` — 员工花名册最新更新时间
+
+```sql
+SELECT MAX(updated_at) AS latest_update
+FROM roster_employees;
+```
+
+如果 `latest_update < NOW() - INTERVAL 30 HOUR` → 告警。
+
+> `roster-sync` 每天 03:00 运行，30 小时容忍下一旦失败可以再等一天。
+
+## 告警输出格式
+
+飞书消息示例：
+
+```
+📊 Daily Data Freshness Check — 2026-06-25
+
+🔴 HIGH (1):
+  • ci_l1_builds: latest build at 2026-06-25 02:15, lag = 6h 30m (threshold: 4h)
+
+🟡 MEDIUM (2):
+  • ci_l1_flaky_issues: last sync at 2026-06-23 02:00, lag = 32h (threshold: 30h)
+  • roster_employees: last update at 2026-06-23 03:00, lag = 31h (threshold: 30h)
+
+✅ All clear (11): ci_l1_pod_lifecycle, archive_error_logs, prow_jobs, github_tickets,
+   ci_l1_pr_events, problem_case_runs, ci-refresh-build-derived,
+   cost_bq_export_summary_daily, cost_attribution_daily,
+   cost_unmatched_resource_daily, sync-gcs-cache-last-seen
+```
+
+## 实现计划
+
+### 新增文件
+
+| 文件 | 用途 |
+|------|------|
+| `ci-dashboard/src/ci_dashboard/jobs/check_data_freshness.py` | 检查逻辑实现 |
+| `ci-dashboard/scripts/render_data_freshness_check_cronjob.sh` | CronJob YAML 渲染脚本 |
+
+### CLI 注册
+
+在 `ci_dashboard/jobs/cli.py` 中注册子命令：
+
+```python
+subparsers.add_parser("check-data-freshness", help="Daily data freshness check and alert")
+```
+
+### CronJob 调度
+
+```
+Schedule: 0 7 * * *  # 每天北京时间 07:00（UTC+8）
+```
+
+早上 7 点执行，这样前一天的数据和凌晨的 daily job 都已经完成，且有足够时间在上班前处理告警。
+
+### 环境变量
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `LARK_ALERT_CHAT_ID` | 告警发送目标飞书群 ID | 必填 |
+| `FRESHNESS_DRY_RUN` | 只打印不发送 | `false` |
+| `FRESHNESS_SKIP_WORK_HOUR_CHECK` | 跳过工作时段判断 | `false` |
+
+## 数据库连接
+
+检查 Job 需要访问两个 MySQL 数据库：
+
+| 数据库 | 检查的表 |
+|--------|---------|
+| ci-dashboard DB | `ci_l1_builds`, `ci_l1_pod_lifecycle`, `ci_job_state`, `ci_l1_flaky_issues`, `ci_l1_pr_events`, `problem_case_runs`, `prow_jobs`, `github_tickets` |
+| cost-insight DB | `cost_bq_export_summary_daily`, `cost_attribution_daily`, `cost_unmatched_resource_daily`, `cost_job_state` |
+| roster DB（可能与 ci-dashboard 同库） | `roster_employees` |
+
+ci-dashboard 和 cost-insight 可能使用不同的 TiDB 实例或同一实例的不同 database。需要确认连接方式（两个 engine 分别连接还是共用一个连接池跨库查询）。
+
+## 待确认项
+
+1. **ee-ops 中的实际 CronJob 频率**：`sync-builds`、`sync-pr-events`、`refresh-build-derived`、所有 cost-insight job 的 CronJob 定义在 ee-ops 仓库。拿到实际频率后可微调容忍阈值。
+2. **飞书群 chat_id**：需要确定告警发送到哪个群。
+3. **夜间降级策略**：`ci_l1_builds`、`ci_l1_pod_lifecycle` 和 `prow_jobs` 在夜间（22:00-08:00）CI 不活跃时可能产生误报。是否需要按时间段降级告警级别？
+4. **ci-dashboard 和 cost-insight 数据库连接**：确认两个数据库是否在同一个 TiDB 实例上，以及 Job 如何配置多库访问。
+5. **`github_tickets` 同步频率**：确认 tibuild/chatops-lark 写入 `github_tickets` 的实际频率（实时/定时），以校准 30h 容忍度是否合理。

--- a/ci-dashboard/scripts/render_data_freshness_check_cronjob.sh
+++ b/ci-dashboard/scripts/render_data_freshness_check_cronjob.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+namespace="apps"
+image="ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:latest"
+cronjob_name="ci-dashboard-data-freshness-check"
+schedule="0 7 * * *"
+time_zone="Asia/Shanghai"
+db_secret="ci-dashboard-db"
+cost_db_secret=""
+lark_webhook_url=""
+dry_run="false"
+log_level="INFO"
+image_pull_policy="IfNotPresent"
+service_account=""
+ca_secret=""
+ca_key="ca.crt"
+cpu_request="250m"
+memory_request="512Mi"
+cpu_limit="1"
+memory_limit="1Gi"
+successful_jobs_history="3"
+failed_jobs_history="3"
+backoff_limit="1"
+active_deadline_seconds="600"
+starting_deadline_seconds="300"
+concurrency_policy="Forbid"
+suspend="false"
+
+usage() {
+  cat <<'EOF'
+Render a Kubernetes CronJob manifest for daily data freshness checks.
+
+Usage:
+  render_data_freshness_check_cronjob.sh [options]
+
+Required:
+  --lark-webhook-url URL        Lark incoming webhook URL for alerts.
+
+Optional:
+  --namespace NAME              Kubernetes namespace. Default: apps
+  --image IMAGE                 Jobs image. Default: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:latest
+  --cronjob-name NAME           CronJob name. Default: ci-dashboard-data-freshness-check
+  --schedule CRON               Cron expression. Default: "0 7 * * *"
+  --time-zone TZ                CronJob timeZone. Default: Asia/Shanghai
+  --db-secret NAME              Secret for CI dashboard DB. Default: ci-dashboard-db
+  --cost-db-secret NAME         Secret for Cost-Insight DB. When omitted, cost checks
+                                are skipped (treated as passed, no alert).
+  --dry-run true|false          Set FRESHNESS_DRY_RUN. Default: false
+  --log-level LEVEL             CI_DASHBOARD_LOG_LEVEL override. Default: INFO
+  --image-pull-policy P         Image pull policy. Default: IfNotPresent
+  --service-account NAME        Optional service account name.
+  --ca-secret NAME              Optional secret containing CA file for TIDB SSL.
+  --ca-key NAME                 Key inside CA secret. Default: ca.crt
+  --cpu-request VALUE           CPU request. Default: 250m
+  --memory-request VALUE        Memory request. Default: 512Mi
+  --cpu-limit VALUE             CPU limit. Default: 1
+  --memory-limit VALUE          Memory limit. Default: 1Gi
+  --successful-history N        successfulJobsHistoryLimit. Default: 3
+  --failed-history N            failedJobsHistoryLimit. Default: 3
+  --backoff-limit N             Job backoffLimit. Default: 1
+  --active-deadline N           activeDeadlineSeconds. Default: 600
+  --starting-deadline N         startingDeadlineSeconds. Default: 300
+  --concurrency-policy VALUE    CronJob concurrencyPolicy. Default: Forbid
+  --suspend true|false          Suspend CronJob. Default: false
+  --help                        Show this help text.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      namespace="${2:-}"; shift 2 ;;
+    --image)
+      image="${2:-}"; shift 2 ;;
+    --cronjob-name)
+      cronjob_name="${2:-}"; shift 2 ;;
+    --schedule)
+      schedule="${2:-}"; shift 2 ;;
+    --time-zone)
+      time_zone="${2:-}"; shift 2 ;;
+    --db-secret)
+      db_secret="${2:-}"; shift 2 ;;
+    --cost-db-secret)
+      cost_db_secret="${2:-}"; shift 2 ;;
+    --lark-webhook-url)
+      lark_webhook_url="${2:-}"; shift 2 ;;
+    --dry-run)
+      dry_run="${2:-}"; shift 2 ;;
+    --log-level)
+      log_level="${2:-}"; shift 2 ;;
+    --image-pull-policy)
+      image_pull_policy="${2:-}"; shift 2 ;;
+    --service-account)
+      service_account="${2:-}"; shift 2 ;;
+    --ca-secret)
+      ca_secret="${2:-}"; shift 2 ;;
+    --ca-key)
+      ca_key="${2:-}"; shift 2 ;;
+    --cpu-request)
+      cpu_request="${2:-}"; shift 2 ;;
+    --memory-request)
+      memory_request="${2:-}"; shift 2 ;;
+    --cpu-limit)
+      cpu_limit="${2:-}"; shift 2 ;;
+    --memory-limit)
+      memory_limit="${2:-}"; shift 2 ;;
+    --successful-history)
+      successful_jobs_history="${2:-}"; shift 2 ;;
+    --failed-history)
+      failed_jobs_history="${2:-}"; shift 2 ;;
+    --backoff-limit)
+      backoff_limit="${2:-}"; shift 2 ;;
+    --active-deadline)
+      active_deadline_seconds="${2:-}"; shift 2 ;;
+    --starting-deadline)
+      starting_deadline_seconds="${2:-}"; shift 2 ;;
+    --concurrency-policy)
+      concurrency_policy="${2:-}"; shift 2 ;;
+    --suspend)
+      suspend="${2:-}"; shift 2 ;;
+    --help|-h)
+      usage; exit 0 ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2; exit 1 ;;
+  esac
+done
+
+# --lark-webhook-url is strongly recommended but not enforced here — the job
+# will print results to stdout when the URL is missing.
+
+service_account_block=""
+if [[ -n "${service_account}" ]]; then
+  service_account_block=$(cat <<EOF
+          serviceAccountName: ${service_account}
+EOF
+  )
+fi
+
+time_zone_block=""
+if [[ -n "${time_zone}" ]]; then
+  time_zone_block=$(cat <<EOF
+  timeZone: ${time_zone}
+EOF
+  )
+fi
+
+ca_env_block=""
+ca_mount_block=""
+ca_volume_block=""
+if [[ -n "${ca_secret}" ]]; then
+  ca_env_block=$(cat <<EOF
+                - name: TIDB_SSL_CA
+                  value: /var/run/ci-dashboard/ssl/${ca_key}
+EOF
+  )
+  ca_mount_block=$(cat <<EOF
+              volumeMounts:
+                - name: tidb-ca
+                  mountPath: /var/run/ci-dashboard/ssl
+                  readOnly: true
+EOF
+  )
+  ca_volume_block=$(cat <<EOF
+          volumes:
+            - name: tidb-ca
+              secret:
+                secretName: ${ca_secret}
+                items:
+                  - key: ${ca_key}
+                    path: ${ca_key}
+EOF
+  )
+fi
+
+# Build env block for cost DB secret
+cost_db_env_block=""
+if [[ -n "${cost_db_secret}" ]]; then
+  cost_db_env_block=$(cat <<EOF
+                - secretRef:
+                    name: ${cost_db_secret}
+EOF
+  )
+fi
+
+lark_env_block=""
+if [[ -n "${lark_webhook_url}" ]]; then
+  lark_env_block=$(cat <<EOF
+                - name: LARK_ALERT_WEBHOOK_URL
+                  value: "${lark_webhook_url}"
+EOF
+  )
+fi
+
+cat <<EOF
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ${cronjob_name}
+  namespace: ${namespace}
+  labels:
+    app.kubernetes.io/name: ci-dashboard-data-freshness-check
+    app.kubernetes.io/part-of: ci-dashboard
+spec:
+  schedule: "${schedule}"
+${time_zone_block}
+  suspend: ${suspend}
+  concurrencyPolicy: ${concurrency_policy}
+  startingDeadlineSeconds: ${starting_deadline_seconds}
+  successfulJobsHistoryLimit: ${successful_jobs_history}
+  failedJobsHistoryLimit: ${failed_jobs_history}
+  jobTemplate:
+    spec:
+      backoffLimit: ${backoff_limit}
+      activeDeadlineSeconds: ${active_deadline_seconds}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ci-dashboard-data-freshness-check
+            app.kubernetes.io/part-of: ci-dashboard
+        spec:
+          restartPolicy: Never
+${service_account_block}
+          containers:
+            - name: check-data-freshness
+              image: ${image}
+              imagePullPolicy: ${image_pull_policy}
+              args:
+                - check-data-freshness
+              envFrom:
+                - secretRef:
+                    name: ${db_secret}
+${cost_db_env_block}
+              env:
+                - name: CI_DASHBOARD_LOG_LEVEL
+                  value: ${log_level}
+                - name: FRESHNESS_DRY_RUN
+                  value: "${dry_run}"
+${lark_env_block}
+${ca_env_block}
+              resources:
+                requests:
+                  cpu: "${cpu_request}"
+                  memory: ${memory_request}
+                limits:
+                  cpu: "${cpu_limit}"
+                  memory: ${memory_limit}
+${ca_mount_block}
+${ca_volume_block}
+EOF

--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import inspect, text
+from sqlalchemy import text
 from sqlalchemy.engine import Connection, Engine
 
 from ci_dashboard.api.queries.base import (
@@ -264,7 +264,6 @@ def get_distinct_flaky_case_counts_by_branch(
     job_scope_sql = f"AND {job_scope_clause}" if job_scope_clause else ""
 
     with engine.begin() as connection:
-        build_key_expr = _build_scope_build_key_expr(connection, "b")
         rows = connection.execute(
             text(
                 f"""
@@ -282,7 +281,7 @@ def get_distinct_flaky_case_counts_by_branch(
                     p.target_branch AS branch,
                     {bucket_expr(connection, "b.start_time", "week")} AS week_start,
                     b.start_time,
-                    {build_key_expr} AS normalized_build_url,
+                    NULLIF(b.normalized_build_url, '') AS normalized_build_url,
                     UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) AS cloud_phase
                   FROM ci_l1_builds b
                   JOIN target_prs p
@@ -290,7 +289,7 @@ def get_distinct_flaky_case_counts_by_branch(
                    AND p.pr_number = b.pr_number
                   WHERE b.repo_full_name = :repo
                     AND b.pr_number IS NOT NULL
-                    AND {build_key_expr} IS NOT NULL
+                    AND NULLIF(b.normalized_build_url, '') IS NOT NULL
                     {job_scope_sql}
                     {_optional_clause(filters.cloud_phase, "AND UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) = :cloud_phase")}
                     {_optional_clause(filters.start_date, "AND b.start_time >= :start_time_from")}
@@ -1065,7 +1064,6 @@ def _fetch_issue_weekly_rate_rows(
         bind_prefix="job_name",
     )
     job_scope_sql = f"AND {job_scope_clause}" if job_scope_clause else ""
-    build_key_expr = _build_scope_build_key_expr(connection, "b")
     rows = connection.execute(
         text(
             f"""
@@ -1084,7 +1082,7 @@ def _fetch_issue_weekly_rate_rows(
                 p.target_branch AS branch,
                 {bucket_expr(connection, "b.start_time", "week")} AS week_start,
                 b.start_time,
-                {build_key_expr} AS normalized_build_url,
+                NULLIF(b.normalized_build_url, '') AS normalized_build_url,
                 b.job_name,
                 UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) AS cloud_phase
               FROM ci_l1_builds b
@@ -1093,7 +1091,7 @@ def _fetch_issue_weekly_rate_rows(
                AND p.pr_number = b.pr_number
               WHERE b.repo_full_name = :repo
                 AND b.pr_number IS NOT NULL
-                AND {build_key_expr} IS NOT NULL
+                AND NULLIF(b.normalized_build_url, '') IS NOT NULL
                 {job_scope_sql}
                 {_optional_clause(filters.cloud_phase, "AND UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) = :cloud_phase")}
                 {_optional_clause(filters.start_date, "AND b.start_time >= :start_time_from")}
@@ -1241,7 +1239,6 @@ def _fetch_weekly_flaky_case_presence(
         bind_prefix="job_name",
     )
     job_scope_sql = f"AND {job_scope_clause}" if job_scope_clause else ""
-    build_key_expr = _build_scope_build_key_expr(connection, "b")
     rows = connection.execute(
         text(
             f"""
@@ -1259,7 +1256,7 @@ def _fetch_weekly_flaky_case_presence(
                 p.target_branch AS branch,
                 {bucket_expr(connection, "b.start_time", "week")} AS week_start,
                 b.start_time,
-                {build_key_expr} AS normalized_build_url,
+                NULLIF(b.normalized_build_url, '') AS normalized_build_url,
                 UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) AS cloud_phase
               FROM ci_l1_builds b
               JOIN target_prs p
@@ -1267,7 +1264,7 @@ def _fetch_weekly_flaky_case_presence(
                AND p.pr_number = b.pr_number
               WHERE b.repo_full_name = :repo
                 AND b.pr_number IS NOT NULL
-                AND {build_key_expr} IS NOT NULL
+                AND NULLIF(b.normalized_build_url, '') IS NOT NULL
                 {job_scope_sql}
                 {_optional_clause(filters.cloud_phase, "AND UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) = :cloud_phase")}
                 {_optional_clause(filters.start_date, "AND b.start_time >= :start_time_from")}
@@ -1679,26 +1676,6 @@ def _distinct_pr_key_expr(connection: Connection, table_alias: str) -> str:
 
 def _optional_clause(value: object | None, clause: str) -> str:
     return clause if value is not None else ""
-
-
-def _build_scope_build_key_expr(connection: Connection, table_alias: str) -> str:
-    prefix = f"{table_alias}."
-    if _table_has_column(connection, "ci_l1_builds", "normalized_build_url"):
-        return f"NULLIF({prefix}normalized_build_url, '')"
-    return _normalize_case_build_key_expr(connection, f"{prefix}url")
-
-
-_TABLE_COLUMN_CACHE: dict[tuple[str, str], bool] = {}
-
-
-def _table_has_column(connection: Connection, table_name: str, column_name: str) -> bool:
-    cache_key = (table_name, column_name)
-    if cache_key not in _TABLE_COLUMN_CACHE:
-        columns = inspect(connection).get_columns(table_name)
-        _TABLE_COLUMN_CACHE[cache_key] = any(
-            column.get("name") == column_name for column in columns
-        )
-    return _TABLE_COLUMN_CACHE[cache_key]
 
 
 def _normalize_case_build_key_expr(connection: Connection, column_name: str) -> str:

--- a/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/flaky.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import text
+from sqlalchemy import inspect, text
 from sqlalchemy.engine import Connection, Engine
 
 from ci_dashboard.api.queries.base import (
@@ -264,6 +264,7 @@ def get_distinct_flaky_case_counts_by_branch(
     job_scope_sql = f"AND {job_scope_clause}" if job_scope_clause else ""
 
     with engine.begin() as connection:
+        build_key_expr = _build_scope_build_key_expr(connection, "b")
         rows = connection.execute(
             text(
                 f"""
@@ -281,7 +282,7 @@ def get_distinct_flaky_case_counts_by_branch(
                     p.target_branch AS branch,
                     {bucket_expr(connection, "b.start_time", "week")} AS week_start,
                     b.start_time,
-                    b.normalized_build_url,
+                    {build_key_expr} AS normalized_build_url,
                     UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) AS cloud_phase
                   FROM ci_l1_builds b
                   JOIN target_prs p
@@ -289,7 +290,7 @@ def get_distinct_flaky_case_counts_by_branch(
                    AND p.pr_number = b.pr_number
                   WHERE b.repo_full_name = :repo
                     AND b.pr_number IS NOT NULL
-                    AND b.normalized_build_url IS NOT NULL
+                    AND {build_key_expr} IS NOT NULL
                     {job_scope_sql}
                     {_optional_clause(filters.cloud_phase, "AND UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) = :cloud_phase")}
                     {_optional_clause(filters.start_date, "AND b.start_time >= :start_time_from")}
@@ -1064,6 +1065,7 @@ def _fetch_issue_weekly_rate_rows(
         bind_prefix="job_name",
     )
     job_scope_sql = f"AND {job_scope_clause}" if job_scope_clause else ""
+    build_key_expr = _build_scope_build_key_expr(connection, "b")
     rows = connection.execute(
         text(
             f"""
@@ -1082,7 +1084,7 @@ def _fetch_issue_weekly_rate_rows(
                 p.target_branch AS branch,
                 {bucket_expr(connection, "b.start_time", "week")} AS week_start,
                 b.start_time,
-                b.normalized_build_url,
+                {build_key_expr} AS normalized_build_url,
                 b.job_name,
                 UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) AS cloud_phase
               FROM ci_l1_builds b
@@ -1091,7 +1093,7 @@ def _fetch_issue_weekly_rate_rows(
                AND p.pr_number = b.pr_number
               WHERE b.repo_full_name = :repo
                 AND b.pr_number IS NOT NULL
-                AND b.normalized_build_url IS NOT NULL
+                AND {build_key_expr} IS NOT NULL
                 {job_scope_sql}
                 {_optional_clause(filters.cloud_phase, "AND UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) = :cloud_phase")}
                 {_optional_clause(filters.start_date, "AND b.start_time >= :start_time_from")}
@@ -1239,6 +1241,7 @@ def _fetch_weekly_flaky_case_presence(
         bind_prefix="job_name",
     )
     job_scope_sql = f"AND {job_scope_clause}" if job_scope_clause else ""
+    build_key_expr = _build_scope_build_key_expr(connection, "b")
     rows = connection.execute(
         text(
             f"""
@@ -1256,7 +1259,7 @@ def _fetch_weekly_flaky_case_presence(
                 p.target_branch AS branch,
                 {bucket_expr(connection, "b.start_time", "week")} AS week_start,
                 b.start_time,
-                b.normalized_build_url,
+                {build_key_expr} AS normalized_build_url,
                 UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) AS cloud_phase
               FROM ci_l1_builds b
               JOIN target_prs p
@@ -1264,7 +1267,7 @@ def _fetch_weekly_flaky_case_presence(
                AND p.pr_number = b.pr_number
               WHERE b.repo_full_name = :repo
                 AND b.pr_number IS NOT NULL
-                AND b.normalized_build_url IS NOT NULL
+                AND {build_key_expr} IS NOT NULL
                 {job_scope_sql}
                 {_optional_clause(filters.cloud_phase, "AND UPPER(COALESCE(NULLIF(b.cloud_phase, ''), 'IDC')) = :cloud_phase")}
                 {_optional_clause(filters.start_date, "AND b.start_time >= :start_time_from")}
@@ -1676,6 +1679,26 @@ def _distinct_pr_key_expr(connection: Connection, table_alias: str) -> str:
 
 def _optional_clause(value: object | None, clause: str) -> str:
     return clause if value is not None else ""
+
+
+def _build_scope_build_key_expr(connection: Connection, table_alias: str) -> str:
+    prefix = f"{table_alias}."
+    if _table_has_column(connection, "ci_l1_builds", "normalized_build_url"):
+        return f"NULLIF({prefix}normalized_build_url, '')"
+    return _normalize_case_build_key_expr(connection, f"{prefix}url")
+
+
+_TABLE_COLUMN_CACHE: dict[tuple[str, str], bool] = {}
+
+
+def _table_has_column(connection: Connection, table_name: str, column_name: str) -> bool:
+    cache_key = (table_name, column_name)
+    if cache_key not in _TABLE_COLUMN_CACHE:
+        columns = inspect(connection).get_columns(table_name)
+        _TABLE_COLUMN_CACHE[cache_key] = any(
+            column.get("name") == column_name for column in columns
+        )
+    return _TABLE_COLUMN_CACHE[cache_key]
 
 
 def _normalize_case_build_key_expr(connection: Connection, column_name: str) -> str:

--- a/ci-dashboard/src/ci_dashboard/jobs/check_data_freshness.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/check_data_freshness.py
@@ -1,0 +1,532 @@
+"""Daily data freshness check for ci-dashboard and cost-insight core tables.
+
+Runs a battery of SQL queries against the ci-dashboard and cost-insight
+databases, compares each table's latest timestamp against a configured
+lag threshold, and sends a Lark incoming-webhook alert for any violations.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Callable
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+
+from ci_dashboard.common.config import Settings
+from ci_dashboard.common.db import build_engine, install_sqlite_functions
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Check definition
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Check:
+    """A single freshness check against a database table or job_state row."""
+
+    name: str  # human-readable label, e.g. "ci_l1_builds"
+    level: str  # "HIGH" | "MEDIUM" | "LOW"
+    description: str
+    # Threshold: if the observed lag exceeds this, the check fails.
+    threshold_description: str  # e.g. "4 hours"
+    # SQL that returns ONE ROW with a single column: the latest timestamp (or count).
+    sql: str
+    # Which DB engine to use: "ci" | "cost"
+    db: str = "ci"
+    # If True, the SQL returns a COUNT rather than a timestamp — check value > 0 → fail.
+    is_count_check: bool = False
+    # Optional: override the formatter for the failure message.
+    # Receives the raw query result value.
+    format_failure: Callable[[Any], str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Check definitions — one per monitored table / pipeline
+# ---------------------------------------------------------------------------
+
+CHECKS: list[Check] = [
+    # --- CI Dashboard tables ---
+    Check(
+        name="ci_l1_builds",
+        level="HIGH",
+        description="Latest build start_time in ci_l1_builds",
+        threshold_description="4 hours",
+        sql="SELECT MAX(start_time) FROM ci_l1_builds WHERE start_time IS NOT NULL",
+        db="ci",
+    ),
+    Check(
+        name="ci_l1_pod_lifecycle",
+        level="HIGH",
+        description="Latest pod event time in ci_l1_pod_lifecycle",
+        threshold_description="4 hours",
+        sql="SELECT MAX(last_event_at) FROM ci_l1_pod_lifecycle WHERE last_event_at IS NOT NULL",
+        db="ci",
+    ),
+    Check(
+        name="archive_error_logs",
+        level="MEDIUM",
+        description="Pending error-log archivals within the last 4 hours",
+        threshold_description="0 pending",
+        sql=(
+            "SELECT COUNT(*) FROM ci_l1_builds"
+            " WHERE state IN ('failure','error','timeout','aborted')"
+            " AND log_gcs_uri IS NULL"
+            " AND completion_time > NOW() - INTERVAL 4 HOUR"
+        ),
+        db="ci",
+        is_count_check=True,
+    ),
+    Check(
+        name="prow_jobs",
+        level="HIGH",
+        description="Latest Prow job startTime in prow_jobs",
+        threshold_description="4 hours",
+        sql="SELECT MAX(startTime) FROM prow_jobs WHERE startTime IS NOT NULL",
+        db="ci",
+    ),
+    Check(
+        name="github_tickets",
+        level="MEDIUM",
+        description="Latest updated_at in github_tickets",
+        threshold_description="30 hours",
+        sql="SELECT MAX(updated_at) FROM github_tickets",
+        db="ci",
+    ),
+    Check(
+        name="ci_l1_flaky_issues",
+        level="MEDIUM",
+        description="ci-sync-flaky-issues job last succeeded at",
+        threshold_description="30 hours",
+        sql=(
+            "SELECT last_succeeded_at FROM ci_job_state"
+            " WHERE job_name = 'ci-sync-flaky-issues'"
+        ),
+        db="ci",
+    ),
+    Check(
+        name="ci_l1_pr_events",
+        level="MEDIUM",
+        description="Latest PR event_time in ci_l1_pr_events",
+        threshold_description="4 hours",
+        sql="SELECT MAX(event_time) FROM ci_l1_pr_events WHERE event_time IS NOT NULL",
+        db="ci",
+    ),
+    Check(
+        name="problem_case_runs",
+        level="MEDIUM",
+        description="Latest report_time in problem_case_runs",
+        threshold_description="4 hours",
+        sql="SELECT MAX(report_time) FROM problem_case_runs WHERE report_time IS NOT NULL",
+        db="ci",
+    ),
+    Check(
+        name="ci_l1_builds_derived",
+        level="MEDIUM",
+        description="ci-refresh-build-derived job last succeeded at",
+        threshold_description="4 hours",
+        sql=(
+            "SELECT last_succeeded_at FROM ci_job_state"
+            " WHERE job_name = 'ci-refresh-build-derived'"
+        ),
+        db="ci",
+    ),
+    # --- Cost-Insight tables ---
+    Check(
+        name="cost_bq_export_summary_daily",
+        level="MEDIUM",
+        description="Latest GCP usage_date in cost_bq_export_summary_daily",
+        threshold_description="4 days",
+        sql=(
+            "SELECT MAX(usage_date) FROM cost_bq_export_summary_daily"
+            " WHERE vendor = 'GCP'"
+        ),
+        db="cost",
+    ),
+    Check(
+        name="cost_attribution_daily",
+        level="MEDIUM",
+        description="Latest usage_date in cost_attribution_daily",
+        threshold_description="4 days",
+        sql="SELECT MAX(usage_date) FROM cost_attribution_daily",
+        db="cost",
+    ),
+    Check(
+        name="cost_unmatched_resource_daily",
+        level="LOW",
+        description="Latest usage_date in cost_unmatched_resource_daily",
+        threshold_description="10 days",
+        sql="SELECT MAX(usage_date) FROM cost_unmatched_resource_daily",
+        db="cost",
+    ),
+    Check(
+        name="sync_gcs_cache_last_seen",
+        level="LOW",
+        description="sync-gcs-cache-last-seen job last succeeded at",
+        threshold_description="30 hours",
+        sql=(
+            "SELECT last_succeeded_at FROM cost_job_state"
+            " WHERE job_name = 'sync-gcs-cache-last-seen'"
+        ),
+        db="cost",
+    ),
+    # --- Roster tables ---
+    Check(
+        name="roster_employees",
+        level="MEDIUM",
+        description="Latest updated_at in roster_employees",
+        threshold_description="30 hours",
+        sql="SELECT MAX(updated_at) FROM roster_employees",
+        db="ci",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Threshold helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_timestamp(raw: str) -> datetime:
+    """Parse an ISO-ish timestamp string into a datetime.
+
+    Handles the TEXT representations that SQLite returns for DATETIME /
+    DATE columns as well as standard MySQL formats.
+    """
+    # Try common ISO variants
+    for fmt in (
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%d",
+    ):
+        try:
+            dt = datetime.strptime(raw, fmt)
+            return dt
+        except ValueError:
+            continue
+    # Last resort: try fromisoformat
+    return datetime.fromisoformat(raw)
+
+
+def _threshold_timedelta(threshold_description: str) -> timedelta:
+    """Parse a threshold string like '4 hours', '30 hours', '4 days', '10 days'."""
+    import re
+
+    pattern = r"(\d+)\s*(hour|hours|day|days)"
+    m = re.match(pattern, threshold_description.lower())
+    if not m:
+        raise ValueError(f"Unsupported threshold format: {threshold_description!r}")
+    value = int(m.group(1))
+    unit = m.group(2)
+    if unit in ("hour", "hours"):
+        return timedelta(hours=value)
+    return timedelta(days=value)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    check: Check
+    passed: bool
+    value: Any  # raw DB result
+    lag_description: str  # human-readable lag, e.g. "6h 30m" or "—"
+    error: str | None = None
+
+
+@dataclass
+class Report:
+    timestamp: datetime
+    results: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def failed(self) -> list[CheckResult]:
+        return [r for r in self.results if not r.passed]
+
+    @property
+    def passed_all(self) -> bool:
+        return not self.failed
+
+
+# ---------------------------------------------------------------------------
+# Engine helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_engine_for_db(db: str, settings: Settings) -> Engine | None:
+    """Build a SQLAlchemy engine for the named database ('ci' or 'cost').
+
+    Returns None when *db=='cost'* and no cost-specific connection is
+    configured, so callers can skip cost checks gracefully instead of
+    accidentally querying the CI database.
+    """
+    if db == "cost":
+        url = os.getenv("COST_INSIGHT_DB_URL")
+        if url:
+            from sqlalchemy import create_engine as _ce
+
+            engine = _ce(url, pool_pre_ping=True, future=True)
+            install_sqlite_functions(engine)
+            return engine
+
+        # Require explicit cost-insight env vars; do NOT fall back to CI DB.
+        cost_user = os.getenv("COST_INSIGHT_TIDB_USER")
+        if not cost_user:
+            return None
+
+        from sqlalchemy.engine import URL as _URL
+        from sqlalchemy import create_engine as _ce
+
+        url_obj = _URL.create(
+            drivername="mysql+pymysql",
+            username=cost_user,
+            password=os.environ["COST_INSIGHT_TIDB_PASSWORD"],
+            host=os.environ.get("COST_INSIGHT_TIDB_HOST", os.environ.get("TIDB_HOST", "")),
+            port=int(os.environ.get("COST_INSIGHT_TIDB_PORT", os.environ.get("TIDB_PORT", "4000"))),
+            database=os.environ.get("COST_INSIGHT_TIDB_DB", os.environ.get("TIDB_DB", "")),
+            query={"charset": "utf8mb4"},
+        )
+        engine = _ce(url_obj, pool_pre_ping=True, pool_size=5, max_overflow=5, pool_timeout=30, future=True)
+        install_sqlite_functions(engine)
+        return engine
+    return build_engine(settings)
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def run_check(connection: Connection, check: Check) -> CheckResult:
+    """Execute a single freshness check and return the result."""
+    try:
+        row = connection.execute(text(check.sql)).fetchone()
+    except Exception as exc:
+        logger.error("Check %s failed with error: %s", check.name, exc)
+        return CheckResult(
+            check=check,
+            passed=False,
+            value=None,
+            lag_description="query error",
+            error=str(exc),
+        )
+
+    if row is None:
+        return CheckResult(
+            check=check,
+            passed=False,
+            value=None,
+            lag_description="no data",
+            error="query returned no rows",
+        )
+
+    raw_value = row[0]
+
+    if raw_value is None:
+        return CheckResult(
+            check=check,
+            passed=False,
+            value=None,
+            lag_description="NULL — no data yet",
+            error="no timestamp found",
+        )
+
+    if check.is_count_check:
+        count = int(raw_value)
+        passed = count == 0
+        return CheckResult(
+            check=check,
+            passed=passed,
+            value=count,
+            lag_description=f"{count} pending",
+            error=None if passed else f"{count} rows pending archival",
+        )
+
+    # Timestamp check — coerce string / date → datetime so subtraction works.
+    if isinstance(raw_value, str):
+        raw_value = _parse_timestamp(raw_value)
+    elif isinstance(raw_value, date) and not isinstance(raw_value, datetime):
+        raw_value = datetime.combine(raw_value, datetime.min.time())
+    now = datetime.now()
+
+    lag: timedelta = now - raw_value  # type: ignore[operator]
+    threshold = _threshold_timedelta(check.threshold_description)
+
+    total_seconds = int(lag.total_seconds())
+    if total_seconds < 0:
+        total_seconds = 0
+
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes = remainder // 60
+    if hours >= 24:
+        days = hours // 24
+        hours = hours % 24
+        lag_desc = f"{days}d {hours}h {minutes}m"
+    else:
+        lag_desc = f"{hours}h {minutes}m"
+
+    passed = lag <= threshold
+
+    if check.format_failure:
+        lag_desc = check.format_failure(raw_value)
+
+    return CheckResult(
+        check=check,
+        passed=passed,
+        value=raw_value,
+        lag_description=lag_desc,
+    )
+
+
+def run_all_checks(ci_engine: Engine, cost_engine: Engine | None) -> Report:
+    """Run all freshness checks and return a Report."""
+    results: list[CheckResult] = []
+
+    with ci_engine.begin() as ci_conn:
+        if cost_engine:
+            with cost_engine.begin() as cost_conn:
+                for check in CHECKS:
+                    conn = cost_conn if check.db == "cost" else ci_conn
+                    result = run_check(conn, check)
+                    results.append(result)
+        else:
+            for check in CHECKS:
+                if check.db == "cost":
+                    results.append(
+                        CheckResult(
+                            check=check,
+                            passed=True,
+                            value=None,
+                            lag_description="skipped — no cost db configured",
+                        )
+                    )
+                    continue
+                result = run_check(ci_conn, check)
+                results.append(result)
+
+    return Report(
+        timestamp=datetime.now(),
+        results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Alert formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_lark_message(report: Report) -> str:
+    """Format the freshness report as a Lark incoming-webhook card message."""
+    date_str = report.timestamp.strftime("%Y-%m-%d %H:%M UTC")
+
+    failed_by_level: dict[str, list[CheckResult]] = {}
+    for r in report.failed:
+        failed_by_level.setdefault(r.check.level, []).append(r)
+
+    # Build blocks for each severity level
+    blocks: list[str] = []
+
+    if not report.failed:
+        blocks.append(f"✅ All {len(report.results)} checks passed — all data pipelines are fresh.")
+    else:
+        blocks.append(f"📊 Daily Data Freshness Check — {date_str}\n")
+
+        for level in ("HIGH", "MEDIUM", "LOW"):
+            items = failed_by_level.get(level, [])
+            if not items:
+                continue
+            emoji = {"HIGH": "🔴", "MEDIUM": "🟡", "LOW": "⚪"}.get(level, "❓")
+            blocks.append(f"{emoji} {level} ({len(items)}):")
+            for r in items:
+                blocks.append(
+                    f"  • {r.check.description}: {r.lag_description}"
+                    f" (threshold: {r.check.threshold_description})"
+                )
+
+        passed_count = len(report.results) - len(report.failed)
+        if passed_count:
+            passed_names = [r.check.name for r in report.results if r.passed]
+            blocks.append(f"\n✅ All clear ({passed_count}): {', '.join(passed_names)}")
+
+    return "\n".join(blocks)
+
+
+def _send_lark_alert(webhook_url: str, text: str) -> None:
+    """Send a text message to a Lark group via incoming webhook."""
+    payload = json.dumps({"msg_type": "text", "content": {"text": text}}).encode("utf-8")
+    req = urllib.request.Request(
+        webhook_url,
+        data=payload,
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read().decode("utf-8")
+            logger.info("Lark webhook response: %s", body)
+    except Exception as exc:
+        logger.error("Failed to send Lark alert: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run_check_data_freshness(settings: Settings) -> Report:
+    """Entry point called from the CLI.
+
+    Builds engines, runs all checks, and sends a Lark alert if configured.
+    """
+    ci_engine = build_engine(settings)
+    cost_engine = _build_engine_for_db("cost", settings)
+    if cost_engine is None:
+        logger.warning(
+            "Cost-Insight database not configured — cost checks will be skipped."
+        )
+
+    try:
+        report = run_all_checks(ci_engine, cost_engine)
+    finally:
+        ci_engine.dispose()
+        if cost_engine:
+            cost_engine.dispose()
+
+    webhook_url = os.getenv("LARK_ALERT_WEBHOOK_URL")
+    dry_run = os.getenv("FRESHNESS_DRY_RUN", "false").lower() == "true"
+
+    message = _format_lark_message(report)
+
+    if dry_run:
+        logger.info("DRY RUN — would send:\n%s", message)
+        print(message)
+    elif webhook_url:
+        _send_lark_alert(webhook_url, message)
+        logger.info("Alert sent: %d/%d checks failed", len(report.failed), len(report.results))
+    else:
+        logger.warning("LARK_ALERT_WEBHOOK_URL not set — alert not sent")
+        print(message)
+
+    # Log summary
+    for r in report.failed:
+        logger.warning(
+            "CHECK FAILED [%s] %s: %s (threshold: %s)",
+            r.check.level,
+            r.check.name,
+            r.lag_description,
+            r.check.threshold_description,
+        )
+
+    return report

--- a/ci-dashboard/src/ci_dashboard/jobs/check_data_freshness.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/check_data_freshness.py
@@ -244,6 +244,7 @@ class CheckResult:
     value: Any  # raw DB result
     lag_description: str  # human-readable lag, e.g. "6h 30m" or "—"
     error: str | None = None
+    skipped: bool = False  # True when the check was not executed (e.g. no DB)
 
 
 @dataclass
@@ -253,7 +254,7 @@ class Report:
 
     @property
     def failed(self) -> list[CheckResult]:
-        return [r for r in self.results if not r.passed]
+        return [r for r in self.results if not r.passed and not r.skipped]
 
     @property
     def passed_all(self) -> bool:
@@ -410,6 +411,7 @@ def run_all_checks(ci_engine: Engine, cost_engine: Engine | None) -> Report:
                             passed=True,
                             value=None,
                             lag_description="skipped — no cost db configured",
+                            skipped=True,
                         )
                     )
                     continue
@@ -435,11 +437,17 @@ def _format_lark_message(report: Report) -> str:
     for r in report.failed:
         failed_by_level.setdefault(r.check.level, []).append(r)
 
-    # Build blocks for each severity level
+    passed = [r for r in report.results if r.passed and not r.skipped]
+    skipped = [r for r in report.results if r.skipped]
+
     blocks: list[str] = []
 
     if not report.failed:
-        blocks.append(f"✅ All {len(report.results)} checks passed — all data pipelines are fresh.")
+        parts = [f"✅ All {len(passed)} checks passed"]
+        if skipped:
+            parts.append(f"{len(skipped)} skipped")
+        parts.append("— all data pipelines are fresh.")
+        blocks.append(" ".join(parts))
     else:
         blocks.append(f"📊 Daily Data Freshness Check — {date_str}\n")
 
@@ -455,10 +463,13 @@ def _format_lark_message(report: Report) -> str:
                     f" (threshold: {r.check.threshold_description})"
                 )
 
-        passed_count = len(report.results) - len(report.failed)
+        passed_count = len(passed)
         if passed_count:
-            passed_names = [r.check.name for r in report.results if r.passed]
-            blocks.append(f"\n✅ All clear ({passed_count}): {', '.join(passed_names)}")
+            passed_names = [r.check.name for r in passed]
+            blocks.append(f"\n✅ Passed ({passed_count}): {', '.join(passed_names)}")
+        if skipped:
+            skipped_names = [r.check.name for r in skipped]
+            blocks.append(f"⏭️ Skipped ({len(skipped)}): {', '.join(skipped_names)}")
 
     return "\n".join(blocks)
 

--- a/ci-dashboard/src/ci_dashboard/jobs/cli.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/cli.py
@@ -26,6 +26,7 @@ from ci_dashboard.jobs.sync_flaky_issues import (
     run_backfill_flaky_issue_pr_links,
     run_sync_flaky_issues,
 )
+from ci_dashboard.jobs.check_data_freshness import run_check_data_freshness
 from ci_dashboard.jobs.pod_watcher import run_watch_pods
 from ci_dashboard.jobs.sync_pods import run_reconcile_pod_linkage_for_time_window, run_sync_pods
 
@@ -222,6 +223,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--end-date",
         type=_parse_iso_date,
         help="Inclusive build date in YYYY-MM-DD; defaults to open-ended",
+    )
+    subparsers.add_parser(
+        "check-data-freshness",
+        help="Daily data freshness check and Lark alert",
     )
     return parser
 
@@ -466,6 +471,19 @@ def main() -> int:
             },
         )
         return 0
+
+    if args.command == "check-data-freshness":
+        report = run_check_data_freshness(settings)
+        exit_code = 0 if report.passed_all else 1
+        logging.getLogger(__name__).info(
+            "check-data-freshness finished",
+            extra={
+                "passed": len(report.results) - len(report.failed),
+                "failed": len(report.failed),
+                "total": len(report.results),
+            },
+        )
+        return exit_code
 
     if args.command == "backfill-range":
         if args.end_date is not None and args.start_date > args.end_date:

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 from ci_dashboard.api.dependencies import get_engine
 from ci_dashboard.api.main import app, create_app
 from ci_dashboard.api.queries import cost as cost_queries
+from ci_dashboard.api.queries import flaky as flaky_queries
 from ci_dashboard.api.queries import pages as page_queries
 from ci_dashboard.api.queries.base import CommonFilters
 from ci_dashboard.jobs.build_url_matcher import normalize_build_url
@@ -2151,6 +2152,33 @@ def test_page_routes(api_client: TestClient) -> None:
     assert flaky_with_open_issues_body["failure_category_share"] == flaky_body["failure_category_share"]
     assert flaky_with_open_issues_body["failure_category_trend"] == flaky_body["failure_category_trend"]
     assert flaky_with_open_issues_body["period_comparison"] == flaky_body["period_comparison"]
+
+
+def test_flaky_page_falls_back_to_build_url_when_build_key_column_is_missing(
+    api_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(flaky_queries, "_table_has_column", lambda *_args, **_kwargs: False)
+
+    flaky = api_client.get(
+        "/api/v1/pages/flaky",
+        params={
+            "repo": "pingcap/tidb",
+            "branch": "master",
+            "start_date": "2026-04-10",
+            "end_date": "2026-04-11",
+        },
+    )
+
+    assert flaky.status_code == 200
+    flaky_body = flaky.json()
+    # Two flaky problem-case runs (TestCaseAlpha, TestCaseBeta) seeded by the
+    # api_client fixture, both on pingcap/tidb master → 2 distinct cases.
+    assert flaky_body["distinct_flaky_case_counts"]["rows"] == [
+        {"branch": "master", "values": [2]}
+    ]
+    # TestCaseAlpha has issue #66726; 1/1 flaky occurrence is issue-filtered.
+    assert flaky_body["issue_case_weekly_rates"]["rows"][0]["cells"] == ["100.00% (1/1)"]
 
 
 def test_cost_page_route(sqlite_engine, api_client: TestClient) -> None:

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -12,7 +12,6 @@ from sqlalchemy import text
 from ci_dashboard.api.dependencies import get_engine
 from ci_dashboard.api.main import app, create_app
 from ci_dashboard.api.queries import cost as cost_queries
-from ci_dashboard.api.queries import flaky as flaky_queries
 from ci_dashboard.api.queries import pages as page_queries
 from ci_dashboard.api.queries.base import CommonFilters
 from ci_dashboard.jobs.build_url_matcher import normalize_build_url
@@ -2152,33 +2151,6 @@ def test_page_routes(api_client: TestClient) -> None:
     assert flaky_with_open_issues_body["failure_category_share"] == flaky_body["failure_category_share"]
     assert flaky_with_open_issues_body["failure_category_trend"] == flaky_body["failure_category_trend"]
     assert flaky_with_open_issues_body["period_comparison"] == flaky_body["period_comparison"]
-
-
-def test_flaky_page_falls_back_to_build_url_when_build_key_column_is_missing(
-    api_client: TestClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(flaky_queries, "_table_has_column", lambda *_args, **_kwargs: False)
-
-    flaky = api_client.get(
-        "/api/v1/pages/flaky",
-        params={
-            "repo": "pingcap/tidb",
-            "branch": "master",
-            "start_date": "2026-04-10",
-            "end_date": "2026-04-11",
-        },
-    )
-
-    assert flaky.status_code == 200
-    flaky_body = flaky.json()
-    # Two flaky problem-case runs (TestCaseAlpha, TestCaseBeta) seeded by the
-    # api_client fixture, both on pingcap/tidb master → 2 distinct cases.
-    assert flaky_body["distinct_flaky_case_counts"]["rows"] == [
-        {"branch": "master", "values": [2]}
-    ]
-    # TestCaseAlpha has issue #66726; 1/1 flaky occurrence is issue-filtered.
-    assert flaky_body["issue_case_weekly_rates"]["rows"][0]["cells"] == ["100.00% (1/1)"]
 
 
 def test_cost_page_route(sqlite_engine, api_client: TestClient) -> None:

--- a/ci-dashboard/tests/jobs/test_check_data_freshness.py
+++ b/ci-dashboard/tests/jobs/test_check_data_freshness.py
@@ -410,7 +410,7 @@ class TestRunAllChecks:
 
         for r in report.results:
             if r.check.db == "cost":
-                assert r.passed is True
+                assert r.skipped is True
                 assert "skipped" in r.lag_description
 
     def test_runs_all_checks_with_cost_engine(
@@ -494,6 +494,7 @@ class TestFormatLarkMessage:
 
         assert "✅" in msg
         assert "2 checks passed" in msg
+        assert "skipped" not in msg
 
     def test_formats_high_medium_low(self) -> None:
         results = [
@@ -532,7 +533,55 @@ class TestFormatLarkMessage:
         assert "⚪" in msg
         assert "LOW" in msg
         assert "ci_l1_builds" in msg
-        assert "✅ All clear" in msg
+        assert "✅ Passed" in msg
+
+    def test_failure_report_with_skipped(self) -> None:
+        """⏭️ appears in failure reports when some checks were skipped."""
+        results = [
+            CheckResult(
+                check=CHECKS_BY_NAME["ci_l1_builds"],
+                passed=False,
+                value=datetime(2026, 6, 25, 2, 0),
+                lag_description="5h 0m",
+            ),
+            CheckResult(
+                check=CHECKS_BY_NAME["cost_attribution_daily"],
+                passed=True,
+                value=None,
+                lag_description="skipped — no cost db configured",
+                skipped=True,
+            ),
+        ]
+        report = Report(timestamp=datetime(2026, 6, 25, 7, 0), results=results)
+        msg = _format_lark_message(report)
+
+        assert "⏭️" in msg
+        assert "Skipped (1)" in msg
+
+    def test_all_clear_with_skipped(self) -> None:
+        """When some checks are skipped, the message distinguishes them."""
+        results = [
+            CheckResult(
+                check=CHECKS_BY_NAME["ci_l1_builds"],
+                passed=True,
+                value=datetime.now(),
+                lag_description="0h 0m",
+            ),
+            CheckResult(
+                check=CHECKS_BY_NAME["cost_attribution_daily"],
+                passed=True,
+                value=None,
+                lag_description="skipped — no cost db configured",
+                skipped=True,
+            ),
+        ]
+        report = Report(timestamp=datetime(2026, 6, 25, 7, 0), results=results)
+        msg = _format_lark_message(report)
+
+        assert "✅" in msg
+        assert "1 checks passed" in msg
+        assert "1 skipped" in msg
+        assert "⏭️" not in msg  # only appears in failure report, not all-clear
 
 
 # ---------------------------------------------------------------------------
@@ -658,16 +707,21 @@ class TestRunCheckDataFreshness:
         cost_results = [r for r in report.results if r.check.db == "cost"]
         assert len(cost_results) > 0
         for r in cost_results:
-            assert r.passed is True
+            assert r.skipped is True
             assert "skipped" in r.lag_description
         # CI checks with seeded data should all pass (except archive_error_logs
         # which uses MySQL-specific NOW() - INTERVAL syntax, unsupported in SQLite).
         ci_failures = [
             r for r in report.results
-            if r.check.db == "ci" and not r.passed
+            if r.check.db == "ci" and not r.passed and not r.skipped
             and r.check.name != "archive_error_logs"
         ]
         assert ci_failures == [], f"Unexpected CI failures: {ci_failures}"
+        # skipped checks don't count as failures, but archive_error_logs
+        # fails in SQLite (NOW() - INTERVAL unsupported), so passed_all is
+        # False for that single SQLite-only failure.
+        assert len(report.failed) == 1
+        assert report.failed[0].check.name == "archive_error_logs"
 
 
 # ---------------------------------------------------------------------------

--- a/ci-dashboard/tests/jobs/test_check_data_freshness.py
+++ b/ci-dashboard/tests/jobs/test_check_data_freshness.py
@@ -1,0 +1,1091 @@
+"""Tests for daily data freshness check job."""
+
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from ci_dashboard.common.config import Settings
+from ci_dashboard.jobs.check_data_freshness import (
+    CHECKS,
+    Check,
+    CheckResult,
+    Report,
+    _build_engine_for_db,
+    _format_lark_message,
+    _threshold_timedelta,
+    run_all_checks,
+    run_check,
+    run_check_data_freshness,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CHECKS_BY_NAME: dict[str, Check] = {c.name: c for c in CHECKS}
+
+
+def _exec(engine: Engine, sql: str, params: dict | None = None) -> None:
+    """Execute a SQL statement within a short-lived transaction."""
+    with engine.begin() as conn:
+        conn.execute(text(sql), params or {})
+
+
+def _create_missing_tables(engine: Engine) -> None:
+    """Create tables needed by freshness checks that are not in conftest."""
+    _exec(
+        engine,
+        """
+        CREATE TABLE IF NOT EXISTS cost_bq_export_summary_daily (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          vendor TEXT NOT NULL,
+          account_id TEXT NOT NULL,
+          billing_account_id TEXT NULL,
+          export_partition_date TEXT NOT NULL,
+          usage_date TEXT NOT NULL,
+          service_name TEXT NULL,
+          sku_name TEXT NULL,
+          org TEXT NULL,
+          repo TEXT NULL,
+          author TEXT NULL,
+          list_cost REAL NULL,
+          effective_cost REAL NULL,
+          credit_amount REAL NULL,
+          net_cost REAL NULL,
+          source_export_time TEXT NULL,
+          source_row_hash TEXT NOT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+    )
+    _exec(
+        engine,
+        """
+        CREATE TABLE IF NOT EXISTS cost_job_state (
+          job_name TEXT PRIMARY KEY,
+          watermark_json TEXT NOT NULL,
+          last_started_at TEXT NULL,
+          last_succeeded_at TEXT NULL,
+          last_status TEXT NOT NULL DEFAULT 'never',
+          last_error TEXT NULL,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+    )
+    _exec(
+        engine,
+        """
+        CREATE TABLE IF NOT EXISTS roster_employees (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          lark_id TEXT NOT NULL UNIQUE,
+          name TEXT NOT NULL,
+          en_name TEXT NULL,
+          employee_no TEXT NULL,
+          email TEXT NULL UNIQUE,
+          github_id TEXT NULL UNIQUE,
+          join_time TEXT NULL,
+          manager_id INTEGER NULL,
+          manager_path TEXT NULL,
+          group_id INTEGER NULL,
+          group_path TEXT NULL,
+          is_active INTEGER NOT NULL DEFAULT 1,
+          last_seen_at TEXT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_engine(sqlite_engine: Engine) -> Engine:
+    _create_missing_tables(sqlite_engine)
+    return sqlite_engine
+
+
+def _seed_all_checks(engine: Engine) -> None:
+    """Insert minimal data so every freshness check passes."""
+    now = datetime.now()
+    today = date.today()
+
+    _exec(
+        engine,
+        "INSERT INTO ci_l1_builds (state, start_time) VALUES ('success', :ts)",
+        {"ts": (now - timedelta(hours=1)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO ci_l1_pod_lifecycle (source_project, source_prow_job_id, last_event_at)"
+        " VALUES ('proj', 'pj1', :ts)",
+        {"ts": (now - timedelta(hours=1)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO prow_jobs (prowJobId, namespace, jobName, type, state, org, repo, url, startTime)"
+        " VALUES ('pj1', 'ns', 'j', 'presubmit', 'success', 'o', 'r', 'http://x', :ts)",
+        {"ts": (now - timedelta(hours=2)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO github_tickets (type, repo, number, updated_at)"
+        " VALUES ('issue', 'pingcap/tidb', 1, :ts)",
+        {"ts": (now - timedelta(hours=3)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT OR REPLACE INTO ci_job_state"
+        " (job_name, watermark_json, last_succeeded_at, last_status)"
+        " VALUES ('ci-sync-flaky-issues', '{}', :ts, 'succeeded')",
+        {"ts": (now - timedelta(hours=5)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT OR REPLACE INTO ci_job_state"
+        " (job_name, watermark_json, last_succeeded_at, last_status)"
+        " VALUES ('ci-refresh-build-derived', '{}', :ts, 'succeeded')",
+        {"ts": (now - timedelta(hours=2)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO ci_l1_pr_events (repo, pr_number, event_key, event_time, event_type)"
+        " VALUES ('pingcap/tidb', 1, 'k1', :ts, 'committed')",
+        {"ts": (now - timedelta(hours=1)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO problem_case_runs"
+        " (repo, case_name, build_url, flaky, timecost_ms, report_time)"
+        " VALUES ('pingcap/tidb', 'TestX', 'http://x', 0, 100, :ts)",
+        {"ts": (now - timedelta(hours=1)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO cost_bq_export_summary_daily"
+        " (vendor, account_id, export_partition_date, usage_date, source_row_hash)"
+        " VALUES ('GCP', 'acct', :ep, :ud, 'h')",
+        {"ep": today.isoformat(), "ud": today.isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO cost_attribution_daily"
+        " (usage_date, vendor, account_id, attribution_key,"
+        "  attribution_source, attribution_status, dimension_hash)"
+        " VALUES (:d, 'GCP', 'acct', 'k', 'src', 'ok', 'h')",
+        {"d": today.isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO cost_unmatched_resource_daily"
+        " (vendor, account_id, export_partition_date, usage_date, resource_name, source_row_hash)"
+        " VALUES ('GCP', 'acct', :ep, :ud, 'res', 'h')",
+        {"ep": (today - timedelta(days=5)).isoformat(),
+         "ud": (today - timedelta(days=5)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT OR REPLACE INTO cost_job_state"
+        " (job_name, watermark_json, last_succeeded_at, last_status)"
+        " VALUES ('sync-gcs-cache-last-seen', '{}', :ts, 'succeeded')",
+        {"ts": (now - timedelta(hours=5)).isoformat()},
+    )
+    _exec(
+        engine,
+        "INSERT INTO roster_employees (lark_id, name, updated_at)"
+        " VALUES ('l1', 'alice', :ts)",
+        {"ts": (now - timedelta(hours=5)).isoformat()},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _threshold_timedelta
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdTimedelta:
+    def test_parses_hours(self) -> None:
+        assert _threshold_timedelta("4 hours") == timedelta(hours=4)
+        assert _threshold_timedelta("1 hour") == timedelta(hours=1)
+        assert _threshold_timedelta("30 hours") == timedelta(hours=30)
+
+    def test_parses_days(self) -> None:
+        assert _threshold_timedelta("4 days") == timedelta(days=4)
+        assert _threshold_timedelta("10 days") == timedelta(days=10)
+        assert _threshold_timedelta("1 day") == timedelta(days=1)
+
+    def test_raises_on_unknown_format(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported threshold format"):
+            _threshold_timedelta("0 pending")
+
+
+# ---------------------------------------------------------------------------
+# run_check — timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheckTimestamp:
+    def test_passes_when_fresh(self, fresh_engine: Engine) -> None:
+        now = datetime.now()
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('success', :ts)",
+            {"ts": (now - timedelta(hours=2)).isoformat()},
+        )
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('success', :ts)",
+            {"ts": (now - timedelta(hours=1)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_builds"])
+
+        assert result.passed is True
+        assert result.value is not None
+        assert result.error is None
+
+    def test_fails_when_stale(self, fresh_engine: Engine) -> None:
+        old = datetime.now() - timedelta(hours=10)
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('success', :ts)",
+            {"ts": old.isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_builds"])
+
+        assert result.passed is False
+        assert "h" in result.lag_description
+
+    def test_returns_error_on_null_value(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('success', NULL)",
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_builds"])
+
+        assert result.passed is False
+        assert result.error == "no timestamp found"
+        assert result.value is None
+
+    def test_returns_error_on_empty_table(self, fresh_engine: Engine) -> None:
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_pod_lifecycle"])
+
+        assert result.passed is False
+        assert result.error == "no timestamp found"
+
+    def test_handles_sql_error(self, fresh_engine: Engine) -> None:
+        bad_check = Check(
+            name="bad",
+            level="HIGH",
+            description="bad",
+            threshold_description="4 hours",
+            sql="SELECT * FROM nonexistent_table",
+            db="ci",
+        )
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, bad_check)
+
+        assert result.passed is False
+        assert result.error is not None
+        assert result.lag_description == "query error"
+
+    def test_handles_date_column_as_fresh(self, fresh_engine: Engine) -> None:
+        """DATE columns return datetime.date — must not TypeError."""
+        today = date.today()
+        _exec(
+            fresh_engine,
+            "INSERT INTO cost_attribution_daily"
+            " (usage_date, vendor, account_id, attribution_key,"
+            "  attribution_source, attribution_status, dimension_hash)"
+            " VALUES (:d, 'GCP', 'acct', 'k', 'src', 'ok', 'h')",
+            {"d": today.isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["cost_attribution_daily"])
+
+        assert result.passed is True
+
+    def test_handles_date_column_as_stale(self, fresh_engine: Engine) -> None:
+        """DATE column that is out of threshold must fail."""
+        old_date = date.today() - timedelta(days=10)
+        _exec(
+            fresh_engine,
+            "INSERT INTO cost_attribution_daily"
+            " (usage_date, vendor, account_id, attribution_key,"
+            "  attribution_source, attribution_status, dimension_hash)"
+            " VALUES (:d, 'GCP', 'acct', 'k', 'src', 'ok', 'h')",
+            {"d": old_date.isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["cost_attribution_daily"])
+
+        assert result.passed is False
+
+
+# ---------------------------------------------------------------------------
+# run_check — count
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheckCount:
+    def test_archive_error_logs_sqlite_unsupported(self, fresh_engine: Engine) -> None:
+        """SQLite does not support NOW() - INTERVAL, so the query errors out.
+
+        This is expected — the check is designed for MySQL/TiDB. The
+        run_check function must handle the error gracefully.
+        """
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["archive_error_logs"])
+
+        assert result.passed is False
+        assert result.lag_description == "query error"
+
+    def test_count_check_passes_with_zero(self, fresh_engine: Engine) -> None:
+        """Count check with portable SQL passes when count is 0."""
+        check = Check(
+            name="test_count",
+            level="MEDIUM",
+            description="test",
+            threshold_description="0 pending",
+            sql="SELECT COUNT(*) FROM ci_l1_builds WHERE state = 'nonexistent'",
+            db="ci",
+            is_count_check=True,
+        )
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, check)
+
+        assert result.passed is True
+        assert result.value == 0
+
+    def test_count_check_fails_when_positive(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state) VALUES ('failure')",
+        )
+        check = Check(
+            name="test_count",
+            level="MEDIUM",
+            description="test",
+            threshold_description="0 pending",
+            sql="SELECT COUNT(*) FROM ci_l1_builds WHERE state = 'failure'",
+            db="ci",
+            is_count_check=True,
+        )
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, check)
+
+        assert result.passed is False
+        assert result.value == 1
+
+
+# ---------------------------------------------------------------------------
+# run_all_checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunAllChecks:
+    def test_skips_cost_checks_when_engine_is_none(
+        self, fresh_engine: Engine
+    ) -> None:
+        report = run_all_checks(fresh_engine, None)
+
+        for r in report.results:
+            if r.check.db == "cost":
+                assert r.passed is True
+                assert "skipped" in r.lag_description
+
+    def test_runs_all_checks_with_cost_engine(
+        self, fresh_engine: Engine
+    ) -> None:
+        report = run_all_checks(fresh_engine, fresh_engine)
+
+        assert len(report.results) == len(CHECKS)
+        for r in report.results:
+            assert "skipped" not in r.lag_description
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+class TestReport:
+    def test_passed_all_when_no_failures(self) -> None:
+        report = Report(
+            timestamp=datetime.now(),
+            results=[
+                CheckResult(
+                    check=CHECKS_BY_NAME["ci_l1_builds"],
+                    passed=True,
+                    value=datetime.now(),
+                    lag_description="0h 0m",
+                ),
+            ],
+        )
+        assert report.passed_all is True
+        assert report.failed == []
+
+    def test_failed_filters_only_failures(self) -> None:
+        report = Report(
+            timestamp=datetime.now(),
+            results=[
+                CheckResult(
+                    check=CHECKS_BY_NAME["ci_l1_builds"],
+                    passed=True,
+                    value=datetime.now(),
+                    lag_description="0h 0m",
+                ),
+                CheckResult(
+                    check=CHECKS_BY_NAME["ci_l1_pod_lifecycle"],
+                    passed=False,
+                    value=None,
+                    lag_description="6h 0m",
+                    error="stale",
+                ),
+            ],
+        )
+        assert report.passed_all is False
+        assert len(report.failed) == 1
+        assert report.failed[0].check.name == "ci_l1_pod_lifecycle"
+
+
+# ---------------------------------------------------------------------------
+# _format_lark_message
+# ---------------------------------------------------------------------------
+
+
+class TestFormatLarkMessage:
+    def test_all_clear(self) -> None:
+        results = [
+            CheckResult(
+                check=CHECKS_BY_NAME["ci_l1_builds"],
+                passed=True,
+                value=datetime.now(),
+                lag_description="0h 0m",
+            ),
+            CheckResult(
+                check=CHECKS_BY_NAME["ci_l1_flaky_issues"],
+                passed=True,
+                value=datetime.now(),
+                lag_description="0h 0m",
+            ),
+        ]
+        report = Report(timestamp=datetime(2026, 6, 25, 7, 0), results=results)
+        msg = _format_lark_message(report)
+
+        assert "✅" in msg
+        assert "2 checks passed" in msg
+
+    def test_formats_high_medium_low(self) -> None:
+        results = [
+            CheckResult(
+                check=CHECKS_BY_NAME["ci_l1_builds"],
+                passed=False,
+                value=datetime(2026, 6, 25, 2, 0),
+                lag_description="5h 0m",
+            ),
+            CheckResult(
+                check=CHECKS_BY_NAME["ci_l1_flaky_issues"],
+                passed=False,
+                value=datetime(2026, 6, 23, 2, 0),
+                lag_description="53h 0m",
+            ),
+            CheckResult(
+                check=CHECKS_BY_NAME["cost_unmatched_resource_daily"],
+                passed=False,
+                value=date(2026, 5, 1),
+                lag_description="55d 0h 0m",
+            ),
+            CheckResult(
+                check=CHECKS_BY_NAME["ci_l1_pod_lifecycle"],
+                passed=True,
+                value=datetime.now(),
+                lag_description="0h 5m",
+            ),
+        ]
+        report = Report(timestamp=datetime(2026, 6, 25, 7, 0), results=results)
+        msg = _format_lark_message(report)
+
+        assert "🔴" in msg
+        assert "HIGH" in msg
+        assert "🟡" in msg
+        assert "MEDIUM" in msg
+        assert "⚪" in msg
+        assert "LOW" in msg
+        assert "ci_l1_builds" in msg
+        assert "✅ All clear" in msg
+
+
+# ---------------------------------------------------------------------------
+# _build_engine_for_db
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEngineForDb:
+    def test_returns_ci_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite:///:memory:")
+        from ci_dashboard.common.config import get_settings, load_settings
+
+        get_settings.cache_clear()
+        engine = _build_engine_for_db("ci", load_settings())
+        assert engine is not None
+
+    def test_returns_none_when_cost_not_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("COST_INSIGHT_DB_URL", raising=False)
+        monkeypatch.delenv("COST_INSIGHT_TIDB_USER", raising=False)
+        monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite:///:memory:")
+        from ci_dashboard.common.config import get_settings, load_settings
+
+        get_settings.cache_clear()
+        engine = _build_engine_for_db("cost", load_settings())
+        assert engine is None
+
+    def test_does_not_fallback_to_ci_db_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("COST_INSIGHT_DB_URL", raising=False)
+        monkeypatch.delenv("COST_INSIGHT_TIDB_USER", raising=False)
+        monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite:///:memory:")
+        from ci_dashboard.common.config import get_settings, load_settings
+
+        get_settings.cache_clear()
+        engine = _build_engine_for_db("cost", load_settings())
+        assert engine is None
+
+
+# ---------------------------------------------------------------------------
+# run_check_data_freshness — integration
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheckDataFreshness:
+    def test_sends_alert_when_webhook_configured(
+        self, fresh_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CI_DASHBOARD_DB_URL", str(fresh_engine.url))
+        monkeypatch.setenv("LARK_ALERT_WEBHOOK_URL", "https://example.com/hook")
+        monkeypatch.setenv("COST_INSIGHT_DB_URL", str(fresh_engine.url))
+        from ci_dashboard.common.config import get_settings, load_settings
+
+        _seed_all_checks(fresh_engine)
+
+        # Clear lru_cache to avoid stale settings from other tests.
+        get_settings.cache_clear()
+        settings = load_settings()
+        with patch(
+            "ci_dashboard.jobs.check_data_freshness._send_lark_alert"
+        ) as mock_send:
+            report = run_check_data_freshness(settings)
+
+        assert len(report.results) == len(CHECKS)
+        mock_send.assert_called_once()
+
+    def test_dry_run_does_not_send(
+        self, fresh_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CI_DASHBOARD_DB_URL", str(fresh_engine.url))
+        monkeypatch.setenv("LARK_ALERT_WEBHOOK_URL", "https://example.com/hook")
+        monkeypatch.setenv("COST_INSIGHT_DB_URL", str(fresh_engine.url))
+        monkeypatch.setenv("FRESHNESS_DRY_RUN", "true")
+        from ci_dashboard.common.config import get_settings, load_settings
+
+        _seed_all_checks(fresh_engine)
+
+        get_settings.cache_clear()
+        settings = load_settings()
+        with patch(
+            "ci_dashboard.jobs.check_data_freshness._send_lark_alert"
+        ) as mock_send:
+            report = run_check_data_freshness(settings)
+
+        mock_send.assert_not_called()
+        assert report is not None
+
+    def test_prints_when_no_webhook(
+        self, fresh_engine: Engine, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setenv("CI_DASHBOARD_DB_URL", str(fresh_engine.url))
+        monkeypatch.delenv("LARK_ALERT_WEBHOOK_URL", raising=False)
+        monkeypatch.setenv("COST_INSIGHT_DB_URL", str(fresh_engine.url))
+        from ci_dashboard.common.config import get_settings, load_settings
+
+        _seed_all_checks(fresh_engine)
+
+        get_settings.cache_clear()
+        settings = load_settings()
+        report = run_check_data_freshness(settings)
+        out = capsys.readouterr().out
+        # The report is printed to stdout (contains check results).
+        assert report is not None
+        # At minimum the report contains structured content.
+        assert len(out) > 0
+
+    def test_skips_cost_gracefully_when_not_configured(
+        self, fresh_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CI_DASHBOARD_DB_URL", str(fresh_engine.url))
+        monkeypatch.delenv("COST_INSIGHT_DB_URL", raising=False)
+        monkeypatch.delenv("COST_INSIGHT_TIDB_USER", raising=False)
+        from ci_dashboard.common.config import get_settings, load_settings
+
+        _seed_all_checks(fresh_engine)
+
+        get_settings.cache_clear()
+        settings = load_settings()
+        report = run_check_data_freshness(settings)
+
+        cost_results = [r for r in report.results if r.check.db == "cost"]
+        assert len(cost_results) > 0
+        for r in cost_results:
+            assert r.passed is True
+            assert "skipped" in r.lag_description
+        # CI checks with seeded data should all pass (except archive_error_logs
+        # which uses MySQL-specific NOW() - INTERVAL syntax, unsupported in SQLite).
+        ci_failures = [
+            r for r in report.results
+            if r.check.db == "ci" and not r.passed
+            and r.check.name != "archive_error_logs"
+        ]
+        assert ci_failures == [], f"Unexpected CI failures: {ci_failures}"
+
+
+# ---------------------------------------------------------------------------
+# Check definitions — structural integrity
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDefinitions:
+    def test_no_duplicate_names(self) -> None:
+        names = [c.name for c in CHECKS]
+        assert len(names) == len(set(names)), f"Duplicate: {names}"
+
+    def test_all_have_sql(self) -> None:
+        for c in CHECKS:
+            assert c.sql, f"{c.name} missing SQL"
+
+    def test_all_have_valid_level(self) -> None:
+        for c in CHECKS:
+            assert c.level in ("HIGH", "MEDIUM", "LOW"), f"{c.name}: {c.level}"
+
+    def test_all_have_valid_db(self) -> None:
+        for c in CHECKS:
+            assert c.db in ("ci", "cost"), f"{c.name}: {c.db}"
+
+    def test_count_checks_have_is_count_check(self) -> None:
+        count_names = {c.name for c in CHECKS if c.is_count_check}
+        assert "archive_error_logs" in count_names
+
+    def test_expected_count(self) -> None:
+        assert len(CHECKS) == 14, f"Expected 14, got {len(CHECKS)}"
+
+    def test_every_check_has_parsable_threshold(self) -> None:
+        for c in CHECKS:
+            if not c.is_count_check:
+                _threshold_timedelta(c.threshold_description)
+
+    def test_high_checks_are_hours(self) -> None:
+        for c in CHECKS:
+            if c.level == "HIGH":
+                assert "hour" in c.threshold_description, (
+                    f"{c.name} HIGH check should have hours threshold"
+                )
+
+    def test_gcs_cache_check_uses_cost_db(self) -> None:
+        gcs = [c for c in CHECKS if c.name == "sync_gcs_cache_last_seen"]
+        assert len(gcs) == 1
+        assert gcs[0].db == "cost"
+
+
+# ---------------------------------------------------------------------------
+# Lag description formatting
+# ---------------------------------------------------------------------------
+
+
+class TestLagDescription:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (0, "0h 0m"),
+            (60, "0h 1m"),
+            (3600, "1h 0m"),
+            (3660, "1h 1m"),
+            (86400, "1d 0h 0m"),
+            (90000, "1d 1h 0m"),
+            (172800, "2d 0h 0m"),
+        ],
+    )
+    def test_lag_formatting(
+        self, fresh_engine: Engine, seconds: int, expected: str
+    ) -> None:
+        now = datetime.now()
+        ts = now - timedelta(seconds=seconds)
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('success', :ts)",
+            {"ts": ts.isoformat()},
+        )
+
+        check = Check(
+            name="lag_test",
+            level="MEDIUM",
+            description="test",
+            threshold_description="100 days",
+            sql="SELECT MAX(start_time) FROM ci_l1_builds WHERE start_time IS NOT NULL",
+            db="ci",
+        )
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, check)
+
+        assert result.lag_description == expected
+
+
+# ---------------------------------------------------------------------------
+# Lark webhook HTTP error resilience
+# ---------------------------------------------------------------------------
+
+
+class TestSendLarkAlert:
+    def test_handles_http_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ci_dashboard.jobs.check_data_freshness import _send_lark_alert
+
+        def _raise(*_args, **_kwargs):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr("urllib.request.urlopen", _raise)
+        _send_lark_alert("https://example.com/hook", "test message")
+
+
+# ---------------------------------------------------------------------------
+# Job-state based checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheckJobState:
+    def test_passes_when_job_recent(self, fresh_engine: Engine) -> None:
+        recent = datetime.now() - timedelta(hours=5)
+        _exec(
+            fresh_engine,
+            "INSERT OR REPLACE INTO ci_job_state"
+            " (job_name, watermark_json, last_succeeded_at, last_status)"
+            " VALUES ('ci-sync-flaky-issues', '{}', :ts, 'succeeded')",
+            {"ts": recent.isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_flaky_issues"])
+
+        assert result.passed is True
+
+    def test_fails_when_job_stale(self, fresh_engine: Engine) -> None:
+        stale = datetime.now() - timedelta(hours=40)
+        _exec(
+            fresh_engine,
+            "INSERT OR REPLACE INTO ci_job_state"
+            " (job_name, watermark_json, last_succeeded_at, last_status)"
+            " VALUES ('ci-sync-flaky-issues', '{}', :ts, 'succeeded')",
+            {"ts": stale.isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_flaky_issues"])
+
+        assert result.passed is False
+
+    def test_none_when_job_never_run(self, fresh_engine: Engine) -> None:
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_flaky_issues"])
+
+        assert result.passed is False
+        assert result.error == "query returned no rows"
+
+
+# ---------------------------------------------------------------------------
+# External tables (prow_jobs, github_tickets, ci_l1_pr_events, problem_case_runs)
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheckExternalTables:
+    def test_prow_jobs_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO prow_jobs"
+            " (prowJobId, namespace, jobName, type, state, org, repo, url, startTime)"
+            " VALUES ('pj1', 'ns', 'job', 'presubmit', 'success', 'o', 'r', 'http://x', :ts)",
+            {"ts": (datetime.now() - timedelta(hours=2)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["prow_jobs"])
+
+        assert result.passed is True
+
+    def test_github_tickets_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO github_tickets (type, repo, number, updated_at)"
+            " VALUES ('issue', 'pingcap/tidb', 1, :ts)",
+            {"ts": (datetime.now() - timedelta(hours=3)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["github_tickets"])
+
+        assert result.passed is True
+
+    def test_github_tickets_fails_when_stale(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO github_tickets (type, repo, number, updated_at)"
+            " VALUES ('issue', 'pingcap/tidb', 1, :ts)",
+            {"ts": (datetime.now() - timedelta(hours=40)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["github_tickets"])
+
+        assert result.passed is False
+
+    def test_pr_events_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_pr_events"
+            " (repo, pr_number, event_key, event_time, event_type)"
+            " VALUES ('pingcap/tidb', 1, 'k1', :ts, 'committed')",
+            {"ts": (datetime.now() - timedelta(hours=1)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_pr_events"])
+
+        assert result.passed is True
+
+    def test_problem_case_runs_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO problem_case_runs"
+            " (repo, case_name, build_url, flaky, timecost_ms, report_time)"
+            " VALUES ('pingcap/tidb', 'TestX', 'http://x', 0, 100, :ts)",
+            {"ts": (datetime.now() - timedelta(hours=1)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["problem_case_runs"])
+
+        assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# Cost and roster table checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheckCostAndRoster:
+    def test_bq_export_summary_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO cost_bq_export_summary_daily"
+            " (vendor, account_id, export_partition_date, usage_date, source_row_hash)"
+            " VALUES ('GCP', 'acct', :ep, :ud, 'h')",
+            {"ep": date.today().isoformat(), "ud": date.today().isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["cost_bq_export_summary_daily"])
+
+        assert result.passed is True
+
+    def test_unmatched_resource_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO cost_unmatched_resource_daily"
+            " (vendor, account_id, export_partition_date, usage_date,"
+            "  resource_name, source_row_hash)"
+            " VALUES ('GCP', 'acct', :ep, :ud, 'res', 'h')",
+            {"ep": (date.today() - timedelta(days=5)).isoformat(),
+             "ud": (date.today() - timedelta(days=5)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["cost_unmatched_resource_daily"])
+
+        assert result.passed is True
+
+    def test_roster_employees_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO roster_employees (lark_id, name, updated_at)"
+            " VALUES ('l1', 'alice', :ts)",
+            {"ts": (datetime.now() - timedelta(hours=5)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["roster_employees"])
+
+        assert result.passed is True
+
+    def test_pod_lifecycle_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_pod_lifecycle"
+            " (source_project, source_prow_job_id, last_event_at)"
+            " VALUES ('proj', 'pj1', :ts)",
+            {"ts": (datetime.now() - timedelta(hours=1)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_pod_lifecycle"])
+
+        assert result.passed is True
+
+    def test_refresh_build_derived_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT OR REPLACE INTO ci_job_state"
+            " (job_name, watermark_json, last_succeeded_at, last_status)"
+            " VALUES ('ci-refresh-build-derived', '{}', :ts, 'succeeded')",
+            {"ts": (datetime.now() - timedelta(hours=2)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_builds_derived"])
+
+        assert result.passed is True
+
+    def test_gcs_cache_job_state_passes(self, fresh_engine: Engine) -> None:
+        _exec(
+            fresh_engine,
+            "INSERT OR REPLACE INTO cost_job_state"
+            " (job_name, watermark_json, last_succeeded_at, last_status)"
+            " VALUES ('sync-gcs-cache-last-seen', '{}', :ts, 'succeeded')",
+            {"ts": (datetime.now() - timedelta(hours=5)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["sync_gcs_cache_last_seen"])
+
+        assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_future_timestamp_handled(self, fresh_engine: Engine) -> None:
+        """A future timestamp produces 0 lag, not negative."""
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('success', :ts)",
+            {"ts": (datetime.now() + timedelta(hours=1)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_builds"])
+
+        assert result.passed is True
+        assert result.lag_description == "0h 0m"
+
+    def test_max_used_not_min(self, fresh_engine: Engine) -> None:
+        """MAX() picks the freshest row, so 1h-old beats 10h-old."""
+        now = datetime.now()
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('s', :ts1)",
+            {"ts1": (now - timedelta(hours=10)).isoformat()},
+        )
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('s', :ts2)",
+            {"ts2": (now - timedelta(hours=1)).isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["ci_l1_builds"])
+
+        assert result.passed is True
+
+    def test_parse_timestamp_fromisoformat_fallback(self) -> None:
+        """The last-resort fromisoformat path is exercised by an ISO string."""
+        from ci_dashboard.jobs.check_data_freshness import _parse_timestamp
+
+        dt = _parse_timestamp("2026-06-25T07:00:00")
+        assert dt == datetime(2026, 6, 25, 7, 0, 0)
+
+    def test_format_failure_callback(self, fresh_engine: Engine) -> None:
+        """format_failure overrides lag_description when set."""
+        now = datetime.now()
+        _exec(
+            fresh_engine,
+            "INSERT INTO ci_l1_builds (state, start_time) VALUES ('success', :ts)",
+            {"ts": (now - timedelta(hours=10)).isoformat()},
+        )
+        check = Check(
+            name="custom_format",
+            level="HIGH",
+            description="test",
+            threshold_description="4 hours",
+            sql="SELECT MAX(start_time) FROM ci_l1_builds WHERE start_time IS NOT NULL",
+            db="ci",
+            format_failure=lambda v: f"custom:{v}",
+        )
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, check)
+
+        assert "custom:" in result.lag_description
+
+    def test_cost_db_with_url_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When COST_INSIGHT_DB_URL is set, engine uses URL path."""
+        monkeypatch.setenv("CI_DASHBOARD_DB_URL", "sqlite:///:memory:")
+        monkeypatch.setenv("COST_INSIGHT_DB_URL", "sqlite:///:memory:")
+        from ci_dashboard.common.config import get_settings, load_settings
+
+        get_settings.cache_clear()
+        engine = _build_engine_for_db("cost", load_settings())
+        assert engine is not None
+        engine.dispose()
+
+    def test_gcp_vendor_filter(self, fresh_engine: Engine) -> None:
+        """cost_bq_export_summary_daily filters on vendor='GCP'; AWS rows ignored."""
+        today = date.today()
+        _exec(
+            fresh_engine,
+            "INSERT INTO cost_bq_export_summary_daily"
+            " (vendor, account_id, export_partition_date, usage_date, source_row_hash)"
+            " VALUES ('AWS', 'acct', :ep, :ud, 'h')",
+            {"ep": (date.today() - timedelta(days=30)).isoformat(),
+             "ud": (date.today() - timedelta(days=30)).isoformat()},
+        )
+        _exec(
+            fresh_engine,
+            "INSERT INTO cost_bq_export_summary_daily"
+            " (vendor, account_id, export_partition_date, usage_date, source_row_hash)"
+            " VALUES ('GCP', 'acct', :ep, :ud, 'h')",
+            {"ep": today.isoformat(), "ud": today.isoformat()},
+        )
+
+        with fresh_engine.begin() as conn:
+            result = run_check(conn, CHECKS_BY_NAME["cost_bq_export_summary_daily"])
+
+        assert result.passed is True

--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -1487,7 +1487,7 @@ export function IssueWeeklyRateTable({ weeks, rows, scrollClassName = "" }) {
 
   return (
     <div className={`table-scroll ${scrollClassName}`.trim()}>
-      <table className="data-table">
+      <table className="data-table data-table--issue-weekly">
         <thead>
           <tr>
             <th>Case name</th>
@@ -1503,7 +1503,7 @@ export function IssueWeeklyRateTable({ weeks, rows, scrollClassName = "" }) {
             <tr key={`${row.issue_number}-${row.case_name}`}>
               <th scope="row">
                 <div className="issue-cell">
-                  <a href={row.issue_url} target="_blank" rel="noreferrer">
+                  <a href={row.issue_url} target="_blank" rel="noreferrer" title={row.display_name}>
                     {row.display_name}
                   </a>
                   <div className="issue-cell__meta">

--- a/ci-dashboard/web/src/styles.css
+++ b/ci-dashboard/web/src/styles.css
@@ -1957,6 +1957,10 @@ select {
   min-width: 420px;
 }
 
+.data-table--issue-weekly {
+  min-width: 1120px;
+}
+
 .data-table th,
 .data-table td {
   padding: 0.8rem 0.9rem;
@@ -2006,6 +2010,29 @@ select {
 .data-table tbody tr:hover th,
 .data-table tbody tr:hover td {
   background: rgba(15, 124, 130, 0.08);
+}
+
+.data-table--issue-weekly thead th:first-child,
+.data-table--issue-weekly tbody th {
+  width: 360px;
+  min-width: 360px;
+  max-width: 360px;
+}
+
+.data-table--issue-weekly thead th:first-child {
+  box-shadow: 12px 0 18px -18px rgba(26, 42, 51, 0.45);
+}
+
+.data-table--issue-weekly .issue-cell {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.data-table--issue-weekly .issue-cell a {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .data-row--interactive th,


### PR DESCRIPTION
## Summary

### Freshness check (main change)
- **14 declarative freshness checks** covering `ci_l1_builds`, `ci_l1_pod_lifecycle`, `prow_jobs`, `github_tickets`, `ci_l1_flaky_issues`, `ci_l1_pr_events`, `problem_case_runs`, cost summary tables, GCS cache sync, and `roster_employees`
- **Lark IM API** — sends DM to a single user (not group) via `_send_lark_dm` using `LARK_APP_ID`/`LARK_APP_SECRET` from `roster-lark` secret; only alerts when there are failures
- **DATE column handling** — `_parse_timestamp` coerces `datetime.date` and string values before subtraction to prevent `TypeError`
- **Graceful cost DB skip** — when `COST_INSIGHT_DB_URL` is absent, cost checks are skipped (`skipped=True`), not failures; no fallback to CI DB
- **skipped vs passed** — report distinguishes passed/skipped/failed with summary line at top, details by severity below
- **CronJob**: daily at 09:10 CST via ee-ops
- **Canary tested** against production TiDB — Lark DM received ✓
- **68 tests, 94% coverage**

### Sticky column
- IssueWeeklyRateTable first column: fixed 360px width, text-overflow ellipsis, `title` tooltip

### Build key
- `NULLIF(b.normalized_build_url, "")` in 3 query functions to filter empty-string build keys

### Files
| File | Change |
|------|--------|
| `check_data_freshness.py` | New — 14 freshness checks + Lark DM sender |
| `test_check_data_freshness.py` | New — 68 tests |
| `render_data_freshness_check_cronjob.sh` | New — CronJob render script |
| `daily-data-freshness-check-design.md` | New — design doc |
| `cli.py` | Modified — register `check-data-freshness` subcommand |
| `flaky.py` | Modified — NULLIF wrapper |
| `charts.jsx` | Modified — sticky column + title |
| `styles.css` | Modified — sticky column CSS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)