### PR TITLE
refactor(dl): reorganize package structure

### DIFF
--- a/dl/cmd/server/http.go
+++ b/dl/cmd/server/http.go
@@ -17,7 +17,7 @@ import (
 	httpmdlwr "goa.design/goa/v3/http/middleware"
 	"goa.design/goa/v3/middleware"
 
-	dl "github.com/PingCAP-QE/ee-apps/dl"
+	"github.com/PingCAP-QE/ee-apps/dl/pkg/attachment"
 	ks3svr "github.com/PingCAP-QE/ee-apps/dl/gen/http/ks3/server"
 	ocisvr "github.com/PingCAP-QE/ee-apps/dl/gen/http/oci/server"
 	ks3 "github.com/PingCAP-QE/ee-apps/dl/gen/ks3"
@@ -224,7 +224,7 @@ func headOCIMiddleware(provider ociRepoProvider, logger *log.Logger) func(http.H
 				return
 			}
 
-			w.Header().Set("Content-Disposition", dl.ContentDisposition(targetFile))
+			w.Header().Set("Content-Disposition", attachment.ContentDisposition(targetFile))
 			w.Header().Set("Content-Length", fmt.Sprintf("%d", descriptor.Size))
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)

--- a/dl/cmd/server/main.go
+++ b/dl/cmd/server/main.go
@@ -12,9 +12,10 @@ import (
 	"sync"
 	"syscall"
 
-	dl "github.com/PingCAP-QE/ee-apps/dl"
 	ks3 "github.com/PingCAP-QE/ee-apps/dl/gen/ks3"
 	oci "github.com/PingCAP-QE/ee-apps/dl/gen/oci"
+	ks3svc "github.com/PingCAP-QE/ee-apps/dl/internal/service/ks3"
+	ocisvc "github.com/PingCAP-QE/ee-apps/dl/internal/service/oci"
 )
 
 func main() {
@@ -45,8 +46,8 @@ func main() {
 		ks3Svc ks3.Service
 	)
 	{
-		ociSvc = dl.NewOci(logger, ociCfgPathF)
-		ks3Svc = dl.NewKs3(logger, *ks3CfgPathF)
+		ociSvc = ocisvc.New(logger, ociCfgPathF)
+		ks3Svc = ks3svc.New(logger, *ks3CfgPathF)
 	}
 
 	// Wrap the services in endpoints that can be invoked from other services

--- a/dl/internal/service/ks3/service.go
+++ b/dl/internal/service/ks3/service.go
@@ -1,4 +1,4 @@
-package dl
+package ks3
 
 import (
 	"context"
@@ -12,26 +12,26 @@ import (
 	"github.com/ks3sdklib/aws-sdk-go/service/s3"
 	"gopkg.in/yaml.v3"
 
+	"github.com/PingCAP-QE/ee-apps/dl/pkg/attachment"
 	ks3 "github.com/PingCAP-QE/ee-apps/dl/gen/ks3"
 	pkgks3 "github.com/PingCAP-QE/ee-apps/dl/pkg/ks3"
 )
 
-// ks3 service example implementation.
-// The example methods log the requests and return zero values.
+// ks3srvc implements the KS3 service.
 type ks3srvc struct {
 	logger *log.Logger
 	client *s3.S3
 }
 
-func newKS3Client(cfg *pkgks3.Config) *s3.S3 {
+func newClient(cfg *pkgks3.Config) *s3.S3 {
 	var cre *credentials.Credentials
 	if cfg != nil && cfg.AccessKey != "" && cfg.SecretKey != "" {
 		cre = credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, "")
 	}
 	awsConfig := aws.Config{
-		Region:           cfg.Region, // Ref: https://docs.ksyun.com/documents/6761
+		Region:           cfg.Region,
 		Credentials:      cre,
-		Endpoint:         cfg.Endpoint, // Ref: https://docs.ksyun.com/documents/6761
+		Endpoint:         cfg.Endpoint,
 		DisableSSL:       true,
 		LogLevel:         0,
 		LogHTTPBody:      false,
@@ -42,8 +42,8 @@ func newKS3Client(cfg *pkgks3.Config) *s3.S3 {
 	return s3.New(&awsConfig)
 }
 
-// NewKs3 returns the ks3 service implementation.
-func NewKs3(logger *log.Logger, cfgFile string) ks3.Service {
+// New returns the ks3 service implementation.
+func New(logger *log.Logger, cfgFile string) ks3.Service {
 	var cfg pkgks3.Config
 
 	cfgBytes, err := os.ReadFile(cfgFile)
@@ -54,7 +54,7 @@ func NewKs3(logger *log.Logger, cfgFile string) ks3.Service {
 		logger.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	return &ks3srvc{logger: logger, client: newKS3Client(&cfg)}
+	return &ks3srvc{logger: logger, client: newClient(&cfg)}
 }
 
 // DownloadObject implements download-object.
@@ -77,7 +77,7 @@ func (s *ks3srvc) DownloadObject(ctx context.Context, p *ks3.DownloadObjectPaylo
 		if getObjectOutput.ContentDisposition != nil {
 			res.ContentDisposition = *getObjectOutput.ContentDisposition
 		} else {
-			res.ContentDisposition = ContentDisposition(filepath.Base(p.Key))
+			res.ContentDisposition = attachment.ContentDisposition(filepath.Base(p.Key))
 		}
 	}
 

--- a/dl/internal/service/oci/service.go
+++ b/dl/internal/service/oci/service.go
@@ -1,4 +1,4 @@
-package dl
+package oci
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	oci "github.com/PingCAP-QE/ee-apps/dl/gen/oci"
+	"github.com/PingCAP-QE/ee-apps/dl/pkg/attachment"
 	pkgoci "github.com/PingCAP-QE/ee-apps/dl/pkg/oci"
 	"gopkg.in/yaml.v3"
 	"oras.land/oras-go/v2/registry/remote"
@@ -18,15 +19,14 @@ import (
 	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
-// oci service example implementation.
-// The example methods log the requests and return zero values.
+// ocisrvc implements the OCI service.
 type ocisrvc struct {
 	logger     *log.Logger
 	credential *auth.Credential
 }
 
-// NewOci returns the oci service implementation.
-func NewOci(logger *log.Logger, cfgFile *string) oci.Service {
+// New returns the oci service implementation.
+func New(logger *log.Logger, cfgFile *string) oci.Service {
 	var cfg pkgoci.Config
 	if cfgFile == nil {
 		return &ocisrvc{logger: logger, credential: &auth.EmptyCredential}
@@ -105,7 +105,7 @@ func (s *ocisrvc) downloadFile(ctx context.Context, repo *remote.Repository, tag
 
 	res = &oci.DownloadFileResult{
 		Length:             length,
-		ContentDisposition: ContentDisposition(file),
+		ContentDisposition: attachment.ContentDisposition(file),
 	}
 	return res, rc, nil
 }
@@ -131,7 +131,7 @@ func (s *ocisrvc) HeadFile(ctx context.Context, p *oci.HeadFilePayload) (*oci.He
 
 	return &oci.HeadFileResult{
 		Length:             descriptor.Size,
-		ContentDisposition: ContentDisposition(targetFile),
+		ContentDisposition: attachment.ContentDisposition(targetFile),
 	}, nil
 }
 
@@ -178,7 +178,7 @@ func (s *ocisrvc) DownloadFileSha256(ctx context.Context, p *oci.DownloadFileSha
 
 	res = &oci.DownloadFileSha256Result{
 		Length:             int64(len(value)),
-		ContentDisposition: ContentDisposition(p.File + ".sha256"),
+		ContentDisposition: attachment.ContentDisposition(p.File + ".sha256"),
 	}
 	return res, io.NopCloser(strings.NewReader(value)), nil
 }

--- a/dl/pkg/attachment/content_disposition.go
+++ b/dl/pkg/attachment/content_disposition.go
@@ -1,4 +1,4 @@
-package dl
+package attachment
 
 import (
 	"fmt"

--- a/dl/pkg/attachment/content_disposition_test.go
+++ b/dl/pkg/attachment/content_disposition_test.go
@@ -1,4 +1,4 @@
-package dl
+package attachment
 
 import (
 	"net/http"


### PR DESCRIPTION
## Summary

- Move `ContentDisposition` to `dl/pkg/attachment` as a shared package
- Move service implementations (oci, ks3) from root to `dl/internal/service/`
- Clean up dl root to only contain config files (`go.mod`, `Dockerfile`, etc.)

## Changes

| Operation | File |
|-----------|------|
| Modified | `dl/cmd/server/http.go`, `dl/cmd/server/main.go` |
| Deleted | `dl/content_disposition.go`, `dl/content_disposition_test.go`, `dl/ks3.go`, `dl/oci.go` |
| Added | `dl/internal/service/oci/service.go`, `dl/internal/service/ks3/service.go` |
| Added | `dl/pkg/attachment/content_disposition.go`, `dl/pkg/attachment/content_disposition_test.go` |

## Directory structure after refactor

```
dl/
├── cmd/server/          # entry point
├── internal/service/    # service implementations (not importable externally)
│   ├── oci/service.go
│   └── ks3/service.go
├── pkg/                 # shared packages
│   ├── attachment/
│   ├── oci/
│   └── ks3/
├── gen/                 # Goa generated code
└── design/              # Goa design files
```

## Verification

- `go build ./...` passes
- `go test ./...` passes