### PR TITLE
chore(cost-insight): log AC reference shard progress

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import warnings
 from contextlib import ExitStack
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from itertools import islice
+from time import perf_counter
 
 from cost_insight.common.bigquery import BigQueryParameter, BigQueryQueryResult, execute_query
 from cost_insight.common.config import GcsCacheSettings
@@ -16,6 +18,7 @@ QueryExecutor = Callable[[str, Sequence[BigQueryParameter]], BigQueryQueryResult
 ReferenceExtractor = Callable[..., tuple[AcReferenceExtraction, ...]]
 RowStreamer = Callable[[str, Sequence[BigQueryParameter]], Iterator[dict[str, object]]]
 JsonLoader = Callable[..., str]
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -91,6 +94,35 @@ def run_sync_gcs_cache_ac_references(
     )
 
     for shard in range(shard_start, resolved_shard_end + 1):
+        shard_started_at = perf_counter()
+        shard_source_start = source_object_count
+        shard_missing_start = missing_object_count
+        shard_parse_error_start = parse_error_count
+        shard_replaced_start = replaced_ac_object_count
+        shard_reference_start = reference_row_count
+        logger.info(
+            "AC reference sync shard started: mode=%s shard=%s shard_end=%s",
+            mode,
+            shard,
+            resolved_shard_end,
+        )
+
+        def log_shard_finished(status: str) -> None:
+            logger.info(
+                "AC reference sync shard finished: mode=%s shard=%s status=%s "
+                "source=%s replaced=%s missing=%s references=%s parse_errors=%s "
+                "elapsed_seconds=%.1f",
+                mode,
+                shard,
+                status,
+                source_object_count - shard_source_start,
+                replaced_ac_object_count - shard_replaced_start,
+                missing_object_count - shard_missing_start,
+                reference_row_count - shard_reference_start,
+                parse_error_count - shard_parse_error_start,
+                perf_counter() - shard_started_at,
+            )
+
         watermark = (
             None
             if mode == "bootstrap"
@@ -177,6 +209,7 @@ def run_sync_gcs_cache_ac_references(
 
         if dry_run:
             indexed_through = run_started_at
+            log_shard_finished("dry_run")
             continue
 
         # Parse error fail-closed: any parse error → clear indexed_through to NULL.
@@ -194,6 +227,7 @@ WHERE shard = {shard}""",
                         parameters=[],
                     ).total_bytes_processed,
                 )
+            log_shard_finished("parse_error")
             continue
 
         # Reconcile missing AC objects from last_seen_current and by_ac.
@@ -246,6 +280,7 @@ WHERE shard = {shard}""",
             ).total_bytes_processed,
         )
         indexed_through = run_started_at
+        log_shard_finished("succeeded")
 
     if failed_shards and not dry_run:
         raise RuntimeError(

--- a/cost-insight/tests/test_sync_gcs_cache_ac_references.py
+++ b/cost-insight/tests/test_sync_gcs_cache_ac_references.py
@@ -98,7 +98,6 @@ def test_run_sync_gcs_cache_ac_references_bootstrap_dry_run_counts_objects_and_r
 
 def test_run_sync_gcs_cache_ac_references_incremental_updates_watermark_and_replaces_refs() -> None:
     captured_queries = []
-    loaded_rows = []
 
     def fake_execute(query, parameters):
         captured_queries.append((query, {param.name: param.value for param in parameters}))
@@ -153,6 +152,64 @@ def test_run_sync_gcs_cache_ac_references_incremental_updates_watermark_and_repl
         in query
         for query, _ in captured_queries
     )
+
+
+def test_run_sync_gcs_cache_ac_references_replaces_once_per_shard() -> None:
+    captured_queries = []
+    load_calls = []
+    extract_calls = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append((query, {param.name: param.value for param in parameters}))
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        yield {"object_name": "ac/00aaaa"}
+        yield {"object_name": "ac/00bbbb"}
+        yield {"object_name": "ac/00cccc"}
+
+    def fake_extract_references(**kwargs):
+        names = kwargs["ac_object_names"]
+        extract_calls.append(names)
+        return tuple(
+            AcReferenceExtraction(
+                ac_object_name=name,
+                exists=True,
+                cas_object_names=(f"cas/{name[-6:]}",),
+            )
+            for name in names
+        )
+
+    def fake_load_json_rows(settings, *, shard, edge_rows, run_suffix=""):
+        load_calls.append((shard, tuple(edge_rows)))
+        return f"`project.dataset._tmp_shard_edge_stage_{shard}`"
+
+    run_sync_gcs_cache_ac_references(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            ac_reference_batch_size=2,
+        ),
+        mode="bootstrap",
+        shard_start=0,
+        shard_end=0,
+        dry_run=False,
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        load_json_rows=fake_load_json_rows,
+        extract_references=fake_extract_references,
+        now=lambda: datetime(2026, 6, 22, 10, 0, tzinfo=UTC),
+    )
+
+    assert extract_calls == [("ac/00aaaa", "ac/00bbbb"), ("ac/00cccc",)]
+    assert len(load_calls) == 1
+    assert len(load_calls[0][1]) == 3
+    replace_queries = [
+        query
+        for query, _ in captured_queries
+        if "DELETE FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_ac_cas_refs_by_ac`"
+        in query
+    ]
+    assert len(replace_queries) == 1
 
 
 def test_run_sync_incremental_zero_ref_ac_writes_sentinel_and_filters_insert() -> None:


### PR DESCRIPTION
## Summary
- Add per-shard start/finish logs for sync-gcs-cache-ac-references, including source/replaced/missing/reference/parse-error counts and elapsed seconds.
- Add a regression test that a shard with multiple AC batches is loaded/replaced once per shard, not once per batch.
- Remove an unused import caught by ruff.

## Context
The current c8dc928 image already does per-shard replace. The slow 0-15 bootstrap run was not the old O(n^2) stage replacement path; it was one pod processing 16 shards sequentially. Shard 0 took about 11 minutes and the stopped 0-15 run completed shards 0-11 in about 2 hours, which is consistent with sequential per-shard throughput.

The next throughput improvement should be operational: fan out bootstrap as one shard per Job or small ranges per Job, rather than making a single pod run a wide shard range.

## Validation
- cd cost-insight && python -m ruff check .
- cd cost-insight && python -m pytest
- pytest result: 169 passed, coverage 92.60%
