### PR TITLE
fix(cost-insight): make AC reference bootstrap safer for parallel shards

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -172,6 +172,11 @@ def build_parser() -> argparse.ArgumentParser:
     sync_gcs_cache_ac_refs.add_argument("--shard-start", type=_parse_non_negative_int, default=0)
     sync_gcs_cache_ac_refs.add_argument("--shard-end", type=_parse_non_negative_int, default=None)
     sync_gcs_cache_ac_refs.add_argument("--dry-run", action="store_true")
+    sync_gcs_cache_ac_refs.add_argument(
+        "--skip-ensure-tables",
+        action="store_true",
+        help="Skip AC reference table creation/state initialization for parallel shard workers",
+    )
 
     cleanup_gcs_cache = subparsers.add_parser(
         "cleanup-gcs-cache",
@@ -396,6 +401,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             shard_start=args.shard_start,
             shard_end=args.shard_end,
             dry_run=args.dry_run,
+            ensure_tables=not args.skip_ensure_tables,
         )
         print(json.dumps(_summaries_to_json([summary]), indent=2, sort_keys=True))
         return 0

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
@@ -109,13 +109,6 @@ def run_sync_gcs_cache_ac_references(
         shard_parse_error_start = parse_error_count
         shard_replaced_start = replaced_ac_object_count
         shard_reference_start = reference_row_count
-        logger.info(
-            "AC reference sync shard started: mode=%s shard=%s shard_end=%s",
-            mode,
-            shard,
-            resolved_shard_end,
-        )
-
         def log_shard_finished(status: str) -> None:
             logger.info(
                 "AC reference sync shard finished: mode=%s shard=%s status=%s "
@@ -146,6 +139,12 @@ def run_sync_gcs_cache_ac_references(
                 "AC reference index bootstrap is incomplete: "
                 f"shard {shard} has no indexed_through watermark"
             )
+        logger.info(
+            "AC reference sync shard started: mode=%s shard=%s run_shard_end=%s",
+            mode,
+            shard,
+            resolved_shard_end,
+        )
 
         query = (
             build_bootstrap_gcs_cache_ac_reference_source_query(settings)

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
@@ -5,9 +5,14 @@ from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from itertools import islice
-from time import perf_counter
+from time import perf_counter, sleep
 
-from cost_insight.common.bigquery import BigQueryParameter, BigQueryQueryResult, execute_query
+from cost_insight.common.bigquery import (
+    BigQueryExecutionError,
+    BigQueryParameter,
+    BigQueryQueryResult,
+    execute_query,
+)
 from cost_insight.common.config import GcsCacheSettings
 from cost_insight.common.gcs_cache_references import (
     AcReferenceExtraction,
@@ -61,6 +66,7 @@ def run_sync_gcs_cache_ac_references(
     stream_rows: RowStreamer | None = None,
     load_json_rows: JsonLoader | None = None,
     extract_references: ReferenceExtractor = extract_action_cache_references_batch,
+    ensure_tables: bool = True,
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> SyncGcsCacheAcReferencesSummary:
     if mode not in {"bootstrap", "incremental"}:
@@ -86,12 +92,15 @@ def run_sync_gcs_cache_ac_references(
     indexed_through: datetime | None = None
     failed_shards: list[int] = []
 
-    bytes_processed_total = _add_bytes(
-        bytes_processed_total,
-        execute(
-            build_ensure_gcs_cache_ac_reference_tables_query(settings), parameters=[]
-        ).total_bytes_processed,
-    )
+    if ensure_tables:
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            _execute_with_bigquery_dml_retry(
+                execute,
+                build_ensure_gcs_cache_ac_reference_tables_query(settings),
+                parameters=[],
+            ).total_bytes_processed,
+        )
 
     for shard in range(shard_start, resolved_shard_end + 1):
         shard_started_at = perf_counter()
@@ -220,7 +229,8 @@ def run_sync_gcs_cache_ac_references(
             if not dry_run:
                 bytes_processed_total = _add_bytes(
                     bytes_processed_total,
-                    execute(
+                    _execute_with_bigquery_dml_retry(
+                        execute,
                         f"""UPDATE {_table_ref(settings.project_id, settings.dataset, settings.ac_reference_index_state_table)}
 SET indexed_through = NULL
 WHERE shard = {shard}""",
@@ -238,7 +248,8 @@ WHERE shard = {shard}""",
             )
             bytes_processed_total = _add_bytes(
                 bytes_processed_total,
-                execute(
+                _execute_with_bigquery_dml_retry(
+                    execute,
                     build_reconcile_missing_ac_query(
                         settings,
                         shard=shard,
@@ -256,7 +267,8 @@ WHERE shard = {shard}""",
         )
         bytes_processed_total = _add_bytes(
             bytes_processed_total,
-            execute(
+            _execute_with_bigquery_dml_retry(
+                execute,
                 build_replace_gcs_cache_ac_references_query(
                     settings,
                     shard=shard,
@@ -271,7 +283,8 @@ WHERE shard = {shard}""",
         # Only update indexed_through if parse error count is 0.
         bytes_processed_total = _add_bytes(
             bytes_processed_total,
-            execute(
+            _execute_with_bigquery_dml_retry(
+                execute,
                 build_update_gcs_cache_ac_reference_index_state_query(settings),
                 parameters=[
                     BigQueryParameter("shard", "INT64", shard),
@@ -642,6 +655,41 @@ def _ac_shard_expression(column_name: str) -> str:
 
 def _table_ref(project_id: str, dataset: str, table: str) -> str:
     return f"`{project_id}.{dataset}.{table}`"
+
+
+def _execute_with_bigquery_dml_retry(
+    execute: QueryExecutor,
+    query: str,
+    *,
+    parameters: Sequence[BigQueryParameter],
+    max_attempts: int = 5,
+    sleep_seconds: Callable[[float], None] = sleep,
+) -> BigQueryQueryResult:
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return execute(query, parameters)
+        except BigQueryExecutionError as exc:
+            if attempt >= max_attempts or not _is_retryable_bigquery_dml_error(exc):
+                raise
+            delay_seconds = min(60.0, 5.0 * (2 ** (attempt - 1)))
+            logger.warning(
+                "Retry BigQuery DML after transient error: attempt=%s max_attempts=%s "
+                "delay_seconds=%.1f error=%s",
+                attempt,
+                max_attempts,
+                delay_seconds,
+                exc,
+            )
+            sleep_seconds(delay_seconds)
+    raise RuntimeError("unreachable BigQuery DML retry state")
+
+
+def _is_retryable_bigquery_dml_error(exc: BigQueryExecutionError) -> bool:
+    message = str(exc).lower()
+    return (
+        "could not serialize access" in message
+        or "too many table update operations" in message
+    )
 
 
 def _add_bytes(total: int, value: int | None) -> int:

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from itertools import islice
+from random import uniform
 from time import perf_counter, sleep
 
 from cost_insight.common.bigquery import (
@@ -663,14 +664,18 @@ def _execute_with_bigquery_dml_retry(
     parameters: Sequence[BigQueryParameter],
     max_attempts: int = 5,
     sleep_seconds: Callable[[float], None] = sleep,
+    jitter_seconds: Callable[[float], float] = lambda delay: uniform(0.0, delay * 0.5),
 ) -> BigQueryQueryResult:
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be positive")
     for attempt in range(1, max_attempts + 1):
         try:
             return execute(query, parameters)
         except BigQueryExecutionError as exc:
             if attempt >= max_attempts or not _is_retryable_bigquery_dml_error(exc):
                 raise
-            delay_seconds = min(60.0, 5.0 * (2 ** (attempt - 1)))
+            base_delay_seconds = min(60.0, 5.0 * (2 ** (attempt - 1)))
+            delay_seconds = base_delay_seconds + jitter_seconds(base_delay_seconds)
             logger.warning(
                 "Retry BigQuery DML after transient error: attempt=%s max_attempts=%s "
                 "delay_seconds=%.1f error=%s",
@@ -680,15 +685,34 @@ def _execute_with_bigquery_dml_retry(
                 exc,
             )
             sleep_seconds(delay_seconds)
-    raise RuntimeError("unreachable BigQuery DML retry state")
 
 
 def _is_retryable_bigquery_dml_error(exc: BigQueryExecutionError) -> bool:
-    message = str(exc).lower()
+    message = _exception_search_text(exc)
     return (
         "could not serialize access" in message
         or "too many table update operations" in message
+        or "exceeded rate limits" in message
+        or "ratelimitexceeded" in message
+        or "rate limit exceeded" in message
+        or "concurrent update" in message
     )
+
+
+def _exception_search_text(exc: BaseException) -> str:
+    parts = [type(exc).__name__, str(exc)]
+    cause = exc.__cause__
+    if cause is not None:
+        parts.extend([type(cause).__name__, str(cause)])
+        reason = getattr(cause, "reason", None)
+        if reason:
+            parts.append(str(reason))
+        for error in getattr(cause, "errors", ()) or ():
+            if isinstance(error, dict):
+                parts.extend(str(error.get(key, "")) for key in ("reason", "message"))
+            else:
+                parts.append(str(error))
+    return " ".join(parts).lower()
 
 
 def _add_bytes(total: int, value: int | None) -> int:

--- a/cost-insight/tests/test_db_and_cli.py
+++ b/cost-insight/tests/test_db_and_cli.py
@@ -396,6 +396,7 @@ def test_cli_rejects_non_positive_cleanup_safety_buffer_days(capsys) -> None:
 
 def test_cli_runs_sync_gcs_cache_ac_references_without_database(monkeypatch, capsys) -> None:
     calls = []
+    run_kwargs = []
     settings = SimpleNamespace(
         gcp_billing=GcpBillingSettings(account_id="pingcap-testing-account"),
         aws_billing=AwsBillingSettings(),
@@ -409,10 +410,9 @@ def test_cli_runs_sync_gcs_cache_ac_references_without_database(monkeypatch, cap
 
     monkeypatch.setattr(cli, "get_settings", fake_get_settings)
     monkeypatch.setattr(cli, "configure_logging", lambda _level: None)
-    monkeypatch.setattr(
-        cli,
-        "run_sync_gcs_cache_ac_references",
-        lambda **kwargs: SyncGcsCacheAcReferencesSummary(
+    def fake_run_sync_gcs_cache_ac_references(**kwargs):
+        run_kwargs.append(kwargs)
+        return SyncGcsCacheAcReferencesSummary(
             account_id="pingcap-testing-account",
             bucket_name="pingcap-ci-bazel-remote-cache-us-central1",
             mode="bootstrap",
@@ -429,7 +429,12 @@ def test_cli_runs_sync_gcs_cache_ac_references_without_database(monkeypatch, cap
             bytes_processed=33,
             run_started_at=datetime(2026, 6, 22, 0, 0, tzinfo=UTC),
             run_finished_at=datetime(2026, 6, 22, 0, 0, tzinfo=UTC),
-        ),
+        )
+
+    monkeypatch.setattr(
+        cli,
+        "run_sync_gcs_cache_ac_references",
+        fake_run_sync_gcs_cache_ac_references,
     )
 
     exit_code = cli.main(
@@ -442,11 +447,13 @@ def test_cli_runs_sync_gcs_cache_ac_references_without_database(monkeypatch, cap
             "--shard-end",
             "15",
             "--dry-run",
+            "--skip-ensure-tables",
         ]
     )
 
     assert exit_code == 0
     assert calls == [False]
+    assert run_kwargs[0]["ensure_tables"] is False
     assert '"reference_row_count": 22' in capsys.readouterr().out
 
 

--- a/cost-insight/tests/test_sync_gcs_cache_ac_references.py
+++ b/cost-insight/tests/test_sync_gcs_cache_ac_references.py
@@ -257,9 +257,97 @@ def test_execute_with_bigquery_dml_retry_retries_concurrent_update() -> None:
         parameters=[],
         max_attempts=2,
         sleep_seconds=sleeps.append,
+        jitter_seconds=lambda _delay: 0.0,
     )
 
     assert result.total_bytes_processed == 7
+    assert calls == 2
+    assert sleeps == [5.0]
+
+
+def test_execute_with_bigquery_dml_retry_uses_cause_reason() -> None:
+    calls = 0
+    sleeps = []
+
+    class FakeRateLimitError(Exception):
+        reason = "rateLimitExceeded"
+        errors = [{"reason": "rateLimitExceeded", "message": "quota"}]
+
+    def fake_execute(query, parameters):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            cause = FakeRateLimitError("wrapped google error")
+            try:
+                raise BigQueryExecutionError("BigQuery query failed") from cause
+            except BigQueryExecutionError as exc:
+                raise exc
+        return BigQueryQueryResult(rows=(), total_bytes_processed=8)
+
+    result = _execute_with_bigquery_dml_retry(
+        fake_execute,
+        "DELETE FROM table",
+        parameters=[],
+        max_attempts=2,
+        sleep_seconds=sleeps.append,
+        jitter_seconds=lambda _delay: 1.5,
+    )
+
+    assert result.total_bytes_processed == 8
+    assert calls == 2
+    assert sleeps == [6.5]
+
+
+def test_execute_with_bigquery_dml_retry_reraises_non_retryable_error() -> None:
+    calls = 0
+    sleeps = []
+
+    def fake_execute(query, parameters):
+        nonlocal calls
+        calls += 1
+        raise BigQueryExecutionError("Syntax error")
+
+    try:
+        _execute_with_bigquery_dml_retry(
+            fake_execute,
+            "bad query",
+            parameters=[],
+            max_attempts=3,
+            sleep_seconds=sleeps.append,
+            jitter_seconds=lambda _delay: 0.0,
+        )
+    except BigQueryExecutionError as exc:
+        assert "Syntax error" in str(exc)
+    else:
+        raise AssertionError("expected BigQueryExecutionError")
+
+    assert calls == 1
+    assert sleeps == []
+
+
+def test_execute_with_bigquery_dml_retry_reraises_after_max_attempts() -> None:
+    calls = 0
+    sleeps = []
+
+    def fake_execute(query, parameters):
+        nonlocal calls
+        calls += 1
+        raise BigQueryExecutionError("Could not serialize access to table")
+
+    try:
+        _execute_with_bigquery_dml_retry(
+            fake_execute,
+            "DELETE FROM table",
+            parameters=[],
+            max_attempts=2,
+            sleep_seconds=sleeps.append,
+            jitter_seconds=lambda _delay: 0.0,
+        )
+    except BigQueryExecutionError as exc:
+        assert "Could not serialize access" in str(exc)
+    else:
+        raise AssertionError("expected BigQueryExecutionError")
+
     assert calls == 2
     assert sleeps == [5.0]
 

--- a/cost-insight/tests/test_sync_gcs_cache_ac_references.py
+++ b/cost-insight/tests/test_sync_gcs_cache_ac_references.py
@@ -1,12 +1,13 @@
 from datetime import UTC, datetime
 
-from cost_insight.common.bigquery import BigQueryQueryResult
+from cost_insight.common.bigquery import BigQueryExecutionError, BigQueryQueryResult
 from cost_insight.common.config import GcsCacheSettings
 from cost_insight.common.gcs_cache_references import AcReferenceExtraction
 from cost_insight.jobs.sync_gcs_cache_ac_references import (
     build_bootstrap_gcs_cache_ac_reference_source_query,
     build_ensure_gcs_cache_ac_reference_tables_query,
     build_incremental_gcs_cache_ac_reference_source_query,
+    _execute_with_bigquery_dml_retry,
     run_sync_gcs_cache_ac_references,
 )
 
@@ -210,6 +211,57 @@ def test_run_sync_gcs_cache_ac_references_replaces_once_per_shard() -> None:
         in query
     ]
     assert len(replace_queries) == 1
+
+
+def test_run_sync_gcs_cache_ac_references_can_skip_ensure_tables() -> None:
+    captured_queries = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append(query)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        return iter(())
+
+    run_sync_gcs_cache_ac_references(
+        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        mode="bootstrap",
+        shard_start=0,
+        shard_end=0,
+        dry_run=True,
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        ensure_tables=False,
+        now=lambda: datetime(2026, 6, 22, 10, 0, tzinfo=UTC),
+    )
+
+    assert captured_queries == []
+
+
+def test_execute_with_bigquery_dml_retry_retries_concurrent_update() -> None:
+    calls = 0
+    sleeps = []
+
+    def fake_execute(query, parameters):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise BigQueryExecutionError(
+                "Could not serialize access to table due to concurrent update"
+            )
+        return BigQueryQueryResult(rows=(), total_bytes_processed=7)
+
+    result = _execute_with_bigquery_dml_retry(
+        fake_execute,
+        "DELETE FROM table",
+        parameters=[],
+        max_attempts=2,
+        sleep_seconds=sleeps.append,
+    )
+
+    assert result.total_bytes_processed == 7
+    assert calls == 2
+    assert sleeps == [5.0]
 
 
 def test_run_sync_incremental_zero_ref_ac_writes_sentinel_and_filters_insert() -> None:


### PR DESCRIPTION
## Summary
- Add --skip-ensure-tables for sync-gcs-cache-ac-references so parallel shard workers can skip repeated table creation/state initialization after one setup run.
- Retry idempotent AC reference BigQuery DML on transient concurrent update / table update rate limit errors.
- Add jitter to retry backoff to avoid synchronized parallel retries.
- Match retryable errors from both the wrapped BigQueryExecutionError message and its underlying cause/reason/errors.
- Move shard started logs after incremental watermark validation and rename the range field to run_shard_end.

## Context
Parallel one-shard bootstrap Jobs exposed two BigQuery transient failures:
- concurrent DELETE on gcs_cache_object_last_seen_current during missing-AC reconcile
- table update rate limit from repeated ensure-table scripts

This keeps default behavior unchanged while giving the bootstrap rollout a safer path: run one ensure pass, then parallel shard workers with --skip-ensure-tables.

## Validation
- cd cost-insight && python -m ruff check .
- cd cost-insight && python -m pytest
- pytest result: 174 passed, coverage 92.61%
