### PR TITLE
feat(tibuild): add EventID, direct Tekton trigger, TektonReconciler, and Lark notification

### DIFF
--- a/tibuild/api/api.go
+++ b/tibuild/api/api.go
@@ -113,6 +113,20 @@ func routeRestAPI(router *gin.Engine, cfg *configs.ConfigYaml) {
 		devBuildGroup.POST("/:id/rerun", devBuildHandler.Rerun)
 	}
 
+	// Start Tekton reconciler if enabled
+	repo := devBuildServer.(*service.DevbuildServer).Repo
+	reconcilerConfig := service.TektonReconcilerConfig{
+		Enabled:        cfg.TektonReconciler.Enabled,
+		Namespace:      cfg.TektonReconciler.Namespace,
+		Interval:       cfg.TektonReconciler.Interval,
+		StaleThreshold: cfg.TektonReconciler.StaleThreshold,
+	}
+	reconciler, err := service.NewTektonReconciler(repo, reconcilerConfig)
+	if err != nil {
+		panic(err)
+	}
+	reconciler.Start(context.Background())
+
 	artifactHelper := controllers.NewArtifactHelperHandler(jenkins)
 	artifactGroup := apiGroup.Group("/artifact")
 	{

--- a/tibuild/configs/config_example.yaml
+++ b/tibuild/configs/config_example.yaml
@@ -16,6 +16,13 @@ restapisecret:
 
 cloudevent:
   endpoint: "http://localhost:8000"
+  tekton_direct_trigger: false
 
 tektonviewurl: "https://do.pingcap.net/tekton/#/namespaces/ee-cd/pipelineruns"
 ocifileserverurl: "https://internal.do.pingcap.net:30443/dl/oci-file"
+
+tekton_reconciler:
+  enabled: false
+  namespace: "ee-cd"
+  interval: 60s
+  stale_threshold: 5m

--- a/tibuild/go.mod
+++ b/tibuild/go.mod
@@ -24,6 +24,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/gorm v1.25.12
+	k8s.io/client-go v0.32.7
 )
 
 require (

--- a/tibuild/go.mod
+++ b/tibuild/go.mod
@@ -24,7 +24,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/gorm v1.25.12
+	k8s.io/apimachinery v0.32.7
 	k8s.io/client-go v0.32.7
+	knative.dev/pkg v0.0.0-20250415155312-ed3e2158b883
 )
 
 require (
@@ -90,6 +92,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
@@ -130,16 +133,14 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/grpc v1.74.2 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/api v0.32.7 // indirect
-	k8s.io/apimachinery v0.32.7 // indirect
-	k8s.io/client-go v0.32.7 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
-	knative.dev/pkg v0.0.0-20250415155312-ed3e2158b883 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/tibuild/pkg/configs/config.go
+++ b/tibuild/pkg/configs/config.go
@@ -4,6 +4,7 @@ package configs
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jinzhu/configor"
 )
@@ -34,6 +35,14 @@ type ConfigYaml struct {
 
 	// ImageMirrorURLMap is a map prefixes for transformation between direct url to mirror url.
 	ImageMirrorURLMap map[string]string `yaml:"image_mirror_url_map,omitempty" json:"image_mirror_url_map,omitempty"`
+
+	// TektonReconciler configures the background reconciler for Tekton PipelineRun status.
+	TektonReconciler struct {
+		Enabled        bool          `yaml:"enabled" json:"enabled"`
+		Namespace      string        `yaml:"namespace" json:"namespace"`
+		Interval       time.Duration `yaml:"interval" json:"interval"`
+		StaleThreshold time.Duration `yaml:"stale_threshold" json:"stale_threshold"`
+	} `yaml:"tekton_reconciler,omitempty" json:"tekton_reconciler,omitempty"`
 }
 
 type RestApiSecret struct {

--- a/tibuild/pkg/configs/config.go
+++ b/tibuild/pkg/configs/config.go
@@ -25,7 +25,8 @@ type ConfigYaml struct {
 
 	RestApiSecret RestApiSecret `yaml:"restapisecret,omitempty" json:"restapisecret,omitempty"`
 	CloudEvent    struct {
-		Endpoint string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
+		Endpoint          string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
+		TektonDirectTrigger bool   `yaml:"tekton_direct_trigger,omitempty" json:"tekton_direct_trigger,omitempty"`
 	} `yaml:"cloudevent,omitempty" json:"cloudevent,omitempty"`
 
 	TektonViewURL    string `yaml:"tektonviewurl,omitempty" json:"tektonviewurl,omitempty"`

--- a/tibuild/pkg/configs/config.go
+++ b/tibuild/pkg/configs/config.go
@@ -43,6 +43,12 @@ type ConfigYaml struct {
 		Interval       time.Duration `yaml:"interval" json:"interval"`
 		StaleThreshold time.Duration `yaml:"stale_threshold" json:"stale_threshold"`
 	} `yaml:"tekton_reconciler,omitempty" json:"tekton_reconciler,omitempty"`
+
+	// Lark configures Lark notifications for build completion events.
+	Lark struct {
+		Enabled    bool   `yaml:"enabled" json:"enabled"`
+		WebhookURL string `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	} `yaml:"lark,omitempty" json:"lark,omitempty"`
 }
 
 type RestApiSecret struct {

--- a/tibuild/pkg/rest/controller/dev_build_handler.go
+++ b/tibuild/pkg/rest/controller/dev_build_handler.go
@@ -38,6 +38,7 @@ func NewDevBuildServer(jenkins service.Jenkins, db *gorm.DB, cfg *configs.Config
 		TektonViewURL:     cfg.TektonViewURL,
 		OciFileserverURL:  cfg.OciFileserverURL,
 		ImageMirrorURLMap: cfg.ImageMirrorURLMap,
+		Notifier:          service.NewLarkNotifier(cfg.Lark.WebhookURL, cfg.Lark.Enabled),
 	}
 }
 

--- a/tibuild/pkg/rest/controller/dev_build_handler.go
+++ b/tibuild/pkg/rest/controller/dev_build_handler.go
@@ -33,7 +33,7 @@ func NewDevBuildServer(jenkins service.Jenkins, db *gorm.DB, cfg *configs.Config
 		Repo:              repo.DevBuildRepo{Db: db},
 		Jenkins:           jenkins,
 		Now:               time.Now,
-		Tekton:            service.NewCEClient(cfg.CloudEvent.Endpoint),
+		Tekton:            service.NewCEClient(cfg.CloudEvent.Endpoint, cfg.CloudEvent.TektonDirectTrigger),
 		GHClient:          service.NewGHClient(cfg.Github.Token),
 		TektonViewURL:     cfg.TektonViewURL,
 		OciFileserverURL:  cfg.OciFileserverURL,

--- a/tibuild/pkg/rest/service/cloud_event_client.go
+++ b/tibuild/pkg/rest/service/cloud_event_client.go
@@ -22,40 +22,67 @@ const (
 )
 
 type BuildTrigger interface {
-	TriggerDevBuild(ctx context.Context, dev DevBuild) error
+	TriggerDevBuild(ctx context.Context, dev DevBuild) (eventID string, err error)
 }
 
-func NewCEClient(endpoint string) CloudEventClient {
+func NewCEClient(endpoint string, directTrigger bool) CloudEventClient {
 	client, err := cloudevents.NewClientHTTP()
 	if err != nil {
 		slog.Error("create cloudevent http client failed", "reason", err)
 	}
 	return CloudEventClient{
-		client:   client,
-		endpoint: endpoint,
+		client:         client,
+		endpoint:       endpoint,
+		directTrigger:  directTrigger,
 	}
 }
 
 type CloudEventClient struct {
-	client   cloudevents.Client
-	endpoint string
+	client        cloudevents.Client
+	endpoint      string
+	directTrigger bool
 }
 
-func (s CloudEventClient) TriggerDevBuild(ctx context.Context, dev DevBuild) error {
+func (s CloudEventClient) TriggerDevBuild(ctx context.Context, dev DevBuild) (string, error) {
 	events, err := newDevBuildCloudEvents(dev)
 	if err != nil {
-		return err
+		return "", err
 	}
 
+	if s.directTrigger {
+		return s.sendDirect(ctx, events)
+	}
+	return s.sendViaFanout(ctx, events)
+}
+
+func (s CloudEventClient) sendDirect(ctx context.Context, events []cloudevents.Event) (string, error) {
+	var eventID string
+	for _, event := range events {
+		c := cloudevents.ContextWithTarget(ctx, s.endpoint)
+		resp, result := s.client.Request(c, event)
+		if !protocol.IsACK(result) {
+			slog.ErrorContext(ctx, "failed to send", "reason", result)
+			return "", fmt.Errorf("failed to send ce:%w", result)
+		}
+		if resp != nil {
+			id := resp.Context.GetID()
+			if id != "" {
+				eventID = id
+			}
+		}
+	}
+	return eventID, nil
+}
+
+func (s CloudEventClient) sendViaFanout(ctx context.Context, events []cloudevents.Event) (string, error) {
 	for _, event := range events {
 		c := cloudevents.ContextWithTarget(ctx, s.endpoint)
 		if result := s.client.Send(c, event); !protocol.IsACK(result) {
 			slog.ErrorContext(ctx, "failed to send", "reason", result)
-			return fmt.Errorf("failed to send ce:%w", result)
+			return "", fmt.Errorf("failed to send ce:%w", result)
 		}
 	}
-
-	return nil
+	return "", nil
 }
 
 func newDevBuildCloudEvents(dev DevBuild) ([]cloudevents.Event, error) {

--- a/tibuild/pkg/rest/service/cloud_event_client_test.go
+++ b/tibuild/pkg/rest/service/cloud_event_client_test.go
@@ -50,7 +50,7 @@ func TestTrigger(t *testing.T) {
 	if os.Getenv("TEST_FANOUT") == "" {
 		t.Skip("Skipping send event")
 	}
-	trigger := NewCEClient("http://localhost:8000")
-	err := trigger.TriggerDevBuild(context.TODO(), sampleDevBuild())
+	trigger := NewCEClient("http://localhost:8000", false)
+	_, err := trigger.TriggerDevBuild(context.TODO(), sampleDevBuild())
 	require.NoError(t, err)
 }

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -133,9 +133,11 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 				entity.Status.TektonStatus = &TektonStatus{}
 			}
 			entity.Status.TektonStatus.EventID = eventID
-			entity, err = s.Repo.Update(ctx, entity.ID, entity)
+			updated, err := s.Repo.Update(ctx, entity.ID, entity)
 			if err != nil {
 				log.Error().Err(err).Msg("save eventID failed")
+			} else {
+				entity = *updated
 			}
 		}
 	}

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -117,7 +117,7 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 			s.Repo.Update(ctx, entity.ID, entity)
 		}(entity)
 	case TektonEngine:
-		err = s.Tekton.TriggerDevBuild(ctx, entity)
+		eventID, err := s.Tekton.TriggerDevBuild(ctx, entity)
 		if err != nil {
 			log.Error().Err(err).Msg("trigger tekton failed")
 			entity.Status.Status = BuildStatusError
@@ -127,6 +127,16 @@ func (s DevbuildServer) Create(ctx context.Context, req DevBuild, option DevBuil
 				log.Error().Err(err).Msg("save triggered entity failed")
 			}
 			return nil, fmt.Errorf("trigger Tekton fail: %w", ErrInternalError)
+		}
+		if eventID != "" {
+			if entity.Status.TektonStatus == nil {
+				entity.Status.TektonStatus = &TektonStatus{}
+			}
+			entity.Status.TektonStatus.EventID = eventID
+			entity, err = s.Repo.Update(ctx, entity.ID, entity)
+			if err != nil {
+				log.Error().Err(err).Msg("save eventID failed")
+			}
 		}
 	}
 

--- a/tibuild/pkg/rest/service/dev_build_service.go
+++ b/tibuild/pkg/rest/service/dev_build_service.go
@@ -40,6 +40,7 @@ type DevbuildServer struct {
 	OciFileserverURL string
 
 	ImageMirrorURLMap map[string]string
+	Notifier          Notifier
 }
 
 type DevBuildRepository interface {
@@ -234,7 +235,21 @@ func (s DevbuildServer) MergeTektonStatus(ctx context.Context, id int, pipeline 
 	if obj.Spec.PipelineEngine == TektonEngine {
 		computeTektonStatus(tekton, &obj.Status)
 	}
-	return s.Update(ctx, id, *obj, options)
+	result, err := s.Update(ctx, id, *obj, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send notification if build reached terminal state
+	if s.Notifier != nil && IsBuildStatusCompleted(result.Status.Status) {
+		go func() {
+			if notifyErr := s.Notifier.Notify(context.Background(), result); notifyErr != nil {
+				log.Error().Err(notifyErr).Int("build_id", id).Msg("failed to send notification")
+			}
+		}()
+	}
+
+	return result, nil
 }
 
 func (s DevbuildServer) sync(ctx context.Context, entity *DevBuild) (*DevBuild, error) {

--- a/tibuild/pkg/rest/service/dev_build_service_test.go
+++ b/tibuild/pkg/rest/service/dev_build_service_test.go
@@ -59,13 +59,14 @@ func (mock mockJenkins) BuildURL(jobName string, number int64) string {
 }
 
 type mockTrigger struct {
-	dev DevBuild
-	err error
+	dev     DevBuild
+	eventID string
+	err     error
 }
 
-func (m *mockTrigger) TriggerDevBuild(ctx context.Context, dev DevBuild) error {
+func (m *mockTrigger) TriggerDevBuild(ctx context.Context, dev DevBuild) (string, error) {
 	m.dev = dev
-	return m.err
+	return m.eventID, m.err
 }
 
 type mockGHClient struct{}

--- a/tibuild/pkg/rest/service/model.go
+++ b/tibuild/pkg/rest/service/model.go
@@ -115,6 +115,7 @@ type DevBuildStatus struct {
 }
 
 type TektonStatus struct {
+	EventID   string           `json:"eventID,omitempty"`
 	Pipelines []TektonPipeline `json:"pipelines"`
 }
 

--- a/tibuild/pkg/rest/service/notifier.go
+++ b/tibuild/pkg/rest/service/notifier.go
@@ -1,0 +1,279 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"text/template"
+	"time"
+)
+
+// Notifier defines the interface for sending build completion notifications.
+type Notifier interface {
+	// Notify sends a notification for a completed build.
+	// It should log errors and not block the caller on failure.
+	Notify(ctx context.Context, build *DevBuild) error
+}
+
+// NotificationInfo contains the information needed for a build notification.
+type NotificationInfo struct {
+	Product    string
+	Version    string
+	Status     string
+	Platform   string
+	ViewURLs   []string
+	CreatedBy  string
+	BuildID    int
+	IsHotfix   bool
+}
+
+// LarkNotifier sends notifications to a Lark webhook.
+type LarkNotifier struct {
+	webhookURL string
+	httpClient *http.Client
+	enabled    bool
+}
+
+// LarkCardMessage represents a Lark interactive card message.
+type LarkCardMessage struct {
+	MsgType string      `json:"msg_type"`
+	Card    LarkCard    `json:"card"`
+}
+
+// LarkCard represents the card structure.
+type LarkCard struct {
+	Header   LarkCardHeader   `json:"header"`
+	Elements []LarkCardElement `json:"elements"`
+}
+
+// LarkCardHeader represents the card header.
+type LarkCardHeader struct {
+	Title    LarkCardTitle `json:"title"`
+	Template string        `json:"template,omitempty"`
+}
+
+// LarkCardTitle represents the card title.
+type LarkCardTitle struct {
+	Content string `json:"content"`
+	Tag     string `json:"tag"`
+}
+
+// LarkCardElement represents a card element.
+type LarkCardElement struct {
+	Tag     string        `json:"tag"`
+	Content string        `json:"content,omitempty"`
+	Text    *LarkCardText `json:"text,omitempty"`
+	Fields  []LarkField   `json:"fields,omitempty"`
+}
+
+// LarkCardText represents text in a card element.
+type LarkCardText struct {
+	Content string `json:"content"`
+	Tag     string `json:"tag"`
+}
+
+// LarkField represents a field in a card element.
+type LarkField struct {
+	IsShort bool          `json:"is_short"`
+	Text    LarkCardText  `json:"text"`
+}
+
+// NewLarkNotifier creates a new LarkNotifier.
+func NewLarkNotifier(webhookURL string, enabled bool) *LarkNotifier {
+	return &LarkNotifier{
+		webhookURL: webhookURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		enabled: enabled,
+	}
+}
+
+// Notify sends a notification for a completed build.
+func (n *LarkNotifier) Notify(ctx context.Context, build *DevBuild) error {
+	if !n.enabled {
+		return nil
+	}
+
+	info := &NotificationInfo{
+		Product:   string(build.Spec.Product),
+		Version:   build.Spec.Version,
+		Status:    build.Status.Status,
+		Platform:  build.Spec.Platform,
+		ViewURLs:  build.Status.PipelineViewURLs,
+		CreatedBy: build.Meta.CreatedBy,
+		BuildID:   build.ID,
+		IsHotfix:  build.Spec.IsHotfix,
+	}
+
+	card, err := buildLarkCard(info)
+	if err != nil {
+		return fmt.Errorf("build lark card: %w", err)
+	}
+
+	msg := LarkCardMessage{
+		MsgType: "interactive",
+		Card:    card,
+	}
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal message: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// StatusToTemplate returns the Lark card template color based on build status.
+func StatusToTemplate(status string) string {
+	switch status {
+	case BuildStatusSuccess:
+		return "green"
+	case BuildStatusFailure, BuildStatusError:
+		return "red"
+	case BuildStatusAborted:
+		return "orange"
+	default:
+		return "blue"
+	}
+}
+
+// StatusToEmoji returns an emoji for the build status.
+func StatusToEmoji(status string) string {
+	switch status {
+	case BuildStatusSuccess:
+		return "✅"
+	case BuildStatusFailure:
+		return "❌"
+	case BuildStatusError:
+		return "⚠️"
+	case BuildStatusAborted:
+		return "🚫"
+	default:
+		return "⏳"
+	}
+}
+
+const larkCardTemplate = `{
+  "header": {
+    "title": {
+      "content": "{{.StatusEmoji}} DevBuild {{.Status}} - {{.Product}} {{.Version}}",
+      "tag": "plain_text"
+    },
+    "template": "{{.Template}}"
+  },
+  "elements": [
+    {
+      "tag": "div",
+      "fields": [
+        {
+          "is_short": true,
+          "text": {
+            "content": "**Product:** {{.Product}}",
+            "tag": "lark_md"
+          }
+        },
+        {
+          "is_short": true,
+          "text": {
+            "content": "**Version:** {{.Version}}",
+            "tag": "lark_md"
+          }
+        },
+        {
+          "is_short": true,
+          "text": {
+            "content": "**Status:** {{.Status}}",
+            "tag": "lark_md"
+          }
+        },
+        {
+          "is_short": true,
+          "text": {
+            "content": "**Platform:** {{.Platform}}",
+            "tag": "lark_md"
+          }
+        },
+        {
+          "is_short": true,
+          "text": {
+            "content": "**Created By:** {{.CreatedBy}}",
+            "tag": "lark_md"
+          }
+        },
+        {
+          "is_short": true,
+          "text": {
+            "content": "**Hotfix:** {{.IsHotfix}}",
+            "tag": "lark_md"
+          }
+        }
+      ]
+    },
+    {{- if .ViewURLs}}
+    {
+      "tag": "div",
+      "text": {
+        "content": "**Pipeline URLs:**\n{{range .ViewURLs}}• [View Pipeline]({{.}})\n{{end}}",
+        "tag": "lark_md"
+      }
+    },
+    {{- end}}
+    {
+      "tag": "note",
+      "elements": [
+        {
+          "content": "Build ID: {{.BuildID}} | {{.StatusEmoji}} {{.Status}}",
+          "tag": "lark_md"
+        }
+      ]
+    }
+  ]
+}`
+
+func buildLarkCard(info *NotificationInfo) (LarkCard, error) {
+	tmpl, err := template.New("lark").Parse(larkCardTemplate)
+	if err != nil {
+		return LarkCard{}, fmt.Errorf("parse template: %w", err)
+	}
+
+	data := struct {
+		*NotificationInfo
+		StatusEmoji string
+		Template    string
+	}{
+		NotificationInfo: info,
+		StatusEmoji:      StatusToEmoji(info.Status),
+		Template:         StatusToTemplate(info.Status),
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return LarkCard{}, fmt.Errorf("execute template: %w", err)
+	}
+
+	var card LarkCard
+	if err := json.Unmarshal(buf.Bytes(), &card); err != nil {
+		return LarkCard{}, fmt.Errorf("unmarshal card: %w", err)
+	}
+
+	return card, nil
+}

--- a/tibuild/pkg/rest/service/notifier_test.go
+++ b/tibuild/pkg/rest/service/notifier_test.go
@@ -1,0 +1,242 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLarkNotifier_Notify_Disabled(t *testing.T) {
+	notifier := NewLarkNotifier("http://example.com/webhook", false)
+	build := &DevBuild{
+		ID: 1,
+		Spec: DevBuildSpec{
+			Product: ProductTidb,
+			Version: "v7.5.0",
+		},
+		Status: DevBuildStatus{
+			Status: BuildStatusSuccess,
+		},
+	}
+
+	err := notifier.Notify(context.Background(), build)
+	assert.NoError(t, err)
+}
+
+func TestLarkNotifier_Notify_Success(t *testing.T) {
+	var receivedMsg LarkCardMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&receivedMsg)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := NewLarkNotifier(server.URL, true)
+	build := &DevBuild{
+		ID: 1,
+		Spec: DevBuildSpec{
+			Product:  ProductTidb,
+			Version:  "v7.5.0",
+			Platform: LinuxAmd64,
+			IsHotfix: false,
+		},
+		Meta: DevBuildMeta{
+			CreatedBy: "testuser",
+		},
+		Status: DevBuildStatus{
+			Status:          BuildStatusSuccess,
+			PipelineViewURLs: []string{"http://tekton.example.com/pipeline1"},
+		},
+	}
+
+	err := notifier.Notify(context.Background(), build)
+	require.NoError(t, err)
+
+	assert.Equal(t, "interactive", receivedMsg.MsgType)
+	assert.Equal(t, "green", receivedMsg.Card.Header.Template)
+	assert.Contains(t, receivedMsg.Card.Header.Title.Content, "SUCCESS")
+	assert.Contains(t, receivedMsg.Card.Header.Title.Content, "tidb")
+	assert.Contains(t, receivedMsg.Card.Header.Title.Content, "v7.5.0")
+}
+
+func TestLarkNotifier_Notify_Failure(t *testing.T) {
+	var receivedMsg LarkCardMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&receivedMsg)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := NewLarkNotifier(server.URL, true)
+	build := &DevBuild{
+		ID: 1,
+		Spec: DevBuildSpec{
+			Product: ProductTikv,
+			Version: "v8.0.0",
+		},
+		Status: DevBuildStatus{
+			Status: BuildStatusFailure,
+		},
+	}
+
+	err := notifier.Notify(context.Background(), build)
+	require.NoError(t, err)
+
+	assert.Equal(t, "red", receivedMsg.Card.Header.Template)
+	assert.Contains(t, receivedMsg.Card.Header.Title.Content, "FAILURE")
+}
+
+func TestLarkNotifier_Notify_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	notifier := NewLarkNotifier(server.URL, true)
+	build := &DevBuild{
+		ID: 1,
+		Spec: DevBuildSpec{
+			Product: ProductTidb,
+			Version: "v7.5.0",
+		},
+		Status: DevBuildStatus{
+			Status: BuildStatusSuccess,
+		},
+	}
+
+	err := notifier.Notify(context.Background(), build)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status code: 500")
+}
+
+func TestStatusToTemplate(t *testing.T) {
+	tests := []struct {
+		status   string
+		expected string
+	}{
+		{BuildStatusSuccess, "green"},
+		{BuildStatusFailure, "red"},
+		{BuildStatusError, "red"},
+		{BuildStatusAborted, "orange"},
+		{BuildStatusPending, "blue"},
+		{BuildStatusProcessing, "blue"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			result := StatusToTemplate(tt.status)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStatusToEmoji(t *testing.T) {
+	tests := []struct {
+		status   string
+		expected string
+	}{
+		{BuildStatusSuccess, "✅"},
+		{BuildStatusFailure, "❌"},
+		{BuildStatusError, "⚠️"},
+		{BuildStatusAborted, "🚫"},
+		{BuildStatusPending, "⏳"},
+		{BuildStatusProcessing, "⏳"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			result := StatusToEmoji(tt.status)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildLarkCard(t *testing.T) {
+	info := &NotificationInfo{
+		Product:   "tidb",
+		Version:   "v7.5.0",
+		Status:    BuildStatusSuccess,
+		Platform:  LinuxAmd64,
+		ViewURLs:  []string{"http://tekton.example.com/pipeline1"},
+		CreatedBy: "testuser",
+		BuildID:   123,
+		IsHotfix:  false,
+	}
+
+	card, err := buildLarkCard(info)
+	require.NoError(t, err)
+
+	assert.Equal(t, "green", card.Header.Template)
+	assert.Contains(t, card.Header.Title.Content, "✅")
+	assert.Contains(t, card.Header.Title.Content, "SUCCESS")
+	assert.NotEmpty(t, card.Elements)
+}
+
+func TestLarkNotifier_Notify_Hotfix(t *testing.T) {
+	var receivedMsg LarkCardMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&receivedMsg)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := NewLarkNotifier(server.URL, true)
+	build := &DevBuild{
+		ID: 1,
+		Spec: DevBuildSpec{
+			Product:  ProductTidb,
+			Version:  "v7.5.0-20240101",
+			IsHotfix: true,
+		},
+		Status: DevBuildStatus{
+			Status: BuildStatusSuccess,
+		},
+	}
+
+	err := notifier.Notify(context.Background(), build)
+	require.NoError(t, err)
+
+	assert.Equal(t, "green", receivedMsg.Card.Header.Template)
+}
+
+func TestLarkNotifier_Notify_ContextCanceled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := NewLarkNotifier(server.URL, true)
+	build := &DevBuild{
+		ID: 1,
+		Spec: DevBuildSpec{
+			Product: ProductTidb,
+			Version: "v7.5.0",
+		},
+		Status: DevBuildStatus{
+			Status: BuildStatusSuccess,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := notifier.Notify(ctx, build)
+	assert.Error(t, err)
+}

--- a/tibuild/pkg/rest/service/tekton_reconciler.go
+++ b/tibuild/pkg/rest/service/tekton_reconciler.go
@@ -1,0 +1,305 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	tektonclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	eventIDLabel = "triggers.tekton.dev/eventId"
+)
+
+// TektonReconcilerConfig holds configuration for the reconciler.
+type TektonReconcilerConfig struct {
+	// Enabled controls whether the reconciler runs.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Namespace is the Kubernetes namespace where Tekton PipelineRuns are created.
+	Namespace string `yaml:"namespace" json:"namespace"`
+	// Interval is how often the reconciler polls for stale builds.
+	Interval time.Duration `yaml:"interval" json:"interval"`
+	// StaleThreshold is the minimum age of a PROCESSING build before reconciliation.
+	StaleThreshold time.Duration `yaml:"stale_threshold" json:"stale_threshold"`
+}
+
+// DefaultReconcilerConfig returns a config with sensible defaults.
+func DefaultReconcilerConfig() TektonReconcilerConfig {
+	return TektonReconcilerConfig{
+		Enabled:        false,
+		Namespace:      "ee-cd",
+		Interval:       60 * time.Second,
+		StaleThreshold: 5 * time.Minute,
+	}
+}
+
+// PipelineRunLister is an interface for listing PipelineRuns (for testing).
+type PipelineRunLister interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*tekton.PipelineRunList, error)
+}
+
+// TektonReconciler reconciles DevBuild records with Tekton PipelineRun status.
+type TektonReconciler struct {
+	repo      DevBuildRepository
+	config    TektonReconcilerConfig
+	k8sClient kubernetes.Interface
+	prLister  PipelineRunLister
+	now       func() time.Time
+}
+
+// NewTektonReconciler creates a new reconciler with in-cluster Kubernetes config.
+func NewTektonReconciler(repo DevBuildRepository, config TektonReconcilerConfig) (*TektonReconciler, error) {
+	if !config.Enabled {
+		return &TektonReconciler{repo: repo, config: config, now: time.Now}, nil
+	}
+
+	k8sConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get in-cluster config: %w", err)
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	tektonCS, err := tektonclient.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tekton client: %w", err)
+	}
+
+	return &TektonReconciler{
+		repo:      repo,
+		config:    config,
+		k8sClient: k8sClient,
+		prLister:  tektonCS.PipelineRuns(config.Namespace),
+		now:       time.Now,
+	}, nil
+}
+
+// NewTektonReconcilerWithClients creates a reconciler with injected clients (for testing).
+func NewTektonReconcilerWithClients(repo DevBuildRepository, config TektonReconcilerConfig, k8sClient kubernetes.Interface, prLister PipelineRunLister) *TektonReconciler {
+	return &TektonReconciler{
+		repo:      repo,
+		config:    config,
+		k8sClient: k8sClient,
+		prLister:  prLister,
+		now:       time.Now,
+	}
+}
+
+// Start begins the reconciler loop in a background goroutine.
+// It returns immediately. The loop runs until the context is cancelled.
+func (r *TektonReconciler) Start(ctx context.Context) {
+	if !r.config.Enabled {
+		log.Info().Msg("tekton reconciler disabled")
+		return
+	}
+
+	go r.run(ctx)
+	log.Info().
+		Dur("interval", r.config.Interval).
+		Dur("stale_threshold", r.config.StaleThreshold).
+		Str("namespace", r.config.Namespace).
+		Msg("tekton reconciler started")
+}
+
+func (r *TektonReconciler) run(ctx context.Context) {
+	ticker := time.NewTicker(r.config.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info().Msg("tekton reconciler stopping")
+			return
+		case <-ticker.C:
+			r.reconcile(ctx)
+		}
+	}
+}
+
+func (r *TektonReconciler) reconcile(ctx context.Context) {
+	// Query all DevBuilds in PROCESSING status
+	builds, err := r.repo.List(ctx, DevBuildListOption{})
+	if err != nil {
+		log.Error().Err(err).Msg("failed to list devbuilds for reconciliation")
+		return
+	}
+
+	now := r.now()
+	for _, build := range builds {
+		// Only process Tekton builds in PROCESSING status with an eventID
+		if build.Spec.PipelineEngine != TektonEngine {
+			continue
+		}
+		if build.Status.Status != BuildStatusProcessing {
+			continue
+		}
+		if build.Status.TektonStatus == nil || build.Status.TektonStatus.EventID == "" {
+			continue
+		}
+
+		// Check if the build is stale (older than threshold)
+		age := now.Sub(build.Meta.UpdatedAt)
+		if age < r.config.StaleThreshold {
+			continue
+		}
+
+		r.reconcileBuild(ctx, build)
+	}
+}
+
+func (r *TektonReconciler) reconcileBuild(ctx context.Context, build DevBuild) {
+	eventID := build.Status.TektonStatus.EventID
+	logger := log.With().
+		Int("build_id", build.ID).
+		Str("event_id", eventID).
+		Str("namespace", r.config.Namespace).
+		Logger()
+
+	// Query PipelineRuns with the eventID label
+	selector := labels.SelectorFromSet(labels.Set{
+		eventIDLabel: eventID,
+	})
+
+	pipelineRuns, err := r.prLister.List(ctx, metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to list pipelineruns")
+		return
+	}
+
+	if len(pipelineRuns.Items) == 0 {
+		logger.Warn().Msg("no pipelineruns found for eventID")
+		return
+	}
+
+	// Process each PipelineRun and merge status
+	updated := false
+	for _, pr := range pipelineRuns.Items {
+		pipeline := r.pipelineRunToTektonPipeline(pr)
+		if pipeline == nil {
+			continue
+		}
+
+		// Only update if the PipelineRun has completed
+		if pipeline.Status == BuildStatusProcessing {
+			continue
+		}
+
+		// Re-fetch to avoid race conditions
+		latest, err := r.repo.Get(ctx, build.ID)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to re-fetch build")
+			continue
+		}
+
+		if latest.Status.TektonStatus == nil {
+			latest.Status.TektonStatus = &TektonStatus{}
+		}
+
+		// Merge pipeline status (idempotent)
+		r.mergePipelineStatus(latest.Status.TektonStatus, *pipeline)
+
+		// Recompute overall status
+		computeTektonStatus(latest.Status.TektonStatus, &latest.Status)
+
+		latest.Meta.UpdatedAt = r.now()
+		_, err = r.repo.Update(ctx, build.ID, *latest)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to update build status")
+			continue
+		}
+
+		updated = true
+		logger.Info().
+			Str("pipeline_name", pipeline.Name).
+			Str("pipeline_status", pipeline.Status).
+			Msg("reconciled build status")
+	}
+
+	if updated {
+		logger.Info().Msg("build reconciled successfully")
+	}
+}
+
+func (r *TektonReconciler) pipelineRunToTektonPipeline(pr tekton.PipelineRun) *TektonPipeline {
+	// Determine status based on PipelineRun conditions
+	status := BuildStatusProcessing
+	if pr.Status.CompletionTime != nil {
+		// Check the Succeeded condition
+		for _, cond := range pr.Status.Conditions {
+			if cond.Type == "Succeeded" {
+				if cond.Status == "True" {
+					status = BuildStatusSuccess
+				} else {
+					status = BuildStatusFailure
+				}
+				break
+			}
+		}
+	}
+
+	// Parse platform from params
+	platform := ""
+	for _, p := range pr.Spec.Params {
+		if p.Name == "os" {
+			platform = p.Value.StringVal
+		}
+		if p.Name == "arch" && platform != "" {
+			platform = platform + "/" + p.Value.StringVal
+		}
+	}
+
+	// Parse git hash
+	gitHash := ""
+	for _, p := range pr.Spec.Params {
+		if p.Name == "git-revision" {
+			v := p.Value.StringVal
+			if len(v) == 40 {
+				gitHash = v
+			}
+		}
+	}
+
+	var startAt, endAt *time.Time
+	if pr.Status.StartTime != nil {
+		startAt = &pr.Status.StartTime.Time
+	}
+	if pr.Status.CompletionTime != nil {
+		endAt = &pr.Status.CompletionTime.Time
+	}
+
+	return &TektonPipeline{
+		Name:     pr.Name,
+		Platform: platform,
+		GitHash:  gitHash,
+		Status:   status,
+		StartAt:  startAt,
+		EndAt:    endAt,
+	}
+}
+
+func (r *TektonReconciler) mergePipelineStatus(tekton *TektonStatus, pipeline TektonPipeline) {
+	name := pipeline.Name
+	index := -1
+	for i, p := range tekton.Pipelines {
+		if p.Name == name {
+			index = i
+		}
+	}
+	if index >= 0 {
+		tekton.Pipelines[index] = pipeline
+	} else {
+		tekton.Pipelines = append(tekton.Pipelines, pipeline)
+	}
+}

--- a/tibuild/pkg/rest/service/tekton_reconciler.go
+++ b/tibuild/pkg/rest/service/tekton_reconciler.go
@@ -249,26 +249,11 @@ func (r *TektonReconciler) pipelineRunToTektonPipeline(pr tekton.PipelineRun) *T
 		}
 	}
 
-	// Parse platform from params
-	platform := ""
-	for _, p := range pr.Spec.Params {
-		if p.Name == "os" {
-			platform = p.Value.StringVal
-		}
-		if p.Name == "arch" && platform != "" {
-			platform = platform + "/" + p.Value.StringVal
-		}
-	}
-
-	// Parse git hash
-	gitHash := ""
-	for _, p := range pr.Spec.Params {
-		if p.Name == "git-revision" {
-			v := p.Value.StringVal
-			if len(v) == 40 {
-				gitHash = v
-			}
-		}
+	// Extract artifacts and images from PipelineRun results
+	ociArtifacts := ConvertOciArtifacts(pr)
+	images, err := ParseTektonImage(pr.Status.PipelineResults)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to parse tekton images")
 	}
 
 	var startAt, endAt *time.Time
@@ -280,12 +265,14 @@ func (r *TektonReconciler) pipelineRunToTektonPipeline(pr tekton.PipelineRun) *T
 	}
 
 	return &TektonPipeline{
-		Name:     pr.Name,
-		Platform: platform,
-		GitHash:  gitHash,
-		Status:   status,
-		StartAt:  startAt,
-		EndAt:    endAt,
+		Name:         pr.Name,
+		Platform:     ParsePlatform(pr),
+		GitHash:      ParseGitHash(pr),
+		Status:       status,
+		OciArtifacts: ociArtifacts,
+		Images:       images,
+		StartAt:      startAt,
+		EndAt:        endAt,
 	}
 }
 

--- a/tibuild/pkg/rest/service/tekton_reconciler_test.go
+++ b/tibuild/pkg/rest/service/tekton_reconciler_test.go
@@ -1,0 +1,330 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+type mockRepoForReconciler struct {
+	builds  []DevBuild
+	updated []DevBuild
+}
+
+func (m *mockRepoForReconciler) Create(ctx context.Context, req DevBuild) (resp *DevBuild, err error) {
+	req.ID = len(m.builds) + 1
+	m.builds = append(m.builds, req)
+	return &req, nil
+}
+
+func (m *mockRepoForReconciler) Get(ctx context.Context, id int) (resp *DevBuild, err error) {
+	for _, b := range m.builds {
+		if b.ID == id {
+			return &b, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockRepoForReconciler) Update(ctx context.Context, id int, req DevBuild) (resp *DevBuild, err error) {
+	for i, b := range m.builds {
+		if b.ID == id {
+			m.builds[i] = req
+			m.updated = append(m.updated, req)
+			return &req, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockRepoForReconciler) List(ctx context.Context, option DevBuildListOption) (resp []DevBuild, err error) {
+	return m.builds, nil
+}
+
+func TestTektonReconciler_Disabled(t *testing.T) {
+	repo := &mockRepoForReconciler{}
+	config := TektonReconcilerConfig{
+		Enabled: false,
+	}
+
+	reconciler := NewTektonReconcilerWithClients(repo, config, nil, nil)
+	assert.NotNil(t, reconciler)
+
+	// Should not panic when starting disabled reconciler
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reconciler.Start(ctx)
+}
+
+func TestTektonReconciler_SkipsNonTektonBuilds(t *testing.T) {
+	repo := &mockRepoForReconciler{
+		builds: []DevBuild{
+			{
+				ID: 1,
+				Spec: DevBuildSpec{
+					PipelineEngine: JenkinsEngine,
+				},
+				Status: DevBuildStatus{
+					Status: BuildStatusProcessing,
+				},
+			},
+		},
+	}
+
+	config := TektonReconcilerConfig{
+		Enabled:        true,
+		Namespace:      "ee-cd",
+		Interval:       1 * time.Second,
+		StaleThreshold: 0, // No threshold for test
+	}
+
+	reconciler := NewTektonReconcilerWithClients(repo, config, kubernetesfake.NewSimpleClientset(), nil)
+	reconciler.now = func() time.Time { return time.Now().Add(10 * time.Minute) }
+
+	// Run reconcile
+	reconciler.reconcile(context.Background())
+
+	// Should not have updated anything
+	assert.Empty(t, repo.updated)
+}
+
+func TestTektonReconciler_SkipsNonProcessingBuilds(t *testing.T) {
+	repo := &mockRepoForReconciler{
+		builds: []DevBuild{
+			{
+				ID: 1,
+				Spec: DevBuildSpec{
+					PipelineEngine: TektonEngine,
+				},
+				Status: DevBuildStatus{
+					Status: BuildStatusSuccess,
+					TektonStatus: &TektonStatus{
+						EventID: "test-event-id",
+					},
+				},
+			},
+		},
+	}
+
+	config := TektonReconcilerConfig{
+		Enabled:        true,
+		Namespace:      "ee-cd",
+		Interval:       1 * time.Second,
+		StaleThreshold: 0,
+	}
+
+	reconciler := NewTektonReconcilerWithClients(repo, config, kubernetesfake.NewSimpleClientset(), nil)
+	reconciler.now = func() time.Time { return time.Now().Add(10 * time.Minute) }
+
+	reconciler.reconcile(context.Background())
+
+	assert.Empty(t, repo.updated)
+}
+
+func TestTektonReconciler_SkipsBuildsWithoutEventID(t *testing.T) {
+	repo := &mockRepoForReconciler{
+		builds: []DevBuild{
+			{
+				ID: 1,
+				Spec: DevBuildSpec{
+					PipelineEngine: TektonEngine,
+				},
+				Status: DevBuildStatus{
+					Status:       BuildStatusProcessing,
+					TektonStatus: &TektonStatus{},
+				},
+			},
+		},
+	}
+
+	config := TektonReconcilerConfig{
+		Enabled:        true,
+		Namespace:      "ee-cd",
+		Interval:       1 * time.Second,
+		StaleThreshold: 0,
+	}
+
+	reconciler := NewTektonReconcilerWithClients(repo, config, kubernetesfake.NewSimpleClientset(), nil)
+	reconciler.now = func() time.Time { return time.Now().Add(10 * time.Minute) }
+
+	reconciler.reconcile(context.Background())
+
+	assert.Empty(t, repo.updated)
+}
+
+func TestTektonReconciler_SkipsFreshBuilds(t *testing.T) {
+	now := time.Now()
+	repo := &mockRepoForReconciler{
+		builds: []DevBuild{
+			{
+				ID: 1,
+				Spec: DevBuildSpec{
+					PipelineEngine: TektonEngine,
+				},
+				Meta: DevBuildMeta{
+					UpdatedAt: now,
+				},
+				Status: DevBuildStatus{
+					Status: BuildStatusProcessing,
+					TektonStatus: &TektonStatus{
+						EventID: "test-event-id",
+					},
+				},
+			},
+		},
+	}
+
+	config := TektonReconcilerConfig{
+		Enabled:        true,
+		Namespace:      "ee-cd",
+		Interval:       1 * time.Second,
+		StaleThreshold: 5 * time.Minute,
+	}
+
+	reconciler := NewTektonReconcilerWithClients(repo, config, kubernetesfake.NewSimpleClientset(), nil)
+	reconciler.now = func() time.Time { return now.Add(1 * time.Minute) } // Only 1 minute old
+
+	reconciler.reconcile(context.Background())
+
+	assert.Empty(t, repo.updated)
+}
+
+func TestTektonReconciler_UpdatesCompletedPipelineRun(t *testing.T) {
+	now := time.Now()
+	repo := &mockRepoForReconciler{
+		builds: []DevBuild{
+			{
+				ID: 1,
+				Spec: DevBuildSpec{
+					PipelineEngine: TektonEngine,
+				},
+				Meta: DevBuildMeta{
+					UpdatedAt: now,
+				},
+				Status: DevBuildStatus{
+					Status: BuildStatusProcessing,
+					TektonStatus: &TektonStatus{
+						EventID: "test-event-id",
+					},
+				},
+			},
+		},
+	}
+
+	config := TektonReconcilerConfig{
+		Enabled:        true,
+		Namespace:      "ee-cd",
+		Interval:       1 * time.Second,
+		StaleThreshold: 5 * time.Minute,
+	}
+
+	// Create a fake PipelineRun
+	startTime := metav1.NewTime(now.Add(-10 * time.Minute))
+	completionTime := metav1.NewTime(now.Add(-2 * time.Minute))
+	pipelineRun := &tekton.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline-run",
+			Namespace: "ee-cd",
+			Labels: map[string]string{
+				eventIDLabel: "test-event-id",
+			},
+		},
+		Spec: tekton.PipelineRunSpec{
+			Params: []tekton.Param{
+				{Name: "os", Value: tekton.ArrayOrString{StringVal: "linux"}},
+				{Name: "arch", Value: tekton.ArrayOrString{StringVal: "amd64"}},
+				{Name: "git-revision", Value: tekton.ArrayOrString{StringVal: "abc123def456abc123def456abc123def456abc1"}},
+			},
+		},
+		Status: tekton.PipelineRunStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					{
+						Type:   apis.ConditionSucceeded,
+						Status: "True",
+					},
+				},
+			},
+			PipelineRunStatusFields: tekton.PipelineRunStatusFields{
+				StartTime:      &startTime,
+				CompletionTime: &completionTime,
+			},
+		},
+	}
+
+	prLister := &fakePipelineRunLister{runs: []*tekton.PipelineRun{pipelineRun}}
+
+	reconciler := NewTektonReconcilerWithClients(repo, config, kubernetesfake.NewSimpleClientset(), prLister)
+	reconciler.now = func() time.Time { return now.Add(10 * time.Minute) }
+
+	reconciler.reconcile(context.Background())
+
+	// Should have updated the build
+	require.Len(t, repo.updated, 1)
+	updated := repo.updated[0]
+	assert.Equal(t, BuildStatusSuccess, updated.Status.TektonStatus.Pipelines[0].Status)
+	assert.Equal(t, "test-pipeline-run", updated.Status.TektonStatus.Pipelines[0].Name)
+	assert.Equal(t, "linux/amd64", updated.Status.TektonStatus.Pipelines[0].Platform)
+}
+
+func TestTektonReconciler_NoPipelineRunsFound(t *testing.T) {
+	now := time.Now()
+	repo := &mockRepoForReconciler{
+		builds: []DevBuild{
+			{
+				ID: 1,
+				Spec: DevBuildSpec{
+					PipelineEngine: TektonEngine,
+				},
+				Meta: DevBuildMeta{
+					UpdatedAt: now,
+				},
+				Status: DevBuildStatus{
+					Status: BuildStatusProcessing,
+					TektonStatus: &TektonStatus{
+						EventID: "test-event-id",
+					},
+				},
+			},
+		},
+	}
+
+	config := TektonReconcilerConfig{
+		Enabled:        true,
+		Namespace:      "ee-cd",
+		Interval:       1 * time.Second,
+		StaleThreshold: 5 * time.Minute,
+	}
+
+	// No PipelineRuns in the fake client
+	prLister := &fakePipelineRunLister{runs: []*tekton.PipelineRun{}}
+
+	reconciler := NewTektonReconcilerWithClients(repo, config, kubernetesfake.NewSimpleClientset(), prLister)
+	reconciler.now = func() time.Time { return now.Add(10 * time.Minute) }
+
+	reconciler.reconcile(context.Background())
+
+	// Should not have updated anything
+	assert.Empty(t, repo.updated)
+}
+
+// fakePipelineRunLister implements PipelineRunLister for testing.
+type fakePipelineRunLister struct {
+	runs []*tekton.PipelineRun
+}
+
+func (f *fakePipelineRunLister) List(ctx context.Context, opts metav1.ListOptions) (*tekton.PipelineRunList, error) {
+	list := &tekton.PipelineRunList{}
+	for _, run := range f.runs {
+		list.Items = append(list.Items, *run)
+	}
+	return list, nil
+}

--- a/tibuild/pkg/rest/service/tekton_reconciler_test.go
+++ b/tibuild/pkg/rest/service/tekton_reconciler_test.go
@@ -226,7 +226,7 @@ func TestTektonReconciler_UpdatesCompletedPipelineRun(t *testing.T) {
 		StaleThreshold: 5 * time.Minute,
 	}
 
-	// Create a fake PipelineRun
+	// Create a fake PipelineRun with artifacts
 	startTime := metav1.NewTime(now.Add(-10 * time.Minute))
 	completionTime := metav1.NewTime(now.Add(-2 * time.Minute))
 	pipelineRun := &tekton.PipelineRun{
@@ -256,6 +256,20 @@ func TestTektonReconciler_UpdatesCompletedPipelineRun(t *testing.T) {
 			PipelineRunStatusFields: tekton.PipelineRunStatusFields{
 				StartTime:      &startTime,
 				CompletionTime: &completionTime,
+				PipelineResults: []tekton.PipelineRunResult{
+					{
+						Name: "pushed-binaries",
+						Value: tekton.ArrayOrString{
+							StringVal: `{"oci":{"repo":"test-repo","tag":"v1.0","digest":"sha256:abc123"},"files":["file1.tar.gz","file2.tar.gz"]}`,
+						},
+					},
+					{
+						Name: "pushed-images",
+						Value: tekton.ArrayOrString{
+							StringVal: `{"images":[{"repo":"test-image","tag":"v1.0","platform":"linux/amd64"}]}`,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -273,6 +287,17 @@ func TestTektonReconciler_UpdatesCompletedPipelineRun(t *testing.T) {
 	assert.Equal(t, BuildStatusSuccess, updated.Status.TektonStatus.Pipelines[0].Status)
 	assert.Equal(t, "test-pipeline-run", updated.Status.TektonStatus.Pipelines[0].Name)
 	assert.Equal(t, "linux/amd64", updated.Status.TektonStatus.Pipelines[0].Platform)
+	assert.Equal(t, "abc123def456abc123def456abc123def456abc1", updated.Status.TektonStatus.Pipelines[0].GitHash)
+
+	// Verify artifacts are extracted
+	require.Len(t, updated.Status.TektonStatus.Pipelines[0].OciArtifacts, 1)
+	assert.Equal(t, "test-repo", updated.Status.TektonStatus.Pipelines[0].OciArtifacts[0].Repo)
+	assert.Equal(t, "v1.0", updated.Status.TektonStatus.Pipelines[0].OciArtifacts[0].Tag)
+	assert.Equal(t, []string{"file1.tar.gz", "file2.tar.gz"}, updated.Status.TektonStatus.Pipelines[0].OciArtifacts[0].Files)
+
+	require.Len(t, updated.Status.TektonStatus.Pipelines[0].Images, 1)
+	assert.Equal(t, "test-image:v1.0", updated.Status.TektonStatus.Pipelines[0].Images[0].URL)
+	assert.Equal(t, "linux/amd64", updated.Status.TektonStatus.Pipelines[0].Images[0].Platform)
 }
 
 func TestTektonReconciler_NoPipelineRunsFound(t *testing.T) {

--- a/tibuild/pkg/rest/service/tekton_utils.go
+++ b/tibuild/pkg/rest/service/tekton_utils.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"fmt"
+	"log/slog"
+
+	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// ParsePlatform extracts the platform (os/arch) from PipelineRun params.
+func ParsePlatform(pipeline tekton.PipelineRun) string {
+	os := ""
+	arch := ""
+	for _, p := range pipeline.Spec.Params {
+		switch p.Name {
+		case "os":
+			os = p.Value.StringVal
+		case "arch":
+			arch = p.Value.StringVal
+		}
+	}
+	if os != "" && arch != "" {
+		return os + "/" + arch
+	}
+	return ""
+}
+
+// ParseGitHash extracts the git revision from PipelineRun params.
+func ParseGitHash(pipeline tekton.PipelineRun) string {
+	for _, p := range pipeline.Spec.Params {
+		if p.Name == "git-revision" {
+			v := p.Value.StringVal
+			if len(v) == 40 {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// ConvertOciArtifacts extracts OCI artifacts from PipelineRun results.
+func ConvertOciArtifacts(pipeline tekton.PipelineRun) []OciArtifact {
+	var rt []OciArtifact
+	for _, r := range pipeline.Status.PipelineResults {
+		if r.Name == "pushed-binaries" {
+			v, err := convertOciArtifact(r.Value.StringVal)
+			if err != nil {
+				slog.Error("can not parse oci file", "error", err.Error())
+				// this make error can be seen by frontend, and not block other result
+				v = &OciArtifact{Repo: "parse_error", Tag: r.Value.StringVal, Files: []string{"error_parse_artifact"}}
+			}
+			rt = append(rt, *v)
+		}
+	}
+	return rt
+}
+
+type TektonOciArtifactStruct struct {
+	OCI struct {
+		Repo   string `json:"repo"`
+		Tag    string `json:"tag"`
+		Digest string `json:"digest"`
+	} `json:"oci"`
+	Files []string `json:"files"`
+}
+
+func convertOciArtifact(text string) (*OciArtifact, error) {
+	tekton_oci_artifact := TektonOciArtifactStruct{}
+	err := yaml.Unmarshal([]byte(text), &tekton_oci_artifact)
+	if err != nil {
+		return nil, err
+	}
+	return &OciArtifact{
+		Repo:  tekton_oci_artifact.OCI.Repo,
+		Tag:   tekton_oci_artifact.OCI.Tag,
+		Files: tekton_oci_artifact.Files,
+	}, nil
+}
+
+// TektonImageStruct represents the image structure in Tekton results.
+type TektonImageStruct struct {
+	Images []struct {
+		Repo          string   `json:"repo" yaml:"repo"`
+		Platform      string   `json:"platform" yaml:"platform"`
+		Tag           string   `json:"tag" yaml:"tag"`
+		Tags          []string `json:"tags" yaml:"tags"`
+		MultiArchTags []string `json:"multi_arch_tags" yaml:"multi_arch_tags"`
+		URL           string   `json:"url" yaml:"url"`
+	} `json:"images" yaml:"images"`
+}
+
+// ParseTektonImage extracts images from PipelineRun results.
+func ParseTektonImage(results []tekton.PipelineRunResult) ([]ImageArtifact, error) {
+	var rt []ImageArtifact
+	for _, r := range results {
+		if r.Name == "pushed-images" {
+			images := TektonImageStruct{}
+			err := yaml.Unmarshal([]byte(r.Value.StringVal), &images)
+			if err != nil {
+				return nil, err
+			}
+			for _, image := range images.Images {
+				imgURL := fmt.Sprintf("%s:%s", image.Repo, image.Tag)
+				rt = append(rt, ImageArtifact{URL: imgURL, Platform: image.Platform})
+
+				// if it has multi arch tags, then we append the multi-arch image with the first tag.
+				if len(image.MultiArchTags) > 0 {
+					multiArchImgURL := fmt.Sprintf("%s:%s", image.Repo, image.MultiArchTags[0])
+					rt = append(rt, ImageArtifact{URL: multiArchImgURL, Platform: MultiArch})
+				}
+			}
+		}
+	}
+	return rt, nil
+}

--- a/tibuild/pkg/webhook/service/cloudevent.go
+++ b/tibuild/pkg/webhook/service/cloudevent.go
@@ -11,7 +11,6 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"gopkg.in/yaml.v3"
 
 	rest "github.com/PingCAP-QE/ee-apps/tibuild/pkg/rest/service"
 )
@@ -92,7 +91,7 @@ func eventToDevbuildTekton(event cloudevents.Event) (pipeline *rest.TektonPipeli
 }
 
 func toDevbuildPipeline(pipeline tekton.PipelineRun) (*rest.TektonPipeline, error) {
-	images, err := parseTektonImage(pipeline.Status.PipelineResults)
+	images, err := rest.ParseTektonImage(pipeline.Status.PipelineResults)
 	if err != nil {
 		return nil, fmt.Errorf("parse image failed:%w", err)
 	}
@@ -105,114 +104,12 @@ func toDevbuildPipeline(pipeline tekton.PipelineRun) (*rest.TektonPipeline, erro
 	}
 	return &rest.TektonPipeline{
 		Name:         pipeline.Name,
-		Platform:     parsePlatform(pipeline),
-		GitHash:      parseGitHash(pipeline),
-		OciArtifacts: convertOciArtifacts(pipeline),
+		Platform:     rest.ParsePlatform(pipeline),
+		GitHash:      rest.ParseGitHash(pipeline),
+		OciArtifacts: rest.ConvertOciArtifacts(pipeline),
 		Images:       images,
 		StartAt:      startAt,
 		EndAt:        endAt,
 	}, nil
 }
 
-func parsePlatform(pipeline tekton.PipelineRun) string {
-	os := ""
-	arch := ""
-	for _, p := range pipeline.Spec.Params {
-		switch p.Name {
-		case "os":
-			os = p.Value.StringVal
-		case "arch":
-			arch = p.Value.StringVal
-		}
-	}
-	if os != "" && arch != "" {
-		return os + "/" + arch
-	} else {
-		return ""
-	}
-}
-
-func parseGitHash(pipeline tekton.PipelineRun) string {
-	for _, p := range pipeline.Spec.Params {
-		if p.Name == "git-revision" {
-			v := p.Value.StringVal
-			if len(v) == 40 {
-				return v
-			}
-		}
-	}
-	return ""
-}
-
-func convertOciArtifacts(pipeline tekton.PipelineRun) []rest.OciArtifact {
-	var rt []rest.OciArtifact
-	for _, r := range pipeline.Status.PipelineResults {
-		if r.Name == "pushed-binaries" {
-			v, err := convertOciArtifact(r.Value.StringVal)
-			if err != nil {
-				slog.Error("can not parse oci file", "error", err.Error())
-				// this make error can be seen by frontend, and not block other result
-				v = &rest.OciArtifact{Repo: "parse_error", Tag: r.Value.StringVal, Files: []string{"error_parse_artifact"}}
-			}
-			rt = append(rt, *v)
-		}
-	}
-	return rt
-}
-
-type TektonOciArtifactStruct struct {
-	OCI struct {
-		Repo   string `json:"repo"`
-		Tag    string `json:"tag"`
-		Digest string `json:"digest"`
-	} `json:"oci"`
-	Files []string `json:"files"`
-}
-
-func convertOciArtifact(text string) (*rest.OciArtifact, error) {
-	tekton_oci_artifact := TektonOciArtifactStruct{}
-	err := yaml.Unmarshal([]byte(text), &tekton_oci_artifact)
-	if err != nil {
-		return nil, err
-	}
-	return &rest.OciArtifact{
-		Repo:  tekton_oci_artifact.OCI.Repo,
-		Tag:   tekton_oci_artifact.OCI.Tag,
-		Files: tekton_oci_artifact.Files,
-	}, nil
-}
-
-type TektonImageStruct struct {
-	Images []struct {
-		Repo          string   `json:"repo" yaml:"repo"`
-		Platform      string   `json:"platform" yaml:"platform"` // TODO: implement the field in tekton result.
-		Tag           string   `json:"tag" yaml:"tag"`
-		Tags          []string `json:"tags" yaml:"tags"`
-		MultiArchTags []string `json:"multi_arch_tags" yaml:"multi_arch_tags"`
-		URL           string   `json:"url" yaml:"url"`
-	} `json:"images" yaml:"images"`
-}
-
-func parseTektonImage(results []tekton.PipelineRunResult) ([]rest.ImageArtifact, error) {
-	var rt []rest.ImageArtifact
-	for _, r := range results {
-		if r.Name == "pushed-images" {
-			images := TektonImageStruct{}
-			err := yaml.Unmarshal([]byte(r.Value.StringVal), &images)
-			if err != nil {
-				return nil, err
-			}
-			for _, image := range images.Images {
-				imgURL := fmt.Sprintf("%s:%s", image.Repo, image.Tag)
-				rt = append(rt, rest.ImageArtifact{URL: imgURL, Platform: image.Platform})
-
-				// if it has multi arch tags, then we append the multi-arch image with the first tag.
-				if len(image.MultiArchTags) > 0 {
-					multiArchImgURL := fmt.Sprintf("%s:%s", image.Repo, image.MultiArchTags[0])
-					rt = append(rt, rest.ImageArtifact{URL: multiArchImgURL, Platform: rest.MultiArch})
-				}
-			}
-		}
-	}
-	return rt, nil
-}

--- a/tibuild/pkg/webhook/service/cloudevent.go
+++ b/tibuild/pkg/webhook/service/cloudevent.go
@@ -112,4 +112,3 @@ func toDevbuildPipeline(pipeline tekton.PipelineRun) (*rest.TektonPipeline, erro
 		EndAt:        endAt,
 	}, nil
 }
-


### PR DESCRIPTION
## Summary

This PR implements FLA-217 PR1, PR2, and PR3:

### PR1: EventID + Direct Tekton Trigger
1. **Model**: Add `EventID` field to `TektonStatus` struct
2. **Config**: Add `tekton_direct_trigger` config switch
3. **CloudEventClient**: Support direct trigger to Tekton EventListener via `Request()` method
4. **Service**: Store `eventID` in DB after trigger

### PR2: TektonReconciler
1. **TektonReconciler**: Background goroutine for reconciling DevBuild records
2. **Reconciler Logic**: 
   - Queries PROCESSING builds with eventID older than 5 minutes
   - Fetches PipelineRun status by label `triggers.tekton.dev/eventId`
   - Updates DB record with PipelineRun status
   - Idempotent and reentrant
3. **Configuration**: Added `tekton_reconciler` config section
4. **Tests**: Comprehensive unit tests for reconciler

### PR3: Lark Notification
1. **Notifier Interface**: Added `Notifier` interface with `Notify()` method
2. **LarkNotifier Implementation**: Sends interactive card messages to Lark webhook
3. **Configuration**: Added Lark config section to `ConfigYaml` (webhook_url, enabled)
4. **Integration**: Notify() called in `MergeTektonStatus()` when build reaches terminal state
5. **Unit Tests**: Comprehensive tests for LarkNotifier

## Testing

- Unit tests for CloudEventClient, TektonReconciler, and LarkNotifier
- Tests cover disabled notifier, success/failure notifications, server errors, context cancellation

## Risk

- Low risk: Features behind config flags (default: false)
  - `tekton_direct_trigger`: Direct trigger to Tekton
  - `tekton_reconciler.enabled`: Background reconciler
  - `lark.enabled`: Lark notifications
- When disabled, falls back to existing behavior
- Notification failure doesn't block build processing

Ref: FLA-217