### PR TITLE
fix(ci-dashboard): lock flaky weekly table columns

### DIFF
--- a/ci-dashboard/web/src/components/charts.jsx
+++ b/ci-dashboard/web/src/components/charts.jsx
@@ -1484,10 +1484,20 @@ export function IssueWeeklyRateTable({ weeks, rows, scrollClassName = "" }) {
   }
 
   const highlightStartIndex = Math.max(weeks.length - 2, 0);
+  const tableWidthPx = 360 + weeks.length * 170;
 
   return (
     <div className={`table-scroll ${scrollClassName}`.trim()}>
-      <table className="data-table data-table--issue-weekly">
+      <table
+        className="data-table data-table--issue-weekly"
+        style={{ "--issue-table-width": `${tableWidthPx}px` }}
+      >
+        <colgroup>
+          <col className="issue-weekly-case-col" />
+          {weeks.map((week) => (
+            <col className="issue-weekly-week-col" key={week} />
+          ))}
+        </colgroup>
         <thead>
           <tr>
             <th>Case name</th>

--- a/ci-dashboard/web/src/styles.css
+++ b/ci-dashboard/web/src/styles.css
@@ -1958,7 +1958,19 @@ select {
 }
 
 .data-table--issue-weekly {
-  min-width: 1120px;
+  --issue-case-column-width: 360px;
+  --issue-week-column-width: 170px;
+  width: max(100%, var(--issue-table-width));
+  min-width: max(1120px, var(--issue-table-width));
+  table-layout: fixed;
+}
+
+.data-table--issue-weekly .issue-weekly-case-col {
+  width: var(--issue-case-column-width);
+}
+
+.data-table--issue-weekly .issue-weekly-week-col {
+  width: var(--issue-week-column-width);
 }
 
 .data-table th,
@@ -2014,9 +2026,9 @@ select {
 
 .data-table--issue-weekly thead th:first-child,
 .data-table--issue-weekly tbody th {
-  width: 360px;
-  min-width: 360px;
-  max-width: 360px;
+  width: var(--issue-case-column-width);
+  min-width: var(--issue-case-column-width);
+  max-width: var(--issue-case-column-width);
 }
 
 .data-table--issue-weekly thead th:first-child {
@@ -2025,6 +2037,7 @@ select {
 
 .data-table--issue-weekly .issue-cell {
   min-width: 0;
+  max-width: 100%;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

- Lock `IssueWeeklyRateTable` column geometry with a `colgroup` and fixed table layout.
- Size the table from the number of weekly columns so large date ranges scroll horizontally without letting case names participate in auto table sizing.
- Keep the sticky case-name column opaque and clipped with ellipsis so scrolled metric cells cannot overlap it.

## Verification

- `npm test` in `ci-dashboard/web`
- `npm run build` in `ci-dashboard/web`
- Playwright checked a long-range flaky table after horizontal scroll: sticky column remained 360px, hit-testing stayed on the sticky `TH`, and case links stayed inside the column.
