### PR TITLE
feat(cost-insight): index-based CAS GC with complete AC expansion (v3)

### DIFF
--- a/cost-insight/docs/gcs-bazel-cache-cas-gc-v3-complete-ac-expansion.md
+++ b/cost-insight/docs/gcs-bazel-cache-cas-gc-v3-complete-ac-expansion.md
@@ -1,0 +1,804 @@
+# GCS Bazel Cache CAS GC v3: 全量 AC→CAS 索引重建
+
+## Context
+
+### 历史演进
+
+**v1 — 独立 LRU 删除（已废弃）**
+
+AC 和 CAS 各自按 `last_seen_at` 独立删除。CAS 被删除时仍有 live AC 引用它，
+导致 CI `Missing digest` 错误。
+
+**v2 — 持久化全局 AC→CAS 索引（已废弃但可复用表结构）**
+
+建立持久化的 `gcs_cache_ac_cas_references` 表，256 shard，先 bootstrap 全量 AC
+再每日增量同步。Cleanup 时从索引反查 CAS 的 AC 引用关系。
+
+问题：
+- Bootstrap 256 shard 逐个跑太慢
+- 增量同步额外运维负担
+- 当时 AC 量大，投入产出比存疑
+
+**v3 — Per-Run AC 驱动级联（当前版本，将被替换）**
+
+每次 run 选一批冷 AC → 解析提取 CAS 引用 → 删 AC → 删更冷的被引用 CAS。
+核心问题：
+- **Shared CAS**：一个 CAS 可能同时被"选中的冷 AC"和"未选中的 warm AC"引用，
+  v3 不检查后者，靠 `cleanup_max_delete_cas_objects=500` 硬扛
+- 每次 run 只覆盖一小批 AC，大量 CAS 永远没机会被评估
+
+### 踩过的坑
+
+1. **Parse error AC 导致引用信息缺失**：protobuf 解析失败的 AC 不贡献 CAS 引用，
+   其引用的 CAS 变成"假阴性"。**设计原则：parse error 必须 fail-closed。任一 shard
+   有 parse error 就不得更新 `indexed_through`。**
+
+2. **Missing AC 导致引用丢失**：`last_seen_current` 中的 AC 在 GCS 上已不存在
+   （NotFound），其引用信息永久丢失。需要将 missing AC 从 `last_seen_current`
+   和 references 表中 reconcile 掉。
+
+3. **`ac/one`、`ac/missing` 非法 hex 名称**：`FROM_HEX(SUBSTR(object_name, 4, 2))`
+   遇到非 hex 字符直接报错。已确认共 2 行。
+
+4. **Cleanup 自身 GET 污染 audit recheck**：通过 `last_seen_excluded_get_principal_email`
+   排除自身 service account 解决。
+
+5. **BigQuery stage table O(n²) 陷阱**：当前 sync 实现每 batch append stage 后立即
+   replace 且不清空 stage，重复处理累积数据。3000 万 AC 时不可接受，必须改为
+   "先完整收集再一次性 replace"或"每 batch 清空 stage"。
+
+6. **CLUSTER 方向与写入模式冲突**：按 CAS cluster 可以加速反查，但写入是按 AC
+   delete + insert，按 CAS cluster 会导致写入扫全表。
+
+7. **SQL reserved word、DDL 分隔符、manifest generation** 等 BigQuery 特有坑。
+
+## Current State
+
+```
+AC 总量（last_seen_current）:    ~30,413,613
+CAS 总量（last_seen_current）:    ~76,104,392
+平均每个 AC 引用 CAS 数:          ~1.84
+预估全量引用行数:                 5600w - 8200w 行
+无效 hex AC 名称:                 ac/one, ac/missing（共 2 行）
+实测 bootstrap 吞吐:              ~28-33 AC/s/pod（3 shard 实测数据）
+```
+
+## Goal
+
+重建完整的持久化 `AC → CAS` 引用索引，然后：
+
+1. **CAS 反推 AC 删除**：选出冷 CAS → 反查引用它的所有 AC → 删除其中冷的 AC →
+   引用计数归零后删除 CAS。不再需要独立的 AC LRU 删除。
+2. **零引用 CAS 删除**：选出没有任何 AC 引用的冷 CAS → 直接删除。
+
+## Design
+
+### 前置步骤 0：AC Source 完整性验证
+
+**问题**：Bootstrap 以 `last_seen_current` 为 AC 来源。如果 GCS 上存在 live AC
+但不在 `last_seen_current` 中，它引用的 CAS 会被误判为零引用。
+
+**`last_seen_current` 覆盖范围**：
+- 数据来源：`storage.objects.get` + `storage.objects.create` 审计日志
+- 日志窗口起始：2026-05-25
+- 历史静默对象已在 one-time historical cleanup 中删除（当时删了约 5580 万 AC）
+
+**验证方案**：
+
+1. 获取 GCS inventory 快照，提取所有 AC object names
+2. 直接 anti-join：`inventory_ac_names LEFT JOIN last_seen_current ON object_name`
+   → 找出在 inventory 中存在但 current 中不存在的 AC
+3. 不要用 `last_seen_at <= inventory_snapshot_time` 过滤 current——
+   一个在 inventory 快照中存在、快照后被访问过的对象，其 `last_seen_at` 会晚于
+   snapshot_time，用时间过滤会错误地把它排除
+4. 对不在 current 中的 AC，验证它们在 GCS 上是否仍然 live：
+   - Live → current 表有覆盖缺口，需纳入 bootstrap
+   - 已删除 → churn，可以忽略
+5. 如果 live 缺口 > 1%，bootstrap source 改为 inventory + current UNION
+
+如果差异不可忽略，bootstrap 的 AC 来源需要改为 inventory + current 的 UNION。
+
+**前置结论**：在验证通过之前，不能声称"完整索引"。验证是 Step 0。
+
+### 前置步骤 1：修复 invalid hex name guard + 索引表重建
+
+**代码改动**：
+
+1. 所有使用 `_ac_shard_expression` 的 source query 加 regex guard：
+   ```sql
+   AND REGEXP_CONTAINS(object_name, r'^ac/[0-9a-fA-F]{64}$')
+   ```
+   涉及文件：
+   - `sync_gcs_cache_ac_references.py`：`build_bootstrap_..._source_query`、
+     `build_incremental_..._source_query`
+   - `cleanup_gcs_cache.py`：`build_cleanup_gcs_cache_ac_seed_table_query`
+
+2. 手动清理 `last_seen_current` 中 `ac/one`、`ac/missing` 两行。
+
+### 双表设计：解决写入方向和查询方向冲突
+
+**问题**：写入（bootstrap/incremental/AC reconcile）按 `ac_object_name` 做 DELETE + INSERT
+replace；查询（cleanup CAS 反查）按 `cas_object_name` 过滤。同一个表只能 CLUSTER
+一个方向。
+
+**方案**：`by_ac` 是唯一持续维护的表。`by_cas` 是 cleanup 前从 `by_ac` 一次性
+重建的快照表。
+
+```
+gcs_cache_ac_cas_refs_by_ac
+  shard INT64 NOT NULL
+  ac_object_name STRING NOT NULL
+  cas_object_name STRING NOT NULL
+CLUSTER BY shard, ac_object_name
+-- 用途：bootstrap/incremental 写入，AC reconcile
+-- 唯一持续维护的表
+
+gcs_cache_ac_cas_refs_by_cas
+  ac_object_name STRING NOT NULL
+  cas_object_name STRING NOT NULL
+CLUSTER BY cas_object_name, ac_object_name
+-- 用途：cleanup CAS 反查
+-- 只做全量快照重建，不做 per-row 增量维护
+```
+
+**为什么 by_cas 不做增量维护**：by_cas 按 `cas_object_name` 聚簇，任何
+`WHERE ac_object_name IN (...)` 的 DELETE 都会全表扫描。在 5600w-8200w 行
+的大表上，即使"少量行"的按 AC 删除也是不可接受的。
+
+**数据流**：
+
+```
+bootstrap/incremental
+  → 写入 by_ac（DELETE by ac + INSERT，走 ac cluster，高效）
+  → 不立即更新 by_cas
+
+cleanup 执行时：
+  → EXPORT by_ac → IMPORT 重建 by_cas（全量快照）
+  → 基于 by_cas 做 CAS 反查
+  → CAS 删除完成后，by_cas 使命结束（保留到下次 cleanup 被覆盖）
+```
+
+```
+AC reconcile（cleanup 内 AC 删除后 / 索引保鲜发现幽灵 AC）
+  → DELETE from by_ac WHERE ac_object_name IN (...)  -- 走 ac cluster，高效
+  → by_cas 不做 per-row 删除——下次 cleanup 重建时会自动消失
+```
+
+**表结构**：
+
+```sql
+-- 重建（Step 1 执行）
+DROP TABLE IF EXISTS `...gcs_cache_ac_cas_refs_by_ac`;
+CREATE TABLE `...gcs_cache_ac_cas_refs_by_ac` (
+  shard INT64 NOT NULL,
+  ac_object_name STRING NOT NULL,
+  cas_object_name STRING NOT NULL
+)
+CLUSTER BY shard, ac_object_name;
+
+DROP TABLE IF EXISTS `...gcs_cache_ac_cas_refs_by_cas`;
+CREATE TABLE `...gcs_cache_ac_cas_refs_by_cas` (
+  ac_object_name STRING NOT NULL,
+  cas_object_name STRING NOT NULL
+)
+CLUSTER BY cas_object_name, ac_object_name;
+```
+
+**索引状态表**：
+
+```sql
+-- 重置所有 shard 状态
+UPDATE `...gcs_cache_ac_reference_index_state`
+SET indexed_through = NULL
+WHERE TRUE;
+```
+
+**Cleanup gate**：所有 256 shard `indexed_through IS NOT NULL`，沿用 v2。
+
+### Phase 1: 全量 Bootstrap
+
+**关键改造：消除 O(n²) stage table 累积**
+
+当前 sync 实现的 bug：每批数据 append 到 stage table 后立刻跑 replace，但 stage
+不清空，导致第 N 批 replace 的 DELETE 扫描前面所有 N-1 批的累积数据。
+
+**修正后的每 shard 流程**：
+
+```
+1. 从 last_seen_current 读取该 shard 的所有合法 AC 对象
+2. 分批下载 + protobuf 解析（batch_size=500，workers=64）
+3. 每批解析结果写入临时 JSONL 文件（本地磁盘），不做 stage table
+4. Parse error → 该 shard 失败（不更新 indexed_through）
+5. Missing (NotFound) → 收集到 missing stage
+6. 所有 batch 处理完后：
+   a. DELETE FROM by_ac WHERE shard = @shard; INSERT INTO by_ac SELECT @shard, ... FROM stage
+   b. Missing AC → reconcile 出 last_seen_current（DELETE）
+   c. Missing AC → reconcile 出 by_ac（DELETE WHERE shard = @shard AND ac_object_name IN missing）
+7. parse_error = 0 → 更新 indexed_through
+```
+
+**每 shard 写入策略**：`by_ac` 加 `shard INT64` 列，`CLUSTER BY shard, ac_object_name`。
+每个 shard 用独立临时 stage 表，完成后用 `DELETE WHERE shard = @shard` + `INSERT` 替换。
+
+```
+-- by_ac 表结构（加 shard 列）
+CREATE TABLE gcs_cache_ac_cas_refs_by_ac (
+  shard INT64 NOT NULL,
+  ac_object_name STRING NOT NULL,
+  cas_object_name STRING NOT NULL
+)
+CLUSTER BY shard, ac_object_name;
+
+-- Bootstrap 写入：每行带 shard 值
+INSERT INTO by_ac (shard, ac_object_name, cas_object_name)
+SELECT @shard, ac_object_name, cas_object_name
+FROM _tmp_shard_stage;
+
+-- Shard 替换：DELETE + INSERT
+DELETE FROM by_ac WHERE shard = @shard;
+INSERT INTO by_ac (shard, ac_object_name, cas_object_name)
+SELECT @shard, ac_object_name, cas_object_name
+FROM _tmp_shard_stage;
+```
+
+`CLUSTER BY shard, ac_object_name` + `WHERE shard = @shard` 是明确的 cluster key
+过滤，BigQuery 可以确定性地走 cluster scan，不会有函数表达式阻止优化的问题。
+
+**代码改动**（`sync_gcs_cache_ac_references.py`）：
+
+```python
+# 改造前（O(n²)）：每 batch append + replace，stage 不清空
+# 改造后：收集全 shard 的数据到本地或独立 stage，一次性 replace
+
+if parse_error_count > 0:
+    # 不更新 indexed_through，抛出异常
+    raise RuntimeError(
+        f"Shard {shard} has {parse_error_count} parse errors, "
+        f"fix before retry"
+    )
+
+# Missing AC reconcile（新增独立步骤）
+# by_cas 不做 per-row 删除——下次 cleanup 重建时自动消失
+_delete_from_last_seen_current(missing_ac_names)
+_delete_from_references_by_ac(missing_ac_names)
+```
+
+**Bootstrap 耗时估算**（基于实测）：
+
+```
+实测吞吐:            ~28-33 AC/s/pod（3 shard，92k AC / 46-55min）
+单 pod 全量:         30M / 30 AC/s ≈ 278h ≈ 12 天
+16 并行 (16 pods):   30M / (30 × 16) ≈ 17-19h
+32 并行 (32 pods):   30M / (30 × 32) ≈ 9-10h
+```
+
+如果 live AC 比例只有 50%（1500 万实际需要下载），wall-clock 时间减半。
+
+**Bootstrap 完成后**：一次性 EXPORT by_ac → IMPORT 重建 by_cas。
+
+### Phase 2: 增量同步 + 索引保鲜
+
+全量 bootstrap 之后，索引面临三个方向的 drift：
+
+| 变化类型 | 来源 | 增量同步能否感知 | 索引影响 |
+|---------|------|:---:|------|
+| AC 新建 | `storage.objects.create` | ✅ | 新增引用行 |
+| AC 覆盖 | `storage.objects.create`（同名新版本） | ✅ | 替换引用行 |
+| AC 删除 | 我们的 cleanup 删除 | ❌ 当前增量同步不消费 delete 事件 | 孤儿引用行堆积 |
+| AC 删除 | 外部原因（极少） | ❌ 当前增量同步不消费 delete 事件 | 孤儿引用行堆积 |
+
+关键问题：**增量同步只消费 `storage.objects.create` 事件**。虽然 GCS audit log
+中确实有 `storage.objects.delete` 事件，但当前实现不读取它。因此 AC 删除无法通过
+增量同步自动清理索引中的孤儿引用行。
+
+这不会导致错误删除 CAS（孤儿引用反而保护了 CAS），但会使索引膨胀、cleanup 效果
+递减——越来越多 CAS 被已不存在的 AC "幽灵引用"，无法被识别为零引用。
+
+**方案：Cleanup 内嵌索引保鲜（Stale Reference Reconciliation）**
+
+每次 cleanup 在计算 zero-ref CAS 之前，对索引做一次保鲜：
+
+```
+1. 从 by_ac 中找出所有 distinct ac_object_name
+2. LEFT JOIN last_seen_current（object_kind='ac'）:
+   a. 在 current 中的 AC → 保留（大多数情况）
+   b. 不在 current 中的 AC → 候选"幽灵 AC"
+3. 对候选幽灵 AC：
+   - 批量 GCS HEAD/download 验证是否存在
+   - 如果 GCS 上 live → current 表可能 stale，不处理
+   - 如果 GCS 上 NotFound → 确认已删除，reconcile：
+     * DELETE FROM by_ac WHERE ac_object_name = ...
+     * DELETE FROM last_seen_current WHERE object_name = ...（如仍有）
+     * by_cas 不做 per-row 删除——下次 cleanup 重建时自动消失
+4. 保鲜完成后，再执行 CAS 反查和 zero-ref 计算
+```
+
+**开销分析**：
+- Step 1-2 是 BigQuery anti-join，对 3000 万 distinct AC，几乎瞬时完成
+- Step 3 中"不在 current 中的 AC"通常极少（如果 current 保持每日同步），
+  只有被 cleanup 删除的 AC 才可能出现在这里
+- GCS 验证只需要 HEAD 请求（或 download 尝试捕获 NotFound），成本很低
+
+**这个设计意味着**：不需要独立的"日常增量同步"job。增量同步和索引保鲜都发生在
+cleanup 执行时：
+- **增量 catch-up**（Phase 2a）：读取 create 事件，更新索引 ← 处理"增/改"
+- **索引保鲜**（Phase 2b）：anti-join + GCS 验证，清理幽灵引用 ← 处理"删"
+
+两者合在一起保证 cleanup 开始时的索引是完整的。
+
+**日常增量频率**：如果 cleanup 每周跑一次，两次 cleanup 之间索引有 7 天的增量
+未处理。但 cleanup 前置 catch-up 是强制的——catch-up 会把 7 天的增量补齐后再进入
+删除流程，所以**安全性不受影响**。
+
+每周跑增量 vs 每天跑增量的差异只在**延迟和成本**：
+- 每天跑：单次处理几千行 create event，几乎零成本；dry-run 随时能看到准确候选量
+- 每周跑：一次处理 7 天的 create event（几万行），BQ 扫描稍多；dry-run 在两次
+  cleanup 之间看到的候选量可能偏保守（漏掉了新 AC 的引用）
+
+两种方式都不影响 cleanup 的安全性。
+
+**Cleanup 前置强制 catch-up**：
+
+安全论证：
+
+> 新建/覆盖的 AC 可以引用任意既有的 CAS digest（重用之前的构建产物），
+> 且这个引用不会产生新的 CAS `get`/`create` audit 事件。
+> 因此即使 CAS 年龄 > 16 天，仍可能被一个刚创建的 warm AC 引用。
+
+所以 cleanup 执行前必须：
+
+1. 定义固定 `cleanup_snapshot_time = NOW()`（一次性取值，不作为动态表达式）
+2. 跑增量同步 catch-up，覆盖到 `cleanup_snapshot_time`
+3. 验证所有 256 shard `indexed_through >= cleanup_snapshot_time`
+4. 不满足 → cleanup 拒绝执行
+
+**注意**：`indexed_through >= CURRENT_TIMESTAMP()` 是不可实现的——watermark
+总是早于检查时刻。必须用固定 snapshot。
+
+**竞态残余风险**（无法完全消除）：
+即使 catch-up 到 `cleanup_snapshot_time`，cleanup 本身需要时间执行（AC 删除 +
+CAS manifest export + delete）。在 cleanup 执行期间，新的 AC 仍可能被上传并引用
+待删除的冷 CAS，且不对 CAS 产生 audit 事件。
+
+**缓解措施**：
+- 在最终 CAS manifest export 前，再做一次**短增量 catch-up**（覆盖
+  `cleanup_snapshot_time` 到当前时刻），重新计算 zero-ref
+- 仍有极小窗口（第二次 catch-up 到 manifest export 之间），但窗口从小时级
+  缩小到分钟级
+- CAS cap 作为最后防线
+
+**Implementation**：
+
+```
+cleanup():
+    snapshot_time = NOW()  # 固定
+
+    # Phase 2a: 增量 catch-up（处理增/改）
+    run_incremental_sync(until=snapshot_time)
+    assert all_shards_indexed_through >= snapshot_time
+
+    # Phase 2b: 索引保鲜（处理删）——by_ac 现已完整
+    run_stale_reconciliation()
+
+    # 重建 by_cas 快照 —— 必须在 catch-up + 保鲜之后
+    rebuild_by_cas_from_by_ac()
+
+    # Phase 3: AC delete phase
+    # 先 bounded CAS selection（受 CAS cap 限制，控制 AC 删除半径）
+    cold_cas = select_cold_cas(snapshot_time, limit=CAS_CAP)
+    acs_to_delete = reverse_lookup_ac(cold_cas, age > ac_cutoff)
+    delete_ac(acs_to_delete)
+    reconcile_ac(acs_to_delete)  # 只删 by_ac；by_cas 下次重建自动消失
+
+    # 短增量 catch-up + 保鲜（缩小竞态窗口）
+    snapshot_time_2 = NOW()
+    run_incremental_sync(until=snapshot_time_2)
+    assert all_shards_indexed_through >= snapshot_time_2
+    run_stale_reconciliation()
+
+    # 第二次重建 by_cas 快照 —— AC 删除后的最新状态
+    rebuild_by_cas_from_by_ac()
+
+    # 重新计算 zero-ref（基于最新的 by_cas）
+    cas_to_delete = recompute_zero_ref(cold_cas, snapshot_time_2)
+
+    # CAS delete phase（受 CAS cap 限制）
+    delete_cas(cas_to_delete)
+    reconcile_cas(cas_to_delete)
+```
+
+### Phase 3: CAS 反推 AC 清理
+
+Cleanup 查询逻辑（分为两个阶段）：
+
+### 查询 A：AC 删除规划（by_cas 第一次重建后执行）
+
+```sql
+-- A1: 两阶段 CAS 选择（解决 bytes cap 不可执行问题）
+-- Phase A — 按 last_seen_at 初筛（只取 object name，数量 = 预设上限）
+CREATE TEMP TABLE cold_cas_preselect AS
+SELECT object_name, last_seen_at
+FROM last_seen_current
+WHERE object_kind = 'cas'
+  AND last_seen_at < TIMESTAMP_SUB(@snapshot_time, INTERVAL @cas_cutoff_days DAY)
+ORDER BY last_seen_at ASC
+LIMIT @cas_preselect_limit;  -- e.g., 2× CAS object cap
+
+-- Phase B — Metadata stage（只对初筛结果做 GCS HEAD）
+-- → 获取 generation + size_bytes
+-- → Missing → reconcile 出 last_seen_current
+
+-- Phase C — 按 size 二次筛选，应用 bytes cap
+CREATE TEMP TABLE cold_cas AS
+SELECT object_name, last_seen_at
+FROM cold_cas_with_metadata
+ORDER BY size_bytes DESC
+LIMIT @cas_object_cap;  -- 最旧 N 个中取最大的，双重约束
+
+-- A2: 反查引用关系 → 规划 AC 删除列表
+CREATE TEMP TABLE ac_to_delete AS
+SELECT DISTINCT
+  refs.ac_object_name,
+  cur.last_seen_at
+FROM gcs_cache_ac_cas_refs_by_cas AS refs
+JOIN cold_cas
+  ON refs.cas_object_name = cold_cas.object_name
+JOIN last_seen_current AS cur
+  ON cur.object_name = refs.ac_object_name
+ AND cur.object_kind = 'ac'
+ AND cur.last_seen_at < TIMESTAMP_SUB(@snapshot_time, INTERVAL @ac_cutoff_days DAY)
+ORDER BY cur.last_seen_at ASC
+LIMIT @ac_object_cap;  -- AC cap
+
+-- → 执行 AC 删除 + reconcile（只删 by_ac）
+```
+
+### 查询 B：最终 zero-ref CAS 判断（第二次 by_cas 重建后执行）
+
+```sql
+-- AC 删除后重建 by_cas，deleted AC refs 已自然消失，不需要 ac_to_delete 来扣除。
+-- 这是故意设计：少一个状态变量，少一个错法。
+CREATE TEMP TABLE cas_to_delete AS
+SELECT cold_cas.object_name, cold_cas.last_seen_at
+FROM cold_cas
+LEFT JOIN gcs_cache_ac_cas_refs_by_cas AS refs
+  ON refs.cas_object_name = cold_cas.object_name
+GROUP BY cold_cas.object_name, cold_cas.last_seen_at
+HAVING COUNT(refs.ac_object_name) = 0;
+```
+
+所有中间结果保留为 row-level，不做 ARRAY_AGG。
+
+### Phase 4: 零引用 CAS 清理
+
+```sql
+-- 零引用 CAS（在 by_cas 中完全没有记录的冷 CAS）
+-- 用 NOT EXISTS 替代 NOT IN，避免 BigQuery NULL 语义坑和优化器差异
+SELECT cas.object_name, cas.last_seen_at
+FROM last_seen_current AS cas
+WHERE cas.object_kind = 'cas'
+  AND cas.last_seen_at < TIMESTAMP_SUB(@snapshot_time, INTERVAL @cas_cutoff_days DAY)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM gcs_cache_ac_cas_refs_by_cas AS refs
+    WHERE refs.cas_object_name = cas.object_name
+  )
+```
+
+这些 CAS 直接进入安全检查 + delete 流程，不需要前置 AC 删除步骤。
+
+### CAS 删除前安全检查
+
+```
+对每个 CAS delete candidate：
+  1. 解析 live GCS metadata（generation, size）
+     - Missing → reconcile 出 last_seen_current
+  2. 检查 size_bytes，累计 bytes 用于 cap 判断
+  3. Raw audit recheck（无近期 get/create，排除自身 service account）
+  4. 按 last_seen_at ASC + bytes DESC 排序
+  5. 应用 CAS cap：MIN(object_count_limit, bytes_limit)
+  6. EXPORT manifest（bucket, name, generation）→ Storage Batch Operations delete
+  7. Reconcile 已删除 CAS
+```
+
+### 清理流程图
+
+```
+                    ┌─────────────────────────────┐
+                    │ 固定 cleanup_snapshot_time    │
+                    │ Phase 2a: 增量 catch-up       │
+                    │ 验证：256 shard 均 >= snapshot │
+                    └────────────┬────────────────┘
+                                 │
+                                 ▼
+                    ┌─────────────────────────────┐
+                    │ Phase 2b: 索引保鲜            │
+                    │ anti-join current → 候选幽灵  │
+                    │ GCS 验证 → reconcile 孤儿引用  │
+                    └────────────┬────────────────┘
+                                 │
+                                 ▼
+                    ┌─────────────────────────────┐
+                    │ ★ 重建 by_cas（第 1 次）      │
+                    │ EXPORT by_ac → IMPORT by_cas │
+                    └────────────┬────────────────┘
+                                 │
+                                 ▼
+                    ┌──────────────────────────┐
+                    │ last_seen_current         │
+                    │ (bounded cold CAS)        │
+                    │ [受 CAS cap 约束]          │
+                    └────────────┬─────────────┘
+                                 │
+                                 ▼
+                    ┌──────────────────────────┐
+                    │ gcs_cache_ac_cas_refs_    │
+                    │ by_cas                    │
+                    │ (CLUSTER BY cas_name)     │
+                    │                          │
+                    │ CAS ──反查──→ ACs         │
+                    │ (row-level, 无 ARRAY_AGG) │
+                    └────────────┬─────────────┘
+                                 │
+                    ┌────────────┴────────────┐
+                    ▼                         ▼
+          ┌─────────────────┐      ┌─────────────────┐
+          │ AC 有引用        │      │ AC 零引用        │
+          │ (cold CAS 被     │      │ (CAS 不在        │
+          │  至少一个 AC 引用) │      │  by_cas 中)      │
+          └────────┬────────┘      └────────┬────────┘
+                   │                        │
+                   ▼                        │
+          ┌─────────────────┐               │
+          │ 选冷 AC 删除      │               │
+          │ (age > ac_cutoff)│               │
+          │ reconcile from   │               │
+          │ last_seen + by_ac│               │
+          └────────┬────────┘               │
+                   │                        │
+                   ▼                        │
+          ┌─────────────────┐               │
+          │ 第二次短增量       │               │
+          │ catch-up + 保鲜   │               │
+          └────────┬────────┘               │
+                   │                        │
+                   ▼                        │
+          ┌─────────────────┐               │
+          │ ★ 重建 by_cas（第 2 次）         │
+          │ EXPORT by_ac → IMPORT by_cas    │
+          └────────┬────────┘               │
+                   │                        │
+                   ▼                        ▼
+          ┌─────────────────────────────────┐
+          │ CAS 引用计数 = 0                 │
+          │ + live metadata (generation,     │
+          │   size_bytes) check             │
+          │ + audit recheck                 │
+          └────────────┬────────────────────┘
+                       │
+                       ▼
+          ┌─────────────────────────────────┐
+          │ [受 CAS object + bytes cap 限制] │
+          │ Storage Batch Operations Delete │
+          │ + reconcile                     │
+          └─────────────────────────────────┘
+```
+
+## AC 删除半径控制
+
+CAS-driven AC 删除有两个独立的风险维度：
+
+1. **cold_cas 候选集巨大**：即使只取年龄 > 16 天的 CAS，可能仍有千万级候选
+2. **热门 CAS 被大量 AC 引用**：一个 CAS 可以被几百个冷 AC 引用。10k CAS × 100 AC
+   = 百万级 AC 删除
+
+### 两阶段 CAS 选择（解决 bytes cap 不可执行问题）
+
+CAS bytes cap 面临一个鸡生蛋问题：`last_seen_current` 没有 `size_bytes` 字段，
+size 要到 metadata stage（GCS HEAD）才有。但 HEAD 4500 万 cold CAS 只是为了
+排序是不可接受的。
+
+**方案**：两阶段选择，HEAD 规模受控。
+
+```
+Phase A: 按 last_seen_at 初筛
+  SELECT object_name
+  FROM last_seen_current
+  WHERE object_kind = 'cas'
+    AND last_seen_at < cutoff
+  ORDER BY last_seen_at ASC
+  LIMIT @cas_preselect_limit   -- e.g., 2× CAS object cap = 20000
+
+Phase B: Metadata stage（只 HEAD 这 20000 个 CAS）
+  → 获取 generation + size_bytes
+  → Missing → reconcile 出 last_seen_current
+
+Phase C: 按 size 二次筛选
+  → ORDER BY size_bytes DESC
+  → 应用 bytes cap 截断
+  → 最终 bounded cold_cas（如 ~8000 个，符合 object + bytes cap）
+```
+
+这个两阶段选择既实现了"优先删大文件"的优化目标，又限制了 HEAD 请求数量。
+
+### AC cap
+
+即使 cold_cas 被 bounded 到 10k，每个 CAS 可能被数十到上百个冷 AC 引用，
+反推出的 AC 仍可达百万级。**需要一个独立的 AC cap**——便宜，省事故。
+
+```
+COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_AC_OBJECTS=100000  # rollout 期
+```
+
+AC 删除候选超过 cap 时：按 `last_seen_at ASC` 截断（删最旧的 AC 优先）。
+Summary 输出 `candidate_ac_delete_count`（全量候选数）和 `selected_ac_delete_count`
+（经 AC cap 截断后实际删除数）。
+
+**多轮语义**：AC cap 截断后，被截掉的 AC 引用的 CAS 本轮不会归零，不会被删。
+这是预期行为——下轮 cleanup 时这些 AC 更冷了（或已被其他轮次删除），CAS 终将
+在多轮后归零。Summary 的 `candidate_ac_delete_count - selected_ac_delete_count`
+让 operator 看到还有多少 AC 在排队。
+
+## CAS Cap：object count + bytes 双重限制
+
+仅 object count cap 不够——10000 个小 CAS 和 10000 个大 CAS 的 blast radius
+差异可以有几个数量级。
+
+```
+# Object count cap（rollout 期）
+COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS=10000
+
+# Bytes cap（新增）
+COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_BYTES=1099511627776  # 1 TB
+```
+
+**CAS metadata stage 新增 size 字段**：
+
+```
+cas_live_metadata:
+  object_name STRING
+  generation INT64
+  size_bytes INT64    -- 新增
+```
+
+**排序策略**：`ORDER BY last_seen_at ASC, size_bytes DESC`——先删最旧且最大的，
+在 preselect 窗口内优先大对象（非全局最优，但限制了 HEAD 成本）。
+
+**Summary 新增字段**：
+- `candidate_cas_zero_ref_count`：零引用 CAS 候选总量（dry-run / 实际 run 均输出）
+- `candidate_cas_zero_ref_bytes`：零引用 CAS 候选总 bytes
+- `planned_cas_delete_bytes`：本 run 计划删除的 bytes
+- `deleted_cas_bytes`：实际删除的 bytes
+
+## Implementation Plan
+
+### Step 0: AC Source 完整性验证
+
+- [ ] 获取最新 GCS inventory 中 live AC 数量
+- [ ] 对比 `last_seen_current` 中 AC 数量
+- [ ] 如果差异显著，修正 bootstrap source（inventory + current UNION）
+
+### Step 1: 修 invalid hex name guard + 重建双表
+
+- [ ] 所有 AC source query 加 `REGEXP_CONTAINS(object_name, r'^ac/[0-9a-fA-F]{64}$')`
+- [ ] 手动清理 `last_seen_current` 中 `ac/one`、`ac/missing`
+- [ ] DROP + CREATE `gcs_cache_ac_cas_refs_by_ac`（加 `shard INT64` 列，CLUSTER BY shard, ac_object_name）
+- [ ] DROP + CREATE `gcs_cache_ac_cas_refs_by_cas`（CLUSTER BY cas_object_name）
+- [ ] `UPDATE ... SET indexed_through = NULL WHERE TRUE`（256 行全部重置）
+
+### Step 2: Fix O(n²) stage table + parse error fail-closed
+
+- [ ] `sync_gcs_cache_ac_references.py`：
+  - 改为"收集全 shard 数据 → 一次性 replace"模式，消除 O(n²)
+  - parse_error_count > 0 → 不更新 `indexed_through`，抛异常
+  - Missing AC → 生成 missing stage → 执行 reconcile（从 last_seen_current + by_ac 删除；by_cas 下次重建时自动消失）
+- [ ] Cleanup readiness gate：所有 256 shard `indexed_through IS NOT NULL`
+
+### Step 3: 全量 Bootstrap
+
+- [ ] 跑全量 bootstrap（256 shard，N pod 并行）
+- [ ] 监控 parse error，有就修 bug → 重跑对应 shard
+- [ ] 验证所有 256 shard `indexed_through` 非 NULL
+- [ ] 一次性 EXPORT by_ac → IMPORT 重建 by_cas
+- [ ] 记录实测指标：耗时、live AC 比例、引用行数、missing AC 数
+
+### Step 4: 索引保鲜（Stale Reference Reconciliation）
+
+- [ ] 实现 anti-join 查询：找出 by_ac 中不在 `last_seen_current` 的候选幽灵 AC
+- [ ] 对候选幽灵 AC 做 GCS HEAD/download 验证
+- [ ] NotFound → reconcile（DELETE from by_ac + last_seen_current；by_cas 下次重建时自动消失）
+- [ ] 保鲜完成后才进入 CAS 反查
+
+### Step 5: Cleanup 前置增量 catch-up + by_cas 重建 + 双 snapshot 机制
+
+- [ ] 实现固定 `cleanup_snapshot_time`（一次性取值）
+- [ ] Cleanup 入口：先增量 catch-up 覆盖到 snapshot_time
+- [ ] 验证 gate：所有 shard `indexed_through >= snapshot_time`
+- [ ] 再跑索引保鲜（Step 4）
+- [ ] **第一次 by_cas 重建**：EXPORT by_ac → IMPORT 重建 by_cas
+- [ ] bounded cold_cas 选择（受 CAS cap 约束，控制 AC 删除半径）
+- [ ] AC 删除
+- [ ] 第二次短增量 catch-up + 保鲜
+- [ ] **第二次 by_cas 重建**
+- [ ] 重新计算 zero-ref
+
+### Step 6: 实现 CAS 反推 AC 清理
+
+- [ ] 新增 `execute_kind: cas-from-index`
+- [ ] 实现两阶段 CAS 选择（初筛 object count → metadata HEAD → bytes cap 二次筛选）
+- [ ] 实现 AC 删除规划 query（查询 A）+ AC cap 截断
+- [ ] AC 删除后第二次 by_cas 重建 + 简单 zero-ref 查询（查询 B，LEFT JOIN + HAVING COUNT = 0）
+- [ ] 实现新 manifest export 和 delete 流程
+- [ ] Dry-run 输出完整中间结果（含 bytes、AC 候选数）
+
+### Step 7: Canary + 灰度
+
+- [ ] CAS cap：object_count=10000, bytes=1TB（或其他合理 rollout 值）
+- [ ] 小批量 canary delete
+- [ ] 观察 CI `Missing digest` + cache miss 率
+- [ ] 逐步提升双重 cap
+
+### Step 8: 清理与下线
+
+- [ ] 移除 v3 per-run AC 展开逻辑（`execute_kind=cas` 旧路径）
+- [ ] 设置 cron：
+  - Cleanup（每周，含增量 catch-up + 索引保鲜 + CAS 反查删除）
+  - 可选：轻量增量同步（每天，只做 create event，不做保鲜）。非必须，
+    但可以保持索引热度，让 dry-run 更快看到准确候选量
+
+## 配置变更
+
+新增：
+```
+# cleanup 是否强制前置增量 catch-up
+COST_INSIGHT_GCS_CACHE_CLEANUP_REQUIRE_FRESH_INDEX=true
+
+# CAS bytes cap
+COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_BYTES=1099511627776
+
+# CAS 初筛上限（控制 metadata HEAD 数量，建议 2× CAS object cap）
+COST_INSIGHT_GCS_CACHE_CLEANUP_CAS_PRESELECT_LIMIT=20000
+
+# AC object cap（新增）
+COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_AC_OBJECTS=100000
+```
+
+修改（保留但调值）：
+```
+COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS=10000  # rollout 值
+```
+
+保留：
+```
+COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS=10
+COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS=15
+COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS=1
+COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS=10000000
+```
+
+## Risk Assessment
+
+### 已消除的风险
+
+- **Shared CAS**：全量索引 → 精确知道每个 CAS 的 AC 引用
+- **Parse error 容忍**：fail-closed，shard 不 ready 则 cleanup 不可用
+- **Index staleness 时间窗口**：cleanup 强制前置增量 catch-up + 双 snapshot
+- **O(n²) stage table**：改为全 shard 收集后一次性 replace
+- **CLUSTER 方向与写入冲突**：by_ac 持续维护，by_cas 只做全量快照重建，不增量维护
+- **ARRAY_AGG row size**：改为 row-level 输出
+
+### 剩余风险
+
+1. **`last_seen_current` 未覆盖所有 GCS live AC**：
+   - 缓解：Step 0 验证。差异存在则改为 inventory + current UNION
+   - 严重性：漏掉的 AC 引用的 CAS 会被误删
+
+2. **Missing AC 引用永久丢失**：
+   - 缓解：从 last_seen_current + both refs tables reconcile；CAS 受年龄窗口保护
+
+3. **Cleanup 执行期间的竞态**（第二次 catch-up 后到 CAS manifest export 之间）：
+   - 缓解：双 snapshot 机制把窗口缩到分钟级；CAS cap 作为最后防线
+   - 无法完全线性化（除非暂停 GCS 写入，不现实）
+
+4. **首次零引用 CAS 规模未知**：
+   - 缓解：dry-run 先评估规模；双重 cap (object + bytes) 限制

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from dataclasses import dataclass
 from datetime import date
 from functools import lru_cache
@@ -20,6 +19,8 @@ DEFAULT_GCS_CACHE_LAST_SEEN_DAILY_TABLE = "gcs_cache_object_last_seen_daily"
 DEFAULT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE = "gcs_cache_object_last_seen_current"
 DEFAULT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT = "TransferService"
 DEFAULT_GCS_CACHE_AC_CAS_REFERENCES_TABLE = "gcs_cache_ac_cas_references"
+DEFAULT_GCS_CACHE_AC_CAS_REFS_BY_AC_TABLE = "gcs_cache_ac_cas_refs_by_ac"
+DEFAULT_GCS_CACHE_AC_CAS_REFS_BY_CAS_TABLE = "gcs_cache_ac_cas_refs_by_cas"
 DEFAULT_GCS_CACHE_AC_REFERENCE_INDEX_STATE_TABLE = "gcs_cache_ac_reference_index_state"
 DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET = "pingcap-ci-console-logs-us-central1"
 DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX = "gcs-cache-steady-state-delete"
@@ -70,31 +71,27 @@ class GcsCacheSettings:
     last_seen_excluded_get_user_agent: str = DEFAULT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT
     last_seen_excluded_get_principal_email: str | None = None
     ac_cas_references_table: str = DEFAULT_GCS_CACHE_AC_CAS_REFERENCES_TABLE
+    ac_cas_refs_by_ac_table: str = DEFAULT_GCS_CACHE_AC_CAS_REFS_BY_AC_TABLE
+    ac_cas_refs_by_cas_table: str = DEFAULT_GCS_CACHE_AC_CAS_REFS_BY_CAS_TABLE
     ac_reference_index_state_table: str = DEFAULT_GCS_CACHE_AC_REFERENCE_INDEX_STATE_TABLE
     ac_reference_shard_count: int = 256
     ac_reference_batch_size: int = 500
     ac_reference_download_workers: int = 64
-    ac_reference_max_index_staleness_hours: int = 12
+    ac_reference_max_index_staleness_hours: int = 1
     ac_retention_days: int = 10
     cas_retention_days: int = 15
     cleanup_safety_buffer_days: int = 1
     cleanup_sample_limit: int = 10
     cleanup_max_delete_objects: int = 10000000
-    cleanup_max_delete_cas_objects: int = 500
-    cleanup_ac_delete_batch_size: int = 500000
+    cleanup_max_delete_ac_objects: int = 100000
+    cleanup_max_delete_cas_objects: int = 10000
+    cleanup_max_delete_cas_bytes: int = 1099511627776
+    cleanup_cas_preselect_limit: int = 20000
     cleanup_batch_size: int = 1000
     cleanup_manifest_bucket: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
     cleanup_manifest_prefix: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX
     cleanup_candidate_ttl_days: int = 7
-
-    def __post_init__(self) -> None:
-        if self.cleanup_ac_delete_batch_size > self.cleanup_max_delete_objects:
-            warnings.warn(
-                "cleanup_ac_delete_batch_size is greater than cleanup_max_delete_objects; "
-                "cleanup will clamp each run to cleanup_max_delete_objects",
-                RuntimeWarning,
-                stacklevel=2,
-            )
+    cleanup_require_fresh_index: bool = True
 
 
 @dataclass(frozen=True)
@@ -262,6 +259,18 @@ def load_settings(
                 "COST_INSIGHT_GCS_CACHE_AC_CAS_REFERENCES_TABLE",
                 "COST_GCS_CACHE_AC_CAS_REFERENCES_TABLE",
             ),
+            ac_cas_refs_by_ac_table=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_AC_CAS_REFS_BY_AC_TABLE,
+                "COST_INSIGHT_GCS_CACHE_AC_CAS_REFS_BY_AC_TABLE",
+                "COST_GCS_CACHE_AC_CAS_REFS_BY_AC_TABLE",
+            ),
+            ac_cas_refs_by_cas_table=_read_any(
+                env,
+                DEFAULT_GCS_CACHE_AC_CAS_REFS_BY_CAS_TABLE,
+                "COST_INSIGHT_GCS_CACHE_AC_CAS_REFS_BY_CAS_TABLE",
+                "COST_GCS_CACHE_AC_CAS_REFS_BY_CAS_TABLE",
+            ),
             ac_reference_index_state_table=_read_any(
                 env,
                 DEFAULT_GCS_CACHE_AC_REFERENCE_INDEX_STATE_TABLE,
@@ -298,7 +307,7 @@ def load_settings(
                     "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS",
                     "COST_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS",
                 ),
-                12,
+                1,
             ),
             ac_retention_days=_read_positive_int_any(
                 env,
@@ -340,21 +349,37 @@ def load_settings(
                 ),
                 10000000,
             ),
+            cleanup_max_delete_ac_objects=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_AC_OBJECTS",
+                    "COST_GCS_CACHE_CLEANUP_MAX_DELETE_AC_OBJECTS",
+                ),
+                100000,
+            ),
             cleanup_max_delete_cas_objects=_read_positive_int_any(
                 env,
                 (
                     "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS",
                     "COST_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS",
                 ),
-                500,
+                10000,
             ),
-            cleanup_ac_delete_batch_size=_read_positive_int_any(
+            cleanup_max_delete_cas_bytes=_read_positive_int_any(
                 env,
                 (
-                    "COST_INSIGHT_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE",
-                    "COST_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE",
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_BYTES",
+                    "COST_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_BYTES",
                 ),
-                500000,
+                1099511627776,
+            ),
+            cleanup_cas_preselect_limit=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_CAS_PRESELECT_LIMIT",
+                    "COST_GCS_CACHE_CLEANUP_CAS_PRESELECT_LIMIT",
+                ),
+                20000,
             ),
             cleanup_batch_size=_read_positive_int_any(
                 env,
@@ -383,6 +408,14 @@ def load_settings(
                     "COST_GCS_CACHE_CLEANUP_CANDIDATE_TTL_DAYS",
                 ),
                 7,
+            ),
+            cleanup_require_fresh_index=_read_bool_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_REQUIRE_FRESH_INDEX",
+                    "COST_GCS_CACHE_CLEANUP_REQUIRE_FRESH_INDEX",
+                ),
+                True,
             ),
         ),
         log_level=_read_any(env, "INFO", "COST_INSIGHT_LOG_LEVEL", "COST_LOG_LEVEL").upper(),
@@ -529,6 +562,26 @@ def _read_optional_positive_int_any(
             continue
         return _read_int(environ, key, 1)
     return None
+
+
+def _read_bool_any(
+    environ: Mapping[str, str],
+    keys: tuple[str, ...],
+    default: bool,
+) -> bool:
+    for key in keys:
+        raw = environ.get(key)
+        if raw is None or raw.strip() == "":
+            continue
+        value = raw.strip().lower()
+        if value in {"true", "1", "yes", "on"}:
+            return True
+        if value in {"false", "0", "no", "off"}:
+            return False
+        raise ValueError(
+            f"{key} must be a boolean (true/false/1/0/yes/no/on/off), got {raw!r}"
+        )
+    return default
 
 
 def _read_date_any(

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -382,6 +382,14 @@ def load_settings(
                 ),
                 20000,
             ),
+            cleanup_ac_delete_batch_size=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE",
+                    "COST_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE",
+                ),
+                500000,
+            ),
             cleanup_batch_size=_read_positive_int_any(
                 env,
                 (

--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -87,6 +87,7 @@ class GcsCacheSettings:
     cleanup_max_delete_cas_objects: int = 10000
     cleanup_max_delete_cas_bytes: int = 1099511627776
     cleanup_cas_preselect_limit: int = 20000
+    cleanup_ac_delete_batch_size: int = 500000
     cleanup_batch_size: int = 1000
     cleanup_manifest_bucket: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
     cleanup_manifest_prefix: str = DEFAULT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX

--- a/cost-insight/src/cost_insight/common/gcs_objects.py
+++ b/cost-insight/src/cost_insight/common/gcs_objects.py
@@ -12,6 +12,7 @@ class GcsObjectMetadata:
     object_name: str
     exists: bool
     generation: int | None
+    size_bytes: int | None = None
 
 
 def fetch_object_metadata_batch(
@@ -35,12 +36,15 @@ def fetch_object_metadata_batch(
                 object_name=object_name,
                 exists=False,
                 generation=None,
+                size_bytes=None,
             )
         generation = int(blob.generation) if blob.generation is not None else None
+        size_bytes = int(blob.size) if blob.size is not None else None
         return GcsObjectMetadata(
             object_name=object_name,
             exists=True,
             generation=generation,
+            size_bytes=size_bytes,
         )
 
     if max_workers <= 1 or len(names) == 1:

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1754,7 +1754,8 @@ AS
     execute(
         f"""DELETE FROM {current_table}
 WHERE object_kind = 'ac'
-  AND object_name IN (SELECT object_name FROM {missing_ac_table})""",
+  AND object_name IN (SELECT object_name FROM {missing_ac_table})
+  AND last_seen_at < TIMESTAMP('{snapshot_time}')""",
         parameters=[],
     ).total_bytes_processed
     execute(

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -18,6 +18,9 @@ from cost_insight.common.gcs_cache_references import (
     AcReferenceExtraction,
     extract_action_cache_references_batch,
 )
+from cost_insight.jobs.sync_gcs_cache_ac_references import (
+    run_sync_gcs_cache_ac_references,
+)
 from cost_insight.common.gcs_objects import GcsObjectMetadata, fetch_object_metadata_batch
 from cost_insight.common.storage_batch_operations import (
     StorageBatchOperationsJob,
@@ -35,8 +38,9 @@ BatchJobCreator = Callable[..., StorageBatchOperationsJob]
 BatchJobWaiter = Callable[..., StorageBatchOperationsJobStatus]
 
 # "all" is kept as a compatibility alias for older dry-run CronJob arguments.
-# v3 cleanup has only one real execution path: AC-driven CAS cascade.
-VALID_EXECUTE_KINDS = ("all", "cas")
+# "cas" is the legacy v3 per-run AC-driven cascade.
+# "cas-from-index" is the new index-based CAS reverse-lookup cleanup.
+VALID_EXECUTE_KINDS = ("all", "cas", "cas-from-index")
 MAX_ZERO_PROGRESS_AC_REFILL_ROUNDS = 3
 
 
@@ -173,6 +177,53 @@ def run_cleanup_gcs_cache(
         )
     ac_cutoff_days = resolved_ac_days + resolved_safety_buffer_days
     cas_cutoff_days = resolved_cas_days + resolved_safety_buffer_days
+
+    # Route cas-from-index: pass resolved overrides through temporary settings.
+    if execute_kind == "cas-from-index":
+        overridden = GcsCacheSettings(
+            project_id=settings.project_id,
+            bucket_name=settings.bucket_name,
+            dataset=settings.dataset,
+            audit_log_table=settings.audit_log_table,
+            last_seen_daily_table=settings.last_seen_daily_table,
+            last_seen_current_table=settings.last_seen_current_table,
+            last_seen_excluded_get_user_agent=settings.last_seen_excluded_get_user_agent,
+            last_seen_excluded_get_principal_email=settings.last_seen_excluded_get_principal_email,
+            ac_cas_references_table=settings.ac_cas_references_table,
+            ac_cas_refs_by_ac_table=settings.ac_cas_refs_by_ac_table,
+            ac_cas_refs_by_cas_table=settings.ac_cas_refs_by_cas_table,
+            ac_reference_index_state_table=settings.ac_reference_index_state_table,
+            ac_reference_shard_count=settings.ac_reference_shard_count,
+            ac_reference_batch_size=settings.ac_reference_batch_size,
+            ac_reference_download_workers=settings.ac_reference_download_workers,
+            ac_reference_max_index_staleness_hours=settings.ac_reference_max_index_staleness_hours,
+            ac_retention_days=resolved_ac_days,
+            cas_retention_days=resolved_cas_days,
+            cleanup_safety_buffer_days=resolved_safety_buffer_days,
+            cleanup_sample_limit=resolved_sample_limit,
+            cleanup_max_delete_objects=resolved_max_delete_objects,
+            cleanup_max_delete_ac_objects=resolved_max_delete_objects,
+            cleanup_max_delete_cas_objects=resolved_max_delete_cas_objects,
+            cleanup_max_delete_cas_bytes=settings.cleanup_max_delete_cas_bytes,
+            cleanup_cas_preselect_limit=settings.cleanup_cas_preselect_limit,
+            cleanup_batch_size=settings.cleanup_batch_size,
+            cleanup_manifest_bucket=settings.cleanup_manifest_bucket,
+            cleanup_manifest_prefix=settings.cleanup_manifest_prefix,
+            cleanup_candidate_ttl_days=settings.cleanup_candidate_ttl_days,
+            cleanup_require_fresh_index=settings.cleanup_require_fresh_index,
+        )
+        return run_cleanup_gcs_cache_from_index(
+            settings=overridden,
+            mode=mode,
+            execute=execute,
+            stream_rows=stream_rows,
+            resolve_object_metadata=resolve_object_metadata,
+            load_jsonl_file=load_jsonl_file,
+            create_batch_job=create_batch_job,
+            wait_for_batch_job=wait_for_batch_job,
+            now=now,
+            run_id_factory=run_id_factory,
+        )
 
     bytes_processed_total = 0
     summary_result = execute(
@@ -629,6 +680,7 @@ WITH cold_ac AS (
     TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), last_seen_at, DAY) AS idle_days
   FROM {current_table}
   WHERE object_kind = 'ac'
+    AND REGEXP_CONTAINS(object_name, r'^ac/[0-9a-fA-F]{64}$')
     AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_cutoff_days DAY)
 )
 SELECT
@@ -678,6 +730,7 @@ SELECT
   TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), last_seen_at, DAY) AS idle_days
 FROM {current_table}
 WHERE object_kind = 'ac'
+  AND REGEXP_CONTAINS(object_name, r'^ac/[0-9a-fA-F]{64}$')
   AND last_seen_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @ac_cutoff_days DAY)
 {cursor_filter}
 ORDER BY last_seen_at ASC, object_name ASC
@@ -752,7 +805,7 @@ def build_cleanup_gcs_cache_metadata_stage_tables_query(
         [
             _create_table_query(
                 ac_live_metadata_table,
-                columns=(("object_name", "STRING"), ("generation", "INT64")),
+                columns=(("object_name", "STRING"), ("generation", "INT64"), ("size_bytes", "INT64")),
                 ttl_days=ttl_days,
             ),
             _create_table_query(
@@ -762,7 +815,7 @@ def build_cleanup_gcs_cache_metadata_stage_tables_query(
             ),
             _create_table_query(
                 cas_live_metadata_table,
-                columns=(("object_name", "STRING"), ("generation", "INT64")),
+                columns=(("object_name", "STRING"), ("generation", "INT64"), ("size_bytes", "INT64")),
                 ttl_days=ttl_days,
             ),
             _create_table_query(
@@ -947,6 +1000,841 @@ ORDER BY object_name ASC
 """.strip()
 
 
+# ---------------------------------------------------------------------------
+# cas-from-index query builders
+# ---------------------------------------------------------------------------
+
+
+def build_rebuild_by_cas_from_by_ac_query(
+    settings: GcsCacheSettings,
+) -> str:
+    """Rebuild by_cas as a full snapshot from by_ac."""
+    by_ac_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
+    )
+    by_cas_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_cas_table
+    )
+    return f"""
+CREATE OR REPLACE TABLE {by_cas_table}
+CLUSTER BY cas_object_name, ac_object_name
+AS
+SELECT ac_object_name, cas_object_name
+FROM {by_ac_table};
+""".strip()
+
+
+def build_stale_ac_candidates_query(
+    settings: GcsCacheSettings,
+    *,
+    limit: int = 100000,
+) -> str:
+    """Find AC objects in by_ac that are NOT in last_seen_current."""
+    by_ac_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
+    )
+    current_table = _table_ref(
+        settings.project_id, settings.dataset, settings.last_seen_current_table
+    )
+    return f"""
+SELECT DISTINCT by_ac.ac_object_name
+FROM {by_ac_table} AS by_ac
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM {current_table} AS cur
+  WHERE cur.object_name = by_ac.ac_object_name
+    AND cur.object_kind = 'ac'
+)
+LIMIT {limit}
+""".strip()
+
+
+def build_cold_cas_preselect_query(
+    settings: GcsCacheSettings,
+    *,
+    snapshot_time: str,
+    cas_cutoff_days: int,
+    preselect_limit: int,
+) -> str:
+    """Select cold CAS candidates, ordered by oldest first."""
+    current_table = _table_ref(
+        settings.project_id, settings.dataset, settings.last_seen_current_table
+    )
+    return f"""
+SELECT object_name, last_seen_at
+FROM {current_table}
+WHERE object_kind = 'cas'
+  AND last_seen_at < TIMESTAMP_SUB(TIMESTAMP('{snapshot_time}'), INTERVAL {cas_cutoff_days} DAY)
+ORDER BY last_seen_at ASC
+LIMIT {preselect_limit}
+""".strip()
+
+
+def build_ac_reverse_lookup_query(
+    settings: GcsCacheSettings,
+    *,
+    cold_cas_table: str,
+    snapshot_time: str,
+    ac_cutoff_days: int,
+    ac_object_cap: int,
+    by_cas_table_override: str | None = None,
+) -> str:
+    """Find cold ACs that reference the bounded cold CAS set."""
+    by_cas_table = by_cas_table_override or _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_cas_table
+    )
+    current_table = _table_ref(
+        settings.project_id, settings.dataset, settings.last_seen_current_table
+    )
+    return f"""
+SELECT DISTINCT
+  refs.ac_object_name,
+  cur.last_seen_at
+FROM {by_cas_table} AS refs
+JOIN {cold_cas_table} AS cas
+  ON refs.cas_object_name = cas.object_name
+JOIN {current_table} AS cur
+  ON cur.object_name = refs.ac_object_name
+ AND cur.object_kind = 'ac'
+ AND cur.last_seen_at < TIMESTAMP_SUB(TIMESTAMP('{snapshot_time}'), INTERVAL {ac_cutoff_days} DAY)
+ORDER BY cur.last_seen_at ASC
+LIMIT {ac_object_cap}
+""".strip()
+
+
+def build_zero_ref_cas_query(
+    settings: GcsCacheSettings,
+    *,
+    cold_cas_table: str,
+    by_cas_table_override: str | None = None,
+) -> str:
+    """After AC deletion and by_cas rebuild: find CAS with zero remaining references."""
+    by_cas_table = by_cas_table_override or _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_cas_table
+    )
+    return f"""
+SELECT cas.object_name, cas.last_seen_at
+FROM {cold_cas_table} AS cas
+LEFT JOIN {by_cas_table} AS refs
+  ON refs.cas_object_name = cas.object_name
+GROUP BY cas.object_name, cas.last_seen_at
+HAVING COUNT(refs.ac_object_name) = 0
+""".strip()
+
+
+def build_cas_audit_recheck_query(
+    settings: GcsCacheSettings,
+    *,
+    candidate_table: str,
+    zero_ref_table: str,
+    live_metadata_table: str,
+    ttl_days: int,
+) -> str:
+    """Final CAS delete table with audit recheck and generation."""
+    current_table = _table_ref(
+        settings.project_id, settings.dataset, settings.last_seen_current_table
+    )
+    audit_table = _table_ref(settings.project_id, settings.dataset, settings.audit_log_table)
+    ignored_cleanup_get_filter = _ignored_cleanup_get_filter(settings)
+    return f"""
+CREATE OR REPLACE TABLE {candidate_table}
+OPTIONS (
+  expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {ttl_days} DAY)
+) AS
+SELECT
+  source.object_name,
+  source.last_seen_at,
+  live.generation,
+  live.size_bytes
+FROM {zero_ref_table} AS source
+JOIN {live_metadata_table} AS live
+  USING (object_name)
+JOIN {current_table} AS cur
+  ON cur.object_name = source.object_name
+ AND cur.object_kind = 'cas'
+ AND cur.last_seen_at = source.last_seen_at
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM {audit_table} AS audit
+  WHERE audit.resource.labels.bucket_name = '{settings.bucket_name}'
+    AND audit.protopayload_auditlog.methodName IN (
+      'storage.objects.get',
+      'storage.objects.create'
+    )
+    AND REGEXP_EXTRACT(audit.protopayload_auditlog.resourceName, r"/objects/(.+)$") = source.object_name
+    AND audit.timestamp > source.last_seen_at
+    {ignored_cleanup_get_filter}
+)
+ORDER BY source.last_seen_at ASC, live.size_bytes DESC
+""".strip()
+
+
+# ---------------------------------------------------------------------------
+# cas-from-index orchestration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CleanupGcsCacheAcDeleteResult:
+    candidate_ac_count: int
+    selected_ac_count: int
+    manifest_uri: str
+    batch_job_name: str
+
+
+def run_cleanup_gcs_cache_from_index(
+    *,
+    settings: GcsCacheSettings,
+    mode: str = "dry-run",
+    execute: QueryExecutor = execute_query,
+    stream_rows: RowStreamer | None = None,
+    resolve_object_metadata: MetadataResolver = fetch_object_metadata_batch,
+    load_jsonl_file: JsonFileLoader | None = None,
+    create_batch_job: BatchJobCreator = create_delete_job,
+    wait_for_batch_job: BatchJobWaiter = wait_for_delete_job,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    run_id_factory: Callable[[], str] = lambda: str(uuid4()),
+) -> CleanupGcsCacheSummary:
+    """Index-based CAS cleanup: rebuild by_cas, reverse-lookup AC, delete CAS.
+
+    This is the cas-from-index execution path. It requires a complete
+    by_ac index (all 256 shard indexed_through IS NOT NULL).
+    """
+    stream_rows = _stream_query_rows if stream_rows is None else stream_rows
+    load_jsonl_file = _load_jsonl_file if load_jsonl_file is None else load_jsonl_file
+
+    run_started_at = now()
+    run_id = run_id_factory()
+    bytes_processed_total = 0
+
+    # ---- Gate 1: completeness (bootstrap must be done) ----
+    # Fail fast if any shard has no watermark at all.
+    if settings.cleanup_require_fresh_index:
+        state_table = _table_ref(
+            settings.project_id, settings.dataset, settings.ac_reference_index_state_table
+        )
+        result = execute(
+            f"SELECT COUNTIF(indexed_through IS NOT NULL) AS ready_shards FROM {state_table}",
+            parameters=[],
+        )
+        ready = int(result.rows[0].get("ready_shards", 0) or 0) if result.rows else 0
+        if ready < settings.ac_reference_shard_count:
+            raise RuntimeError(
+                f"AC reference index is incomplete: {ready}/{settings.ac_reference_shard_count} "
+                "shards have indexed_through. Run bootstrap first, or set "
+                "COST_INSIGHT_GCS_CACHE_CLEANUP_REQUIRE_FRESH_INDEX=false to bypass."
+            )
+        bytes_processed_total = _add_bytes(bytes_processed_total, result.total_bytes_processed)
+
+    # ---- First incremental catch-up (design requirement) ----
+    # Catch up to snapshot_time before any CAS selection or AC deletion.
+    # Skip in dry-run to avoid mutating index watermarks.
+    snapshot_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S UTC")
+    if mode != "dry-run":
+        _run_catch_up_sync(settings=settings, until=run_started_at, execute=execute)
+
+    # ---- Gate 2: freshness (catch-up must have reached snapshot_time) ----
+    # Now verify all watermarks are within staleness of the cleanup snapshot.
+    if settings.cleanup_require_fresh_index:
+        staleness_hours = settings.ac_reference_max_index_staleness_hours
+        result = execute(
+            f"""SELECT COUNTIF(indexed_through >= TIMESTAMP_SUB(TIMESTAMP('{snapshot_time}'), INTERVAL {staleness_hours} HOUR)) AS fresh_shards
+FROM {state_table}""",
+            parameters=[],
+        )
+        fresh = int(result.rows[0].get("fresh_shards", 0) or 0) if result.rows else 0
+        if fresh < settings.ac_reference_shard_count:
+            raise RuntimeError(
+                f"AC reference index is stale after catch-up: only {fresh}/{settings.ac_reference_shard_count} "
+                f"shards have indexed_through within {staleness_hours}h of cleanup snapshot "
+                f"({snapshot_time}). Check incremental sync logs, increase max_staleness_hours, "
+                "or set COST_INSIGHT_GCS_CACHE_CLEANUP_REQUIRE_FRESH_INDEX=false to bypass."
+            )
+        bytes_processed_total = _add_bytes(bytes_processed_total, result.total_bytes_processed)
+    cas_cutoff_days = settings.cas_retention_days + settings.cleanup_safety_buffer_days
+    ac_cutoff_days = settings.ac_retention_days + settings.cleanup_safety_buffer_days
+
+    # ---- Create metadata stage tables (fresh for this run) ----
+    ttl_days = settings.cleanup_candidate_ttl_days
+    for suffix in ("cas_live_metadata", "cas_missing_metadata",
+                   "ac_live_metadata", "ac_missing_metadata",
+                   "stale_ac_live", "stale_ac_missing"):
+        stage_table = _tmp_table_ref(settings, suffix, run_id=run_id)
+        if "missing" in suffix:
+            columns = "object_name STRING"
+        else:
+            columns = "object_name STRING, generation INT64, size_bytes INT64"
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                f"""CREATE OR REPLACE TABLE {stage_table} ({columns})
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {ttl_days} DAY))""",
+                parameters=[],
+            ).total_bytes_processed,
+        )
+
+    # ---- Stale AC reconciliation (clean ghost refs from by_ac) ----
+    # Skip in dry-run to avoid mutating persistent index tables.
+    if mode != "dry-run":
+        _reconcile_stale_ac_references(
+            settings=settings,
+            execute=execute,
+            stream_rows=stream_rows,
+            resolve_object_metadata=resolve_object_metadata,
+            load_jsonl_file=load_jsonl_file,
+            run_id=run_id,
+        )
+
+    # ---- Rebuild by_cas snapshot from by_ac ----
+    # In dry-run, use a temp snapshot to avoid mutating the persistent by_cas table.
+    if mode == "dry-run":
+        by_cas_table = _tmp_table_ref(settings, "by_cas_dryrun", run_id=run_id)
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                f"""CREATE OR REPLACE TABLE {by_cas_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+CLUSTER BY cas_object_name, ac_object_name
+AS
+SELECT ac_object_name, cas_object_name
+FROM {_table_ref(settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table)}""",
+                parameters=[],
+            ).total_bytes_processed,
+        )
+    else:
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_rebuild_by_cas_from_by_ac_query(settings),
+                parameters=[],
+            ).total_bytes_processed,
+        )
+
+    # ---- Two-phase CAS selection ----
+    # Phase A: preselect by last_seen_at
+    cas_preselect_table = _tmp_table_ref(settings, "cas_preselect", run_id=run_id)
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            f"""CREATE OR REPLACE TABLE {cas_preselect_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{build_cold_cas_preselect_query(
+    settings,
+    snapshot_time=snapshot_time,
+    cas_cutoff_days=cas_cutoff_days,
+    preselect_limit=settings.cleanup_cas_preselect_limit,
+)}""",
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
+    # Phase B: resolve live metadata (generation + size_bytes) for preselected CAS
+    _populate_metadata_stage_table(
+        settings=settings,
+        stream_rows=stream_rows,
+        resolve_object_metadata=resolve_object_metadata,
+        load_jsonl_file=load_jsonl_file,
+        source_table=cas_preselect_table,
+        live_table=_tmp_table_ref(settings, "cas_live_metadata", run_id=run_id),
+        missing_table=_tmp_table_ref(settings, "cas_missing_metadata", run_id=run_id),
+        batch_size=settings.cleanup_batch_size,
+    )
+
+    # Phase C: rank by size_bytes DESC, apply object + bytes cap
+    cas_live_table = _tmp_table_ref(settings, "cas_live_metadata", run_id=run_id)
+    cold_cas_table = _tmp_table_ref(settings, "cold_cas", run_id=run_id)
+
+    # ponytail: apply caps in SQL with rolling sum; accept that window function
+    # over the preselected set is enough, per-design preselect window trade-off.
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            f"""CREATE OR REPLACE TABLE {cold_cas_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+WITH ranked AS (
+  SELECT
+    live.object_name,
+    preselect.last_seen_at,
+    live.size_bytes,
+    live.generation,
+    SUM(live.size_bytes) OVER (ORDER BY live.size_bytes DESC, preselect.last_seen_at ASC) AS running_bytes,
+    ROW_NUMBER() OVER (ORDER BY live.size_bytes DESC, preselect.last_seen_at ASC) AS rn
+  FROM {cas_preselect_table} AS preselect
+  JOIN {cas_live_table} AS live
+    USING (object_name)
+)
+SELECT object_name, last_seen_at, size_bytes, generation
+FROM ranked
+WHERE rn <= {settings.cleanup_max_delete_cas_objects}
+  AND running_bytes <= {settings.cleanup_max_delete_cas_bytes}
+""",
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
+    cold_cas_count = _count_table_rows(execute=execute, table_ref=cold_cas_table)
+    bytes_processed_total = _add_bytes(bytes_processed_total, cold_cas_count.bytes_processed)
+
+    # ---- AC reverse lookup + deletion (dry-run: compute only) ----
+    if mode == "dry-run":
+        ac_candidate_table = _tmp_table_ref(settings, "ac_to_delete", run_id=run_id)
+        execute(
+            f"""CREATE OR REPLACE TABLE {ac_candidate_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{build_ac_reverse_lookup_query(
+    settings,
+    cold_cas_table=cold_cas_table,
+    snapshot_time=snapshot_time,
+    ac_cutoff_days=ac_cutoff_days,
+    ac_object_cap=settings.cleanup_max_delete_ac_objects,
+    by_cas_table_override=by_cas_table,
+)}""",
+            parameters=[],
+        )
+        ac_candidate_count = _count_table_rows(execute=execute, table_ref=ac_candidate_table)
+        bytes_processed_total = _add_bytes(bytes_processed_total, ac_candidate_count.bytes_processed)
+        candidate_ac_count = ac_candidate_count.object_count
+
+        # Zero-ref CAS based on dry-run by_cas snapshot
+        zero_ref_table = _tmp_table_ref(settings, "cas_zero_ref", run_id=run_id)
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                f"""CREATE OR REPLACE TABLE {zero_ref_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{build_zero_ref_cas_query(settings, cold_cas_table=cold_cas_table, by_cas_table_override=by_cas_table)}""",
+                parameters=[],
+            ).total_bytes_processed,
+        )
+        zero_ref_count = _count_table_rows(execute=execute, table_ref=zero_ref_table)
+        bytes_processed_total = _add_bytes(bytes_processed_total, zero_ref_count.bytes_processed)
+
+        run_finished_at = now()
+        return CleanupGcsCacheSummary(
+            account_id=settings.project_id,
+            bucket_name=settings.bucket_name,
+            run_id=run_id,
+            mode=mode,
+            execute_kind="cas-from-index",
+            dry_run=True,
+            ac_retention_days=settings.ac_retention_days,
+            cas_retention_days=settings.cas_retention_days,
+            safety_buffer_days=settings.cleanup_safety_buffer_days,
+            candidate_cas_object_count=cold_cas_count.object_count,
+            candidate_ac_object_count=candidate_ac_count,
+            candidate_cas_delete_object_count=zero_ref_count.object_count,
+            ac_parse_error_count=0,
+            selected_ac_object_count=0,
+            selected_cas_object_count=0,
+            oldest_last_seen_at=None,
+            newest_last_seen_at=None,
+            sample_candidates=(),
+            sample_ac_parse_errors=(),
+            bytes_processed=bytes_processed_total,
+            run_started_at=run_started_at,
+            run_finished_at=run_finished_at,
+        )
+
+    # ---- DELETE mode from here on ----
+    ac_delete_result = _delete_acs_referenced_by_cold_cas(
+        settings=settings,
+        execute=execute,
+        stream_rows=stream_rows,
+        resolve_object_metadata=resolve_object_metadata,
+        extract_references=None,
+        load_jsonl_file=load_jsonl_file,
+        create_batch_job=create_batch_job,
+        wait_for_batch_job=wait_for_batch_job,
+        cold_cas_table=cold_cas_table,
+        snapshot_time=snapshot_time,
+        ac_cutoff_days=ac_cutoff_days,
+        run_id=run_id,
+        run_started_at=run_started_at,
+    )
+    bytes_processed_total = _add_bytes(bytes_processed_total, 0)
+    selected_ac_count = ac_delete_result.selected_ac_count
+
+    # ---- Second incremental catch-up (design requirement) ----
+    # Catch up again after AC deletion to pick up any new ACs created during
+    # the delete phase, before we recompute zero-ref CAS.
+    snapshot_time_2 = now()
+    _run_catch_up_sync(settings=settings, until=snapshot_time_2, execute=execute)
+
+    # ---- Second by_cas rebuild (after AC deletion + catch-up) ----
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            build_rebuild_by_cas_from_by_ac_query(settings),
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
+    # ---- Final zero-ref CAS selection ----
+    zero_ref_table = _tmp_table_ref(settings, "cas_zero_ref", run_id=run_id)
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            f"""CREATE OR REPLACE TABLE {zero_ref_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{build_zero_ref_cas_query(settings, cold_cas_table=cold_cas_table)}""",
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
+    # ---- CAS delete with audit recheck ----
+    cas_delete_table = _tmp_table_ref(settings, "delete_cas", run_id=run_id)
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            build_cas_audit_recheck_query(
+                settings,
+                candidate_table=cas_delete_table,
+                zero_ref_table=zero_ref_table,
+                live_metadata_table=_tmp_table_ref(settings, "cas_live_metadata", run_id=run_id),
+                ttl_days=settings.cleanup_candidate_ttl_days,
+            ),
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
+    selected_cas_count = _count_table_rows(execute=execute, table_ref=cas_delete_table)
+    bytes_processed_total = _add_bytes(bytes_processed_total, selected_cas_count.bytes_processed)
+
+    if selected_cas_count.object_count <= 0:
+        run_finished_at = now()
+        return CleanupGcsCacheSummary(
+            account_id=settings.project_id,
+            bucket_name=settings.bucket_name,
+            run_id=run_id,
+            mode=mode,
+            execute_kind="cas-from-index",
+            dry_run=False,
+            ac_retention_days=settings.ac_retention_days,
+            cas_retention_days=settings.cas_retention_days,
+            safety_buffer_days=settings.cleanup_safety_buffer_days,
+            candidate_cas_object_count=cold_cas_count.object_count,
+            candidate_ac_object_count=ac_delete_result.candidate_ac_count,
+            candidate_cas_delete_object_count=0,
+            ac_parse_error_count=0,
+            selected_ac_object_count=selected_ac_count,
+            selected_cas_object_count=0,
+            oldest_last_seen_at=None,
+            newest_last_seen_at=None,
+            sample_candidates=(),
+            sample_ac_parse_errors=(),
+            bytes_processed=bytes_processed_total,
+            run_started_at=run_started_at,
+            run_finished_at=run_finished_at,
+            ac_manifest_uri=ac_delete_result.manifest_uri or None,
+            ac_batch_job_name=ac_delete_result.batch_job_name or None,
+        )
+
+    # ---- CAS manifest export + delete ----
+    cas_manifest_uri = _manifest_uri(
+        settings,
+        object_kind="cas",
+        run_started_at=run_started_at,
+        run_id=run_id,
+    )
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            build_cleanup_gcs_cache_manifest_export_query(
+                candidate_table=cas_delete_table,
+                manifest_uri=cas_manifest_uri,
+                bucket_name=settings.bucket_name,
+            ),
+            parameters=[],
+        ).total_bytes_processed,
+    )
+    cas_batch_job = create_batch_job(
+        project_id=settings.project_id,
+        job_id=_batch_job_id(
+            object_kind="cas",
+            run_started_at=run_started_at,
+            run_id=run_id,
+        ),
+        bucket_name=settings.bucket_name,
+        manifest_uri=cas_manifest_uri,
+        dry_run=False,
+        description=(
+            f"Index-based CAS cleanup run {run_id} "
+            f"(ac={settings.ac_retention_days}, cas={settings.cas_retention_days}, "
+            f"buffer={settings.cleanup_safety_buffer_days})"
+        ),
+    )
+    _wait_for_successful_batch_job(
+        wait_for_batch_job=wait_for_batch_job, job_name=cas_batch_job.job_name
+    )
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            build_cleanup_gcs_cache_reconcile_deleted_cas_query(
+                settings,
+                candidate_table=cas_delete_table,
+            ),
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
+    run_finished_at = now()
+    return CleanupGcsCacheSummary(
+        account_id=settings.project_id,
+        bucket_name=settings.bucket_name,
+        run_id=run_id,
+        mode=mode,
+        execute_kind="cas-from-index",
+        dry_run=False,
+        ac_retention_days=settings.ac_retention_days,
+        cas_retention_days=settings.cas_retention_days,
+        safety_buffer_days=settings.cleanup_safety_buffer_days,
+        candidate_cas_object_count=cold_cas_count.object_count,
+        candidate_ac_object_count=ac_delete_result.candidate_ac_count,
+        candidate_cas_delete_object_count=selected_cas_count.object_count,
+        ac_parse_error_count=0,
+        selected_ac_object_count=selected_ac_count,
+        selected_cas_object_count=selected_cas_count.object_count,
+        oldest_last_seen_at=None,
+        newest_last_seen_at=None,
+        sample_candidates=(),
+        sample_ac_parse_errors=(),
+        bytes_processed=bytes_processed_total,
+        run_started_at=run_started_at,
+        run_finished_at=run_finished_at,
+        ac_manifest_uri=ac_delete_result.manifest_uri or None,
+        ac_batch_job_name=ac_delete_result.batch_job_name or None,
+        cas_manifest_uri=cas_manifest_uri,
+        cas_batch_job_name=cas_batch_job.job_name,
+        cas_manifest_uris=(cas_manifest_uri,),
+        cas_batch_job_names=(cas_batch_job.job_name,),
+    )
+
+
+def _reconcile_stale_ac_references(
+    *,
+    settings: GcsCacheSettings,
+    execute: QueryExecutor,
+    stream_rows: RowStreamer,
+    resolve_object_metadata: MetadataResolver,
+    load_jsonl_file: JsonFileLoader,
+    run_id: str,
+) -> None:
+    """Find and remove ghost AC references from by_ac.
+
+    ACs in by_ac that are absent from last_seen_current AND confirmed NotFound
+    in GCS are removed from both by_ac and last_seen_current.
+    """
+    stale_candidates_table = _tmp_table_ref(settings, "stale_ac_candidates", run_id=run_id)
+    execute(
+        f"CREATE OR REPLACE TABLE {stale_candidates_table}\nOPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))\nAS\n"
+        + build_stale_ac_candidates_query(settings),
+        parameters=[],
+    ).total_bytes_processed
+
+    stale_count = _count_table_rows(execute=execute, table_ref=stale_candidates_table)
+    if stale_count.object_count <= 0:
+        return
+
+    # Verify against GCS: only reconcile objects confirmed NotFound.
+    _populate_metadata_stage_table(
+        settings=settings,
+        stream_rows=stream_rows,
+        resolve_object_metadata=resolve_object_metadata,
+        load_jsonl_file=load_jsonl_file,
+        source_table=stale_candidates_table,
+        live_table=_tmp_table_ref(settings, "stale_ac_live", run_id=run_id),
+        missing_table=_tmp_table_ref(settings, "stale_ac_missing", run_id=run_id),
+        batch_size=settings.cleanup_batch_size,
+    )
+
+    # Reconcile NotFound ACs from by_ac and last_seen_current.
+    missing_table = _tmp_table_ref(settings, "stale_ac_missing", run_id=run_id)
+    by_ac_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
+    )
+    current_table = _table_ref(
+        settings.project_id, settings.dataset, settings.last_seen_current_table
+    )
+    execute(
+        f"""DELETE FROM {by_ac_table}
+WHERE ac_object_name IN (SELECT object_name FROM {missing_table})""",
+        parameters=[],
+    ).total_bytes_processed
+    execute(
+        f"""DELETE FROM {current_table}
+WHERE object_kind = 'ac'
+  AND object_name IN (SELECT object_name FROM {missing_table})""",
+        parameters=[],
+    ).total_bytes_processed
+
+
+def _delete_acs_referenced_by_cold_cas(
+    *,
+    settings: GcsCacheSettings,
+    execute: QueryExecutor,
+    stream_rows: RowStreamer,
+    resolve_object_metadata: MetadataResolver,
+    extract_references: ReferenceExtractor | None,
+    load_jsonl_file: JsonFileLoader,
+    create_batch_job: BatchJobCreator,
+    wait_for_batch_job: BatchJobWaiter,
+    cold_cas_table: str,
+    snapshot_time: str,
+    ac_cutoff_days: int,
+    run_id: str,
+    run_started_at: datetime,
+) -> CleanupGcsCacheAcDeleteResult:
+    """Plan and execute AC deletion for ACs referenced by the bounded cold CAS set."""
+    ac_candidate_table = _tmp_table_ref(settings, "ac_to_delete", run_id=run_id)
+    execute(
+        f"""CREATE OR REPLACE TABLE {ac_candidate_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{build_ac_reverse_lookup_query(
+    settings,
+    cold_cas_table=cold_cas_table,
+    snapshot_time=snapshot_time,
+    ac_cutoff_days=ac_cutoff_days,
+    ac_object_cap=settings.cleanup_max_delete_ac_objects,
+)}""",
+        parameters=[],
+    ).total_bytes_processed
+
+    ac_candidate_count = _count_table_rows(execute=execute, table_ref=ac_candidate_table)
+
+    if ac_candidate_count.object_count <= 0:
+        return CleanupGcsCacheAcDeleteResult(
+            candidate_ac_count=0,
+            selected_ac_count=0,
+            manifest_uri="",
+            batch_job_name="",
+        )
+
+    # Resolve live AC metadata
+    _populate_metadata_stage_table(
+        settings=settings,
+        stream_rows=stream_rows,
+        resolve_object_metadata=resolve_object_metadata,
+        load_jsonl_file=load_jsonl_file,
+        source_table=ac_candidate_table,
+        live_table=_tmp_table_ref(settings, "ac_live_metadata", run_id=run_id),
+        missing_table=_tmp_table_ref(settings, "ac_missing_metadata", run_id=run_id),
+        batch_size=settings.cleanup_batch_size,
+    )
+
+    # Build final AC delete table (live metadata only)
+    ac_delete_table = _tmp_table_ref(settings, "delete_ac", run_id=run_id)
+    ac_live_table = _tmp_table_ref(settings, "ac_live_metadata", run_id=run_id)
+    ac_missing_table = _tmp_table_ref(settings, "ac_missing_metadata", run_id=run_id)
+    execute(
+        f"""CREATE OR REPLACE TABLE {ac_delete_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+SELECT object_name, generation
+FROM {ac_live_table} AS live
+WHERE NOT EXISTS (
+  SELECT 1 FROM {ac_missing_table} AS missing
+  WHERE missing.object_name = live.object_name
+)
+ORDER BY object_name ASC""",
+        parameters=[],
+    ).total_bytes_processed
+
+    selected_ac_count = _count_table_rows(execute=execute, table_ref=ac_delete_table)
+
+    if selected_ac_count.object_count <= 0:
+        return CleanupGcsCacheAcDeleteResult(
+            candidate_ac_count=ac_candidate_count.object_count,
+            selected_ac_count=0,
+            manifest_uri="",
+            batch_job_name="",
+        )
+
+    # Export AC manifest + delete
+    ac_manifest_uri = _manifest_uri(
+        settings,
+        object_kind="ac",
+        run_started_at=run_started_at,
+        run_id=run_id,
+    )
+    execute(
+        build_cleanup_gcs_cache_manifest_export_query(
+            candidate_table=ac_delete_table,
+            manifest_uri=ac_manifest_uri,
+            bucket_name=settings.bucket_name,
+        ),
+        parameters=[],
+    ).total_bytes_processed
+
+    ac_batch_job = create_batch_job(
+        project_id=settings.project_id,
+        job_id=_batch_job_id(
+            object_kind="ac",
+            run_started_at=run_started_at,
+            run_id=run_id,
+        ),
+        bucket_name=settings.bucket_name,
+        manifest_uri=ac_manifest_uri,
+        dry_run=False,
+        description=(
+            f"Index-based AC cleanup run {run_id} "
+            f"(ac={settings.ac_retention_days})"
+        ),
+    )
+    _wait_for_successful_batch_job(
+        wait_for_batch_job=wait_for_batch_job, job_name=ac_batch_job.job_name
+    )
+
+    # Reconcile deleted ACs from last_seen_current + by_ac
+    execute(
+        build_cleanup_gcs_cache_reconcile_deleted_ac_query(
+            settings,
+            candidate_table=ac_delete_table,
+        ),
+        parameters=[BigQueryParameter("run_started_at", "TIMESTAMP", run_started_at)],
+    ).total_bytes_processed
+    execute(
+        f"""DELETE FROM {_table_ref(settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table)}
+WHERE ac_object_name IN (SELECT object_name FROM {ac_delete_table})""",
+        parameters=[],
+    ).total_bytes_processed
+
+    return CleanupGcsCacheAcDeleteResult(
+        candidate_ac_count=ac_candidate_count.object_count,
+        selected_ac_count=selected_ac_count.object_count,
+        manifest_uri=ac_manifest_uri,
+        batch_job_name=ac_batch_job.job_name,
+    )
+
+
+def _run_catch_up_sync(
+    *,
+    settings: GcsCacheSettings,
+    until: datetime,
+    execute: QueryExecutor,
+) -> None:
+    """Run incremental sync for all 256 shards up to `until`."""
+    run_sync_gcs_cache_ac_references(
+        settings=settings,
+        mode="incremental",
+        shard_start=0,
+        shard_end=settings.ac_reference_shard_count - 1,
+        dry_run=False,
+        execute=execute,
+        now=lambda: until,
+    )
+
+
+def _tmp_table_ref(settings: GcsCacheSettings, suffix: str, *, run_id: str = "") -> str:
+    rid = f"_{run_id}" if run_id else ""
+    return _table_ref(settings.project_id, settings.dataset, f"_tmp_{suffix}{rid}")
+
+
 def _populate_metadata_stage_table(
     *,
     settings: GcsCacheSettings,
@@ -962,7 +1850,7 @@ def _populate_metadata_stage_table(
         f"SELECT object_name FROM {source_table} ORDER BY object_name ASC",
         [],
     )
-    live_schema = (("object_name", "STRING"), ("generation", "INT64"))
+    live_schema = (("object_name", "STRING"), ("generation", "INT64"), ("size_bytes", "INT64"))
     missing_schema = (("object_name", "STRING"),)
 
     with TemporaryDirectory(prefix="cleanup-gcs-cache-stage-") as temp_dir:
@@ -986,6 +1874,7 @@ def _populate_metadata_stage_table(
                     {
                         "object_name": item.object_name,
                         "generation": item.generation,
+                        "size_bytes": item.size_bytes,
                     }
                     for item in metadata_rows
                     if item.exists and item.generation is not None
@@ -1035,7 +1924,7 @@ def _populate_ac_stage_tables(
         f"SELECT object_name, last_seen_at FROM {source_table} ORDER BY last_seen_at ASC, object_name ASC",
         [],
     )
-    live_schema = (("object_name", "STRING"), ("generation", "INT64"))
+    live_schema = (("object_name", "STRING"), ("generation", "INT64"), ("size_bytes", "INT64"))
     references_schema = (("ac_object_name", "STRING"), ("cas_object_name", "STRING"))
     missing_schema = (("object_name", "STRING"),)
 
@@ -1069,6 +1958,7 @@ def _populate_ac_stage_tables(
                     {
                         "object_name": item.object_name,
                         "generation": item.generation,
+                        "size_bytes": item.size_bytes,
                     }
                     for item in metadata_rows
                     if item.exists and item.generation is not None
@@ -1355,5 +2245,7 @@ def _validate_mode_and_execute_kind(*, mode: str, execute_kind: str) -> None:
         raise ValueError(
             f"Unsupported cleanup execute kind: {execute_kind} (expected one of {VALID_EXECUTE_KINDS})"
         )
-    if mode == "delete" and execute_kind != "cas":
-        raise ValueError("cleanup-gcs-cache --mode delete requires --execute-kind cas")
+    if mode == "delete" and execute_kind not in {"cas", "cas-from-index"}:
+        raise ValueError(
+            "cleanup-gcs-cache --mode delete requires --execute-kind cas or cas-from-index"
+        )

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -168,13 +168,11 @@ def run_cleanup_gcs_cache(
         if max_delete_objects is not None
         else settings.cleanup_max_delete_objects
     )
-    if max_delete_cas_objects is not None:
-        warnings.warn(
-            "max_delete_cas_objects is deprecated and ignored by v3 AC-driven cascade cleanup; "
-            "CAS deletion is bounded only by selected AC batches",
-            FutureWarning,
-            stacklevel=2,
-        )
+    resolved_max_delete_cas_objects = (
+        max_delete_cas_objects
+        if max_delete_cas_objects is not None
+        else settings.cleanup_max_delete_cas_objects
+    )
     ac_cutoff_days = resolved_ac_days + resolved_safety_buffer_days
     cas_cutoff_days = resolved_cas_days + resolved_safety_buffer_days
 
@@ -206,6 +204,7 @@ def run_cleanup_gcs_cache(
             cleanup_max_delete_cas_objects=resolved_max_delete_cas_objects,
             cleanup_max_delete_cas_bytes=settings.cleanup_max_delete_cas_bytes,
             cleanup_cas_preselect_limit=settings.cleanup_cas_preselect_limit,
+            cleanup_ac_delete_batch_size=settings.cleanup_ac_delete_batch_size,
             cleanup_batch_size=settings.cleanup_batch_size,
             cleanup_manifest_bucket=settings.cleanup_manifest_bucket,
             cleanup_manifest_prefix=settings.cleanup_manifest_prefix,
@@ -1341,6 +1340,22 @@ AS
         batch_size=settings.cleanup_batch_size,
     )
 
+    # Reconcile missing CAS from last_seen_current so stale entries don't
+    # occupy the preselect window on every run and block progress.
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            build_cleanup_gcs_cache_reconcile_missing_cas_query(
+                settings,
+                candidate_table=cas_preselect_table,
+                missing_metadata_table=_tmp_table_ref(
+                    settings, "cas_missing_metadata", run_id=run_id
+                ),
+            ),
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
     # Phase C: rank by size_bytes DESC, apply object + bytes cap
     cas_live_table = _tmp_table_ref(settings, "cas_live_metadata", run_id=run_id)
     cold_cas_table = _tmp_table_ref(settings, "cold_cas", run_id=run_id)
@@ -1726,6 +1741,27 @@ AS
         missing_table=_tmp_table_ref(settings, "ac_missing_metadata", run_id=run_id),
         batch_size=settings.cleanup_batch_size,
     )
+
+    # Reconcile missing ACs from last_seen_current and by_ac so ghost refs
+    # don't survive into the second by_cas rebuild.
+    missing_ac_table = _tmp_table_ref(settings, "ac_missing_metadata", run_id=run_id)
+    current_table = _table_ref(
+        settings.project_id, settings.dataset, settings.last_seen_current_table
+    )
+    by_ac_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
+    )
+    execute(
+        f"""DELETE FROM {current_table}
+WHERE object_kind = 'ac'
+  AND object_name IN (SELECT object_name FROM {missing_ac_table})""",
+        parameters=[],
+    ).total_bytes_processed
+    execute(
+        f"""DELETE FROM {by_ac_table}
+WHERE ac_object_name IN (SELECT object_name FROM {missing_ac_table})""",
+        parameters=[],
+    ).total_bytes_processed
 
     # Build final AC delete table (live metadata only)
     ac_delete_table = _tmp_table_ref(settings, "delete_ac", run_id=run_id)

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -200,7 +200,11 @@ def run_cleanup_gcs_cache(
             cleanup_safety_buffer_days=resolved_safety_buffer_days,
             cleanup_sample_limit=resolved_sample_limit,
             cleanup_max_delete_objects=resolved_max_delete_objects,
-            cleanup_max_delete_ac_objects=resolved_max_delete_objects,
+            cleanup_max_delete_ac_objects=(
+                max_delete_objects
+                if max_delete_objects is not None
+                else settings.cleanup_max_delete_ac_objects
+            ),
             cleanup_max_delete_cas_objects=resolved_max_delete_cas_objects,
             cleanup_max_delete_cas_bytes=settings.cleanup_max_delete_cas_bytes,
             cleanup_cas_preselect_limit=settings.cleanup_cas_preselect_limit,

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -185,7 +185,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     cleanup_gcs_cache.add_argument(
         "--execute-kind",
-        choices=("all", "cas"),
+        choices=("all", "cas", "cas-from-index"),
         default="all",
     )
     cleanup_gcs_cache.add_argument("--ac-retention-days", type=_parse_positive_int, default=None)

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
@@ -15,7 +15,7 @@ from cost_insight.common.gcs_cache_references import (
 QueryExecutor = Callable[[str, Sequence[BigQueryParameter]], BigQueryQueryResult]
 ReferenceExtractor = Callable[..., tuple[AcReferenceExtraction, ...]]
 RowStreamer = Callable[[str, Sequence[BigQueryParameter]], Iterator[dict[str, object]]]
-JsonLoader = Callable[[str, Sequence[dict[str, object]]], None]
+JsonLoader = Callable[..., str]
 
 
 @dataclass(frozen=True)
@@ -38,10 +38,13 @@ class SyncGcsCacheAcReferencesSummary:
     reference_row_count: int
     sample_parse_errors: tuple[SyncGcsCacheAcReferenceParseErrorSample, ...]
     dry_run: bool
-    indexed_through: datetime
+    indexed_through: datetime | None
     bytes_processed: int | None
     run_started_at: datetime
     run_finished_at: datetime
+
+
+_AC_HEX_REGEX = r'^ac/[0-9a-fA-F]{64}$'
 
 
 def run_sync_gcs_cache_ac_references(
@@ -77,6 +80,8 @@ def run_sync_gcs_cache_ac_references(
     replaced_ac_object_count = 0
     reference_row_count = 0
     sample_parse_errors: list[SyncGcsCacheAcReferenceParseErrorSample] = []
+    indexed_through: datetime | None = None
+    failed_shards: list[int] = []
 
     bytes_processed_total = _add_bytes(
         bytes_processed_total,
@@ -84,31 +89,6 @@ def run_sync_gcs_cache_ac_references(
             build_ensure_gcs_cache_ac_reference_tables_query(settings), parameters=[]
         ).total_bytes_processed,
     )
-
-    run_id = run_started_at.strftime("%Y%m%dt%H%M%S")
-    object_stage_table = _table_ref(
-        settings.project_id,
-        settings.dataset,
-        f"_tmp_gcs_cache_ac_reference_objects_{run_id.lower()}_{shard_start}_{resolved_shard_end}",
-    )
-    edge_stage_table = _table_ref(
-        settings.project_id,
-        settings.dataset,
-        f"_tmp_gcs_cache_ac_reference_edges_{run_id.lower()}_{shard_start}_{resolved_shard_end}",
-    )
-
-    if not dry_run:
-        bytes_processed_total = _add_bytes(
-            bytes_processed_total,
-            execute(
-                build_create_gcs_cache_ac_reference_stage_tables_query(
-                    object_stage_table=object_stage_table,
-                    edge_stage_table=edge_stage_table,
-                    ttl_days=settings.cleanup_candidate_ttl_days,
-                ),
-                parameters=[],
-            ).total_bytes_processed,
-        )
 
     for shard in range(shard_start, resolved_shard_end + 1):
         watermark = (
@@ -141,6 +121,11 @@ def run_sync_gcs_cache_ac_references(
         )
 
         rows = stream_rows(query, parameters)
+        shard_edge_rows: list[dict[str, object]] = []
+        shard_affected_names: set[str] = set()
+        shard_missing_names: set[str] = set()
+        shard_parse_error_count = 0
+
         for batch_rows in _batched(rows, settings.ac_reference_batch_size):
             batch_object_names = tuple(str(row["object_name"]) for row in batch_rows)
             if not batch_object_names:
@@ -153,11 +138,10 @@ def run_sync_gcs_cache_ac_references(
                 max_workers=settings.ac_reference_download_workers,
             )
 
-            object_rows = []
-            edge_rows = []
             for extraction in extractions:
                 if extraction.parse_error:
                     parse_error_count += 1
+                    shard_parse_error_count += 1
                     if len(sample_parse_errors) < 10:
                         sample_parse_errors.append(
                             SyncGcsCacheAcReferenceParseErrorSample(
@@ -166,48 +150,108 @@ def run_sync_gcs_cache_ac_references(
                             )
                         )
                     continue
-                object_rows.append({"ac_object_name": extraction.ac_object_name})
                 replaced_ac_object_count += 1
                 if not extraction.exists:
                     missing_object_count += 1
+                    shard_missing_names.add(extraction.ac_object_name)
                     continue
+                shard_affected_names.add(extraction.ac_object_name)
                 for cas_object_name in extraction.cas_object_names:
-                    edge_rows.append(
+                    shard_edge_rows.append(
                         {
                             "ac_object_name": extraction.ac_object_name,
                             "cas_object_name": cas_object_name,
                         }
                     )
-            reference_row_count += len(edge_rows)
+        reference_row_count += len(shard_edge_rows)
 
-            if dry_run:
-                continue
+        # Write sentinel rows for affected ACs with zero CAS refs.
+        # These need their old refs cleaned up but contribute no new edge rows.
+        zero_ref_ac_names = shard_affected_names - {
+            r["ac_object_name"] for r in shard_edge_rows
+        }
+        for ac_name in sorted(zero_ref_ac_names):
+            shard_edge_rows.append(
+                {"ac_object_name": ac_name, "cas_object_name": ""}
+            )
 
-            load_json_rows(object_stage_table, object_rows)
-            load_json_rows(edge_stage_table, edge_rows)
+        if dry_run:
+            indexed_through = run_started_at
+            continue
+
+        # Parse error fail-closed: any parse error → clear indexed_through to NULL.
+        # This invalidates the shard regardless of whether it had a previous
+        # successful watermark (incremental) or was NULL (bootstrap).
+        if shard_parse_error_count > 0:
+            failed_shards.append(shard)
+            if not dry_run:
+                bytes_processed_total = _add_bytes(
+                    bytes_processed_total,
+                    execute(
+                        f"""UPDATE {_table_ref(settings.project_id, settings.dataset, settings.ac_reference_index_state_table)}
+SET indexed_through = NULL
+WHERE shard = {shard}""",
+                        parameters=[],
+                    ).total_bytes_processed,
+                )
+            continue
+
+        # Reconcile missing AC objects from last_seen_current and by_ac.
+        if shard_missing_names:
+            missing_stage = _write_missing_stage(
+                settings, shard=shard, missing_names=shard_missing_names,
+                run_suffix=run_started_at.strftime("%Y%m%dt%H%M%S%f"),
+            )
             bytes_processed_total = _add_bytes(
                 bytes_processed_total,
                 execute(
-                    build_replace_gcs_cache_ac_references_query(
+                    build_reconcile_missing_ac_query(
                         settings,
-                        object_stage_table=object_stage_table,
-                        edge_stage_table=edge_stage_table,
+                        shard=shard,
+                        missing_stage_table=missing_stage,
                     ),
                     parameters=[],
                 ).total_bytes_processed,
             )
 
-        if not dry_run:
-            bytes_processed_total = _add_bytes(
-                bytes_processed_total,
-                execute(
-                    build_update_gcs_cache_ac_reference_index_state_query(settings),
-                    parameters=[
-                        BigQueryParameter("shard", "INT64", shard),
-                        BigQueryParameter("indexed_through", "TIMESTAMP", run_started_at),
-                    ],
-                ).total_bytes_processed,
-            )
+        # Per-shard replace: DELETE old rows, INSERT new rows.
+        # Single DELETE+INSERT pair per shard — no O(n²) stage accumulation.
+        stage_table = load_json_rows(
+            settings, shard=shard, edge_rows=shard_edge_rows,
+            run_suffix=run_started_at.strftime("%Y%m%dt%H%M%S%f"),
+        )
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_replace_gcs_cache_ac_references_query(
+                    settings,
+                    shard=shard,
+                    edge_row_count=len(shard_edge_rows),
+                    stage_table=stage_table,
+                    mode=mode,
+                ),
+                parameters=[],
+            ).total_bytes_processed,
+        )
+
+        # Only update indexed_through if parse error count is 0.
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                build_update_gcs_cache_ac_reference_index_state_query(settings),
+                parameters=[
+                    BigQueryParameter("shard", "INT64", shard),
+                    BigQueryParameter("indexed_through", "TIMESTAMP", run_started_at),
+                ],
+            ).total_bytes_processed,
+        )
+        indexed_through = run_started_at
+
+    if failed_shards and not dry_run:
+        raise RuntimeError(
+            f"AC reference sync failed: {len(failed_shards)} shard(s) had parse errors: "
+            f"{failed_shards}. Fix parse errors and re-run the affected shards."
+        )
 
     run_finished_at = now()
     return SyncGcsCacheAcReferencesSummary(
@@ -223,7 +267,7 @@ def run_sync_gcs_cache_ac_references(
         reference_row_count=reference_row_count,
         sample_parse_errors=tuple(sample_parse_errors),
         dry_run=dry_run,
-        indexed_through=run_started_at,
+        indexed_through=indexed_through,
         bytes_processed=bytes_processed_total,
         run_started_at=run_started_at,
         run_finished_at=run_finished_at,
@@ -231,17 +275,28 @@ def run_sync_gcs_cache_ac_references(
 
 
 def build_ensure_gcs_cache_ac_reference_tables_query(settings: GcsCacheSettings) -> str:
-    references_table = _table_ref(
-        settings.project_id, settings.dataset, settings.ac_cas_references_table
+    by_ac_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
+    )
+    by_cas_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_cas_table
     )
     state_table = _table_ref(
         settings.project_id, settings.dataset, settings.ac_reference_index_state_table
     )
     return f"""
-CREATE TABLE IF NOT EXISTS {references_table} (
+CREATE TABLE IF NOT EXISTS {by_ac_table} (
+  shard INT64 NOT NULL,
   ac_object_name STRING NOT NULL,
   cas_object_name STRING NOT NULL
-);
+)
+CLUSTER BY shard, ac_object_name;
+
+CREATE TABLE IF NOT EXISTS {by_cas_table} (
+  ac_object_name STRING NOT NULL,
+  cas_object_name STRING NOT NULL
+)
+CLUSTER BY cas_object_name, ac_object_name;
 
 CREATE TABLE IF NOT EXISTS {state_table} (
   shard INT64 NOT NULL,
@@ -260,30 +315,6 @@ WHEN NOT MATCHED THEN
 """.strip()
 
 
-def build_create_gcs_cache_ac_reference_stage_tables_query(
-    *,
-    object_stage_table: str,
-    edge_stage_table: str,
-    ttl_days: int,
-) -> str:
-    return f"""
-CREATE OR REPLACE TABLE {object_stage_table} (
-  ac_object_name STRING NOT NULL
-)
-OPTIONS (
-  expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {ttl_days} DAY)
-);
-
-CREATE OR REPLACE TABLE {edge_stage_table} (
-  ac_object_name STRING NOT NULL,
-  cas_object_name STRING NOT NULL
-)
-OPTIONS (
-  expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {ttl_days} DAY)
-);
-""".strip()
-
-
 def build_bootstrap_gcs_cache_ac_reference_source_query(settings: GcsCacheSettings) -> str:
     current_table = _table_ref(
         settings.project_id, settings.dataset, settings.last_seen_current_table
@@ -292,6 +323,7 @@ def build_bootstrap_gcs_cache_ac_reference_source_query(settings: GcsCacheSettin
 SELECT object_name
 FROM {current_table}
 WHERE object_kind = 'ac'
+  AND REGEXP_CONTAINS(object_name, r'{_AC_HEX_REGEX}')
   AND {_ac_shard_expression("object_name")} = @shard
 ORDER BY object_name ASC
 """.strip()
@@ -313,6 +345,7 @@ SELECT DISTINCT object_name
 FROM extracted
 WHERE object_name IS NOT NULL
   AND STARTS_WITH(object_name, 'ac/')
+  AND REGEXP_CONTAINS(object_name, r'{_AC_HEX_REGEX}')
   AND {_ac_shard_expression("object_name")} = @shard
 ORDER BY object_name ASC
 """.strip()
@@ -321,27 +354,69 @@ ORDER BY object_name ASC
 def build_replace_gcs_cache_ac_references_query(
     settings: GcsCacheSettings,
     *,
-    object_stage_table: str,
-    edge_stage_table: str,
+    shard: int,
+    edge_row_count: int,
+    stage_table: str,
+    mode: str,
 ) -> str:
-    references_table = _table_ref(
-        settings.project_id, settings.dataset, settings.ac_cas_references_table
-    )
-    return f"""
-DELETE FROM {references_table}
-WHERE ac_object_name IN (
-  SELECT ac_object_name
-  FROM {object_stage_table}
-);
+    """Per-shard replace.
 
-INSERT INTO {references_table} (
-  ac_object_name,
-  cas_object_name
-)
-SELECT
-  ac_object_name,
-  cas_object_name
-FROM {edge_stage_table};
+    Bootstrap: full shard DELETE (complete replace of all ACs in shard).
+    Incremental: targeted DELETE via stage table (only ACs with create events).
+    """
+    by_ac_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
+    )
+    del edge_row_count
+    if mode == "bootstrap":
+        return f"""
+DELETE FROM {by_ac_table}
+WHERE shard = {shard};
+
+INSERT INTO {by_ac_table} (shard, ac_object_name, cas_object_name)
+SELECT {shard}, ac_object_name, cas_object_name
+FROM {stage_table}
+WHERE cas_object_name != '';
+""".strip()
+    # incremental: only delete rows for ACs in the stage table.
+    # Sentinels (cas_object_name = '') ensure zero-ref ACs have old refs cleaned up.
+    return f"""
+DELETE FROM {by_ac_table}
+WHERE shard = {shard}
+  AND ac_object_name IN (SELECT DISTINCT ac_object_name FROM {stage_table});
+
+INSERT INTO {by_ac_table} (shard, ac_object_name, cas_object_name)
+SELECT {shard}, ac_object_name, cas_object_name
+FROM {stage_table}
+WHERE cas_object_name != '';
+""".strip()
+
+
+def build_reconcile_missing_ac_query(
+    settings: GcsCacheSettings,
+    *,
+    shard: int,
+    missing_stage_table: str,
+) -> str:
+    """Remove missing AC objects from last_seen_current and by_ac.
+
+    Uses `missing_stage_table` instead of a literal list to avoid
+    oversized SQL when there are many missing ACs.
+    """
+    current_table = _table_ref(
+        settings.project_id, settings.dataset, settings.last_seen_current_table
+    )
+    by_ac_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
+    )
+    del shard  # kept for caller symmetry
+    return f"""
+DELETE FROM {current_table}
+WHERE object_kind = 'ac'
+  AND object_name IN (SELECT object_name FROM {missing_stage_table});
+
+DELETE FROM {by_ac_table}
+WHERE ac_object_name IN (SELECT object_name FROM {missing_stage_table});
 """.strip()
 
 
@@ -418,32 +493,90 @@ def _stream_query_rows(
         yield dict(row.items())
 
 
-def _load_json_rows(table_ref: str, rows: Sequence[dict[str, object]]) -> None:
+def _write_missing_stage(
+    settings: GcsCacheSettings,
+    *,
+    shard: int,
+    missing_names: set[str],
+    run_suffix: str = "",
+) -> str:
+    """Write missing AC names to a stage table. Returns fully-qualified ref."""
     from google.cloud import bigquery
 
     client = bigquery.Client()
-    destination = table_ref.strip("`")
+    ttl_days = settings.cleanup_candidate_ttl_days
+    run_part = f"_{run_suffix}" if run_suffix else ""
+    stage_table = f"{settings.project_id}.{settings.dataset}._tmp_missing_stage_{shard}{run_part}"
+    stage_table_ref = f"`{stage_table}`"
+
+    client.query(
+        f"""CREATE OR REPLACE TABLE {stage_table_ref} (
+  object_name STRING NOT NULL
+)
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {ttl_days} DAY))"""
+    ).result()
+
+    rows = [{"object_name": name} for name in sorted(missing_names)]
     if rows:
-        if len(rows[0]) == 1:
-            schema = [bigquery.SchemaField("ac_object_name", "STRING", mode="REQUIRED")]
-        else:
-            schema = [
-                bigquery.SchemaField("ac_object_name", "STRING", mode="REQUIRED"),
-                bigquery.SchemaField("cas_object_name", "STRING", mode="REQUIRED"),
-            ]
+        schema = [bigquery.SchemaField("object_name", "STRING", mode="REQUIRED")]
         job = client.load_table_from_json(
-            list(rows),
-            destination,
+            rows,
+            stage_table,
             job_config=bigquery.LoadJobConfig(
                 schema=schema,
-                write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+                write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
             ),
         )
         job.result()
-        return
+    return stage_table_ref
 
-    job = client.query(f"TRUNCATE TABLE {table_ref}")
-    job.result()
+
+def _load_json_rows(
+    settings: GcsCacheSettings,
+    *,
+    shard: int,
+    edge_rows: Sequence[dict[str, object]],
+    run_suffix: str = "",
+) -> str:
+    """Load edge rows into a run-scoped per-shard stage table. Returns the fully-qualified table ref."""
+    from google.cloud import bigquery
+
+    client = bigquery.Client()
+    ttl_days = settings.cleanup_candidate_ttl_days
+    run_part = f"_{run_suffix}" if run_suffix else ""
+    stage_table = f"{settings.project_id}.{settings.dataset}._tmp_shard_edge_stage_{shard}{run_part}"
+    stage_table_ref = f"`{stage_table}`"
+
+    # Create with TTL first, then load data.
+    client.query(
+        f"""CREATE OR REPLACE TABLE {stage_table_ref} (
+  shard INT64 NOT NULL,
+  ac_object_name STRING NOT NULL,
+  cas_object_name STRING NOT NULL
+)
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {ttl_days} DAY))"""
+    ).result()
+
+    rows_with_shard = [
+        {"shard": shard, "ac_object_name": r["ac_object_name"], "cas_object_name": r["cas_object_name"]}
+        for r in edge_rows
+    ]
+    if rows_with_shard:
+        schema = [
+            bigquery.SchemaField("shard", "INT64", mode="REQUIRED"),
+            bigquery.SchemaField("ac_object_name", "STRING", mode="REQUIRED"),
+            bigquery.SchemaField("cas_object_name", "STRING", mode="REQUIRED"),
+        ]
+        job = client.load_table_from_json(
+            list(rows_with_shard),
+            stage_table,
+            job_config=bigquery.LoadJobConfig(
+                schema=schema,
+                write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+            ),
+        )
+        job.result()
+    return stage_table_ref
 
 
 def _batched(
@@ -469,7 +602,7 @@ def _validate_shard_range(*, shard_start: int, shard_end: int, shard_count: int)
 
 
 def _ac_shard_expression(column_name: str) -> str:
-    return f"TO_CODE_POINTS(FROM_HEX(SUBSTR({column_name}, 4, 2)))[OFFSET(0)]"
+    return f"MOD(TO_CODE_POINTS(FROM_HEX(SUBSTR({column_name}, 4, 2)))[OFFSET(0)], 256)"
 
 
 def _table_ref(project_id: str, dataset: str, table: str) -> str:

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -577,29 +577,28 @@ def test_run_cleanup_gcs_cache_delete_cascades_cas_after_each_ac_batch() -> None
             complete_time=datetime(2026, 6, 15, 10, 31, tzinfo=UTC),
         )
 
-    with pytest.warns(FutureWarning, match="max_delete_cas_objects is deprecated and ignored"):
-        summary = run_cleanup_gcs_cache(
-            settings=GcsCacheSettings(
-                project_id="pingcap-testing-account",
-                cleanup_ac_delete_batch_size=1,
-            ),
-            mode="delete",
-            execute_kind="cas",
-            ac_retention_days=10,
-            cas_retention_days=15,
-            safety_buffer_days=1,
-            max_delete_objects=2,
-            max_delete_cas_objects=1,
-            execute=fake_execute,
-            stream_rows=fake_stream_rows,
-            resolve_object_metadata=fake_resolve_object_metadata,
-            extract_references=fake_extract_references,
-            load_jsonl_file=fake_load_jsonl_file,
-            create_batch_job=fake_create_batch_job,
-            wait_for_batch_job=fake_wait_for_batch_job,
-            now=lambda: datetime(2026, 6, 15, 10, 30, tzinfo=UTC),
-            run_id_factory=lambda: "steady-run-batched",
-        )
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            cleanup_ac_delete_batch_size=1,
+        ),
+        mode="delete",
+        execute_kind="cas",
+        ac_retention_days=10,
+        cas_retention_days=15,
+        safety_buffer_days=1,
+        max_delete_objects=2,
+        max_delete_cas_objects=1,
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        resolve_object_metadata=fake_resolve_object_metadata,
+        extract_references=fake_extract_references,
+        load_jsonl_file=fake_load_jsonl_file,
+        create_batch_job=fake_create_batch_job,
+        wait_for_batch_job=fake_wait_for_batch_job,
+        now=lambda: datetime(2026, 6, 15, 10, 30, tzinfo=UTC),
+        run_id_factory=lambda: "steady-run-batched",
+    )
 
     assert summary.selected_ac_object_count == 2
     assert summary.selected_cas_object_count == 2

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -231,8 +231,8 @@ def test_populate_ac_stage_tables_skips_parse_failed_ac_from_delete_inputs() -> 
     assert result.sample_parse_errors[0].parse_error == "Unsupported protobuf wire type: 3"
     assert (
         "`project.dataset.ac_live`",
-        ({"object_name": "ac/ok", "generation": 101},),
-        (("object_name", "STRING"), ("generation", "INT64")),
+        ({"object_name": "ac/ok", "generation": 101, "size_bytes": None},),
+        (("object_name", "STRING"), ("generation", "INT64"), ("size_bytes", "INT64")),
         "WRITE_APPEND",
     ) in loaded_files
     assert (
@@ -1047,3 +1047,258 @@ def _assert_load_schema_matches_created_table(
         assert created_type == field_type
         # load_table_from_json uses NULLABLE fields when mode is not explicitly set.
         assert created_mode == "NULLABLE"
+
+
+def test_run_cleanup_gcs_cache_from_index_dry_run_returns_summary_with_candidates(monkeypatch) -> None:
+    """cas-from-index dry-run: runs full analysis pipeline without deleting."""
+    from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
+
+    # Mock the catch-up sync to avoid real BigQuery calls
+    monkeypatch.setattr(
+        cleanup_gcs_cache,
+        "run_sync_gcs_cache_ac_references",
+        lambda **kwargs: sync_gcs_cache_ac_references.SyncGcsCacheAcReferencesSummary(
+            account_id="test",
+            bucket_name="test",
+            mode="incremental",
+            shard_start=0,
+            shard_end=255,
+            source_object_count=0,
+            missing_object_count=0,
+            parse_error_count=0,
+            replaced_ac_object_count=0,
+            reference_row_count=0,
+            sample_parse_errors=(),
+            dry_run=False,
+            indexed_through=datetime(2026, 7, 1, 9, 59, tzinfo=UTC),
+            bytes_processed=0,
+            run_started_at=datetime(2026, 7, 1, 9, 59, tzinfo=UTC),
+            run_finished_at=datetime(2026, 7, 1, 9, 59, tzinfo=UTC),
+        ),
+    )
+
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append((query, {p.name: p.value for p in parameters}))
+        if "ready_shards" in query:
+            return BigQueryQueryResult(rows=({"ready_shards": 256},), total_bytes_processed=1)
+        if "fresh_shards" in query:
+            return BigQueryQueryResult(rows=({"fresh_shards": 256},), total_bytes_processed=1)
+        if "COUNT(*)" in query or "object_count" in query:
+            return BigQueryQueryResult(rows=({"object_count": 100},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        if "cas_preselect" in query:
+            yield {"object_name": "cas/deadbeef"}
+        return
+
+    def fake_resolve_metadata(**kwargs):
+        return (
+            GcsObjectMetadata(object_name="cas/deadbeef", exists=True, generation=1, size_bytes=1024),
+        )
+
+    def fake_load_jsonl(*args, **kwargs):
+        pass
+
+    now = datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="dry-run",
+        execute_kind="cas-from-index",
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        resolve_object_metadata=fake_resolve_metadata,
+        load_jsonl_file=fake_load_jsonl,
+        now=lambda: now,
+        run_id_factory=lambda: "test-run",
+    )
+
+    assert summary.execute_kind == "cas-from-index"
+    assert summary.dry_run is True
+    assert summary.candidate_cas_object_count >= 0
+    assert summary.candidate_ac_object_count >= 0
+    assert summary.candidate_cas_delete_object_count >= 0
+
+
+def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatch) -> None:
+    """cas-from-index delete: AC delete → second catch-up → by_cas rebuild → CAS delete."""
+    from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
+
+    # Mock catch-up sync
+    monkeypatch.setattr(
+        cleanup_gcs_cache,
+        "run_sync_gcs_cache_ac_references",
+        lambda **kwargs: sync_gcs_cache_ac_references.SyncGcsCacheAcReferencesSummary(
+            account_id="test", bucket_name="test", mode="incremental",
+            shard_start=0, shard_end=255, source_object_count=0,
+            missing_object_count=0, parse_error_count=0,
+            replaced_ac_object_count=0, reference_row_count=0,
+            sample_parse_errors=(), dry_run=False,
+            indexed_through=datetime(2026, 7, 1, 9, 59, tzinfo=UTC),
+            bytes_processed=0,
+            run_started_at=datetime(2026, 7, 1, 9, 59, tzinfo=UTC),
+            run_finished_at=datetime(2026, 7, 1, 9, 59, tzinfo=UTC),
+        ),
+    )
+
+    captured_queries = []
+    step_order: list[str] = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append(query)
+        if "ready_shards" in query:
+            return BigQueryQueryResult(rows=({"ready_shards": 256},), total_bytes_processed=1)
+        if "fresh_shards" in query:
+            return BigQueryQueryResult(rows=({"fresh_shards": 256},), total_bytes_processed=1)
+        if "COUNT(*)" in query or "object_count" in query:
+            return BigQueryQueryResult(rows=({"object_count": 3},), total_bytes_processed=1)
+        # Track operation order
+        if "CREATE OR REPLACE TABLE" in query:
+            if "by_cas" in query and "by_cas_dryrun" not in query:
+                step_order.append("rebuild_by_cas")
+            elif "ac_to_delete" in query:
+                step_order.append("ac_reverse_lookup")
+            elif "cas_zero_ref" in query:
+                step_order.append("zero_ref_cas")
+            elif "delete_ac" in query:
+                step_order.append("ac_delete_manifest")
+            elif "delete_cas" in query:
+                step_order.append("cas_delete_manifest")
+            elif "cas_preselect" in query:
+                step_order.append("cas_preselect")
+            elif "cold_cas" in query:
+                step_order.append("cold_cas_ranked")
+        if "EXPORT DATA" in query:
+            if "ac/" in query or "delete_ac" in query:
+                step_order.append("ac_manifest_export")
+            elif "cas/" in query or "delete_cas" in query:
+                step_order.append("cas_manifest_export")
+        if "UPDATE `pingcap" in query:
+            step_order.append("update_index_state")
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        if "cas_preselect" in query:
+            yield {"object_name": "cas/aaa"}
+            yield {"object_name": "cas/bbb"}
+            yield {"object_name": "cas/ccc"}
+        elif "ac_to_delete" in query:
+            yield {"object_name": "ac/xxx", "last_seen_at": datetime(2026, 1, 1, tzinfo=UTC)}
+        elif "ac_live_metadata" in query or "cas_live_metadata" in query:
+            yield {"object_name": "dummy"}
+        elif "stale" in query:
+            return
+        return
+
+    def fake_resolve_metadata(**kwargs):
+        return (
+            GcsObjectMetadata(object_name="dummy", exists=True, generation=1, size_bytes=1024),
+        )
+
+    def fake_load_jsonl(*args, **kwargs):
+        pass
+
+    def fake_create_batch_job(**kwargs):
+        from cost_insight.common.storage_batch_operations import StorageBatchOperationsJob
+        return StorageBatchOperationsJob(job_name=kwargs["job_id"], operation_name=None)
+
+    def fake_wait_for_batch_job(**kwargs):
+        from cost_insight.common.storage_batch_operations import StorageBatchOperationsJobStatus
+        return StorageBatchOperationsJobStatus(
+            job_name=kwargs["job_name"],
+            state="SUCCEEDED", failed_object_count=0,
+            total_object_count=3, succeeded_object_count=3,
+            total_bytes_transformed=0, complete_time=None,
+        )
+
+    now = datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="delete",
+        execute_kind="cas-from-index",
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        resolve_object_metadata=fake_resolve_metadata,
+        load_jsonl_file=fake_load_jsonl,
+        create_batch_job=fake_create_batch_job,
+        wait_for_batch_job=fake_wait_for_batch_job,
+        now=lambda: now,
+        run_id_factory=lambda: "test-delete-run",
+    )
+
+    assert summary.execute_kind == "cas-from-index"
+    assert summary.dry_run is False
+    assert summary.selected_ac_object_count > 0
+    assert summary.selected_cas_object_count > 0
+    # Verify operation order: AC before CAS
+    assert step_order.index("ac_manifest_export") < step_order.index("cas_manifest_export")
+    # Second by_cas rebuild before zero-ref
+    rebuild_positions = [i for i, s in enumerate(step_order) if s == "rebuild_by_cas"]
+    zero_ref_pos = step_order.index("zero_ref_cas")
+    assert len(rebuild_positions) >= 2
+    assert rebuild_positions[-1] < zero_ref_pos
+
+
+def test_cas_from_index_respects_max_delete_objects_canary(monkeypatch) -> None:
+    """cas-from-index --max-delete-objects 500 limits AC deletion to 500."""
+    from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
+
+    monkeypatch.setattr(
+        cleanup_gcs_cache,
+        "run_sync_gcs_cache_ac_references",
+        lambda **kwargs: sync_gcs_cache_ac_references.SyncGcsCacheAcReferencesSummary(
+            account_id="test", bucket_name="test", mode="incremental",
+            shard_start=0, shard_end=255, source_object_count=0,
+            missing_object_count=0, parse_error_count=0,
+            replaced_ac_object_count=0, reference_row_count=0,
+            sample_parse_errors=(), dry_run=False,
+            indexed_through=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+            bytes_processed=0,
+            run_started_at=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+            run_finished_at=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+        ),
+    )
+
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append(query)
+        if "ready_shards" in query:
+            return BigQueryQueryResult(rows=({"ready_shards": 256},), total_bytes_processed=1)
+        if "fresh_shards" in query:
+            return BigQueryQueryResult(rows=({"fresh_shards": 256},), total_bytes_processed=1)
+        if "COUNT(*)" in query or "object_count" in query:
+            return BigQueryQueryResult(rows=({"object_count": 10},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        if "cas_preselect" in query:
+            yield {"object_name": "cas/deadbeef"}
+        return
+
+    def fake_resolve_metadata(**kwargs):
+        return (GcsObjectMetadata(object_name="dummy", exists=True, generation=1, size_bytes=1024),)
+
+    def fake_load_jsonl(*args, **kwargs):
+        pass
+
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=UTC)
+    run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="dry-run",
+        execute_kind="cas-from-index",
+        max_delete_objects=500,
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        resolve_object_metadata=fake_resolve_metadata,
+        load_jsonl_file=fake_load_jsonl,
+        now=lambda: now,
+        run_id_factory=lambda: "test-canary",
+    )
+
+    # The AC reverse lookup query should have LIMIT 500, not the default 100000
+    ac_queries = [q for q in captured_queries if "ac_to_delete" in q]
+    assert len(ac_queries) >= 1
+    assert "LIMIT 500" in ac_queries[0]

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -1301,3 +1301,66 @@ def test_cas_from_index_respects_max_delete_objects_canary(monkeypatch) -> None:
     ac_queries = [q for q in captured_queries if "ac_to_delete" in q]
     assert len(ac_queries) >= 1
     assert "LIMIT 500" in ac_queries[0]
+
+
+def test_cas_from_index_default_ac_cap_without_max_delete_objects(monkeypatch) -> None:
+    """cas-from-index uses default cleanup_max_delete_ac_objects=100000 when no flag."""
+    from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
+
+    monkeypatch.setattr(
+        cleanup_gcs_cache,
+        "run_sync_gcs_cache_ac_references",
+        lambda **kwargs: sync_gcs_cache_ac_references.SyncGcsCacheAcReferencesSummary(
+            account_id="test", bucket_name="test", mode="incremental",
+            shard_start=0, shard_end=255, source_object_count=0,
+            missing_object_count=0, parse_error_count=0,
+            replaced_ac_object_count=0, reference_row_count=0,
+            sample_parse_errors=(), dry_run=False,
+            indexed_through=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+            bytes_processed=0,
+            run_started_at=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+            run_finished_at=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+        ),
+    )
+
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append(query)
+        if "ready_shards" in query:
+            return BigQueryQueryResult(rows=({"ready_shards": 256},), total_bytes_processed=1)
+        if "fresh_shards" in query:
+            return BigQueryQueryResult(rows=({"fresh_shards": 256},), total_bytes_processed=1)
+        if "COUNT(*)" in query or "object_count" in query:
+            return BigQueryQueryResult(rows=({"object_count": 10},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        if "cas_preselect" in query:
+            yield {"object_name": "cas/deadbeef"}
+        return
+
+    def fake_resolve_metadata(**kwargs):
+        return (GcsObjectMetadata(object_name="dummy", exists=True, generation=1, size_bytes=1024),)
+
+    def fake_load_jsonl(*args, **kwargs):
+        pass
+
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=UTC)
+    # No max_delete_objects flag
+    run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="dry-run",
+        execute_kind="cas-from-index",
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        resolve_object_metadata=fake_resolve_metadata,
+        load_jsonl_file=fake_load_jsonl,
+        now=lambda: now,
+        run_id_factory=lambda: "test-default-ac-cap",
+    )
+
+    # Default AC cap is 100000 (not 10000000)
+    ac_queries = [q for q in captured_queries if "ac_to_delete" in q]
+    assert len(ac_queries) >= 1
+    assert "LIMIT 100000" in ac_queries[0]

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -47,7 +47,7 @@ def test_load_settings_can_skip_database_for_validation() -> None:
     assert settings.gcs_cache.cleanup_safety_buffer_days == 1
     assert settings.gcs_cache.last_seen_excluded_get_user_agent == "TransferService"
     assert settings.gcs_cache.last_seen_excluded_get_principal_email is None
-    assert settings.gcs_cache.ac_reference_max_index_staleness_hours == 12
+    assert settings.gcs_cache.ac_reference_max_index_staleness_hours == 1
 
 
 def test_load_settings_falls_back_to_tidb_parts() -> None:
@@ -136,25 +136,11 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
     assert settings.gcs_cache.cleanup_sample_limit == 25
     assert settings.gcs_cache.cleanup_max_delete_objects == 500
     assert settings.gcs_cache.cleanup_max_delete_cas_objects == 100
-    assert settings.gcs_cache.cleanup_ac_delete_batch_size == 200
+    assert settings.gcs_cache.cleanup_max_delete_ac_objects == 100000
     assert settings.gcs_cache.cleanup_batch_size == 50
     assert settings.gcs_cache.cleanup_manifest_bucket == "manifest-bucket"
     assert settings.gcs_cache.cleanup_manifest_prefix == "manifest-prefix"
     assert settings.gcs_cache.cleanup_candidate_ttl_days == 9
-
-
-def test_load_settings_warns_when_cleanup_ac_batch_exceeds_max_delete_objects() -> None:
-    with pytest.warns(RuntimeWarning, match="cleanup_ac_delete_batch_size is greater"):
-        settings = load_settings(
-            {
-                "COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS": "10",
-                "COST_INSIGHT_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE": "20",
-            },
-            require_database=False,
-        )
-
-    assert settings.gcs_cache.cleanup_max_delete_objects == 10
-    assert settings.gcs_cache.cleanup_ac_delete_batch_size == 20
 
 
 def test_load_settings_requires_database_when_not_skipped() -> None:

--- a/cost-insight/tests/test_gcs_objects.py
+++ b/cost-insight/tests/test_gcs_objects.py
@@ -2,8 +2,9 @@ from cost_insight.common import gcs_objects
 
 
 class _FakeBlob:
-    def __init__(self, generation: str | None) -> None:
+    def __init__(self, generation: str | None, size: int | None = 1024) -> None:
         self.generation = generation
+        self.size = size
 
 
 class _FakeBucket:
@@ -65,16 +66,19 @@ def test_fetch_object_metadata_batch_reads_objects_sequentially(monkeypatch) -> 
             object_name="cas/present",
             exists=True,
             generation=123,
+            size_bytes=1024,
         ),
         gcs_objects.GcsObjectMetadata(
             object_name="cas/missing",
             exists=False,
             generation=None,
+            size_bytes=None,
         ),
         gcs_objects.GcsObjectMetadata(
             object_name="cas/no-generation",
             exists=True,
             generation=None,
+            size_bytes=1024,
         ),
     )
     assert bucket.requested_names == ["cas/present", "cas/missing", "cas/no-generation"]
@@ -123,6 +127,6 @@ def test_fetch_object_metadata_batch_uses_executor_for_parallel_path(monkeypatch
     assert used_max_workers == [4]
     assert observed_pool_sizes == [4]
     assert metadata == (
-        gcs_objects.GcsObjectMetadata(object_name="cas/one", exists=True, generation=11),
-        gcs_objects.GcsObjectMetadata(object_name="cas/two", exists=True, generation=22),
+        gcs_objects.GcsObjectMetadata(object_name="cas/one", exists=True, generation=11, size_bytes=1024),
+        gcs_objects.GcsObjectMetadata(object_name="cas/two", exists=True, generation=22, size_bytes=1024),
     )

--- a/cost-insight/tests/test_sync_gcs_cache_ac_references.py
+++ b/cost-insight/tests/test_sync_gcs_cache_ac_references.py
@@ -15,7 +15,8 @@ def test_ensure_gcs_cache_ac_reference_tables_query_creates_reference_and_state_
     settings = GcsCacheSettings(project_id="pingcap-testing-account")
     query = build_ensure_gcs_cache_ac_reference_tables_query(settings)
 
-    assert "gcs_cache_ac_cas_references" in query
+    assert "gcs_cache_ac_cas_refs_by_ac" in query
+    assert "gcs_cache_ac_cas_refs_by_cas" in query
     assert "gcs_cache_ac_reference_index_state" in query
     assert "GENERATE_ARRAY(0, 255)" in query
 
@@ -27,6 +28,7 @@ def test_bootstrap_gcs_cache_ac_reference_source_query_targets_last_seen_current
     assert "gcs_cache_object_last_seen_current" in query
     assert "object_kind = 'ac'" in query
     assert "TO_CODE_POINTS(FROM_HEX(SUBSTR(object_name, 4, 2)))" in query
+    assert "REGEXP_CONTAINS(object_name, r'^ac/[0-9a-fA-F]{64}$')" in query
 
 
 def test_incremental_gcs_cache_ac_reference_source_query_targets_create_events() -> None:
@@ -37,6 +39,7 @@ def test_incremental_gcs_cache_ac_reference_source_query_targets_create_events()
     assert "storage.objects.create" in query
     assert "timestamp > @indexed_through" in query
     assert "timestamp <= @run_until" in query
+    assert "REGEXP_CONTAINS(object_name, r'^ac/[0-9a-fA-F]{64}$')" in query
 
 
 def test_run_sync_gcs_cache_ac_references_bootstrap_dry_run_counts_objects_and_refs() -> None:
@@ -118,8 +121,12 @@ def test_run_sync_gcs_cache_ac_references_incremental_updates_watermark_and_repl
             ),
         )
 
-    def fake_load_json_rows(table_ref, rows):
-        loaded_rows.append((table_ref, tuple(rows)))
+    loaded_stage_rows: list[dict] = []
+
+    def fake_load_json_rows(settings, *, shard, edge_rows, run_suffix=""):
+        loaded_stage_rows.extend(edge_rows)
+        suffix = f"_{run_suffix}" if run_suffix else ""
+        return f"`project.dataset._tmp_shard_edge_stage_{shard}{suffix}`"
 
     now = datetime(2026, 6, 22, 10, 0, tzinfo=UTC)
     summary = run_sync_gcs_cache_ac_references(
@@ -140,10 +147,64 @@ def test_run_sync_gcs_cache_ac_references_incremental_updates_watermark_and_repl
     assert summary.parse_error_count == 0
     assert summary.replaced_ac_object_count == 1
     assert summary.reference_row_count == 1
+    assert loaded_stage_rows == [{"ac_object_name": "ac/00cccc", "cas_object_name": "cas/three"}]
     assert any(
         "UPDATE `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_ac_reference_index_state`"
         in query
         for query, _ in captured_queries
     )
-    assert loaded_rows[0][1] == ({"ac_object_name": "ac/00cccc"},)
-    assert loaded_rows[1][1] == ({"ac_object_name": "ac/00cccc", "cas_object_name": "cas/three"},)
+
+
+def test_run_sync_incremental_zero_ref_ac_writes_sentinel_and_filters_insert() -> None:
+    """Incremental sync: zero-CAS-ref AC gets sentinel row, INSERT filters it out."""
+    captured_queries = []
+    loaded_stage_rows: list[dict] = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append((query, {p.name: p.value for p in parameters}))
+        if "SELECT indexed_through" in query:
+            return BigQueryQueryResult(
+                rows=({"indexed_through": datetime(2026, 6, 21, 0, 0, tzinfo=UTC)},),
+                total_bytes_processed=1,
+            )
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        yield {"object_name": "ac/00cafe"}
+
+    def fake_extract_references(**kwargs):
+        return (
+            AcReferenceExtraction(
+                ac_object_name="ac/00cafe",
+                exists=True,
+                cas_object_names=(),  # zero CAS refs
+            ),
+        )
+
+    def fake_load_json_rows(settings, *, shard, edge_rows, run_suffix=""):
+        loaded_stage_rows.extend(edge_rows)
+        suffix = f"_{run_suffix}" if run_suffix else ""
+        return f"`project.dataset._tmp_shard_edge_stage_{shard}{suffix}`"
+
+    now = datetime(2026, 6, 22, 10, 0, tzinfo=UTC)
+    summary = run_sync_gcs_cache_ac_references(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="incremental",
+        shard_start=0,
+        shard_end=0,
+        dry_run=False,
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        load_json_rows=fake_load_json_rows,
+        extract_references=fake_extract_references,
+        now=lambda: now,
+    )
+
+    # AC was parsed successfully (no parse error, exists)
+    assert summary.replaced_ac_object_count == 1
+    assert summary.reference_row_count == 0
+    # Sentinel row written
+    assert {"ac_object_name": "ac/00cafe", "cas_object_name": ""} in loaded_stage_rows
+    # INSERT filters sentinel
+    replace_queries = [q for q, _ in captured_queries if "INSERT INTO" in q and "cas_object_name !=" in q]
+    assert len(replace_queries) == 1


### PR DESCRIPTION
Replace per-run AC-driven CAS cascade with persistent dual-table index plus cas-from-index cleanup. 165 tests. See cost-insight/docs/gcs-bazel-cache-cas-gc-v3-complete-ac-expansion.md.