### PR TITLE
fix(cost-insight): order clustered dry-run table options

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1295,8 +1295,8 @@ OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {ttl
             bytes_processed_total,
             execute(
                 f"""CREATE OR REPLACE TABLE {by_cas_table}
-OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 CLUSTER BY cas_object_name, ac_object_name
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 AS
 SELECT ac_object_name, cas_object_name
 FROM {_table_ref(settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table)}""",

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -1119,6 +1119,10 @@ def test_run_cleanup_gcs_cache_from_index_dry_run_returns_summary_with_candidate
     assert summary.candidate_cas_object_count >= 0
     assert summary.candidate_ac_object_count >= 0
     assert summary.candidate_cas_delete_object_count >= 0
+    by_cas_dryrun_query = next(
+        query for query, _ in captured_queries if "by_cas_dryrun" in query
+    )
+    assert by_cas_dryrun_query.index("CLUSTER BY") < by_cas_dryrun_query.index("OPTIONS")
 
 
 def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Fix `cas-from-index` dry-run temp `by_cas` table DDL by placing `CLUSTER BY` before `OPTIONS`.
- Add a regression assertion for the generated SQL order.

## Why

Manual dry-run with relaxed AC reference staleness failed in BigQuery:

```text
Syntax error: Expected end of input but got keyword CLUSTER
```

BigQuery expects `CREATE TABLE ... CLUSTER BY ... OPTIONS ... AS SELECT`, not `OPTIONS ... CLUSTER BY ...`.

## Validation

- `python -m ruff check cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py cost-insight/tests/test_cleanup_gcs_cache.py`
- `cd cost-insight && python -m pytest` (`174 passed`, coverage `92.61%`)
