### PR TITLE
chore(renovate): stop renovate from monitoring tibuild/ paths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:base"
   ],
+  "ignorePaths": [
+    "tibuild/**"
+  ],
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"


### PR DESCRIPTION
## Summary
Add `ignorePaths` to renovate config so renovate bot no longer monitors or creates dependency update PRs for `tibuild/` paths.

## Changes
- Added `ignorePaths: ["tibuild/**"]` to `.github/renovate.json`

## Testing
No functional changes; renovate config syntax is validated by renovate bot on scan.

## Risk
Low — only affects renovate's scan scope for the `tibuild/` directory.
