### PR TITLE
feat(tibuild-v2): implement config hot-reload with file polling and SIGHUP

### DIFF
--- a/experiments/tibuild-v2/cmd/tibuild/init.go
+++ b/experiments/tibuild-v2/cmd/tibuild/init.go
@@ -1,27 +1,13 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"gopkg.in/yaml.v3"
+	_ "github.com/go-sql-driver/mysql"
 
 	"github.com/PingCAP-QE/ee-apps/tibuild/pkg/config"
-
-	_ "github.com/go-sql-driver/mysql"
 )
 
-// Load and parse configuration
-func loadConfig(configFile string) (*config.Service, error) {
-	var config config.Service
-	{
-		configData, err := os.ReadFile(configFile)
-		if err != nil {
-			return nil, fmt.Errorf("error reading config file: %v", err)
-		}
-		if err := yaml.Unmarshal(configData, &config); err != nil {
-			return nil, fmt.Errorf("error parsing config file: %v", err)
-		}
-	}
-	return &config, nil
+// loadConfig reads and parses the YAML config file, returning a thread-safe
+// Reloadable wrapper that supports hot-reload via file polling or SIGHUP.
+func loadConfig(configFile string) (*config.Reloadable, error) {
+	return config.Load(configFile)
 }

--- a/experiments/tibuild-v2/cmd/tibuild/main.go
+++ b/experiments/tibuild-v2/cmd/tibuild/main.go
@@ -22,7 +22,13 @@ import (
 	"github.com/PingCAP-QE/ee-apps/tibuild/internal/service/gen/devbuild"
 	"github.com/PingCAP-QE/ee-apps/tibuild/internal/service/gen/hotfix"
 	"github.com/PingCAP-QE/ee-apps/tibuild/internal/service/impl"
+	"github.com/PingCAP-QE/ee-apps/tibuild/pkg/config"
 )
+
+// reloader is an interface for services that support config hot-reload.
+type reloader interface {
+	Reload(cfg *config.Service)
+}
 
 func main() {
 	// Define command line flags, add any other flag required to configure the
@@ -49,7 +55,7 @@ func main() {
 	}
 	log.Print(ctx, log.KV{K: "http-port", V: *httpPortF})
 
-	// Load and parse configuration
+	// Load configuration with hot-reload support.
 	cfg, err := loadConfig(*configFile)
 	if err != nil {
 		log.Fatalf(ctx, err, "failed to load configuration")
@@ -73,19 +79,25 @@ func main() {
 		}
 		{
 			logger := zerolog.New(os.Stderr).With().Timestamp().Str("service", devbuild.ServiceName).Logger()
-			devbuildSvc = impl.NewDevbuild(&logger, cfg)
+			devbuildSvc = impl.NewDevbuild(&logger, cfg.Get())
 			if devbuildSvc == nil {
 				log.Fatalf(ctx, errors.New("failed to initialize devbuild service"), "please check the configuration")
 			}
 
+			// Register devbuild config hot-reload handler.
+			if r, ok := devbuildSvc.(reloader); ok {
+				cfg.OnReload(func(newCfg *config.Service) { r.Reload(newCfg) })
+			}
+
 			// Start Tekton reconciler
-			if cfg.Tekton.ViewURL != "" {
+			initialCfg := cfg.Get()
+			if initialCfg.Tekton.ViewURL != "" {
 				interval := 1 * time.Minute // default
-				if cfg.Tekton.ReconcilerInterval != "" {
-					if d, err := time.ParseDuration(cfg.Tekton.ReconcilerInterval); err == nil {
+				if initialCfg.Tekton.ReconcilerInterval != "" {
+					if d, err := time.ParseDuration(initialCfg.Tekton.ReconcilerInterval); err == nil {
 						interval = d
 					} else {
-						log.Fatalf(ctx, err, "invalid reconciler_interval: %s", cfg.Tekton.ReconcilerInterval)
+						log.Fatalf(ctx, err, "invalid reconciler_interval: %s", initialCfg.Tekton.ReconcilerInterval)
 					}
 				}
 
@@ -115,8 +127,13 @@ func main() {
 		}
 		{
 			logger := zerolog.New(os.Stderr).With().Timestamp().Str("service", hotfix.ServiceName).Logger()
-			ghClient := impl.NewGitHubClient(cfg.Github.Token)
+			ghClient := impl.NewGitHubClient(cfg.Get().Github.Token)
 			hotfixSvc = impl.NewHotfix(&logger, ghClient)
+
+			// Register hotfix config hot-reload handler.
+			if r, ok := hotfixSvc.(reloader); ok {
+				cfg.OnReload(func(newCfg *config.Service) { r.Reload(newCfg) })
+			}
 		}
 	}
 
@@ -147,12 +164,27 @@ func main() {
 	// that SIGINT and SIGTERM signals cause the services to stop gracefully.
 	go func() {
 		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-		errc <- fmt.Errorf("%s", <-c)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+		sig := <-c
+		if sig == syscall.SIGHUP {
+			log.Printf(ctx, "received SIGHUP, reloading configuration")
+			if err := cfg.Reload(); err != nil {
+				log.Printf(ctx, "config reload on SIGHUP failed: %v", err)
+			} else {
+				log.Printf(ctx, "configuration reloaded successfully")
+			}
+			// Continue listening for SIGINT/SIGTERM.
+			errc <- fmt.Errorf("%s", <-c)
+		} else {
+			errc <- fmt.Errorf("%s", sig)
+		}
 	}()
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(ctx)
+
+	// Start background config file watcher (polls every 30 seconds).
+	go cfg.AutoReload(ctx, 30*time.Second)
 
 	// Start the servers and send errors (if any) to the error channel.
 	switch *hostF {

--- a/experiments/tibuild-v2/internal/service/impl/devbuild.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild.go
@@ -32,6 +32,7 @@ type devbuildsrvc struct {
 	dashboardURL           string
 	reconcilerSince        time.Duration
 	httpClient             *http.Client
+	larkNotifier           *LarkNotifier
 	jenkins                struct {
 		client  *gojenkins.Jenkins
 		jobName string
@@ -76,8 +77,8 @@ func NewDevbuild(logger *zerolog.Logger, cfg *config.Service) devbuild.Service {
 
 	// Register Lark notification hook if enabled
 	if cfg.Lark.Enabled && cfg.Lark.WebhookURL != "" {
-		notifier := NewLarkNotifier(cfg.Lark.WebhookURL, logger)
-		registerNotificationHook(dbClient, notifier, logger)
+		srvc.larkNotifier = NewLarkNotifier(cfg.Lark.WebhookURL, logger)
+		registerNotificationHook(dbClient, srvc.larkNotifier, logger)
 		logger.Info().Msg("lark notification hook registered")
 	}
 

--- a/experiments/tibuild-v2/internal/service/impl/devbuild_reload.go
+++ b/experiments/tibuild-v2/internal/service/impl/devbuild_reload.go
@@ -1,0 +1,64 @@
+package impl
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/PingCAP-QE/ee-apps/tibuild/pkg/config"
+
+	"github.com/bndr/gojenkins"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/go-github/v69/github"
+)
+
+// Reload updates the service configuration at runtime. It is called by the
+// config reloader when the config file changes on disk.
+func (s *devbuildsrvc) Reload(cfg *config.Service) {
+	s.logger.Info().Msg("hot-reloading devbuild configuration")
+
+	// Update GitHub client with new token.
+	s.ghClient = github.NewClientWithEnvProxy().WithAuthToken(cfg.Github.Token)
+
+	// Update product repo and image mirror maps.
+	s.productRepoMap = cfg.ProductRepoMap
+	s.imageMirrorURLMap = cfg.ImageMirrorURLMap
+
+	// Update Tekton dashboard URL.
+	s.dashboardURL = cfg.Tekton.ViewURL
+
+	// Update reconciler lookback duration.
+	if cfg.Tekton.ReconcilerSince != "" {
+		if d, err := time.ParseDuration(cfg.Tekton.ReconcilerSince); err == nil {
+			s.reconcilerSince = d
+		} else {
+			s.logger.Warn().Str("reconciler_since", cfg.Tekton.ReconcilerSince).Msg("invalid reconciler_since in reload, keeping previous value")
+		}
+	}
+
+	// Recreate cloud events client if endpoint changed.
+	if cfg.Tekton.CloudeventEndpoint != "" {
+		client, err := cloudevents.NewClientHTTP(cloudevents.WithTarget(cfg.Tekton.CloudeventEndpoint))
+		if err == nil {
+			s.tektonCloudEventClient = client
+		} else {
+			s.logger.Err(err).Msg("failed to recreate cloud events client on reload, keeping previous")
+		}
+	}
+
+	// Update Jenkins client and job name.
+	s.jenkins.client = gojenkins.CreateJenkins(http.DefaultClient, cfg.Jenkins.URL)
+	s.jenkins.jobName = cfg.Jenkins.JobName
+
+	// Update Lark notifier webhook URL if a notifier is registered.
+	if s.larkNotifier != nil {
+		if cfg.Lark.Enabled && cfg.Lark.WebhookURL != "" {
+			s.larkNotifier.SetWebhookURL(cfg.Lark.WebhookURL)
+			s.logger.Debug().Msg("lark notifier webhook URL updated on reload")
+		} else if !cfg.Lark.Enabled {
+			s.larkNotifier.SetWebhookURL("")
+			s.logger.Debug().Msg("lark notifier disabled on reload")
+		}
+	}
+
+	s.logger.Info().Msg("devbuild configuration reloaded successfully")
+}

--- a/experiments/tibuild-v2/internal/service/impl/hotfix.go
+++ b/experiments/tibuild-v2/internal/service/impl/hotfix.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/PingCAP-QE/ee-apps/tibuild/internal/service/gen/hotfix"
+	"github.com/PingCAP-QE/ee-apps/tibuild/pkg/config"
 )
 
 // hotfixsrvc service implementation.
@@ -31,6 +32,13 @@ func NewHotfix(logger *zerolog.Logger, ghClient *github.Client) hotfix.Service {
 		logger:   logger,
 		ghClient: ghClient,
 	}
+}
+
+// Reload updates the hotfix service configuration at runtime.
+func (s *hotfixsrvc) Reload(cfg *config.Service) {
+	s.logger.Info().Msg("hot-reloading hotfix configuration")
+	s.ghClient = github.NewClientWithEnvProxy().WithAuthToken(cfg.Github.Token)
+	s.logger.Info().Msg("hotfix configuration reloaded successfully")
 }
 
 // verifyAndGetCommit verifies that the branch or commit exists and returns the commit SHA.

--- a/experiments/tibuild-v2/internal/service/impl/notifier.go
+++ b/experiments/tibuild-v2/internal/service/impl/notifier.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -19,24 +20,32 @@ type Notifier interface {
 }
 
 // LarkNotifier sends Lark webhook notifications when builds reach terminal state.
+// The webhookURL is stored atomically to support safe runtime updates via config reload.
 type LarkNotifier struct {
-	webhookURL string
+	webhookURL atomic.Value // stores string
 	httpClient *http.Client
 	logger     *zerolog.Logger
 }
 
 // NewLarkNotifier creates a new LarkNotifier.
 func NewLarkNotifier(webhookURL string, logger *zerolog.Logger) *LarkNotifier {
-	return &LarkNotifier{
-		webhookURL: webhookURL,
+	n := &LarkNotifier{
 		httpClient: &http.Client{Timeout: 10 * time.Second},
 		logger:     logger,
 	}
+	n.webhookURL.Store(webhookURL)
+	return n
+}
+
+// SetWebhookURL updates the webhook URL atomically. Safe to call concurrently with Notify.
+func (n *LarkNotifier) SetWebhookURL(url string) {
+	n.webhookURL.Store(url)
 }
 
 // Notify sends a Lark notification for the given build.
 func (n *LarkNotifier) Notify(ctx context.Context, build *ent.DevBuild) error {
-	if n.webhookURL == "" {
+	webhookURL := n.webhookURL.Load().(string)
+	if webhookURL == "" {
 		n.logger.Debug().Msg("lark webhook URL not configured, skipping notification")
 		return nil
 	}
@@ -53,9 +62,9 @@ func (n *LarkNotifier) Notify(ctx context.Context, build *ent.DevBuild) error {
 		return err
 	}
 
-	n.logger.Debug().Str("webhook", n.webhookURL).Str("body", string(body)).Msg("debug lark message")
+	n.logger.Debug().Str("webhook", webhookURL).Str("body", string(body)).Msg("debug lark message")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.webhookURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
 	if err != nil {
 		n.logger.Err(err).Int("build_id", build.ID).Msg("failed to create notification request")
 		return err

--- a/experiments/tibuild-v2/pkg/config/reloadable.go
+++ b/experiments/tibuild-v2/pkg/config/reloadable.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReloadHandler is a callback invoked with the new config after a successful reload.
+type ReloadHandler func(*Service)
+
+// Reloadable wraps Service with thread-safe reload capability.
+// It watches a YAML config file for changes and notifies registered handlers.
+type Reloadable struct {
+	mu       sync.RWMutex
+	cfg      *Service
+	path     string
+	mtime    time.Time
+	handlers []ReloadHandler
+}
+
+// Load reads the YAML config file and returns a Reloadable.
+func Load(path string) (*Reloadable, error) {
+	cfg, fi, err := loadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	return &Reloadable{
+		cfg:   cfg,
+		path:  path,
+		mtime: fi.ModTime(),
+	}, nil
+}
+
+// Get returns the current config in a thread-safe manner.
+func (r *Reloadable) Get() *Service {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.cfg
+}
+
+// Reload re-reads the config file from disk and calls all registered handlers
+// with the new config. It is safe to call concurrently.
+func (r *Reloadable) Reload() error {
+	cfg, fi, err := loadFile(r.path)
+	if err != nil {
+		return fmt.Errorf("reload config: %w", err)
+	}
+
+	// Snapshot handlers under lock, then call them outside to avoid deadlock
+	// if a handler calls Get().
+	r.mu.Lock()
+	r.cfg = cfg
+	r.mtime = fi.ModTime()
+	handlers := make([]ReloadHandler, len(r.handlers))
+	copy(handlers, r.handlers)
+	r.mu.Unlock()
+
+	for _, h := range handlers {
+		h(cfg)
+	}
+	return nil
+}
+
+// OnReload registers a handler that is called after each successful reload.
+// Handlers are called in registration order.
+func (r *Reloadable) OnReload(handler ReloadHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handlers = append(r.handlers, handler)
+}
+
+// AutoReload polls the config file for modification changes at the given
+// interval and triggers a reload when a change is detected. It blocks until
+// the context is cancelled.
+func (r *Reloadable) AutoReload(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		fi, err := os.Stat(r.path)
+		if err != nil {
+			continue
+		}
+
+		r.mu.RLock()
+		old := r.mtime
+		r.mu.RUnlock()
+
+		if fi.ModTime().After(old) {
+			if err := r.Reload(); err != nil {
+				// Log to stderr but keep running with old config.
+				fmt.Fprintf(os.Stderr, "config auto-reload error: %v\n", err)
+			}
+		}
+	}
+}
+
+// loadFile reads and parses a YAML config file, returning the parsed config
+// along with the file info for mtime tracking.
+func loadFile(path string) (*Service, os.FileInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	var cfg Service
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, nil, err
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &cfg, fi, nil
+}


### PR DESCRIPTION
## Summary

Add configuration hot-reload support for tibuild-v2 service. When the config file (`config.yaml`) is updated, the service can reload configuration at runtime without restarting.

## How it works

- **File polling**: Background goroutine checks `config.yaml` mtime every 30 seconds and automatically triggers reload on change
- **SIGHUP signal**: `kill -HUP <pid>` triggers immediate config reload
- **Thread-safe**: `config.Reloadable` uses `sync.RWMutex` for concurrent access

## What gets reloaded

| Field | Service | How |
|-------|---------|-----|
| `Github.Token` | devbuild + hotfix | Recreate GitHub client |
| `ProductRepoMap` / `ImageMirrorURLMap` | devbuild | Replace maps |
| `Tekton.ViewURL` / `ReconcilerSince` | devbuild | Update fields |
| `Tekton.CloudeventEndpoint` | devbuild | Recreate CloudEvents client |
| `Jenkins.URL` / `JobName` | devbuild | Recreate Jenkins client |
| `Lark.WebhookURL` | devbuild | Atomic update (notifier) |

## Files changed

- `pkg/config/reloadable.go` (new) — Thread-safe config wrapper with auto-reload
- `internal/service/impl/devbuild_reload.go` (new) — Devbuild reload handler
- `internal/service/impl/hotfix.go` — Add Reload method
- `internal/service/impl/devbuild.go` — Store larkNotifier reference
- `internal/service/impl/notifier.go` — Atomic webhookURL for safe concurrent updates
- `cmd/tibuild/init.go` — Use config.Load
- `cmd/tibuild/main.go` — Wire up reload handlers, auto-reload goroutine, SIGHUP