### PR TITLE
fix(tibuild-v2): persist platform field when creating devbuild

### DIFF
--- a/experiments/tibuild-v2/internal/service/impl/devbuild.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild.go
@@ -201,6 +201,7 @@ func (s *devbuildsrvc) Rerun(ctx context.Context, p *devbuild.RerunPayload) (res
 		SetPluginGitRef(existingBuild.PluginGitRef).
 		SetIsHotfix(existingBuild.IsHotfix).
 		SetIsPushGcr(existingBuild.IsPushGcr).
+		SetPlatform(existingBuild.Platform).
 		SetStatus("pending").
 		SetCreatedAt(time.Now()).
 		Save(ctx)

--- a/experiments/tibuild-v2/internal/service/impl/devbuild_create.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_create.go
@@ -43,6 +43,7 @@ func (s *devbuildsrvc) newBuildEntity(ctx context.Context, p *devbuild.CreatePay
 		SetCreatedBy(p.CreatedBy).
 		SetNillablePluginGitRef(p.Request.PluginGitRef).
 		SetNillablePipelineEngine(p.Request.PipelineEngine).
+		SetPlatform(p.Request.Platform).
 		SetStatus("pending")
 
 	return create.Save(ctx)

--- a/experiments/tibuild-v2/internal/service/impl/devbuild_transform.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_transform.go
@@ -27,6 +27,7 @@ func transformDevBuild(build *ent.DevBuild) *devbuild.DevBuild {
 			IsHotfix:          &build.IsHotfix,
 			IsPushGcr:         &build.IsPushGcr,
 			PipelineEngine:    &build.PipelineEngine,
+			Platform:          build.Platform,
 			PluginGitRef:      &build.PluginGitRef,
 			Product:           build.Product,
 			ProductBaseImg:    &build.ProductBaseImg,

--- a/experiments/tibuild-v2/internal/service/tests/devbuild_platform_test.go
+++ b/experiments/tibuild-v2/internal/service/tests/devbuild_platform_test.go
@@ -1,0 +1,104 @@
+package impl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/PingCAP-QE/ee-apps/tibuild/internal/service/gen/devbuild"
+)
+
+func TestDevBuildPlatformField(t *testing.T) {
+	env := setupTestEnv(t)
+	defer teardownTestEnv(env)
+
+	ctx := context.Background()
+
+	t.Run("Create with platform field should persist platform", func(t *testing.T) {
+		platform := "linux/amd64"
+		createPayload := &devbuild.CreatePayload{
+			CreatedBy: "test-user",
+			Request: &devbuild.DevBuildSpec{
+				Product: "pd",
+				Edition: "community",
+				Version: "v9.0.0-test2",
+				GitRef:  "branch/master",
+				Platform: platform,
+			},
+			Dryrun: true,
+		}
+
+		build, err := env.service.Create(ctx, createPayload)
+		require.NoError(t, err)
+		assert.NotNil(t, build)
+		assert.Equal(t, platform, build.Spec.Platform)
+	})
+
+	t.Run("Create with empty platform should persist empty", func(t *testing.T) {
+		createPayload := &devbuild.CreatePayload{
+			CreatedBy: "test-user",
+			Request: &devbuild.DevBuildSpec{
+				Product: "pd",
+				Edition: "community",
+				Version: "v9.0.0-test2",
+				GitRef:  "branch/master",
+				Platform: "",
+			},
+			Dryrun: true,
+		}
+
+		build, err := env.service.Create(ctx, createPayload)
+		require.NoError(t, err)
+		assert.NotNil(t, build)
+		assert.Equal(t, "", build.Spec.Platform)
+	})
+
+	t.Run("Create with linux/arm64 platform should persist correctly", func(t *testing.T) {
+		platform := "linux/arm64"
+		createPayload := &devbuild.CreatePayload{
+			CreatedBy: "test-user",
+			Request: &devbuild.DevBuildSpec{
+				Product: "pd",
+				Edition: "community",
+				Version: "v9.0.0-test2",
+				GitRef:  "branch/master",
+				Platform: platform,
+			},
+			Dryrun: true,
+		}
+
+		build, err := env.service.Create(ctx, createPayload)
+		require.NoError(t, err)
+		assert.NotNil(t, build)
+		assert.Equal(t, platform, build.Spec.Platform)
+	})
+
+	t.Run("Create and Get should return same platform", func(t *testing.T) {
+		platform := "linux/amd64"
+		createPayload := &devbuild.CreatePayload{
+			CreatedBy: "test-user",
+			Request: &devbuild.DevBuildSpec{
+				Product: "pd",
+				Edition: "community",
+				Version: "v9.0.0-test2",
+				GitRef:  "branch/master",
+				Platform: platform,
+			},
+			Dryrun: true,
+		}
+
+		created, err := env.service.Create(ctx, createPayload)
+		require.NoError(t, err)
+
+		getPayload := &devbuild.GetPayload{
+			ID:   created.ID,
+			Sync: false,
+		}
+
+		fetched, err := env.service.Get(ctx, getPayload)
+		require.NoError(t, err)
+		assert.Equal(t, platform, fetched.Spec.Platform)
+	})
+}


### PR DESCRIPTION
## Summary

This PR fixes the bug where the `platform` field was not being persisted when creating a devbuild entity in tibuild-v2.

## Changes

1. **devbuild_create.go**: Added `SetPlatform(p.Request.Platform)` to the entity creation chain in `newBuildEntity()`
2. **devbuild.go**: Added `SetPlatform(existingBuild.Platform)` to the `Rerun()` function to preserve platform on reruns
3. **devbuild_transform.go**: Added `Platform: build.Platform` to the transform function so the field is returned in API responses
4. **devbuild_platform_test.go**: Added TDD tests to verify the platform field is persisted correctly

## Testing

Added comprehensive tests covering:
- Creating a devbuild with `linux/amd64` platform
- Creating a devbuild with empty platform
- Creating a devbuild with `linux/arm64` platform
- Verifying platform persists through Create and Get operations

## Root Cause

The `newBuildEntity()` function was missing the `SetPlatform()` call, so the platform field from the request was never being saved to the database.

Fixes #515
