### PR TITLE
fix: normalize v26.3.* versions to v26.3.99 for ops platform

### DIFF
--- a/publisher/internal/service/impl/tidbcloud/ops.go
+++ b/publisher/internal/service/impl/tidbcloud/ops.go
@@ -12,11 +12,15 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const nextgenCalendarTagThreshold = "v26.0.0"
+const (
+	nextgenCalendarTagThreshold = "v26.0.0"
+	v263FixedVersion            = "v26.3.99"
+)
 
 var (
 	legacyNextgenImageTagRegexp         = regexp.MustCompile(`^v\d+\.\d+\.\d+-nextgen\.\d{6}\.\d+$`)
 	calendarSemverNextgenImageTagRegexp = regexp.MustCompile(`^v2[6-9]\.\d+\.\d+(-nextgen)?$`)
+	v263VersionRegexp                   = regexp.MustCompile(`^v26\.3\.\d+$`)
 )
 
 // UpdateComponentVersionInCloudconfig implements
@@ -62,6 +66,10 @@ func (s *tidbcloudsrvc) UpdateComponentVersionInCloudconfig(ctx context.Context,
 	slices.Sort(components)
 
 	componentVersion := strings.SplitN(imageTag, "-", 2)[0]
+
+	// Normalize v26.3.* versions to v26.3.99 as a transition measure.
+	// See: https://github.com/pingcap-qe/ee-apps/issues/FLA-223
+	componentVersion = normalizeComponentVersion(componentVersion)
 
 	for _, component := range components {
 		c := stageCfg.Components[component]
@@ -194,4 +202,11 @@ func isSupportedNextgenImageTag(tag string) bool {
 	}
 
 	return false
+}
+
+func normalizeComponentVersion(version string) string {
+	if v263VersionRegexp.MatchString(version) {
+		return v263FixedVersion
+	}
+	return version
 }

--- a/publisher/internal/service/impl/tidbcloud/ops.go
+++ b/publisher/internal/service/impl/tidbcloud/ops.go
@@ -68,7 +68,6 @@ func (s *tidbcloudsrvc) UpdateComponentVersionInCloudconfig(ctx context.Context,
 	componentVersion := strings.SplitN(imageTag, "-", 2)[0]
 
 	// Normalize v26.3.* versions to v26.3.99 as a transition measure.
-	// See: https://github.com/pingcap-qe/ee-apps/issues/FLA-223
 	componentVersion = normalizeComponentVersion(componentVersion)
 
 	for _, component := range components {

--- a/publisher/internal/service/impl/tidbcloud/ops_test.go
+++ b/publisher/internal/service/impl/tidbcloud/ops_test.go
@@ -23,3 +23,27 @@ func TestIsSupportedNextgenImageTag(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeComponentVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{version: "v26.3.0", want: "v26.3.99"},
+		{version: "v26.3.1", want: "v26.3.99"},
+		{version: "v26.3.2", want: "v26.3.99"},
+		{version: "v26.3.99", want: "v26.3.99"},
+		{version: "v26.3.100", want: "v26.3.99"},
+		{version: "v26.2.0", want: "v26.2.0"},
+		{version: "v26.4.0", want: "v26.4.0"},
+		{version: "v27.0.0", want: "v27.0.0"},
+		{version: "v8.5.4", want: "v8.5.4"},
+		{version: "v25.12.9", want: "v25.12.9"},
+	}
+
+	for _, tt := range tests {
+		if got := normalizeComponentVersion(tt.version); got != tt.want {
+			t.Fatalf("normalizeComponentVersion(%q) = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Normalize v26.3.* versions to v26.3.99 for the tidbcloud ops platform as requested.

## Changes

- Added  function to handle v26.3.* version normalization
- Added regex pattern  to match v26.3.* versions
- Applied normalization in  function
- Added unit tests for the normalization logic

## Testing

- Added  with comprehensive test cases
- All existing tests pass
- Verified that only v26.3.* versions are affected, all other versions remain unchanged

## Risk

Low risk - change is minimal and only affects v26.3.* versions as specified.