### PR TITLE
feat(dl): add config hot-reload support for GCS, KS3, and OCI services

### DIFF
--- a/dl/cmd/server/main.go
+++ b/dl/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	gcssvc "github.com/PingCAP-QE/ee-apps/dl/internal/service/gcs"
 	ks3svc "github.com/PingCAP-QE/ee-apps/dl/internal/service/ks3"
 	ocisvc "github.com/PingCAP-QE/ee-apps/dl/internal/service/oci"
+	"github.com/PingCAP-QE/ee-apps/dl/pkg/reload"
 )
 
 func main() {
@@ -82,6 +83,28 @@ func main() {
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start config file watchers for hot reload.
+	{
+		type reloader interface {
+			Reload(ctx context.Context, cfgFile string) error
+		}
+		if r, ok := gcsSvc.(reloader); ok {
+			go reload.WatchFile(ctx, *gcsCfgPathF, logger, func() error {
+				return r.Reload(ctx, *gcsCfgPathF)
+			})
+		}
+		if r, ok := ks3Svc.(reloader); ok {
+			go reload.WatchFile(ctx, *ks3CfgPathF, logger, func() error {
+				return r.Reload(ctx, *ks3CfgPathF)
+			})
+		}
+		if r, ok := ociSvc.(reloader); ok {
+			go reload.WatchFile(ctx, *ociCfgPathF, logger, func() error {
+				return r.Reload(ctx, *ociCfgPathF)
+			})
+		}
+	}
 
 	// Start the servers and send errors (if any) to the error channel.
 	switch *hostF {

--- a/dl/internal/service/gcs/service.go
+++ b/dl/internal/service/gcs/service.go
@@ -2,11 +2,14 @@ package gcs
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/option"
@@ -17,9 +20,12 @@ import (
 	pkggcs "github.com/PingCAP-QE/ee-apps/dl/pkg/gcs"
 )
 
+var errGCSNotConfigured = errors.New("GCS is not configured")
+
 type gcssrvc struct {
 	logger *log.Logger
 	client *storage.Client
+	mu     sync.RWMutex
 }
 
 func newClient(ctx context.Context, cfg *pkggcs.Config) (*storage.Client, error) {
@@ -40,33 +46,84 @@ func isJSONFile(filename string) bool {
 }
 
 func New(logger *log.Logger, cfgFile string) gcs.Service {
+	if cfgFile == "" {
+		return &gcssrvc{logger: logger}
+	}
+
 	var cfg pkggcs.Config
 
-	if cfgFile != "" {
-		cfgBytes, err := os.ReadFile(cfgFile)
-		if err != nil {
-			logger.Printf("Config file %q not found, using Application Default Credentials", cfgFile)
-		} else {
-			if isJSONFile(cfgFile) {
-				cfg.CredentialsJSON = string(cfgBytes)
-			} else {
-				if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
-					logger.Fatalf("Failed to load configuration: %v", err)
-				}
-			}
+	cfgBytes, err := os.ReadFile(cfgFile)
+	if err != nil {
+		logger.Printf("Config file %q not found, GCS service unavailable", cfgFile)
+		return &gcssrvc{logger: logger}
+	}
+
+	if isJSONFile(cfgFile) {
+		cfg.CredentialsJSON = string(cfgBytes)
+	} else {
+		if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+			logger.Fatalf("Failed to load configuration: %v", err)
 		}
 	}
 
 	client, err := newClient(context.Background(), &cfg)
 	if err != nil {
-		logger.Fatalf("Failed to create GCS client: %v", err)
+		logger.Printf("Failed to create GCS client: %v", err)
+		return &gcssrvc{logger: logger}
 	}
 
 	return &gcssrvc{logger: logger, client: client}
 }
 
+func (s *gcssrvc) getClient() (*storage.Client, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.client == nil {
+		return nil, errGCSNotConfigured
+	}
+	return s.client, nil
+}
+
+// Reload re-reads the config file and recreates the GCS client. It is safe for
+// concurrent use with DownloadObject and HeadObject.
+func (s *gcssrvc) Reload(ctx context.Context, cfgFile string) error {
+	var cfg pkggcs.Config
+	cfgBytes, err := os.ReadFile(cfgFile)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %q: %w", cfgFile, err)
+	}
+	if isJSONFile(cfgFile) {
+		cfg.CredentialsJSON = string(cfgBytes)
+	} else {
+		if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+			return fmt.Errorf("failed to parse config file %q: %w", cfgFile, err)
+		}
+	}
+	client, err := newClient(ctx, &cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create GCS client from %q: %w", cfgFile, err)
+	}
+
+	s.mu.Lock()
+	old := s.client
+	s.client = client
+	s.mu.Unlock()
+
+	if old != nil {
+		old.Close()
+	}
+
+	s.logger.Printf("GCS client reloaded from %q", cfgFile)
+	return nil
+}
+
 func (s *gcssrvc) DownloadObject(ctx context.Context, p *gcs.DownloadObjectPayload) (res *gcs.DownloadObjectResult, resp io.ReadCloser, err error) {
-	obj := s.client.Bucket(p.Bucket).Object(p.Key)
+	client, err := s.getClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	obj := client.Bucket(p.Bucket).Object(p.Key)
 	attrs, err := obj.Attrs(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -91,7 +148,12 @@ func (s *gcssrvc) DownloadObject(ctx context.Context, p *gcs.DownloadObjectPaylo
 
 // HeadObject implements head-object.
 func (s *gcssrvc) HeadObject(ctx context.Context, p *gcs.HeadObjectPayload) (*gcs.HeadObjectResult, error) {
-	obj := s.client.Bucket(p.Bucket).Object(p.Key)
+	client, err := s.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	obj := client.Bucket(p.Bucket).Object(p.Key)
 	attrs, err := obj.Attrs(ctx)
 	if err != nil {
 		return nil, err

--- a/dl/internal/service/ks3/service.go
+++ b/dl/internal/service/ks3/service.go
@@ -2,10 +2,12 @@ package ks3
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/ks3sdklib/aws-sdk-go/aws"
 	"github.com/ks3sdklib/aws-sdk-go/aws/credentials"
@@ -21,6 +23,7 @@ import (
 type ks3srvc struct {
 	logger *log.Logger
 	client *s3.S3
+	mu     sync.RWMutex
 }
 
 func newClient(cfg *pkgks3.Config) *s3.S3 {
@@ -45,7 +48,6 @@ func newClient(cfg *pkgks3.Config) *s3.S3 {
 // New returns the ks3 service implementation.
 func New(logger *log.Logger, cfgFile string) ks3.Service {
 	var cfg pkgks3.Config
-
 	cfgBytes, err := os.ReadFile(cfgFile)
 	if err != nil {
 		logger.Fatalf("Failed to load configuration: %v", err)
@@ -53,8 +55,33 @@ func New(logger *log.Logger, cfgFile string) ks3.Service {
 	if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
 		logger.Fatalf("Failed to load configuration: %v", err)
 	}
-
 	return &ks3srvc{logger: logger, client: newClient(&cfg)}
+}
+
+func (s *ks3srvc) getClient() *s3.S3 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.client
+}
+
+// Reload re-reads the config file and recreates the KS3 client. It is safe for
+// concurrent use with DownloadObject and HeadObject.
+func (s *ks3srvc) Reload(ctx context.Context, cfgFile string) error {
+	var cfg pkgks3.Config
+	cfgBytes, err := os.ReadFile(cfgFile)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %q: %w", cfgFile, err)
+	}
+	if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+		return fmt.Errorf("failed to parse config file %q: %w", cfgFile, err)
+	}
+
+	s.mu.Lock()
+	s.client = newClient(&cfg)
+	s.mu.Unlock()
+
+	s.logger.Printf("KS3 client reloaded from %q", cfgFile)
+	return nil
 }
 
 // DownloadObject implements download-object.
@@ -64,7 +91,7 @@ func (s *ks3srvc) DownloadObject(ctx context.Context, p *ks3.DownloadObjectPaylo
 		Key:    aws.String(p.Key),
 	}
 
-	getObjectOutput, err := s.client.GetObject(getParams)
+	getObjectOutput, err := s.getClient().GetObject(getParams)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -86,7 +113,7 @@ func (s *ks3srvc) DownloadObject(ctx context.Context, p *ks3.DownloadObjectPaylo
 
 // HeadObject implements head-object.
 func (s *ks3srvc) HeadObject(ctx context.Context, p *ks3.HeadObjectPayload) (*ks3.HeadObjectResult, error) {
-	output, err := s.client.HeadObject(&s3.HeadObjectInput{
+	output, err := s.getClient().HeadObject(&s3.HeadObjectInput{
 		Bucket: aws.String(p.Bucket),
 		Key:    aws.String(p.Key),
 	})

--- a/dl/internal/service/oci/service.go
+++ b/dl/internal/service/oci/service.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	oci "github.com/PingCAP-QE/ee-apps/dl/gen/oci"
 	"github.com/PingCAP-QE/ee-apps/dl/pkg/attachment"
@@ -23,6 +24,7 @@ import (
 type ocisrvc struct {
 	logger     *log.Logger
 	credential *auth.Credential
+	mu         sync.RWMutex
 }
 
 // New returns the oci service implementation.
@@ -63,6 +65,37 @@ func (s *ocisrvc) ListFiles(ctx context.Context, p *oci.ListFilesPayload) (res [
 	return files, nil
 }
 
+func (s *ocisrvc) getCredential() *auth.Credential {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.credential
+}
+
+// Reload re-reads the config file and updates the OCI credentials. It is safe
+// for concurrent use with all other methods.
+func (s *ocisrvc) Reload(ctx context.Context, cfgFile string) error {
+	var cfg pkgoci.Config
+	cfgBytes, err := os.ReadFile(cfgFile)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %q: %w", cfgFile, err)
+	}
+	if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+		return fmt.Errorf("failed to parse config file %q: %w", cfgFile, err)
+	}
+
+	cred := &auth.Credential{
+		Username: cfg.Username,
+		Password: cfg.Password,
+	}
+
+	s.mu.Lock()
+	s.credential = cred
+	s.mu.Unlock()
+
+	s.logger.Printf("OCI credentials reloaded from %q", cfgFile)
+	return nil
+}
+
 // GetTargetRepo creates a remote.Repository with auth configured for the given repo string.
 func (s *ocisrvc) GetTargetRepo(repo string) (*remote.Repository, error) {
 	repository, err := remote.NewRepository(repo)
@@ -74,7 +107,7 @@ func (s *ocisrvc) GetTargetRepo(repo string) (*remote.Repository, error) {
 	repository.Client = &auth.Client{
 		Client:     retry.DefaultClient,
 		Cache:      auth.DefaultCache,
-		Credential: auth.StaticCredential(reg, *s.credential),
+		Credential: auth.StaticCredential(reg, *s.getCredential()),
 	}
 
 	return repository, nil

--- a/dl/pkg/reload/watcher.go
+++ b/dl/pkg/reload/watcher.go
@@ -1,0 +1,42 @@
+package reload
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+)
+
+const interval = 30 * time.Second
+
+// WatchFile polls filePath for modification. When the file changes (or appears
+// after not existing), it calls reloadFn. Runs until ctx is cancelled.
+func WatchFile(ctx context.Context, filePath string, logger *log.Logger, reloadFn func() error) {
+	if filePath == "" {
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastMod time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fi, err := os.Stat(filePath)
+			if err != nil {
+				continue
+			}
+			modTime := fi.ModTime()
+			if modTime.After(lastMod) {
+				lastMod = modTime
+				logger.Printf("Config %q changed, reloading...", filePath)
+				if err := reloadFn(); err != nil {
+					logger.Printf("Reload of %q failed: %v", filePath, err)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Summary

Add configuration hot-reload capability to avoid service restart when config files change.

### Changes

- **pkg/reload/watcher.go**: Generic file polling watcher — checks config file `ModTime` every 30s and triggers a reload callback on change.
- **GCS service**: Added `Reload()` method with `sync.RWMutex` protection. Old `storage.Client` is closed after swap. Without GCS config, service starts gracefully and activates when the config file appears.
- **KS3 service**: Added `Reload()` method with `sync.RWMutex` protection.
- **OCI service**: Added `Reload()` method with `sync.RWMutex` protection.
- **cmd/server/main.go**: Starts a watcher goroutine for each config file (GCS/KS3/OCI), cancelled via `context.WithCancel` on shutdown.

### Usage

```bash
# Start without GCS config
./server

# Later create gcs.yaml — service picks it up within 30s without restart
echo "credentials_json: '...'" > gcs.yaml
```