### PR TITLE
fix(cost-insight): alias stale AC candidates for metadata stage

### DIFF
--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1088,7 +1088,7 @@ def build_ac_reverse_lookup_query(
     )
     return f"""
 SELECT DISTINCT
-  refs.ac_object_name,
+  refs.ac_object_name AS object_name,
   cur.last_seen_at
 FROM {by_cas_table} AS refs
 JOIN {cold_cas_table} AS cas

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1038,7 +1038,7 @@ def build_stale_ac_candidates_query(
         settings.project_id, settings.dataset, settings.last_seen_current_table
     )
     return f"""
-SELECT DISTINCT by_ac.ac_object_name
+SELECT DISTINCT by_ac.ac_object_name AS object_name
 FROM {by_ac_table} AS by_ac
 WHERE NOT EXISTS (
   SELECT 1

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -14,6 +14,7 @@ from cost_insight.common.storage_batch_operations import (
 )
 from cost_insight.jobs.cleanup_gcs_cache import (
     _populate_ac_stage_tables,
+    build_ac_reverse_lookup_query,
     build_cleanup_gcs_cache_cas_candidate_table_query,
     build_cleanup_gcs_cache_final_cas_delete_table_query,
     build_cleanup_gcs_cache_final_ac_delete_table_query,
@@ -69,6 +70,17 @@ def test_stale_ac_candidates_query_outputs_object_name_for_metadata_stage() -> N
     )
 
     assert "by_ac.ac_object_name AS object_name" in query
+
+
+def test_ac_reverse_lookup_query_outputs_object_name_for_metadata_stage() -> None:
+    query = build_ac_reverse_lookup_query(
+        GcsCacheSettings(project_id="pingcap-testing-account"),
+        cold_cas_table="`project.dataset.ready_cas`",
+        snapshot_time="2026-07-03 10:00:00 UTC",
+        ac_cutoff_days=11,
+    )
+
+    assert "refs.ac_object_name AS object_name" in query
 
 
 def test_cleanup_gcs_cache_manifest_export_query_uses_generation() -> None:

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -23,6 +23,7 @@ from cost_insight.jobs.cleanup_gcs_cache import (
     build_cleanup_gcs_cache_run_references_table_query,
     build_cleanup_gcs_cache_summary_query,
     build_cas_ready_for_cascade_query,
+    build_stale_ac_candidates_query,
     run_cleanup_gcs_cache,
 )
 
@@ -60,6 +61,14 @@ def test_cas_ready_for_cascade_query_blocks_warm_ac_references() -> None:
         "cur.last_seen_at >= TIMESTAMP_SUB(TIMESTAMP('2026-07-03 10:00:00 UTC'), "
         "INTERVAL 11 DAY)"
     ) in query
+
+
+def test_stale_ac_candidates_query_outputs_object_name_for_metadata_stage() -> None:
+    query = build_stale_ac_candidates_query(
+        GcsCacheSettings(project_id="pingcap-testing-account")
+    )
+
+    assert "by_ac.ac_object_name AS object_name" in query
 
 
 def test_cleanup_gcs_cache_manifest_export_query_uses_generation() -> None:


### PR DESCRIPTION
## Summary
- fix cas-from-index stale AC reconciliation by returning object_name from stale AC candidate query
- add a regression test for the metadata-stage column contract

## Why
The merged #557 image failed after completing incremental catch-up because stale_ac_candidates exposed ac_object_name while the shared metadata stage reads object_name.

## Validation
- python -m ruff check cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py cost-insight/tests/test_cleanup_gcs_cache.py
- cd cost-insight && python -m pytest