### PR TITLE
fix(cost-insight): cap index cleanup by CAS candidates

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1295,8 +1295,8 @@ OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {ttl
             bytes_processed_total,
             execute(
                 f"""CREATE OR REPLACE TABLE {by_cas_table}
-OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 CLUSTER BY cas_object_name, ac_object_name
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 AS
 SELECT ac_object_name, cas_object_name
 FROM {_table_ref(settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table)}""",

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -199,7 +199,6 @@ def run_cleanup_gcs_cache(
             cleanup_safety_buffer_days=resolved_safety_buffer_days,
             cleanup_sample_limit=resolved_sample_limit,
             cleanup_max_delete_objects=resolved_max_delete_objects,
-            cleanup_max_delete_ac_objects=settings.cleanup_max_delete_ac_objects,
             cleanup_max_delete_cas_objects=(
                 resolved_max_delete_objects
                 if max_delete_objects is not None

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -199,12 +199,12 @@ def run_cleanup_gcs_cache(
             cleanup_safety_buffer_days=resolved_safety_buffer_days,
             cleanup_sample_limit=resolved_sample_limit,
             cleanup_max_delete_objects=resolved_max_delete_objects,
-            cleanup_max_delete_ac_objects=(
-                max_delete_objects
+            cleanup_max_delete_ac_objects=settings.cleanup_max_delete_ac_objects,
+            cleanup_max_delete_cas_objects=(
+                resolved_max_delete_objects
                 if max_delete_objects is not None
-                else settings.cleanup_max_delete_ac_objects
+                else resolved_max_delete_cas_objects
             ),
-            cleanup_max_delete_cas_objects=resolved_max_delete_cas_objects,
             cleanup_max_delete_cas_bytes=settings.cleanup_max_delete_cas_bytes,
             cleanup_cas_preselect_limit=settings.cleanup_cas_preselect_limit,
             cleanup_ac_delete_batch_size=settings.cleanup_ac_delete_batch_size,
@@ -1078,7 +1078,6 @@ def build_ac_reverse_lookup_query(
     cold_cas_table: str,
     snapshot_time: str,
     ac_cutoff_days: int,
-    ac_object_cap: int,
     by_cas_table_override: str | None = None,
 ) -> str:
     """Find cold ACs that reference the bounded cold CAS set."""
@@ -1100,7 +1099,39 @@ JOIN {current_table} AS cur
  AND cur.object_kind = 'ac'
  AND cur.last_seen_at < TIMESTAMP_SUB(TIMESTAMP('{snapshot_time}'), INTERVAL {ac_cutoff_days} DAY)
 ORDER BY cur.last_seen_at ASC
-LIMIT {ac_object_cap}
+""".strip()
+
+
+def build_cas_ready_for_cascade_query(
+    settings: GcsCacheSettings,
+    *,
+    cold_cas_table: str,
+    snapshot_time: str,
+    ac_cutoff_days: int,
+    by_cas_table_override: str | None = None,
+) -> str:
+    """Keep cold CAS only when every indexed AC reference is known and cold."""
+    by_cas_table = by_cas_table_override or _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_cas_table
+    )
+    current_table = _table_ref(
+        settings.project_id, settings.dataset, settings.last_seen_current_table
+    )
+    return f"""
+SELECT cas.object_name, cas.last_seen_at, cas.size_bytes, cas.generation
+FROM {cold_cas_table} AS cas
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM {by_cas_table} AS refs
+  LEFT JOIN {current_table} AS cur
+    ON cur.object_name = refs.ac_object_name
+   AND cur.object_kind = 'ac'
+  WHERE refs.cas_object_name = cas.object_name
+    AND (
+      cur.object_name IS NULL
+      OR cur.last_seen_at >= TIMESTAMP_SUB(TIMESTAMP('{snapshot_time}'), INTERVAL {ac_cutoff_days} DAY)
+    )
+)
 """.strip()
 
 
@@ -1304,6 +1335,9 @@ FROM {_table_ref(settings.project_id, settings.dataset, settings.ac_cas_refs_by_
             ).total_bytes_processed,
         )
     else:
+        by_cas_table = _table_ref(
+            settings.project_id, settings.dataset, settings.ac_cas_refs_by_cas_table
+        )
         bytes_processed_total = _add_bytes(
             bytes_processed_total,
             execute(
@@ -1395,6 +1429,26 @@ WHERE rn <= {settings.cleanup_max_delete_cas_objects}
     cold_cas_count = _count_table_rows(execute=execute, table_ref=cold_cas_table)
     bytes_processed_total = _add_bytes(bytes_processed_total, cold_cas_count.bytes_processed)
 
+    ready_cas_table = _tmp_table_ref(settings, "ready_cas", run_id=run_id)
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            f"""CREATE OR REPLACE TABLE {ready_cas_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{build_cas_ready_for_cascade_query(
+    settings,
+    cold_cas_table=cold_cas_table,
+    snapshot_time=snapshot_time,
+    ac_cutoff_days=ac_cutoff_days,
+    by_cas_table_override=by_cas_table,
+)}""",
+            parameters=[],
+        ).total_bytes_processed,
+    )
+    ready_cas_count = _count_table_rows(execute=execute, table_ref=ready_cas_table)
+    bytes_processed_total = _add_bytes(bytes_processed_total, ready_cas_count.bytes_processed)
+
     # ---- AC reverse lookup + deletion (dry-run: compute only) ----
     if mode == "dry-run":
         ac_candidate_table = _tmp_table_ref(settings, "ac_to_delete", run_id=run_id)
@@ -1404,10 +1458,9 @@ OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DA
 AS
 {build_ac_reverse_lookup_query(
     settings,
-    cold_cas_table=cold_cas_table,
+    cold_cas_table=ready_cas_table,
     snapshot_time=snapshot_time,
     ac_cutoff_days=ac_cutoff_days,
-    ac_object_cap=settings.cleanup_max_delete_ac_objects,
     by_cas_table_override=by_cas_table,
 )}""",
             parameters=[],
@@ -1415,21 +1468,6 @@ AS
         ac_candidate_count = _count_table_rows(execute=execute, table_ref=ac_candidate_table)
         bytes_processed_total = _add_bytes(bytes_processed_total, ac_candidate_count.bytes_processed)
         candidate_ac_count = ac_candidate_count.object_count
-
-        # Zero-ref CAS based on dry-run by_cas snapshot
-        zero_ref_table = _tmp_table_ref(settings, "cas_zero_ref", run_id=run_id)
-        bytes_processed_total = _add_bytes(
-            bytes_processed_total,
-            execute(
-                f"""CREATE OR REPLACE TABLE {zero_ref_table}
-OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
-AS
-{build_zero_ref_cas_query(settings, cold_cas_table=cold_cas_table, by_cas_table_override=by_cas_table)}""",
-                parameters=[],
-            ).total_bytes_processed,
-        )
-        zero_ref_count = _count_table_rows(execute=execute, table_ref=zero_ref_table)
-        bytes_processed_total = _add_bytes(bytes_processed_total, zero_ref_count.bytes_processed)
 
         run_finished_at = now()
         return CleanupGcsCacheSummary(
@@ -1444,7 +1482,7 @@ AS
             safety_buffer_days=settings.cleanup_safety_buffer_days,
             candidate_cas_object_count=cold_cas_count.object_count,
             candidate_ac_object_count=candidate_ac_count,
-            candidate_cas_delete_object_count=zero_ref_count.object_count,
+            candidate_cas_delete_object_count=ready_cas_count.object_count,
             ac_parse_error_count=0,
             selected_ac_object_count=0,
             selected_cas_object_count=0,
@@ -1467,7 +1505,7 @@ AS
         load_jsonl_file=load_jsonl_file,
         create_batch_job=create_batch_job,
         wait_for_batch_job=wait_for_batch_job,
-        cold_cas_table=cold_cas_table,
+        cold_cas_table=ready_cas_table,
         snapshot_time=snapshot_time,
         ac_cutoff_days=ac_cutoff_days,
         run_id=run_id,
@@ -1499,7 +1537,7 @@ AS
             f"""CREATE OR REPLACE TABLE {zero_ref_table}
 OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 AS
-{build_zero_ref_cas_query(settings, cold_cas_table=cold_cas_table)}""",
+{build_zero_ref_cas_query(settings, cold_cas_table=ready_cas_table)}""",
             parameters=[],
         ).total_bytes_processed,
     )
@@ -1718,7 +1756,6 @@ AS
     cold_cas_table=cold_cas_table,
     snapshot_time=snapshot_time,
     ac_cutoff_days=ac_cutoff_days,
-    ac_object_cap=settings.cleanup_max_delete_ac_objects,
 )}""",
         parameters=[],
     ).total_bytes_processed

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -196,12 +196,24 @@ def build_parser() -> argparse.ArgumentParser:
     cleanup_gcs_cache.add_argument("--ac-retention-days", type=_parse_positive_int, default=None)
     cleanup_gcs_cache.add_argument("--cas-retention-days", type=_parse_positive_int, default=None)
     cleanup_gcs_cache.add_argument("--safety-buffer-days", type=_parse_positive_int, default=None)
-    cleanup_gcs_cache.add_argument("--max-delete-objects", type=_parse_positive_int, default=None)
+    cleanup_gcs_cache.add_argument(
+        "--max-delete-objects",
+        type=_parse_positive_int,
+        default=None,
+        help=(
+            "Maximum delete target count. For --execute-kind cas-from-index, "
+            "this caps CAS candidates; referenced cold ACs are expanded and "
+            "deleted first."
+        ),
+    )
     cleanup_gcs_cache.add_argument(
         "--max-delete-cas-objects",
         type=_parse_positive_int,
         default=None,
-        help="Deprecated compatibility option; ignored by v3 AC-driven cascade cleanup",
+        help=(
+            "CAS candidate cap used by --execute-kind cas-from-index when "
+            "--max-delete-objects is not set."
+        ),
     )
     cleanup_gcs_cache.add_argument("--sample-limit", type=_parse_positive_int, default=None)
 

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -22,6 +22,7 @@ from cost_insight.jobs.cleanup_gcs_cache import (
     build_cleanup_gcs_cache_reconcile_deleted_cas_query,
     build_cleanup_gcs_cache_run_references_table_query,
     build_cleanup_gcs_cache_summary_query,
+    build_cas_ready_for_cascade_query,
     run_cleanup_gcs_cache,
 )
 
@@ -38,6 +39,27 @@ def test_cleanup_gcs_cache_summary_query_targets_current_and_reference_tables() 
     assert "@ac_cutoff_days" in query
     assert "WITH cold_ac AS" in query
     assert "0 AS candidate_cas_object_count" in query
+
+
+def test_cas_ready_for_cascade_query_blocks_warm_ac_references() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    query = build_cas_ready_for_cascade_query(
+        settings,
+        cold_cas_table="`project.dataset.cold_cas`",
+        snapshot_time="2026-07-03 10:00:00 UTC",
+        ac_cutoff_days=11,
+    )
+
+    assert "FROM `project.dataset.cold_cas` AS cas" in query
+    assert "WHERE NOT EXISTS" in query
+    assert "refs.cas_object_name = cas.object_name" in query
+    assert "LEFT JOIN" in query
+    assert "cur.object_kind = 'ac'" in query
+    assert "cur.object_name IS NULL" in query
+    assert (
+        "cur.last_seen_at >= TIMESTAMP_SUB(TIMESTAMP('2026-07-03 10:00:00 UTC'), "
+        "INTERVAL 11 DAY)"
+    ) in query
 
 
 def test_cleanup_gcs_cache_manifest_export_query_uses_generation() -> None:
@@ -1245,7 +1267,7 @@ def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatc
 
 
 def test_cas_from_index_respects_max_delete_objects_canary(monkeypatch) -> None:
-    """cas-from-index --max-delete-objects 500 limits AC deletion to 500."""
+    """cas-from-index --max-delete-objects 500 limits CAS selection to 500."""
     from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
 
     monkeypatch.setattr(
@@ -1301,14 +1323,18 @@ def test_cas_from_index_respects_max_delete_objects_canary(monkeypatch) -> None:
         run_id_factory=lambda: "test-canary",
     )
 
-    # The AC reverse lookup query should have LIMIT 500, not the default 100000
+    cold_cas_queries = [q for q in captured_queries if "CREATE OR REPLACE TABLE" in q and "cold_cas" in q]
+    assert len(cold_cas_queries) >= 1
+    assert "rn <= 500" in cold_cas_queries[0]
+
+    # AC refs are expanded for the selected CAS set and are not independently capped.
     ac_queries = [q for q in captured_queries if "ac_to_delete" in q]
     assert len(ac_queries) >= 1
-    assert "LIMIT 500" in ac_queries[0]
+    assert "LIMIT 500" not in ac_queries[0]
 
 
-def test_cas_from_index_default_ac_cap_without_max_delete_objects(monkeypatch) -> None:
-    """cas-from-index uses default cleanup_max_delete_ac_objects=100000 when no flag."""
+def test_cas_from_index_default_cas_cap_without_max_delete_objects(monkeypatch) -> None:
+    """cas-from-index uses the default CAS cap when no max-delete flag is set."""
     from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
 
     monkeypatch.setattr(
@@ -1361,10 +1387,13 @@ def test_cas_from_index_default_ac_cap_without_max_delete_objects(monkeypatch) -
         resolve_object_metadata=fake_resolve_metadata,
         load_jsonl_file=fake_load_jsonl,
         now=lambda: now,
-        run_id_factory=lambda: "test-default-ac-cap",
+        run_id_factory=lambda: "test-default-cas-cap",
     )
 
-    # Default AC cap is 100000 (not 10000000)
+    cold_cas_queries = [q for q in captured_queries if "CREATE OR REPLACE TABLE" in q and "cold_cas" in q]
+    assert len(cold_cas_queries) >= 1
+    assert "rn <= 10000" in cold_cas_queries[0]
+
     ac_queries = [q for q in captured_queries if "ac_to_delete" in q]
     assert len(ac_queries) >= 1
-    assert "LIMIT 100000" in ac_queries[0]
+    assert "LIMIT 100000" not in ac_queries[0]

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -1119,6 +1119,10 @@ def test_run_cleanup_gcs_cache_from_index_dry_run_returns_summary_with_candidate
     assert summary.candidate_cas_object_count >= 0
     assert summary.candidate_ac_object_count >= 0
     assert summary.candidate_cas_delete_object_count >= 0
+    by_cas_dryrun_query = next(
+        query for query, _ in captured_queries if "by_cas_dryrun" in query
+    )
+    assert by_cas_dryrun_query.index("CLUSTER BY") < by_cas_dryrun_query.index("OPTIONS")
 
 
 def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatch) -> None:

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -1323,7 +1323,12 @@ def test_cas_from_index_respects_max_delete_objects_canary(monkeypatch) -> None:
         run_id_factory=lambda: "test-canary",
     )
 
-    cold_cas_queries = [q for q in captured_queries if "CREATE OR REPLACE TABLE" in q and "cold_cas" in q]
+    cold_cas_table = (
+        "`pingcap-testing-account.ci_bazel_cache_logs._tmp_cold_cas_test-canary`"
+    )
+    cold_cas_queries = [
+        q for q in captured_queries if f"CREATE OR REPLACE TABLE {cold_cas_table}" in q
+    ]
     assert len(cold_cas_queries) >= 1
     assert "rn <= 500" in cold_cas_queries[0]
 
@@ -1390,7 +1395,12 @@ def test_cas_from_index_default_cas_cap_without_max_delete_objects(monkeypatch) 
         run_id_factory=lambda: "test-default-cas-cap",
     )
 
-    cold_cas_queries = [q for q in captured_queries if "CREATE OR REPLACE TABLE" in q and "cold_cas" in q]
+    cold_cas_table = (
+        "`pingcap-testing-account.ci_bazel_cache_logs._tmp_cold_cas_test-default-cas-cap`"
+    )
+    cold_cas_queries = [
+        q for q in captured_queries if f"CREATE OR REPLACE TABLE {cold_cas_table}" in q
+    ]
     assert len(cold_cas_queries) >= 1
     assert "rn <= 10000" in cold_cas_queries[0]
 


### PR DESCRIPTION
## Summary
- make cas-from-index --max-delete-objects cap CAS candidates instead of AC refs
- add ready CAS filtering so CAS with warm or unresolved AC refs is skipped
- expand all cold AC refs for ready CAS before CAS deletion
- clarify cleanup-gcs-cache cap flag help text

## Notes
- dry-run skips stale AC reconciliation, so ghost AC refs can make the dry-run estimate more conservative than delete mode
- candidate_cas_delete_object_count in cas-from-index dry-run now means ready CAS count, including CAS that become deletable after referenced cold ACs are deleted

## Validation
- python -m ruff check cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py cost-insight/src/cost_insight/jobs/cli.py cost-insight/tests/test_cleanup_gcs_cache.py
- cd cost-insight && python -m pytest