### PR TITLE
feat(tibuild): add paramPluginGitRef CloudEvent extension

### DIFF
--- a/experiments/tibuild-v2/internal/service/impl/devbuild_tekton.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_tekton.go
@@ -140,6 +140,9 @@ func (s *devbuildsrvc) newDevBuildCloudEvent(record *ent.DevBuild, platform stri
 	if platform != "" {
 		event.SetExtension("paramPlatform", platform)
 	}
+	if record.PluginGitRef != "" {
+		event.SetExtension("paramPluginGitRef", record.PluginGitRef)
+	}
 
 	return &event, nil
 }

--- a/experiments/tibuild-v2/internal/service/impl/devbuild_tekton_test.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_tekton_test.go
@@ -1,0 +1,43 @@
+package impl
+
+import (
+	"testing"
+
+	"github.com/PingCAP-QE/ee-apps/tibuild/internal/database/ent"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDevBuildCloudEvent_PluginGitRef(t *testing.T) {
+	s := &devbuildsrvc{}
+	record := &ent.DevBuild{
+		ID:          1,
+		CreatedBy:   "test@pingcap.com",
+		Product:     "tidb",
+		Edition:     "community",
+		GithubRepo:  "pingcap/tidb",
+		GitRef:      "branch/master",
+		PluginGitRef: "release-8.5.4",
+	}
+
+	event, err := s.newDevBuildCloudEvent(record, LinuxAmd64)
+	require.NoError(t, err)
+	require.Equal(t, "release-8.5.4", event.Extensions()["paramplugingitref"])
+}
+
+func TestNewDevBuildCloudEvent_PluginGitRefEmpty(t *testing.T) {
+	s := &devbuildsrvc{}
+	record := &ent.DevBuild{
+		ID:          1,
+		CreatedBy:   "test@pingcap.com",
+		Product:     "tidb",
+		Edition:     "community",
+		GithubRepo:  "pingcap/tidb",
+		GitRef:      "branch/master",
+		PluginGitRef: "",
+	}
+
+	event, err := s.newDevBuildCloudEvent(record, LinuxAmd64)
+	require.NoError(t, err)
+	_, ok := event.Extensions()["paramplugingitref"]
+	require.False(t, ok)
+}

--- a/tibuild/pkg/rest/service/cloud_event_client.go
+++ b/tibuild/pkg/rest/service/cloud_event_client.go
@@ -108,6 +108,9 @@ func newDevBuildCloudEvents(dev DevBuild) ([]cloudevents.Event, error) {
 		if platform != "" {
 			event.SetExtension("paramPlatform", platform)
 		}
+		if dev.Spec.PluginGitRef != "" {
+			event.SetExtension("paramPluginGitRef", dev.Spec.PluginGitRef)
+		}
 		events = append(events, event)
 	}
 

--- a/tibuild/pkg/rest/service/cloud_event_client_test.go
+++ b/tibuild/pkg/rest/service/cloud_event_client_test.go
@@ -46,6 +46,30 @@ func TestNewEventNormalizesNextGenProfile(t *testing.T) {
 	require.Equal(t, "nextgen", evs[1].Extensions()["paramprofile"])
 }
 
+func TestNewEventPluginGitRef(t *testing.T) {
+	dev := sampleDevBuild()
+	dev.Spec.GitHash = "754095a9f460dcf31f053045cfedfb00b9ad8e81"
+	dev.Spec.PluginGitRef = "release-8.5.4"
+
+	evs, err := newDevBuildCloudEvents(dev)
+	require.NoError(t, err)
+	require.Len(t, evs, 2)
+	require.Equal(t, "release-8.5.4", evs[0].Extensions()["paramplugingitref"])
+	require.Equal(t, "release-8.5.4", evs[1].Extensions()["paramplugingitref"])
+}
+
+func TestNewEventPluginGitRefEmpty(t *testing.T) {
+	dev := sampleDevBuild()
+	dev.Spec.GitHash = "754095a9f460dcf31f053045cfedfb00b9ad8e81"
+	dev.Spec.PluginGitRef = ""
+
+	evs, err := newDevBuildCloudEvents(dev)
+	require.NoError(t, err)
+	require.Len(t, evs, 2)
+	_, ok := evs[0].Extensions()["paramplugingitref"]
+	require.False(t, ok)
+}
+
 func TestTrigger(t *testing.T) {
 	if os.Getenv("TEST_FANOUT") == "" {
 		t.Skip("Skipping send event")


### PR DESCRIPTION
## Summary

Add `paramPluginGitRef` CloudEvent extension in tibuild's `newDevBuildCloudEvents()` when `PluginGitRef` is non-empty.

## Changes

- `cloud_event_client.go`: Add conditional `event.SetExtension("paramPluginGitRef", dev.Spec.PluginGitRef)` after existing extensions
- `cloud_event_client_test.go`: Add 2 unit tests — non-empty (verifies extension present) and empty (verifies extension absent)

## Testing

- `TestNewEventPluginGitRef`: PluginGitRef="release-8.5.4" → CloudEvent includes `ce-paramPluginGitRef` header
- `TestNewEventPluginGitRefEmpty`: PluginGitRef="" → no `paramPluginGitRef` extension
- Full package tests pass: `go test ./pkg/rest/service/`
- `go vet` clean

## Risk

Low. Additive-only change — new extension is only set when PluginGitRef is non-empty, so existing behavior is unchanged. Tekton ignores unknown extensions.

## Rollback

Remove the `SetExtension` line — CloudEvent reverts, Tekton falls back to derived ref.

Refs: FLA-225 PR1