### PR TITLE
fix(cost-insight): batch AC-driven GCS cache cascade cleanup

### DIFF
--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -80,6 +80,7 @@ class GcsCacheSettings:
     cleanup_sample_limit: int = 10
     cleanup_max_delete_objects: int = 10000000
     cleanup_max_delete_cas_objects: int = 500
+    cleanup_ac_delete_batch_size: int = 500000
     cleanup_batch_size: int = 1000
     cleanup_manifest_bucket: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
     cleanup_manifest_prefix: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX
@@ -336,6 +337,14 @@ def load_settings(
                     "COST_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS",
                 ),
                 500,
+            ),
+            cleanup_ac_delete_batch_size=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE",
+                    "COST_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE",
+                ),
+                500000,
             ),
             cleanup_batch_size=_read_positive_int_any(
                 env,

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import dataclass
 from datetime import date
 from functools import lru_cache
@@ -85,6 +86,15 @@ class GcsCacheSettings:
     cleanup_manifest_bucket: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
     cleanup_manifest_prefix: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX
     cleanup_candidate_ttl_days: int = 7
+
+    def __post_init__(self) -> None:
+        if self.cleanup_ac_delete_batch_size > self.cleanup_max_delete_objects:
+            warnings.warn(
+                "cleanup_ac_delete_batch_size is greater than cleanup_max_delete_objects; "
+                "cleanup will clamp each run to cleanup_max_delete_objects",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
 
 @dataclass(frozen=True)

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -55,6 +55,14 @@ class CleanupGcsCacheParseErrorSample:
 
 @dataclass(frozen=True)
 class CleanupGcsCacheSummary:
+    """Runtime summary for one cleanup run.
+
+    The singular manifest/job fields are deprecated compatibility fields that
+    contain only the last submitted batch. New consumers should use the plural
+    fields, which retain every batch manifest URI and Storage Batch Operations
+    job name created by the run.
+    """
+
     account_id: str
     bucket_name: str
     run_id: str
@@ -77,8 +85,10 @@ class CleanupGcsCacheSummary:
     bytes_processed: int | None
     run_started_at: datetime
     run_finished_at: datetime
+    # Deprecated: last batch only. Prefer ac_manifest_uris / ac_batch_job_names.
     ac_manifest_uri: str | None = None
     ac_batch_job_name: str | None = None
+    # Deprecated: last batch only. Prefer cas_manifest_uris / cas_batch_job_names.
     cas_manifest_uri: str | None = None
     cas_batch_job_name: str | None = None
     ac_manifest_uris: tuple[str, ...] | None = None
@@ -244,8 +254,6 @@ def run_cleanup_gcs_cache(
             settings.cleanup_ac_delete_batch_size,
             resolved_max_delete_objects - selected_ac_object_count,
         )
-        if batch_target <= 0:
-            break
 
         ac_candidate_table = _batch_candidate_table_name(
             settings, prefix="candidate_ac", run_id=run_id, batch_index=batch_index
@@ -819,6 +827,8 @@ JOIN {live_metadata_table} AS live
   USING (object_name)
 JOIN {current_table} AS current_obj
   ON current_obj.object_name = source.object_name
+ -- Defensive re-check: source_table is expected to contain only CAS rows, but
+ -- this keeps accidental table reuse from deleting non-CAS objects.
  AND current_obj.object_kind = 'cas'
  AND current_obj.last_seen_at = source.last_seen_at
 WHERE NOT EXISTS (

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from contextlib import ExitStack
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
@@ -36,6 +37,7 @@ BatchJobWaiter = Callable[..., StorageBatchOperationsJobStatus]
 # "all" is kept as a compatibility alias for older dry-run CronJob arguments.
 # v3 cleanup has only one real execution path: AC-driven CAS cascade.
 VALID_EXECUTE_KINDS = ("all", "cas")
+MAX_ZERO_PROGRESS_AC_REFILL_ROUNDS = 3
 
 
 @dataclass(frozen=True)
@@ -79,6 +81,10 @@ class CleanupGcsCacheSummary:
     ac_batch_job_name: str | None = None
     cas_manifest_uri: str | None = None
     cas_batch_job_name: str | None = None
+    ac_manifest_uris: tuple[str, ...] | None = None
+    ac_batch_job_names: tuple[str, ...] | None = None
+    cas_manifest_uris: tuple[str, ...] | None = None
+    cas_batch_job_names: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -148,11 +154,13 @@ def run_cleanup_gcs_cache(
         if max_delete_objects is not None
         else settings.cleanup_max_delete_objects
     )
-    resolved_max_delete_cas_objects = (
-        max_delete_cas_objects
-        if max_delete_cas_objects is not None
-        else settings.cleanup_max_delete_cas_objects
-    )
+    if max_delete_cas_objects is not None:
+        warnings.warn(
+            "max_delete_cas_objects is deprecated and ignored by v3 AC-driven cascade cleanup; "
+            "CAS deletion is bounded only by selected AC batches",
+            FutureWarning,
+            stacklevel=2,
+        )
     ac_cutoff_days = resolved_ac_days + resolved_safety_buffer_days
     cas_cutoff_days = resolved_cas_days + resolved_safety_buffer_days
 
@@ -211,152 +219,199 @@ def run_cleanup_gcs_cache(
 
     run_id = run_id_factory()
     ttl_days = settings.cleanup_candidate_ttl_days
-    ac_candidate_table = _candidate_table_name(settings, prefix="candidate_ac", run_id=run_id)
-    run_references_table = _candidate_table_name(settings, prefix="run_ac_cas_refs", run_id=run_id)
-    cas_candidate_table = _candidate_table_name(settings, prefix="candidate_cas", run_id=run_id)
-    ac_live_metadata_table = _candidate_table_name(
-        settings, prefix="ac_live_metadata", run_id=run_id
-    )
-    ac_missing_metadata_table = _candidate_table_name(
-        settings, prefix="ac_missing_metadata", run_id=run_id
-    )
-    cas_live_metadata_table = _candidate_table_name(
-        settings, prefix="cas_live_metadata", run_id=run_id
-    )
-    cas_missing_metadata_table = _candidate_table_name(
-        settings, prefix="cas_missing_metadata", run_id=run_id
-    )
-    ac_delete_table = _candidate_table_name(settings, prefix="delete_ac", run_id=run_id)
-    cas_delete_table = _candidate_table_name(settings, prefix="delete_cas", run_id=run_id)
-
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
-            build_cleanup_gcs_cache_run_references_table_query(
-                run_references_table=run_references_table,
-                ttl_days=ttl_days,
-            ),
-            parameters=[],
-        ).total_bytes_processed,
-    )
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
-            build_cleanup_gcs_cache_metadata_stage_tables_query(
-                ttl_days=ttl_days,
-                ac_live_metadata_table=ac_live_metadata_table,
-                ac_missing_metadata_table=ac_missing_metadata_table,
-                cas_live_metadata_table=cas_live_metadata_table,
-                cas_missing_metadata_table=cas_missing_metadata_table,
-            ),
-            parameters=[],
-        ).total_bytes_processed,
-    )
     ac_parse_error_count = 0
     sample_ac_parse_errors: list[CleanupGcsCacheParseErrorSample] = []
     selected_ac_object_count = 0
-    ac_seed_cursor: AcSeedCursor | None = None
-
-    while selected_ac_object_count < resolved_max_delete_objects:
-        remaining_ac_target = resolved_max_delete_objects - selected_ac_object_count
-        ac_seed_parameters = [
-            BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days),
-            BigQueryParameter("limit", "INT64", remaining_ac_target),
-        ]
-        if ac_seed_cursor is not None:
-            ac_seed_parameters.extend(
-                [
-                    BigQueryParameter(
-                        "cursor_last_seen_at", "TIMESTAMP", ac_seed_cursor.last_seen_at
-                    ),
-                    BigQueryParameter("cursor_object_name", "STRING", ac_seed_cursor.object_name),
-                ]
-            )
-        bytes_processed_total = _add_bytes(
-            bytes_processed_total,
-            execute(
-                build_cleanup_gcs_cache_ac_seed_table_query(
-                    settings,
-                    candidate_table=ac_candidate_table,
-                    ttl_days=ttl_days,
-                    has_cursor=ac_seed_cursor is not None,
-                ),
-                parameters=ac_seed_parameters,
-            ).total_bytes_processed,
-        )
-        ac_stage_result = _populate_ac_stage_tables(
-            settings=settings,
-            stream_rows=stream_rows,
-            resolve_object_metadata=resolve_object_metadata,
-            extract_references=extract_references,
-            load_jsonl_file=load_jsonl_file,
-            source_table=ac_candidate_table,
-            live_table=ac_live_metadata_table,
-            missing_table=ac_missing_metadata_table,
-            references_table=run_references_table,
-            stream_batch_size=settings.cleanup_batch_size,
-            reference_batch_size=settings.ac_reference_batch_size,
-        )
-        ac_parse_error_count += ac_stage_result.parse_error_count
-        sample_ac_parse_errors.extend(ac_stage_result.sample_parse_errors)
-        del sample_ac_parse_errors[10:]
-        if ac_stage_result.seeded_object_count == 0:
-            break
-        ac_seed_cursor = ac_stage_result.last_seed_cursor
-
-        bytes_processed_total = _add_bytes(
-            bytes_processed_total,
-            execute(
-                build_cleanup_gcs_cache_reconcile_missing_ac_query(
-                    settings,
-                    missing_metadata_table=ac_missing_metadata_table,
-                ),
-                parameters=[BigQueryParameter("run_started_at", "TIMESTAMP", run_started_at)],
-            ).total_bytes_processed,
-        )
-
-        bytes_processed_total = _add_bytes(
-            bytes_processed_total,
-            execute(
-                build_cleanup_gcs_cache_final_ac_delete_table_query(
-                    ac_live_metadata_table=ac_live_metadata_table,
-                    ac_missing_metadata_table=ac_missing_metadata_table,
-                    candidate_table=ac_delete_table,
-                    ttl_days=ttl_days,
-                ),
-                parameters=[],
-            ).total_bytes_processed,
-        )
-
-        selected_ac_count = _count_table_rows(execute=execute, table_ref=ac_delete_table)
-        selected_ac_object_count = selected_ac_count.object_count
-        bytes_processed_total = _add_bytes(bytes_processed_total, selected_ac_count.bytes_processed)
-        if selected_ac_object_count >= resolved_max_delete_objects:
-            break
-        if ac_stage_result.seeded_object_count < remaining_ac_target:
-            break
-
-    cas_from_ac_count = _count_distinct_run_cas_rows(
-        execute=execute,
-        table_ref=run_references_table,
-    )
-    candidate_cas_object_count = cas_from_ac_count.object_count
-    bytes_processed_total = _add_bytes(bytes_processed_total, cas_from_ac_count.bytes_processed)
-
     selected_cas_object_count = 0
+    candidate_cas_object_count = 0
+    candidate_cas_delete_object_count = 0
 
     ac_manifest_uri = None
     ac_batch_job_name = None
     cas_manifest_uri = None
     cas_batch_job_name = None
+    ac_manifest_uris: list[str] = []
+    ac_batch_job_names: list[str] = []
+    cas_manifest_uris: list[str] = []
+    cas_batch_job_names: list[str] = []
+    ac_seed_cursor: AcSeedCursor | None = None
+    ac_candidates_exhausted = False
+    batch_index = 0
 
-    if selected_ac_object_count > 0:
+    while selected_ac_object_count < resolved_max_delete_objects and not ac_candidates_exhausted:
+        batch_index += 1
+        batch_target = min(
+            settings.cleanup_ac_delete_batch_size,
+            resolved_max_delete_objects - selected_ac_object_count,
+        )
+        if batch_target <= 0:
+            break
+
+        ac_candidate_table = _batch_candidate_table_name(
+            settings, prefix="candidate_ac", run_id=run_id, batch_index=batch_index
+        )
+        run_references_table = _batch_candidate_table_name(
+            settings, prefix="run_ac_cas_refs", run_id=run_id, batch_index=batch_index
+        )
+        cas_candidate_table = _batch_candidate_table_name(
+            settings, prefix="candidate_cas", run_id=run_id, batch_index=batch_index
+        )
+        ac_live_metadata_table = _batch_candidate_table_name(
+            settings, prefix="ac_live_metadata", run_id=run_id, batch_index=batch_index
+        )
+        ac_missing_metadata_table = _batch_candidate_table_name(
+            settings, prefix="ac_missing_metadata", run_id=run_id, batch_index=batch_index
+        )
+        cas_live_metadata_table = _batch_candidate_table_name(
+            settings, prefix="cas_live_metadata", run_id=run_id, batch_index=batch_index
+        )
+        cas_missing_metadata_table = _batch_candidate_table_name(
+            settings, prefix="cas_missing_metadata", run_id=run_id, batch_index=batch_index
+        )
+        ac_delete_table = _batch_candidate_table_name(
+            settings, prefix="delete_ac", run_id=run_id, batch_index=batch_index
+        )
+        cas_delete_table = _batch_candidate_table_name(
+            settings, prefix="delete_cas", run_id=run_id, batch_index=batch_index
+        )
+
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_cleanup_gcs_cache_run_references_table_query(
+                    run_references_table=run_references_table,
+                    ttl_days=ttl_days,
+                ),
+                parameters=[],
+            ).total_bytes_processed,
+        )
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_cleanup_gcs_cache_metadata_stage_tables_query(
+                    ttl_days=ttl_days,
+                    ac_live_metadata_table=ac_live_metadata_table,
+                    ac_missing_metadata_table=ac_missing_metadata_table,
+                    cas_live_metadata_table=cas_live_metadata_table,
+                    cas_missing_metadata_table=cas_missing_metadata_table,
+                ),
+                parameters=[],
+            ).total_bytes_processed,
+        )
+
+        selected_ac_in_batch = 0
+        zero_progress_refill_rounds = 0
+        while selected_ac_in_batch < batch_target:
+            remaining_ac_target = batch_target - selected_ac_in_batch
+            ac_seed_parameters = [
+                BigQueryParameter("ac_cutoff_days", "INT64", ac_cutoff_days),
+                BigQueryParameter("limit", "INT64", remaining_ac_target),
+            ]
+            if ac_seed_cursor is not None:
+                ac_seed_parameters.extend(
+                    [
+                        BigQueryParameter(
+                            "cursor_last_seen_at", "TIMESTAMP", ac_seed_cursor.last_seen_at
+                        ),
+                        BigQueryParameter(
+                            "cursor_object_name", "STRING", ac_seed_cursor.object_name
+                        ),
+                    ]
+                )
+            bytes_processed_total = _add_bytes(
+                bytes_processed_total,
+                execute(
+                    build_cleanup_gcs_cache_ac_seed_table_query(
+                        settings,
+                        candidate_table=ac_candidate_table,
+                        ttl_days=ttl_days,
+                        has_cursor=ac_seed_cursor is not None,
+                    ),
+                    parameters=ac_seed_parameters,
+                ).total_bytes_processed,
+            )
+            ac_stage_result = _populate_ac_stage_tables(
+                settings=settings,
+                stream_rows=stream_rows,
+                resolve_object_metadata=resolve_object_metadata,
+                extract_references=extract_references,
+                load_jsonl_file=load_jsonl_file,
+                source_table=ac_candidate_table,
+                live_table=ac_live_metadata_table,
+                missing_table=ac_missing_metadata_table,
+                references_table=run_references_table,
+                stream_batch_size=settings.cleanup_batch_size,
+                reference_batch_size=settings.ac_reference_batch_size,
+            )
+            ac_parse_error_count += ac_stage_result.parse_error_count
+            sample_ac_parse_errors.extend(ac_stage_result.sample_parse_errors)
+            del sample_ac_parse_errors[10:]
+            if ac_stage_result.seeded_object_count == 0:
+                ac_candidates_exhausted = True
+                break
+            ac_seed_cursor = ac_stage_result.last_seed_cursor
+
+            bytes_processed_total = _add_bytes(
+                bytes_processed_total,
+                execute(
+                    build_cleanup_gcs_cache_reconcile_missing_ac_query(
+                        settings,
+                        missing_metadata_table=ac_missing_metadata_table,
+                    ),
+                    parameters=[BigQueryParameter("run_started_at", "TIMESTAMP", run_started_at)],
+                ).total_bytes_processed,
+            )
+
+            bytes_processed_total = _add_bytes(
+                bytes_processed_total,
+                execute(
+                    build_cleanup_gcs_cache_final_ac_delete_table_query(
+                        ac_live_metadata_table=ac_live_metadata_table,
+                        ac_missing_metadata_table=ac_missing_metadata_table,
+                        candidate_table=ac_delete_table,
+                        ttl_days=ttl_days,
+                    ),
+                    parameters=[],
+                ).total_bytes_processed,
+            )
+
+            previous_selected_ac_in_batch = selected_ac_in_batch
+            selected_ac_count = _count_table_rows(execute=execute, table_ref=ac_delete_table)
+            selected_ac_in_batch = selected_ac_count.object_count
+            bytes_processed_total = _add_bytes(
+                bytes_processed_total, selected_ac_count.bytes_processed
+            )
+            if selected_ac_in_batch == previous_selected_ac_in_batch:
+                zero_progress_refill_rounds += 1
+            else:
+                zero_progress_refill_rounds = 0
+            if selected_ac_in_batch >= batch_target:
+                break
+            if zero_progress_refill_rounds >= MAX_ZERO_PROGRESS_AC_REFILL_ROUNDS:
+                ac_candidates_exhausted = True
+                break
+            if ac_stage_result.seeded_object_count < remaining_ac_target:
+                ac_candidates_exhausted = True
+                break
+
+        if selected_ac_in_batch <= 0:
+            continue
+
+        cas_from_ac_count = _count_distinct_run_cas_rows(
+            execute=execute,
+            table_ref=run_references_table,
+        )
+        candidate_cas_object_count += cas_from_ac_count.object_count
+        bytes_processed_total = _add_bytes(bytes_processed_total, cas_from_ac_count.bytes_processed)
+
         ac_manifest_uri = _manifest_uri(
             settings,
             object_kind="ac",
             run_started_at=run_started_at,
             run_id=run_id,
+            batch_index=batch_index,
         )
+        ac_manifest_uris.append(ac_manifest_uri)
         bytes_processed_total = _add_bytes(
             bytes_processed_total,
             execute(
@@ -370,7 +425,12 @@ def run_cleanup_gcs_cache(
         )
         ac_batch_job = create_batch_job(
             project_id=settings.project_id,
-            job_id=_batch_job_id(object_kind="ac", run_started_at=run_started_at, run_id=run_id),
+            job_id=_batch_job_id(
+                object_kind="ac",
+                run_started_at=run_started_at,
+                run_id=run_id,
+                batch_index=batch_index,
+            ),
             bucket_name=settings.bucket_name,
             manifest_uri=ac_manifest_uri,
             dry_run=False,
@@ -381,6 +441,7 @@ def run_cleanup_gcs_cache(
             ),
         )
         ac_batch_job_name = ac_batch_job.job_name
+        ac_batch_job_names.append(ac_batch_job_name)
         _wait_for_successful_batch_job(
             wait_for_batch_job=wait_for_batch_job, job_name=ac_batch_job.job_name
         )
@@ -394,68 +455,75 @@ def run_cleanup_gcs_cache(
                 parameters=[BigQueryParameter("run_started_at", "TIMESTAMP", run_started_at)],
             ).total_bytes_processed,
         )
+        selected_ac_object_count += selected_ac_in_batch
 
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
-            build_cleanup_gcs_cache_cas_candidate_table_query(
-                settings,
-                run_references_table=run_references_table,
-                candidate_table=cas_candidate_table,
-                ttl_days=ttl_days,
-            ),
-            parameters=[
-                BigQueryParameter("cas_cutoff_days", "INT64", cas_cutoff_days),
-                BigQueryParameter("limit", "INT64", resolved_max_delete_cas_objects),
-            ],
-        ).total_bytes_processed,
-    )
-    _populate_metadata_stage_table(
-        settings=settings,
-        stream_rows=stream_rows,
-        resolve_object_metadata=resolve_object_metadata,
-        load_jsonl_file=load_jsonl_file,
-        source_table=cas_candidate_table,
-        live_table=cas_live_metadata_table,
-        missing_table=cas_missing_metadata_table,
-        batch_size=settings.cleanup_batch_size,
-    )
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
-            build_cleanup_gcs_cache_reconcile_missing_cas_query(
-                settings,
-                candidate_table=cas_candidate_table,
-                missing_metadata_table=cas_missing_metadata_table,
-            ),
-            parameters=[],
-        ).total_bytes_processed,
-    )
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
-            build_cleanup_gcs_cache_final_cas_delete_table_query(
-                settings,
-                source_table=cas_candidate_table,
-                live_metadata_table=cas_live_metadata_table,
-                candidate_table=cas_delete_table,
-                ttl_days=ttl_days,
-            ),
-            parameters=[],
-        ).total_bytes_processed,
-    )
-    selected_cas_count = _count_table_rows(execute=execute, table_ref=cas_delete_table)
-    selected_cas_object_count = selected_cas_count.object_count
-    bytes_processed_total = _add_bytes(bytes_processed_total, selected_cas_count.bytes_processed)
-    candidate_cas_delete_object_count = selected_cas_object_count
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_cleanup_gcs_cache_cas_candidate_table_query(
+                    settings,
+                    run_references_table=run_references_table,
+                    candidate_table=cas_candidate_table,
+                    ttl_days=ttl_days,
+                ),
+                parameters=[
+                    BigQueryParameter("cas_cutoff_days", "INT64", cas_cutoff_days),
+                ],
+            ).total_bytes_processed,
+        )
+        _populate_metadata_stage_table(
+            settings=settings,
+            stream_rows=stream_rows,
+            resolve_object_metadata=resolve_object_metadata,
+            load_jsonl_file=load_jsonl_file,
+            source_table=cas_candidate_table,
+            live_table=cas_live_metadata_table,
+            missing_table=cas_missing_metadata_table,
+            batch_size=settings.cleanup_batch_size,
+        )
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_cleanup_gcs_cache_reconcile_missing_cas_query(
+                    settings,
+                    candidate_table=cas_candidate_table,
+                    missing_metadata_table=cas_missing_metadata_table,
+                ),
+                parameters=[],
+            ).total_bytes_processed,
+        )
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_cleanup_gcs_cache_final_cas_delete_table_query(
+                    settings,
+                    source_table=cas_candidate_table,
+                    live_metadata_table=cas_live_metadata_table,
+                    candidate_table=cas_delete_table,
+                    ttl_days=ttl_days,
+                ),
+                parameters=[],
+            ).total_bytes_processed,
+        )
+        selected_cas_count = _count_table_rows(execute=execute, table_ref=cas_delete_table)
+        selected_cas_in_batch = selected_cas_count.object_count
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total, selected_cas_count.bytes_processed
+        )
+        candidate_cas_delete_object_count += selected_cas_in_batch
+        selected_cas_object_count += selected_cas_in_batch
 
-    if selected_cas_object_count > 0:
+        if selected_cas_in_batch <= 0:
+            continue
+
         cas_manifest_uri = _manifest_uri(
             settings,
             object_kind="cas",
             run_started_at=run_started_at,
             run_id=run_id,
+            batch_index=batch_index,
         )
+        cas_manifest_uris.append(cas_manifest_uri)
         bytes_processed_total = _add_bytes(
             bytes_processed_total,
             execute(
@@ -469,7 +537,12 @@ def run_cleanup_gcs_cache(
         )
         cas_batch_job = create_batch_job(
             project_id=settings.project_id,
-            job_id=_batch_job_id(object_kind="cas", run_started_at=run_started_at, run_id=run_id),
+            job_id=_batch_job_id(
+                object_kind="cas",
+                run_started_at=run_started_at,
+                run_id=run_id,
+                batch_index=batch_index,
+            ),
             bucket_name=settings.bucket_name,
             manifest_uri=cas_manifest_uri,
             dry_run=False,
@@ -480,6 +553,7 @@ def run_cleanup_gcs_cache(
             ),
         )
         cas_batch_job_name = cas_batch_job.job_name
+        cas_batch_job_names.append(cas_batch_job_name)
         _wait_for_successful_batch_job(
             wait_for_batch_job=wait_for_batch_job, job_name=cas_batch_job.job_name
         )
@@ -522,6 +596,10 @@ def run_cleanup_gcs_cache(
         ac_batch_job_name=ac_batch_job_name,
         cas_manifest_uri=cas_manifest_uri,
         cas_batch_job_name=cas_batch_job_name,
+        ac_manifest_uris=tuple(ac_manifest_uris) or None,
+        ac_batch_job_names=tuple(ac_batch_job_names) or None,
+        cas_manifest_uris=tuple(cas_manifest_uris) or None,
+        cas_batch_job_names=tuple(cas_batch_job_names) or None,
     )
 
 
@@ -651,7 +729,6 @@ SELECT
   cas.idle_days
 FROM cas_after_extra_idle AS cas
 ORDER BY cas.last_seen_at ASC, cas.object_name ASC
-LIMIT @limit
 """.strip()
 
 
@@ -998,7 +1075,9 @@ def _populate_ac_stage_tables(
                     )
                 )
                 parse_failed_names = {
-                    extraction.ac_object_name for extraction in extractions if extraction.parse_error
+                    extraction.ac_object_name
+                    for extraction in extractions
+                    if extraction.parse_error
                 }
                 parse_error_count += len(parse_failed_names)
                 for extraction in extractions:
@@ -1024,7 +1103,9 @@ def _populate_ac_stage_tables(
                 missing_names = {item.object_name for item in metadata_rows if not item.exists} | {
                     extraction.ac_object_name for extraction in extractions if not extraction.exists
                 }
-                missing_rows = [{"object_name": object_name} for object_name in sorted(missing_names)]
+                missing_rows = [
+                    {"object_name": object_name} for object_name in sorted(missing_names)
+                ]
                 if deletable_live_rows:
                     for row in deletable_live_rows:
                         live_handle.write(json.dumps(row, separators=(",", ":")))
@@ -1124,24 +1205,48 @@ def _candidate_table_name(settings: GcsCacheSettings, *, prefix: str, run_id: st
     return _table_ref(settings.project_id, settings.dataset, f"_tmp_gcs_cache_{prefix}_{suffix}")
 
 
+def _batch_candidate_table_name(
+    settings: GcsCacheSettings,
+    *,
+    prefix: str,
+    run_id: str,
+    batch_index: int,
+) -> str:
+    return _candidate_table_name(
+        settings,
+        prefix=f"{prefix}_b{batch_index:04d}",
+        run_id=run_id,
+    )
+
+
 def _manifest_uri(
     settings: GcsCacheSettings,
     *,
     object_kind: str,
     run_started_at: datetime,
     run_id: str,
+    batch_index: int | None = None,
 ) -> str:
     date_prefix = run_started_at.strftime("%Y-%m-%d")
+    batch_path = "" if batch_index is None else f"/batch-{batch_index:04d}"
     return (
         f"gs://{settings.cleanup_manifest_bucket}/"
-        f"{settings.cleanup_manifest_prefix}/{date_prefix}/{object_kind}/{run_id}/manifest-*.csv"
+        f"{settings.cleanup_manifest_prefix}/{date_prefix}/{object_kind}/{run_id}"
+        f"{batch_path}/manifest-*.csv"
     )
 
 
-def _batch_job_id(*, object_kind: str, run_started_at: datetime, run_id: str) -> str:
+def _batch_job_id(
+    *,
+    object_kind: str,
+    run_started_at: datetime,
+    run_id: str,
+    batch_index: int | None = None,
+) -> str:
     timestamp = run_started_at.strftime("%Y%m%dt%H%M%S")
     suffix = run_id.replace("-", "")[:12]
-    return f"gcs-cache-cleanup-{object_kind}-{timestamp}-{suffix}".lower()
+    batch_suffix = "" if batch_index is None else f"-b{batch_index:04d}"
+    return f"gcs-cache-cleanup-{object_kind}-{timestamp}-{suffix}{batch_suffix}".lower()
 
 
 def _create_table_query(

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -193,7 +193,10 @@ def build_parser() -> argparse.ArgumentParser:
     cleanup_gcs_cache.add_argument("--safety-buffer-days", type=_parse_positive_int, default=None)
     cleanup_gcs_cache.add_argument("--max-delete-objects", type=_parse_positive_int, default=None)
     cleanup_gcs_cache.add_argument(
-        "--max-delete-cas-objects", type=_parse_positive_int, default=None
+        "--max-delete-cas-objects",
+        type=_parse_positive_int,
+        default=None,
+        help="Deprecated compatibility option; ignored by v3 AC-driven cascade cleanup",
     )
     cleanup_gcs_cache.add_argument("--sample-limit", type=_parse_positive_int, default=None)
 
@@ -241,7 +244,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         limit=args.limit,
                         replace_existing_partitions=args.replace_existing_partitions,
                     )
-                    )
+                )
             print(json.dumps(_summaries_to_json(summaries), indent=2, sort_keys=True))
             return 0
         finally:

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -144,7 +144,10 @@ def test_cleanup_gcs_cache_final_cas_delete_ignores_cleanup_metadata_gets() -> N
         ttl_days=7,
     )
 
-    assert "FROM `pingcap-testing-account.ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access` AS audit" in query
+    assert (
+        "FROM `pingcap-testing-account.ci_bazel_cache_logs.cloudaudit_googleapis_com_data_access` AS audit"
+        in query
+    )
     assert "audit.protopayload_auditlog.methodName IN" in query
     assert "audit.timestamp > source.last_seen_at" in query
     assert "AND NOT (" in query
@@ -422,7 +425,6 @@ def test_run_cleanup_gcs_cache_delete_cascades_ac_then_cas() -> None:
         cas_retention_days=15,
         safety_buffer_days=1,
         max_delete_objects=10000000,
-        max_delete_cas_objects=2,
         execute=fake_execute,
         stream_rows=fake_stream_rows,
         resolve_object_metadata=fake_resolve_object_metadata,
@@ -455,16 +457,17 @@ def test_run_cleanup_gcs_cache_delete_cascades_ac_then_cas() -> None:
         for table_ref, _rows, schema, _disposition in loaded_files
     )
     assert {
-        table_ref.rsplit(".", 1)[-1].rstrip("`") for table_ref, _rows, _schema, _disposition in loaded_files
+        table_ref.rsplit(".", 1)[-1].rstrip("`")
+        for table_ref, _rows, _schema, _disposition in loaded_files
     } == {
-        "_tmp_gcs_cache_ac_live_metadata_steadyrun001",
-        "_tmp_gcs_cache_ac_missing_metadata_steadyrun001",
-        "_tmp_gcs_cache_run_ac_cas_refs_steadyrun001",
-        "_tmp_gcs_cache_cas_live_metadata_steadyrun001",
-        "_tmp_gcs_cache_cas_missing_metadata_steadyrun001",
+        "_tmp_gcs_cache_ac_live_metadata_b0001_steadyrun001",
+        "_tmp_gcs_cache_ac_missing_metadata_b0001_steadyrun001",
+        "_tmp_gcs_cache_run_ac_cas_refs_b0001_steadyrun001",
+        "_tmp_gcs_cache_cas_live_metadata_b0001_steadyrun001",
+        "_tmp_gcs_cache_cas_missing_metadata_b0001_steadyrun001",
     }
     assert any(
-        "cas_from_deleted_ac" in query and params.get("limit") == 2
+        "cas_from_deleted_ac" in query and "LIMIT @limit" not in query and "limit" not in params
         for query, params in captured_queries
     )
     deleted_ac_reconcile_index = next(
@@ -480,6 +483,174 @@ def test_run_cleanup_gcs_cache_delete_cascades_ac_then_cas() -> None:
         if "cas_from_deleted_ac" in query
     )
     assert deleted_ac_reconcile_index < cas_candidate_index
+
+
+def test_run_cleanup_gcs_cache_delete_cascades_cas_after_each_ac_batch() -> None:
+    captured_queries = []
+    created_jobs = []
+    waited_jobs = []
+
+    def fake_execute(query, parameters):
+        rendered = {param.name: param.value for param in parameters}
+        captured_queries.append((query, rendered))
+        if "candidate_cas_object_count" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_cas_object_count": 0,
+                        "candidate_ac_object_count": 2,
+                        "candidate_cas_delete_object_count": 0,
+                        "oldest_last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+                        "newest_last_seen_at": datetime(2026, 5, 2, 0, 0, tzinfo=UTC),
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=2,
+            )
+        if "SELECT COUNT(DISTINCT cas_object_name) AS object_count FROM" in query:
+            return BigQueryQueryResult(rows=({"object_count": 1},), total_bytes_processed=1)
+        if "SELECT COUNT(*) AS object_count FROM" in query:
+            return BigQueryQueryResult(rows=({"object_count": 1},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        del parameters
+        if "_tmp_gcs_cache_candidate_ac_b0001_" in query:
+            yield {"object_name": "ac/one", "last_seen_at": datetime(2026, 5, 1, tzinfo=UTC)}
+            return
+        if "_tmp_gcs_cache_candidate_ac_b0002_" in query:
+            yield {"object_name": "ac/two", "last_seen_at": datetime(2026, 5, 2, tzinfo=UTC)}
+            return
+        if "_tmp_gcs_cache_candidate_cas_b0001_" in query:
+            yield {"object_name": "cas/one"}
+            return
+        if "_tmp_gcs_cache_candidate_cas_b0002_" in query:
+            yield {"object_name": "cas/two"}
+            return
+        raise AssertionError(f"Unexpected stream query: {query}")
+
+    def fake_resolve_object_metadata(**kwargs):
+        names = tuple(kwargs["object_names"])
+        generations = {
+            "ac/one": 101,
+            "ac/two": 102,
+            "cas/one": 201,
+            "cas/two": 202,
+        }
+        return tuple(GcsObjectMetadata(name, True, generations[name]) for name in names)
+
+    def fake_extract_references(**kwargs):
+        names = tuple(kwargs["ac_object_names"])
+        refs = {
+            "ac/one": ("cas/one",),
+            "ac/two": ("cas/two",),
+        }
+        return tuple(
+            AcReferenceExtraction(
+                ac_object_name=name,
+                exists=True,
+                cas_object_names=refs[name],
+            )
+            for name in names
+        )
+
+    def fake_load_jsonl_file(table_ref, jsonl_path, schema, write_disposition):
+        del table_ref, schema, write_disposition
+        assert jsonl_path.exists()
+
+    def fake_create_batch_job(**kwargs):
+        created_jobs.append(kwargs)
+        return StorageBatchOperationsJob(
+            job_name=f"projects/pingcap-testing-account/locations/global/jobs/{kwargs['job_id']}",
+            operation_name="operations/op-1",
+        )
+
+    def fake_wait_for_batch_job(**kwargs):
+        waited_jobs.append(kwargs)
+        return StorageBatchOperationsJobStatus(
+            job_name=kwargs["job_name"],
+            state="SUCCEEDED",
+            total_object_count=1,
+            succeeded_object_count=1,
+            failed_object_count=0,
+            total_bytes_transformed=123,
+            complete_time=datetime(2026, 6, 15, 10, 31, tzinfo=UTC),
+        )
+
+    with pytest.warns(FutureWarning, match="max_delete_cas_objects is deprecated and ignored"):
+        summary = run_cleanup_gcs_cache(
+            settings=GcsCacheSettings(
+                project_id="pingcap-testing-account",
+                cleanup_ac_delete_batch_size=1,
+            ),
+            mode="delete",
+            execute_kind="cas",
+            ac_retention_days=10,
+            cas_retention_days=15,
+            safety_buffer_days=1,
+            max_delete_objects=2,
+            max_delete_cas_objects=1,
+            execute=fake_execute,
+            stream_rows=fake_stream_rows,
+            resolve_object_metadata=fake_resolve_object_metadata,
+            extract_references=fake_extract_references,
+            load_jsonl_file=fake_load_jsonl_file,
+            create_batch_job=fake_create_batch_job,
+            wait_for_batch_job=fake_wait_for_batch_job,
+            now=lambda: datetime(2026, 6, 15, 10, 30, tzinfo=UTC),
+            run_id_factory=lambda: "steady-run-batched",
+        )
+
+    assert summary.selected_ac_object_count == 2
+    assert summary.selected_cas_object_count == 2
+    assert summary.candidate_cas_object_count == 2
+    assert summary.candidate_cas_delete_object_count == 2
+    assert [job["job_id"] for job in created_jobs] == [
+        "gcs-cache-cleanup-ac-20260615t103000-steadyrunbat-b0001",
+        "gcs-cache-cleanup-cas-20260615t103000-steadyrunbat-b0001",
+        "gcs-cache-cleanup-ac-20260615t103000-steadyrunbat-b0002",
+        "gcs-cache-cleanup-cas-20260615t103000-steadyrunbat-b0002",
+    ]
+    assert all("/batch-000" in job["manifest_uri"] for job in created_jobs)
+    assert summary.ac_manifest_uris == (
+        created_jobs[0]["manifest_uri"],
+        created_jobs[2]["manifest_uri"],
+    )
+    assert summary.cas_manifest_uris == (
+        created_jobs[1]["manifest_uri"],
+        created_jobs[3]["manifest_uri"],
+    )
+    assert summary.ac_batch_job_names == (
+        "projects/pingcap-testing-account/locations/global/jobs/"
+        "gcs-cache-cleanup-ac-20260615t103000-steadyrunbat-b0001",
+        "projects/pingcap-testing-account/locations/global/jobs/"
+        "gcs-cache-cleanup-ac-20260615t103000-steadyrunbat-b0002",
+    )
+    assert summary.cas_batch_job_names == (
+        "projects/pingcap-testing-account/locations/global/jobs/"
+        "gcs-cache-cleanup-cas-20260615t103000-steadyrunbat-b0001",
+        "projects/pingcap-testing-account/locations/global/jobs/"
+        "gcs-cache-cleanup-cas-20260615t103000-steadyrunbat-b0002",
+    )
+    assert summary.ac_manifest_uri == created_jobs[2]["manifest_uri"]
+    assert summary.cas_manifest_uri == created_jobs[3]["manifest_uri"]
+    assert len(waited_jobs) == 4
+    first_cas_candidate_index = next(
+        index
+        for index, (query, _params) in enumerate(captured_queries)
+        if "_tmp_gcs_cache_candidate_cas_b0001_" in query
+    )
+    second_ac_seed_index = next(
+        index
+        for index, (query, _params) in enumerate(captured_queries)
+        if "_tmp_gcs_cache_candidate_ac_b0002_" in query
+    )
+    assert first_cas_candidate_index < second_ac_seed_index
+    assert all(
+        "LIMIT @limit" not in query and "limit" not in params
+        for query, params in captured_queries
+        if "cas_from_deleted_ac" in query
+    )
 
 
 def test_run_cleanup_gcs_cache_delete_refills_live_ac_target_after_stale_rows() -> None:
@@ -624,7 +795,6 @@ def test_run_cleanup_gcs_cache_delete_refills_live_ac_target_after_stale_rows() 
         cas_retention_days=15,
         safety_buffer_days=1,
         max_delete_objects=3,
-        max_delete_cas_objects=5,
         execute=fake_execute,
         stream_rows=fake_stream_rows,
         resolve_object_metadata=fake_resolve_object_metadata,
@@ -644,8 +814,7 @@ def test_run_cleanup_gcs_cache_delete_refills_live_ac_target_after_stale_rows() 
     ac_seed_queries = [
         params
         for query, params in captured_queries
-        if "_tmp_gcs_cache_candidate_ac_steadyrunrefill" in query
-        and "LIMIT @limit" in query
+        if "_tmp_gcs_cache_candidate_ac_b0001_steadyrunrefill" in query and "LIMIT @limit" in query
     ]
     assert len(ac_seed_queries) == 2
     assert ac_seed_queries[0]["limit"] == 3
@@ -658,9 +827,108 @@ def test_run_cleanup_gcs_cache_delete_refills_live_ac_target_after_stale_rows() 
         if "DELETE FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_object_last_seen_current`"
         in query
         and "object_kind = 'ac'" in query
-        and "_tmp_gcs_cache_ac_missing_metadata_steadyrunrefill" in query
+        and "_tmp_gcs_cache_ac_missing_metadata_b0001_steadyrunrefill" in query
     ]
     assert len(reconcile_queries) == 2
+
+
+def test_run_cleanup_gcs_cache_delete_stops_after_repeated_zero_progress_refills() -> None:
+    captured_queries = []
+    loaded_files = []
+    ac_stream_call_count = 0
+
+    def fake_execute(query, parameters):
+        rendered = {param.name: param.value for param in parameters}
+        captured_queries.append((query, rendered))
+        if "candidate_cas_object_count" in query:
+            return BigQueryQueryResult(
+                rows=(
+                    {
+                        "candidate_cas_object_count": 0,
+                        "candidate_ac_object_count": 50,
+                        "candidate_cas_delete_object_count": 0,
+                        "oldest_last_seen_at": datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
+                        "newest_last_seen_at": datetime(2026, 5, 20, 0, 0, tzinfo=UTC),
+                        "sample_candidates": [],
+                    },
+                ),
+                total_bytes_processed=2,
+            )
+        if "SELECT COUNT(*) AS object_count FROM" in query and "delete_ac" in query:
+            return BigQueryQueryResult(rows=({"object_count": 0},), total_bytes_processed=1)
+        if "SELECT COUNT(DISTINCT cas_object_name) AS object_count FROM" in query:
+            return BigQueryQueryResult(rows=({"object_count": 0},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        nonlocal ac_stream_call_count
+        del parameters
+        if (
+            "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_ac_"
+            in query
+        ):
+            ac_stream_call_count += 1
+            if ac_stream_call_count > 3:
+                raise AssertionError("zero-progress guard should stop after three refill rounds")
+            for index in range(5):
+                yield {
+                    "object_name": f"ac/stale-{ac_stream_call_count}-{index}",
+                    "last_seen_at": datetime(2026, 5, ac_stream_call_count, index, tzinfo=UTC),
+                }
+            return
+        if (
+            "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_cas_"
+            in query
+        ):
+            raise AssertionError("CAS stage should not run without live AC")
+        raise AssertionError(f"Unexpected stream query: {query}")
+
+    def fake_resolve_object_metadata(**kwargs):
+        return tuple(GcsObjectMetadata(str(name), False, None) for name in kwargs["object_names"])
+
+    def fake_load_jsonl_file(table_ref, jsonl_path, schema, write_disposition):
+        with jsonl_path.open(encoding="utf-8") as handle:
+            payload = tuple(json.loads(line) for line in handle if line.strip())
+        loaded_files.append((table_ref, payload, tuple(schema), write_disposition))
+
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="delete",
+        execute_kind="cas",
+        ac_retention_days=10,
+        cas_retention_days=15,
+        safety_buffer_days=1,
+        max_delete_objects=5,
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        resolve_object_metadata=fake_resolve_object_metadata,
+        extract_references=lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError(f"should not extract references: {kwargs}")
+        ),
+        load_jsonl_file=fake_load_jsonl_file,
+        create_batch_job=lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError(f"should not create batch job: {kwargs}")
+        ),
+        wait_for_batch_job=lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError(f"should not wait for batch job: {kwargs}")
+        ),
+        now=lambda: datetime(2026, 6, 15, 10, 30, tzinfo=UTC),
+        run_id_factory=lambda: "steady-run-zero-progress",
+    )
+
+    assert summary.selected_ac_object_count == 0
+    assert summary.selected_cas_object_count == 0
+    assert summary.ac_manifest_uri is None
+    assert summary.ac_manifest_uris is None
+    assert ac_stream_call_count == 3
+    assert len(loaded_files) == 3
+    ac_seed_queries = [
+        params
+        for query, params in captured_queries
+        if "_tmp_gcs_cache_candidate_ac_b0001_steadyrunzeroprogress" in query
+        and "LIMIT @limit" in query
+    ]
+    assert len(ac_seed_queries) == 3
 
 
 def test_run_cleanup_gcs_cache_delete_exits_when_seed_batch_is_empty() -> None:
@@ -695,14 +963,13 @@ def test_run_cleanup_gcs_cache_delete_exits_when_seed_batch_is_empty() -> None:
             "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_ac_"
             in query
         ):
-            return
+            return iter(())
         if (
             "FROM `pingcap-testing-account.ci_bazel_cache_logs._tmp_gcs_cache_candidate_cas_"
             in query
         ):
-            return
+            return iter(())
         raise AssertionError(f"Unexpected stream query: {query}")
-        yield
 
     summary = run_cleanup_gcs_cache(
         settings=GcsCacheSettings(project_id="pingcap-testing-account"),
@@ -712,7 +979,6 @@ def test_run_cleanup_gcs_cache_delete_exits_when_seed_batch_is_empty() -> None:
         cas_retention_days=15,
         safety_buffer_days=1,
         max_delete_objects=3,
-        max_delete_cas_objects=5,
         execute=fake_execute,
         stream_rows=fake_stream_rows,
         create_batch_job=lambda **kwargs: (_ for _ in ()).throw(

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -143,6 +143,20 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
     assert settings.gcs_cache.cleanup_candidate_ttl_days == 9
 
 
+def test_load_settings_warns_when_cleanup_ac_batch_exceeds_max_delete_objects() -> None:
+    with pytest.warns(RuntimeWarning, match="cleanup_ac_delete_batch_size is greater"):
+        settings = load_settings(
+            {
+                "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS": "10",
+                "COST_INSIGHT_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE": "20",
+            },
+            require_database=False,
+        )
+
+    assert settings.gcs_cache.cleanup_max_delete_objects == 10
+    assert settings.gcs_cache.cleanup_ac_delete_batch_size == 20
+
+
 def test_load_settings_requires_database_when_not_skipped() -> None:
     with pytest.raises(ValueError, match="Missing required environment variable"):
         load_settings({})

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -112,6 +112,7 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
             "COST_INSIGHT_GCS_CACHE_CLEANUP_SAMPLE_LIMIT": "25",
             "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS": "500",
             "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS": "100",
+            "COST_INSIGHT_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE": "200",
             "COST_INSIGHT_GCS_CACHE_CLEANUP_BATCH_SIZE": "50",
             "COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET": "manifest-bucket",
             "COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX": "manifest-prefix",
@@ -135,6 +136,7 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
     assert settings.gcs_cache.cleanup_sample_limit == 25
     assert settings.gcs_cache.cleanup_max_delete_objects == 500
     assert settings.gcs_cache.cleanup_max_delete_cas_objects == 100
+    assert settings.gcs_cache.cleanup_ac_delete_batch_size == 200
     assert settings.gcs_cache.cleanup_batch_size == 50
     assert settings.gcs_cache.cleanup_manifest_bucket == "manifest-bucket"
     assert settings.gcs_cache.cleanup_manifest_prefix == "manifest-prefix"


### PR DESCRIPTION
## Summary

- Change GCS cache delete mode to process AC-driven cascade cleanup in internal AC batches.
- Keep `max_delete_objects` as the only delete cap; CAS deletion is no longer independently capped.
- Delete each AC batch first, reconcile it, then immediately delete all eligible CAS referenced by that batch before moving to the next AC batch.
- Add per-batch manifest/job names and summary lists so every batch can be audited.
- Keep `max_delete_cas_objects` as a deprecated compatibility option and emit a `FutureWarning` when it is provided.
- Stop refill scanning after repeated zero-progress AC rounds to avoid wasting work on all-stale candidate windows.

## Validation

- `cd cost-insight && pytest` (`163 passed`, coverage `93.42%`)
- `cd cost-insight && ruff check src tests`
- `git diff --check`
