### PR TITLE
fix(cost-insight): refill live AC cleanup target after stale rows

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -88,9 +88,17 @@ class TableCountResult:
 
 
 @dataclass(frozen=True)
+class AcSeedCursor:
+    last_seen_at: datetime
+    object_name: str
+
+
+@dataclass(frozen=True)
 class AcStageResult:
     parse_error_count: int
     sample_parse_errors: tuple[CleanupGcsCacheParseErrorSample, ...]
+    source_object_count: int
+    last_seed_cursor: AcSeedCursor | None
 
 
 def run_cleanup_gcs_cache(
@@ -224,20 +232,6 @@ def run_cleanup_gcs_cache(
     bytes_processed_total = _add_bytes(
         bytes_processed_total,
         execute(
-            build_cleanup_gcs_cache_ac_seed_table_query(
-                settings,
-                candidate_table=ac_candidate_table,
-                ttl_days=ttl_days,
-            ),
-            parameters=[
-                BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days),
-                BigQueryParameter("limit", "INT64", resolved_max_delete_objects),
-            ],
-        ).total_bytes_processed,
-    )
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
             build_cleanup_gcs_cache_run_references_table_query(
                 run_references_table=run_references_table,
                 ttl_days=ttl_days,
@@ -258,19 +252,92 @@ def run_cleanup_gcs_cache(
             parameters=[],
         ).total_bytes_processed,
     )
-    ac_stage_result = _populate_ac_stage_tables(
-        settings=settings,
-        stream_rows=stream_rows,
-        resolve_object_metadata=resolve_object_metadata,
-        extract_references=extract_references,
-        load_jsonl_file=load_jsonl_file,
-        source_table=ac_candidate_table,
-        live_table=ac_live_metadata_table,
-        missing_table=ac_missing_metadata_table,
-        references_table=run_references_table,
-        stream_batch_size=settings.cleanup_batch_size,
-        reference_batch_size=settings.ac_reference_batch_size,
-    )
+    ac_parse_error_count = 0
+    sample_ac_parse_errors: list[CleanupGcsCacheParseErrorSample] = []
+    selected_ac_object_count = 0
+    ac_seed_cursor: AcSeedCursor | None = None
+
+    while selected_ac_object_count < resolved_max_delete_objects:
+        remaining_ac_target = resolved_max_delete_objects - selected_ac_object_count
+        ac_seed_parameters = [
+            BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days),
+            BigQueryParameter("limit", "INT64", remaining_ac_target),
+        ]
+        if ac_seed_cursor is not None:
+            ac_seed_parameters.extend(
+                [
+                    BigQueryParameter(
+                        "cursor_last_seen_at", "TIMESTAMP", ac_seed_cursor.last_seen_at
+                    ),
+                    BigQueryParameter("cursor_object_name", "STRING", ac_seed_cursor.object_name),
+                ]
+            )
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_cleanup_gcs_cache_ac_seed_table_query(
+                    settings,
+                    candidate_table=ac_candidate_table,
+                    ttl_days=ttl_days,
+                    has_cursor=ac_seed_cursor is not None,
+                ),
+                parameters=ac_seed_parameters,
+            ).total_bytes_processed,
+        )
+        ac_stage_result = _populate_ac_stage_tables(
+            settings=settings,
+            stream_rows=stream_rows,
+            resolve_object_metadata=resolve_object_metadata,
+            extract_references=extract_references,
+            load_jsonl_file=load_jsonl_file,
+            source_table=ac_candidate_table,
+            live_table=ac_live_metadata_table,
+            missing_table=ac_missing_metadata_table,
+            references_table=run_references_table,
+            stream_batch_size=settings.cleanup_batch_size,
+            reference_batch_size=settings.ac_reference_batch_size,
+        )
+        ac_parse_error_count += ac_stage_result.parse_error_count
+        for sample in ac_stage_result.sample_parse_errors:
+            if len(sample_ac_parse_errors) >= 10:
+                break
+            sample_ac_parse_errors.append(sample)
+        if ac_stage_result.source_object_count == 0:
+            break
+        ac_seed_cursor = ac_stage_result.last_seed_cursor
+
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_cleanup_gcs_cache_reconcile_missing_ac_query(
+                    settings,
+                    missing_metadata_table=ac_missing_metadata_table,
+                ),
+                parameters=[BigQueryParameter("run_started_at", "TIMESTAMP", run_started_at)],
+            ).total_bytes_processed,
+        )
+
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_cleanup_gcs_cache_final_ac_delete_table_query(
+                    ac_live_metadata_table=ac_live_metadata_table,
+                    ac_missing_metadata_table=ac_missing_metadata_table,
+                    candidate_table=ac_delete_table,
+                    ttl_days=ttl_days,
+                ),
+                parameters=[],
+            ).total_bytes_processed,
+        )
+
+        selected_ac_count = _count_table_rows(execute=execute, table_ref=ac_delete_table)
+        selected_ac_object_count = selected_ac_count.object_count
+        bytes_processed_total = _add_bytes(bytes_processed_total, selected_ac_count.bytes_processed)
+        if selected_ac_object_count >= resolved_max_delete_objects:
+            break
+        if ac_stage_result.source_object_count < remaining_ac_target:
+            break
+
     cas_from_ac_count = _count_distinct_run_cas_rows(
         execute=execute,
         table_ref=run_references_table,
@@ -278,33 +345,6 @@ def run_cleanup_gcs_cache(
     candidate_cas_object_count = cas_from_ac_count.object_count
     bytes_processed_total = _add_bytes(bytes_processed_total, cas_from_ac_count.bytes_processed)
 
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
-            build_cleanup_gcs_cache_reconcile_missing_ac_query(
-                settings,
-                missing_metadata_table=ac_missing_metadata_table,
-            ),
-            parameters=[BigQueryParameter("run_started_at", "TIMESTAMP", run_started_at)],
-        ).total_bytes_processed,
-    )
-
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
-            build_cleanup_gcs_cache_final_ac_delete_table_query(
-                ac_live_metadata_table=ac_live_metadata_table,
-                ac_missing_metadata_table=ac_missing_metadata_table,
-                candidate_table=ac_delete_table,
-                ttl_days=ttl_days,
-            ),
-            parameters=[],
-        ).total_bytes_processed,
-    )
-
-    selected_ac_count = _count_table_rows(execute=execute, table_ref=ac_delete_table)
-    selected_ac_object_count = selected_ac_count.object_count
-    bytes_processed_total = _add_bytes(bytes_processed_total, selected_ac_count.bytes_processed)
     selected_cas_object_count = 0
 
     ac_manifest_uri = None
@@ -470,13 +510,13 @@ def run_cleanup_gcs_cache(
         candidate_cas_object_count=candidate_cas_object_count,
         candidate_ac_object_count=candidate_ac_object_count,
         candidate_cas_delete_object_count=candidate_cas_delete_object_count,
-        ac_parse_error_count=ac_stage_result.parse_error_count,
+        ac_parse_error_count=ac_parse_error_count,
         selected_ac_object_count=selected_ac_object_count,
         selected_cas_object_count=selected_cas_object_count,
         oldest_last_seen_at=oldest_last_seen_at,
         newest_last_seen_at=newest_last_seen_at,
         sample_candidates=(),
-        sample_ac_parse_errors=ac_stage_result.sample_parse_errors,
+        sample_ac_parse_errors=tuple(sample_ac_parse_errors),
         bytes_processed=bytes_processed_total,
         run_started_at=run_started_at,
         run_finished_at=run_finished_at,
@@ -531,10 +571,18 @@ def build_cleanup_gcs_cache_ac_seed_table_query(
     *,
     candidate_table: str,
     ttl_days: int,
+    has_cursor: bool = False,
 ) -> str:
     current_table = _table_ref(
         settings.project_id, settings.dataset, settings.last_seen_current_table
     )
+    cursor_filter = ""
+    if has_cursor:
+        cursor_filter = """
+  AND (
+    last_seen_at > @cursor_last_seen_at
+    OR (last_seen_at = @cursor_last_seen_at AND object_name > @cursor_object_name)
+  )"""
     return f"""
 CREATE OR REPLACE TABLE {candidate_table}
 OPTIONS (
@@ -547,6 +595,7 @@ SELECT
 FROM {current_table}
 WHERE object_kind = 'ac'
   AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_cutoff_days DAY)
+{cursor_filter}
 ORDER BY last_seen_at ASC, object_name ASC
 LIMIT @limit
 """.strip()
@@ -895,8 +944,10 @@ def _populate_ac_stage_tables(
 ) -> AcStageResult:
     parse_error_count = 0
     sample_parse_errors: list[CleanupGcsCacheParseErrorSample] = []
+    source_object_count = 0
+    last_seed_cursor: AcSeedCursor | None = None
     rows = stream_rows(
-        f"SELECT object_name FROM {source_table} ORDER BY object_name ASC",
+        f"SELECT object_name, last_seen_at FROM {source_table} ORDER BY last_seen_at ASC, object_name ASC",
         [],
     )
     live_schema = (("object_name", "STRING"), ("generation", "INT64"))
@@ -917,6 +968,12 @@ def _populate_ac_stage_tables(
 
             for batch in _batched(rows, stream_batch_size):
                 object_names = tuple(str(row["object_name"]) for row in batch)
+                source_object_count += len(object_names)
+                last_row = batch[-1]
+                last_seed_cursor = AcSeedCursor(
+                    last_seen_at=coerce_datetime(last_row["last_seen_at"]),
+                    object_name=str(last_row["object_name"]),
+                )
                 metadata_rows = resolve_object_metadata(
                     project_id=settings.project_id,
                     bucket_name=settings.bucket_name,
@@ -999,6 +1056,8 @@ def _populate_ac_stage_tables(
     return AcStageResult(
         parse_error_count=parse_error_count,
         sample_parse_errors=tuple(sample_parse_errors),
+        source_object_count=source_object_count,
+        last_seed_cursor=last_seed_cursor,
     )
 
 

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -97,7 +97,7 @@ class AcSeedCursor:
 class AcStageResult:
     parse_error_count: int
     sample_parse_errors: tuple[CleanupGcsCacheParseErrorSample, ...]
-    source_object_count: int
+    seeded_object_count: int
     last_seed_cursor: AcSeedCursor | None
 
 
@@ -298,11 +298,9 @@ def run_cleanup_gcs_cache(
             reference_batch_size=settings.ac_reference_batch_size,
         )
         ac_parse_error_count += ac_stage_result.parse_error_count
-        for sample in ac_stage_result.sample_parse_errors:
-            if len(sample_ac_parse_errors) >= 10:
-                break
-            sample_ac_parse_errors.append(sample)
-        if ac_stage_result.source_object_count == 0:
+        sample_ac_parse_errors.extend(ac_stage_result.sample_parse_errors)
+        del sample_ac_parse_errors[10:]
+        if ac_stage_result.seeded_object_count == 0:
             break
         ac_seed_cursor = ac_stage_result.last_seed_cursor
 
@@ -335,7 +333,7 @@ def run_cleanup_gcs_cache(
         bytes_processed_total = _add_bytes(bytes_processed_total, selected_ac_count.bytes_processed)
         if selected_ac_object_count >= resolved_max_delete_objects:
             break
-        if ac_stage_result.source_object_count < remaining_ac_target:
+        if ac_stage_result.seeded_object_count < remaining_ac_target:
             break
 
     cas_from_ac_count = _count_distinct_run_cas_rows(
@@ -944,7 +942,7 @@ def _populate_ac_stage_tables(
 ) -> AcStageResult:
     parse_error_count = 0
     sample_parse_errors: list[CleanupGcsCacheParseErrorSample] = []
-    source_object_count = 0
+    seeded_object_count = 0
     last_seed_cursor: AcSeedCursor | None = None
     rows = stream_rows(
         f"SELECT object_name, last_seen_at FROM {source_table} ORDER BY last_seen_at ASC, object_name ASC",
@@ -968,7 +966,7 @@ def _populate_ac_stage_tables(
 
             for batch in _batched(rows, stream_batch_size):
                 object_names = tuple(str(row["object_name"]) for row in batch)
-                source_object_count += len(object_names)
+                seeded_object_count += len(object_names)
                 last_row = batch[-1]
                 last_seed_cursor = AcSeedCursor(
                     last_seen_at=coerce_datetime(last_row["last_seen_at"]),
@@ -1056,7 +1054,7 @@ def _populate_ac_stage_tables(
     return AcStageResult(
         parse_error_count=parse_error_count,
         sample_parse_errors=tuple(sample_parse_errors),
-        source_object_count=source_object_count,
+        seeded_object_count=seeded_object_count,
         last_seed_cursor=last_seed_cursor,
     )
 

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -220,7 +220,7 @@ def test_populate_ac_stage_tables_skips_parse_failed_ac_from_delete_inputs() -> 
     )
 
     assert result.parse_error_count == 1
-    assert result.source_object_count == 3
+    assert result.seeded_object_count == 3
     assert result.last_seed_cursor is not None
     assert result.last_seed_cursor.object_name == "ac/missing"
     assert result.last_seed_cursor.last_seen_at == datetime(2026, 5, 3, tzinfo=UTC)
@@ -661,6 +661,79 @@ def test_run_cleanup_gcs_cache_delete_refills_live_ac_target_after_stale_rows() 
         and "_tmp_gcs_cache_ac_missing_metadata_steadyrunrefill" in query
     ]
     assert len(reconcile_queries) == 2
+
+
+def test_run_cleanup_gcs_cache_delete_exits_when_seed_batch_is_empty() -> None:
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        rendered = {param.name: param.value for param in parameters}
+        captured_queries.append((query, rendered))
+        if "candidate_cas_object_count" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_cas_object_count": 0,
+                        "candidate_ac_object_count": 0,
+                        "candidate_cas_delete_object_count": 0,
+                        "oldest_last_seen_at": None,
+                        "newest_last_seen_at": None,
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=2,
+            )
+        if "SELECT COUNT(DISTINCT cas_object_name) AS object_count FROM" in query:
+            return BigQueryQueryResult(rows=({"object_count": 0},), total_bytes_processed=1)
+        if "SELECT COUNT(*) AS object_count FROM" in query:
+            return BigQueryQueryResult(rows=({"object_count": 0},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        del parameters
+        if (
+            "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_ac_"
+            in query
+        ):
+            return
+        if (
+            "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_cas_"
+            in query
+        ):
+            return
+        raise AssertionError(f"Unexpected stream query: {query}")
+        yield
+
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="delete",
+        execute_kind="cas",
+        ac_retention_days=10,
+        cas_retention_days=15,
+        safety_buffer_days=1,
+        max_delete_objects=3,
+        max_delete_cas_objects=5,
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        create_batch_job=lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError(f"should not create batch job: {kwargs}")
+        ),
+        wait_for_batch_job=lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError(f"should not wait for batch job: {kwargs}")
+        ),
+        now=lambda: datetime(2026, 6, 15, 10, 30, tzinfo=UTC),
+        run_id_factory=lambda: "steady-run-empty",
+    )
+
+    assert summary.selected_ac_object_count == 0
+    assert summary.selected_cas_object_count == 0
+    assert summary.ac_manifest_uri is None
+    assert summary.cas_manifest_uri is None
+    assert not any(
+        "_tmp_gcs_cache_ac_missing_metadata_steadyrunempty" in query
+        and "object_kind = 'ac'" in query
+        for query, _params in captured_queries
+    )
 
 
 def test_run_cleanup_gcs_cache_delete_requires_execute_kind_cas() -> None:

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -172,9 +172,9 @@ def test_populate_ac_stage_tables_skips_parse_failed_ac_from_delete_inputs() -> 
 
     def fake_stream_rows(query, parameters):
         del query, parameters
-        yield {"object_name": "ac/ok"}
-        yield {"object_name": "ac/corrupt"}
-        yield {"object_name": "ac/missing"}
+        yield {"object_name": "ac/ok", "last_seen_at": datetime(2026, 5, 1, tzinfo=UTC)}
+        yield {"object_name": "ac/corrupt", "last_seen_at": datetime(2026, 5, 2, tzinfo=UTC)}
+        yield {"object_name": "ac/missing", "last_seen_at": datetime(2026, 5, 3, tzinfo=UTC)}
 
     def fake_resolve_object_metadata(**kwargs):
         assert tuple(kwargs["object_names"]) == ("ac/ok", "ac/corrupt", "ac/missing")
@@ -220,6 +220,10 @@ def test_populate_ac_stage_tables_skips_parse_failed_ac_from_delete_inputs() -> 
     )
 
     assert result.parse_error_count == 1
+    assert result.source_object_count == 3
+    assert result.last_seed_cursor is not None
+    assert result.last_seed_cursor.object_name == "ac/missing"
+    assert result.last_seed_cursor.last_seen_at == datetime(2026, 5, 3, tzinfo=UTC)
     assert result.sample_parse_errors[0].object_name == "ac/corrupt"
     assert result.sample_parse_errors[0].parse_error == "Unsupported protobuf wire type: 3"
     assert (
@@ -341,8 +345,11 @@ def test_run_cleanup_gcs_cache_delete_cascades_ac_then_cas() -> None:
             "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_ac_"
             in query
         ):
-            yield {"object_name": "ac/one"}
-            yield {"object_name": "ac/missing"}
+            yield {"object_name": "ac/one", "last_seen_at": datetime(2026, 5, 1, tzinfo=UTC)}
+            yield {
+                "object_name": "ac/missing",
+                "last_seen_at": datetime(2026, 5, 2, tzinfo=UTC),
+            }
             return
         if (
             "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_cas_"
@@ -473,6 +480,187 @@ def test_run_cleanup_gcs_cache_delete_cascades_ac_then_cas() -> None:
         if "cas_from_deleted_ac" in query
     )
     assert deleted_ac_reconcile_index < cas_candidate_index
+
+
+def test_run_cleanup_gcs_cache_delete_refills_live_ac_target_after_stale_rows() -> None:
+    captured_queries = []
+    created_jobs = []
+    waited_jobs = []
+    loaded_files = []
+    table_schemas = {}
+    delete_ac_counts = iter((1, 3))
+    ac_stream_call_count = 0
+
+    def fake_execute(query, parameters):
+        rendered = {param.name: param.value for param in parameters}
+        captured_queries.append((query, rendered))
+        _record_explicit_create_table_schemas(query, table_schemas)
+        if "candidate_cas_object_count" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_cas_object_count": 0,
+                        "candidate_ac_object_count": 6,
+                        "candidate_cas_delete_object_count": 0,
+                        "oldest_last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+                        "newest_last_seen_at": datetime(2026, 5, 6, 0, 0, tzinfo=UTC),
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=2,
+            )
+        if "SELECT COUNT(DISTINCT cas_object_name) AS object_count FROM" in query:
+            return BigQueryQueryResult(rows=({"object_count": 0},), total_bytes_processed=1)
+        if "SELECT COUNT(*) AS object_count FROM" in query:
+            if "delete_ac" in query:
+                return BigQueryQueryResult(
+                    rows=({"object_count": next(delete_ac_counts)},), total_bytes_processed=1
+                )
+            if "delete_cas" in query:
+                return BigQueryQueryResult(rows=({"object_count": 0},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        nonlocal ac_stream_call_count
+        if (
+            "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_ac_"
+            in query
+        ):
+            ac_stream_call_count += 1
+            if ac_stream_call_count == 1:
+                yield {
+                    "object_name": "ac/stale-1",
+                    "last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+                }
+                yield {
+                    "object_name": "ac/live-1",
+                    "last_seen_at": datetime(2026, 5, 2, 0, 0, tzinfo=UTC),
+                }
+                yield {
+                    "object_name": "ac/stale-2",
+                    "last_seen_at": datetime(2026, 5, 3, 0, 0, tzinfo=UTC),
+                }
+                return
+            if ac_stream_call_count == 2:
+                yield {
+                    "object_name": "ac/live-2",
+                    "last_seen_at": datetime(2026, 5, 4, 0, 0, tzinfo=UTC),
+                }
+                yield {
+                    "object_name": "ac/live-3",
+                    "last_seen_at": datetime(2026, 5, 5, 0, 0, tzinfo=UTC),
+                }
+                return
+            return
+        if (
+            "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_cas_"
+            in query
+        ):
+            return
+        raise AssertionError(f"Unexpected stream query: {query}")
+
+    def fake_resolve_object_metadata(**kwargs):
+        names = tuple(kwargs["object_names"])
+        mapping = {
+            "ac/stale-1": GcsObjectMetadata("ac/stale-1", False, None),
+            "ac/live-1": GcsObjectMetadata("ac/live-1", True, 101),
+            "ac/stale-2": GcsObjectMetadata("ac/stale-2", False, None),
+            "ac/live-2": GcsObjectMetadata("ac/live-2", True, 102),
+            "ac/live-3": GcsObjectMetadata("ac/live-3", True, 103),
+        }
+        return tuple(mapping[name] for name in names)
+
+    def fake_extract_references(**kwargs):
+        names = tuple(kwargs["ac_object_names"])
+        mapping = {
+            "ac/live-1": AcReferenceExtraction(
+                ac_object_name="ac/live-1",
+                exists=True,
+                cas_object_names=(),
+            ),
+            "ac/live-2": AcReferenceExtraction(
+                ac_object_name="ac/live-2",
+                exists=True,
+                cas_object_names=(),
+            ),
+            "ac/live-3": AcReferenceExtraction(
+                ac_object_name="ac/live-3",
+                exists=True,
+                cas_object_names=(),
+            ),
+        }
+        return tuple(mapping[name] for name in names)
+
+    def fake_load_jsonl_file(table_ref, jsonl_path, schema, write_disposition):
+        _assert_load_schema_matches_created_table(table_schemas, table_ref, schema)
+        with jsonl_path.open(encoding="utf-8") as handle:
+            payload = tuple(json.loads(line) for line in handle if line.strip())
+        loaded_files.append((table_ref, payload, tuple(schema), write_disposition))
+
+    def fake_create_batch_job(**kwargs):
+        created_jobs.append(kwargs)
+        return StorageBatchOperationsJob(
+            job_name=f"projects/pingcap-testing-account/locations/global/jobs/{kwargs['job_id']}",
+            operation_name="operations/op-1",
+        )
+
+    def fake_wait_for_batch_job(**kwargs):
+        waited_jobs.append(kwargs)
+        return StorageBatchOperationsJobStatus(
+            job_name=kwargs["job_name"],
+            state="SUCCEEDED",
+            total_object_count=1,
+            succeeded_object_count=1,
+            failed_object_count=0,
+            total_bytes_transformed=123,
+            complete_time=datetime(2026, 6, 15, 10, 31, tzinfo=UTC),
+        )
+
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="delete",
+        execute_kind="cas",
+        ac_retention_days=10,
+        cas_retention_days=15,
+        safety_buffer_days=1,
+        max_delete_objects=3,
+        max_delete_cas_objects=5,
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        resolve_object_metadata=fake_resolve_object_metadata,
+        extract_references=fake_extract_references,
+        load_jsonl_file=fake_load_jsonl_file,
+        create_batch_job=fake_create_batch_job,
+        wait_for_batch_job=fake_wait_for_batch_job,
+        now=lambda: datetime(2026, 6, 15, 10, 30, tzinfo=UTC),
+        run_id_factory=lambda: "steady-run-refill",
+    )
+
+    assert summary.selected_ac_object_count == 3
+    assert summary.selected_cas_object_count == 0
+    assert ac_stream_call_count == 2
+    assert len(created_jobs) == 1
+    assert len(waited_jobs) == 1
+    ac_seed_queries = [
+        params
+        for query, params in captured_queries
+        if "_tmp_gcs_cache_candidate_ac_steadyrunrefill" in query
+        and "LIMIT @limit" in query
+    ]
+    assert len(ac_seed_queries) == 2
+    assert ac_seed_queries[0]["limit"] == 3
+    assert ac_seed_queries[1]["limit"] == 2
+    assert ac_seed_queries[1]["cursor_object_name"] == "ac/stale-2"
+    assert ac_seed_queries[1]["cursor_last_seen_at"] == datetime(2026, 5, 3, 0, 0, tzinfo=UTC)
+    reconcile_queries = [
+        query
+        for query, _params in captured_queries
+        if "DELETE FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`"
+        in query
+        and "object_kind = 'ac'" in query
+        and "_tmp_gcs_cache_ac_missing_metadata_steadyrunrefill" in query
+    ]
+    assert len(reconcile_queries) == 2
 
 
 def test_run_cleanup_gcs_cache_delete_requires_execute_kind_cas() -> None:


### PR DESCRIPTION
## Summary

Fix the steady-state GCS cache cleanup delete path so stale AC rows in `gcs_cache_object_last_seen_current` do not consume the real daily live-delete quota.

Yesterday's prod run showed the current behavior clearly:
- the job seeded `5,000,000` cold AC rows
- `4,340,290` of them were already missing in GCS
- only `659,710` live AC objects were actually deleted
- the run then reached CAS with `0` candidates

The root cause is that `max_delete_objects` currently limits the initial cold-AC seed query, not the final live AC delete set.

## Changes

- Change AC selection in `cleanup-gcs-cache --mode delete --execute-kind cas` from one-shot seeding to refill-until-live-target behavior.
- Seed cold AC rows ordered by `(last_seen_at, object_name)` using the remaining live AC target as the per-pass limit.
- After each pass:
  - stage live AC metadata and extracted AC->CAS references
  - reconcile stale/missing AC rows from `gcs_cache_object_last_seen_current`
  - rebuild the live AC delete table
- If the run still has fewer live AC objects than `max_delete_objects`, continue from a cursor `(last_seen_at, object_name)` and fetch the next cold AC batch.
- Stop when either:
  - the live AC delete table reaches the target, or
  - the cold AC candidate space is exhausted.
- Preserve the existing CAS phase, but feed it from the accumulated live AC delete set instead of a single diluted seed batch.

## Why This Helps

With this change, stale AC rows are cleaned up immediately and no longer waste the daily live delete budget. A `5,000,000` delete target now means "try to delete up to 5,000,000 live AC objects", rather than "scan 5,000,000 rows and hope enough are live".

## Tests

- `pytest tests/test_cleanup_gcs_cache.py -q -o addopts='--cov=cost_insight.jobs.cleanup_gcs_cache --cov-report=term-missing --cov-fail-under=90'`
- `pytest tests/test_cleanup_gcs_cache.py tests/test_db_and_cli.py -q -o addopts=''`
- `git diff --check`

Module coverage for `cleanup_gcs_cache.py`: `95%`