### PR TITLE
fix(ci-dashboard): relax PR events freshness threshold

### DIFF
--- a/ci-dashboard/src/ci_dashboard/jobs/check_data_freshness.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/check_data_freshness.py
@@ -115,7 +115,7 @@ CHECKS: list[Check] = [
         name="ci_l1_pr_events",
         level="MEDIUM",
         description="Latest PR event_time in ci_l1_pr_events",
-        threshold_description="4 hours",
+        threshold_description="30 hours",
         sql="SELECT MAX(event_time) FROM ci_l1_pr_events WHERE event_time IS NOT NULL",
         db="ci",
     ),


### PR DESCRIPTION
Summary:
- Relax ci_l1_pr_events freshness threshold from 4 hours to 30 hours to match the daily github_tickets cadence.

Tests:
- pytest tests/jobs/test_check_data_freshness.py