### PR TITLE
feat(dl): add HEAD support for ks3-obj and gcs-obj via HTTP middleware

### DIFF
--- a/dl/cmd/server/http.go
+++ b/dl/cmd/server/http.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"goa.design/clue/health"
 	goahttp "goa.design/goa/v3/http"
 	httpmdlwr "goa.design/goa/v3/http/middleware"
@@ -25,6 +26,7 @@ import (
 	ks3 "github.com/PingCAP-QE/ee-apps/dl/gen/ks3"
 	oci "github.com/PingCAP-QE/ee-apps/dl/gen/oci"
 	pkgoci "github.com/PingCAP-QE/ee-apps/dl/pkg/oci"
+	"github.com/ks3sdklib/aws-sdk-go/service/s3"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
@@ -33,9 +35,19 @@ type ociRepoProvider interface {
 	GetTargetRepo(repo string) (*remote.Repository, error)
 }
 
+// ks3HeadProvider is implemented by KS3 service types that can check object existence.
+type ks3HeadProvider interface {
+	HeadObject(bucket, key string) (*s3.HeadObjectOutput, error)
+}
+
+// gcsHeadProvider is implemented by GCS service types that can check object existence.
+type gcsHeadProvider interface {
+	HeadObject(ctx context.Context, bucket, key string) (*storage.ObjectAttrs, error)
+}
+
 // handleHTTPServer starts configures and starts a HTTP server on the given
 // URL. It shuts down the server if any error is received in the error channel.
-func handleHTTPServer(ctx context.Context, u *url.URL, ociEndpoints *oci.Endpoints, ks3Endpoints *ks3.Endpoints, gcsEndpoints *gcs.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool, ociSvc oci.Service) {
+func handleHTTPServer(ctx context.Context, u *url.URL, ociEndpoints *oci.Endpoints, ks3Endpoints *ks3.Endpoints, gcsEndpoints *gcs.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool, ociSvc oci.Service, ks3Svc ks3.Service, gcsSvc gcs.Service) {
 
 	// Setup goa log adapter.
 	var (
@@ -100,6 +112,12 @@ func handleHTTPServer(ctx context.Context, u *url.URL, ociEndpoints *oci.Endpoin
 	{
 		if provider, ok := ociSvc.(ociRepoProvider); ok {
 			handler = headOCIMiddleware(provider, logger)(handler)
+		}
+		if provider, ok := ks3Svc.(ks3HeadProvider); ok {
+			handler = headKS3Middleware(provider, logger)(handler)
+		}
+		if provider, ok := gcsSvc.(gcsHeadProvider); ok {
+			handler = headGCSMiddleware(provider, logger)(handler)
 		}
 		handler = httpmdlwr.Log(adapter)(handler)
 		handler = httpmdlwr.RequestID()(handler)
@@ -235,6 +253,83 @@ func headOCIMiddleware(provider ociRepoProvider, logger *log.Logger) func(http.H
 
 			w.Header().Set("Content-Disposition", attachment.ContentDisposition(targetFile))
 			w.Header().Set("Content-Length", fmt.Sprintf("%d", descriptor.Size))
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+}
+
+// headKS3Middleware intercepts HEAD requests to /s3-obj/{bucket}/{*key} and
+// checks object existence without downloading, enabling wget --spider.
+func headKS3Middleware(provider ks3HeadProvider, logger *log.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodHead {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if !strings.HasPrefix(r.URL.Path, "/s3-obj/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			path := strings.TrimPrefix(r.URL.Path, "/s3-obj/")
+			parts := strings.SplitN(path, "/", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				http.Error(w, "invalid path: expected /s3-obj/{bucket}/{key}", http.StatusBadRequest)
+				return
+			}
+
+			result, err := provider.HeadObject(parts[0], parts[1])
+			if err != nil {
+				logger.Printf("HEAD s3-obj: %v", err)
+				http.Error(w, "object not found", http.StatusNotFound)
+				return
+			}
+
+			w.Header().Set("Content-Disposition", attachment.ContentDisposition(parts[1]))
+			if result.ContentLength != nil {
+				w.Header().Set("Content-Length", fmt.Sprintf("%d", *result.ContentLength))
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+}
+
+// headGCSMiddleware intercepts HEAD requests to /gcs-obj/{bucket}/{*key} and
+// checks object existence without downloading, enabling wget --spider.
+func headGCSMiddleware(provider gcsHeadProvider, logger *log.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodHead {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if !strings.HasPrefix(r.URL.Path, "/gcs-obj/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			path := strings.TrimPrefix(r.URL.Path, "/gcs-obj/")
+			parts := strings.SplitN(path, "/", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				http.Error(w, "invalid path: expected /gcs-obj/{bucket}/{key}", http.StatusBadRequest)
+				return
+			}
+
+			ctx := r.Context()
+			attrs, err := provider.HeadObject(ctx, parts[0], parts[1])
+			if err != nil {
+				logger.Printf("HEAD gcs-obj: %v", err)
+				http.Error(w, "object not found", http.StatusNotFound)
+				return
+			}
+
+			w.Header().Set("Content-Disposition", attachment.ContentDisposition(parts[1]))
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", attrs.Size))
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
 		})

--- a/dl/cmd/server/main.go
+++ b/dl/cmd/server/main.go
@@ -107,7 +107,7 @@ func main() {
 			} else if u.Port() == "" {
 				u.Host = net.JoinHostPort(u.Host, "80")
 			}
-			handleHTTPServer(ctx, u, ociEndpoints, ks3Endpoints, gcsEndpoints, &wg, errc, logger, *dbgF, ociSvc)
+			handleHTTPServer(ctx, u, ociEndpoints, ks3Endpoints, gcsEndpoints, &wg, errc, logger, *dbgF, ociSvc, ks3Svc, gcsSvc)
 		}
 
 	default:

--- a/dl/internal/service/gcs/service.go
+++ b/dl/internal/service/gcs/service.go
@@ -65,6 +65,11 @@ func New(logger *log.Logger, cfgFile string) gcs.Service {
 	return &gcssrvc{logger: logger, client: client}
 }
 
+func (s *gcssrvc) HeadObject(ctx context.Context, bucket, key string) (*storage.ObjectAttrs, error) {
+	obj := s.client.Bucket(bucket).Object(key)
+	return obj.Attrs(ctx)
+}
+
 func (s *gcssrvc) DownloadObject(ctx context.Context, p *gcs.DownloadObjectPayload) (res *gcs.DownloadObjectResult, resp io.ReadCloser, err error) {
 	obj := s.client.Bucket(p.Bucket).Object(p.Key)
 	attrs, err := obj.Attrs(ctx)

--- a/dl/internal/service/ks3/service.go
+++ b/dl/internal/service/ks3/service.go
@@ -57,6 +57,15 @@ func New(logger *log.Logger, cfgFile string) ks3.Service {
 	return &ks3srvc{logger: logger, client: newClient(&cfg)}
 }
 
+// HeadObject checks if an object exists in KS3 without downloading.
+func (s *ks3srvc) HeadObject(bucket, key string) (*s3.HeadObjectOutput, error) {
+	headParams := &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+	return s.client.HeadObject(headParams)
+}
+
 // DownloadObject implements download-object.
 func (s *ks3srvc) DownloadObject(ctx context.Context, p *ks3.DownloadObjectPayload) (res *ks3.DownloadObjectResult, resp io.ReadCloser, err error) {
 	getParams := &s3.GetObjectInput{


### PR DESCRIPTION
## Summary

Add HEAD request support for KS3 and GCS object paths in the dl service, enabling `wget --spider` to check object existence without downloading.

## Changes

1. **dl/internal/service/ks3/service.go** - Added `HeadObject(bucket, key)` method that calls S3 `HeadObject` API
2. **dl/internal/service/gcs/service.go** - Added `HeadObject(ctx, bucket, key)` method that calls GCS `obj.Attrs(ctx)`
3. **dl/cmd/server/http.go** - Added `headKS3Middleware` and `headGCSMiddleware` following the existing `headOCIMiddleware` pattern; defined `ks3HeadProvider` and `gcsHeadProvider` interfaces; wired both middlewares in `handleHTTPServer`
4. **dl/cmd/server/main.go** - Passed `ks3Svc` and `gcsSvc` to `handleHTTPServer`

## Testing

- `go build ./...` passes
- `go test ./...` passes

## Risk

Low. Both middlewares are read-only, use existing SDK clients, and follow the production-tested `headOCIMiddleware` pattern. No changes to existing GET endpoints.