### PR TITLE
fix(cost-insight): parallelize GCS cache catch-up safely

### DIFF
--- a/cost-insight/src/cost_insight/common/config.py
+++ b/cost-insight/src/cost_insight/common/config.py
@@ -78,6 +78,14 @@ class GcsCacheSettings:
     ac_reference_shard_count: int = 256
     ac_reference_batch_size: int = 500
     ac_reference_download_workers: int = 64
+    ac_reference_http_pool_maxsize: int = 128
+    # Catch-up shard workers are capped separately from GCS download workers
+    # because each shard also issues BigQuery DML. Workers are clamped to
+    # min(catch_up_workers, catch_up_max_workers, shard_count, download_workers).
+    # They share ac_reference_download_workers as a global GCS download budget,
+    # so per-shard GCS workers can drop to 1 when catch_up_workers is high.
+    ac_reference_catch_up_workers: int = 4
+    ac_reference_catch_up_max_workers: int = 8
     ac_reference_max_index_staleness_hours: int = 1
     ac_retention_days: int = 10
     cas_retention_days: int = 15
@@ -302,6 +310,30 @@ def load_settings(
                     "COST_GCS_CACHE_AC_REFERENCE_DOWNLOAD_WORKERS",
                 ),
                 64,
+            ),
+            ac_reference_http_pool_maxsize=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_HTTP_POOL_MAXSIZE",
+                    "COST_GCS_CACHE_AC_REFERENCE_HTTP_POOL_MAXSIZE",
+                ),
+                128,
+            ),
+            ac_reference_catch_up_workers=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_CATCH_UP_WORKERS",
+                    "COST_GCS_CACHE_AC_REFERENCE_CATCH_UP_WORKERS",
+                ),
+                4,
+            ),
+            ac_reference_catch_up_max_workers=_read_positive_int_any(
+                env,
+                (
+                    "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_CATCH_UP_MAX_WORKERS",
+                    "COST_GCS_CACHE_AC_REFERENCE_CATCH_UP_MAX_WORKERS",
+                ),
+                8,
             ),
             ac_reference_max_index_staleness_hours=_read_positive_int_any(
                 env,

--- a/cost-insight/src/cost_insight/common/gcs_cache_references.py
+++ b/cost-insight/src/cost_insight/common/gcs_cache_references.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from threading import Event, Lock
 
-from cost_insight.common.gcs_client import create_storage_client
+from cost_insight.common.gcs_client import create_storage_client, resolve_storage_pool_maxsize
 
 
 @dataclass(frozen=True)
@@ -35,6 +35,7 @@ def extract_action_cache_references_batch(
     bucket_name: str,
     ac_object_names: Iterable[str],
     max_workers: int = 64,
+    pool_maxsize: int | None = None,
 ) -> tuple[AcReferenceExtraction, ...]:
     from google.api_core.exceptions import NotFound
 
@@ -42,7 +43,13 @@ def extract_action_cache_references_batch(
     if not names:
         return ()
 
-    client = create_storage_client(project_id=project_id, pool_maxsize=max_workers)
+    client = create_storage_client(
+        project_id=project_id,
+        pool_maxsize=resolve_storage_pool_maxsize(
+            max_workers=max_workers,
+            pool_maxsize=pool_maxsize,
+        ),
+    )
     bucket = client.bucket(bucket_name)
     blob_cache: dict[str, bytes | None | Event | BaseException] = {}
     blob_cache_lock = Lock()

--- a/cost-insight/src/cost_insight/common/gcs_client.py
+++ b/cost-insight/src/cost_insight/common/gcs_client.py
@@ -13,6 +13,14 @@ def create_storage_client(*, project_id: str, pool_maxsize: int):
     return client
 
 
+def resolve_storage_pool_maxsize(*, max_workers: int, pool_maxsize: int | None) -> int:
+    if pool_maxsize is None:
+        return max_workers
+    if pool_maxsize <= 0:
+        return pool_maxsize
+    return max(max_workers, pool_maxsize)
+
+
 def configure_storage_client_http_pool(*, client, pool_maxsize: int) -> None:
     if pool_maxsize <= 0:
         return

--- a/cost-insight/src/cost_insight/common/gcs_objects.py
+++ b/cost-insight/src/cost_insight/common/gcs_objects.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Iterable
 
-from cost_insight.common.gcs_client import create_storage_client
+from cost_insight.common.gcs_client import create_storage_client, resolve_storage_pool_maxsize
 
 
 @dataclass(frozen=True)
@@ -21,12 +21,19 @@ def fetch_object_metadata_batch(
     bucket_name: str,
     object_names: Iterable[str],
     max_workers: int = 64,
+    pool_maxsize: int | None = None,
 ) -> tuple[GcsObjectMetadata, ...]:
     names = tuple(object_names)
     if not names:
         return ()
 
-    client = create_storage_client(project_id=project_id, pool_maxsize=max_workers)
+    client = create_storage_client(
+        project_id=project_id,
+        pool_maxsize=resolve_storage_pool_maxsize(
+            max_workers=max_workers,
+            pool_maxsize=pool_maxsize,
+        ),
+    )
     bucket = client.bucket(bucket_name)
 
     def fetch_one(object_name: str) -> GcsObjectMetadata:

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
-from contextlib import ExitStack
+import logging
 from collections.abc import Callable, Iterable, Iterator, Sequence
-from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import ExitStack
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from itertools import islice
 from pathlib import Path
@@ -35,6 +37,7 @@ ReferenceExtractor = Callable[..., tuple[AcReferenceExtraction, ...]]
 JsonFileLoader = Callable[[str, Path, Sequence[tuple[str, str]], str], None]
 BatchJobCreator = Callable[..., StorageBatchOperationsJob]
 BatchJobWaiter = Callable[..., StorageBatchOperationsJobStatus]
+logger = logging.getLogger(__name__)
 
 # "all" is kept as a compatibility alias for older dry-run CronJob arguments.
 # "cas" is the legacy v3 per-run AC-driven cascade.
@@ -1899,16 +1902,71 @@ def _run_catch_up_sync(
     until: datetime,
     execute: QueryExecutor,
 ) -> None:
-    """Run incremental sync for all 256 shards up to `until`."""
-    run_sync_gcs_cache_ac_references(
-        settings=settings,
-        mode="incremental",
-        shard_start=0,
-        shard_end=settings.ac_reference_shard_count - 1,
-        dry_run=False,
-        execute=execute,
-        now=lambda: until,
+    """Run incremental sync for all AC reference shards up to `until`."""
+    shard_count = settings.ac_reference_shard_count
+    if shard_count <= 0:
+        return
+    if settings.ac_reference_download_workers <= 0:
+        raise ValueError("ac_reference_download_workers must be positive")
+    if settings.ac_reference_catch_up_workers <= 0:
+        raise ValueError("ac_reference_catch_up_workers must be positive")
+    if settings.ac_reference_catch_up_max_workers <= 0:
+        raise ValueError("ac_reference_catch_up_max_workers must be positive")
+    worker_count = min(
+        settings.ac_reference_catch_up_workers,
+        settings.ac_reference_catch_up_max_workers,
+        shard_count,
+        settings.ac_reference_download_workers,
     )
+    per_shard_download_workers = max(1, settings.ac_reference_download_workers // worker_count)
+    catch_up_settings = replace(
+        settings,
+        ac_reference_download_workers=per_shard_download_workers,
+        ac_reference_http_pool_maxsize=max(
+            per_shard_download_workers,
+            settings.ac_reference_http_pool_maxsize // worker_count,
+        ),
+    )
+
+    def sync_one_shard(shard: int) -> None:
+        run_sync_gcs_cache_ac_references(
+            settings=catch_up_settings,
+            mode="incremental",
+            shard_start=shard,
+            shard_end=shard,
+            dry_run=False,
+            execute=execute,
+            now=lambda: until,
+            ensure_tables=False,
+        )
+
+    failed: list[tuple[int, Exception]] = []
+
+    def record_failure(shard: int, exc: Exception) -> None:
+        logger.exception("AC reference catch-up shard failed: shard=%s", shard)
+        failed.append((shard, exc))
+
+    if worker_count <= 1:
+        for shard in range(shard_count):
+            try:
+                sync_one_shard(shard)
+            except Exception as exc:
+                record_failure(shard, exc)
+    else:
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            futures = {executor.submit(sync_one_shard, shard): shard for shard in range(shard_count)}
+            for future in as_completed(futures):
+                shard = futures[future]
+                try:
+                    future.result()
+                except Exception as exc:
+                    record_failure(shard, exc)
+
+    if failed:
+        failed.sort(key=lambda item: item[0])
+        details = ", ".join(f"shard {shard}: {exc}" for shard, exc in failed[:10])
+        suffix = "" if len(failed) <= 10 else f", ... {len(failed) - 10} more"
+        raise RuntimeError(f"AC reference catch-up failed for {len(failed)} shard(s): {details}{suffix}")
 
 
 def _tmp_table_ref(settings: GcsCacheSettings, suffix: str, *, run_id: str = "") -> str:
@@ -1950,6 +2008,7 @@ def _populate_metadata_stage_table(
                     bucket_name=settings.bucket_name,
                     object_names=object_names,
                     max_workers=settings.ac_reference_download_workers,
+                    pool_maxsize=settings.ac_reference_http_pool_maxsize,
                 )
                 live_rows = [
                     {
@@ -2034,6 +2093,7 @@ def _populate_ac_stage_tables(
                     bucket_name=settings.bucket_name,
                     object_names=object_names,
                     max_workers=settings.ac_reference_download_workers,
+                    pool_maxsize=settings.ac_reference_http_pool_maxsize,
                 )
                 live_rows = [
                     {
@@ -2053,6 +2113,7 @@ def _populate_ac_stage_tables(
                         bucket_name=settings.bucket_name,
                         ac_object_names=reference_batch,
                         max_workers=settings.ac_reference_download_workers,
+                        pool_maxsize=settings.ac_reference_http_pool_maxsize,
                     )
                 )
                 parse_failed_names = {

--- a/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
+++ b/cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py
@@ -177,6 +177,7 @@ def run_sync_gcs_cache_ac_references(
                 bucket_name=settings.bucket_name,
                 ac_object_names=batch_object_names,
                 max_workers=settings.ac_reference_download_workers,
+                pool_maxsize=settings.ac_reference_http_pool_maxsize,
             )
 
             for extraction in extractions:
@@ -457,14 +458,14 @@ def build_reconcile_missing_ac_query(
     by_ac_table = _table_ref(
         settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
     )
-    del shard  # kept for caller symmetry
     return f"""
 DELETE FROM {current_table}
 WHERE object_kind = 'ac'
   AND object_name IN (SELECT object_name FROM {missing_stage_table});
 
 DELETE FROM {by_ac_table}
-WHERE ac_object_name IN (SELECT object_name FROM {missing_stage_table});
+WHERE shard = {shard}
+  AND ac_object_name IN (SELECT object_name FROM {missing_stage_table});
 """.strip()
 
 

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -1,6 +1,7 @@
 import json
 import re
 from datetime import UTC, datetime
+from threading import Event, Lock
 
 import pytest
 
@@ -14,6 +15,7 @@ from cost_insight.common.storage_batch_operations import (
 )
 from cost_insight.jobs.cleanup_gcs_cache import (
     _populate_ac_stage_tables,
+    _run_catch_up_sync,
     build_ac_reverse_lookup_query,
     build_cleanup_gcs_cache_cas_candidate_table_query,
     build_cleanup_gcs_cache_final_cas_delete_table_query,
@@ -27,6 +29,248 @@ from cost_insight.jobs.cleanup_gcs_cache import (
     build_stale_ac_candidates_query,
     run_cleanup_gcs_cache,
 )
+
+
+def test_run_catch_up_sync_invokes_all_shards(monkeypatch) -> None:
+    from cost_insight.jobs import cleanup_gcs_cache
+
+    calls: list[dict[str, object]] = []
+    active_count = 0
+    max_active_count = 0
+    lock = Lock()
+    two_workers_active = Event()
+
+    def fake_sync(**kwargs):
+        nonlocal active_count, max_active_count
+        calls.append(kwargs)
+        with lock:
+            active_count += 1
+            max_active_count = max(max_active_count, active_count)
+            if active_count >= 2:
+                two_workers_active.set()
+        two_workers_active.wait(timeout=2)
+        with lock:
+            active_count -= 1
+
+    monkeypatch.setattr(cleanup_gcs_cache, "run_sync_gcs_cache_ac_references", fake_sync)
+
+    until = datetime(2026, 7, 5, 10, 0, tzinfo=UTC)
+    settings = GcsCacheSettings(
+        project_id="pingcap-testing-account",
+        ac_reference_shard_count=4,
+        ac_reference_download_workers=64,
+        ac_reference_catch_up_workers=2,
+        ac_reference_catch_up_max_workers=8,
+    )
+
+    _run_catch_up_sync(settings=settings, until=until, execute=lambda query, parameters: None)
+
+    assert sorted(call["shard_start"] for call in calls) == [0, 1, 2, 3]
+    assert [call["shard_start"] for call in calls] == [call["shard_end"] for call in calls]
+    assert all(call["mode"] == "incremental" for call in calls)
+    assert all(call["ensure_tables"] is False for call in calls)
+    assert all(call["now"]() == until for call in calls)
+    assert all(
+        call["settings"].ac_reference_download_workers == 32
+        for call in calls
+    )
+    assert all(
+        call["settings"].ac_reference_http_pool_maxsize == 64
+        for call in calls
+    )
+    assert max_active_count >= 2
+
+
+def test_run_catch_up_sync_clamps_shard_workers_to_download_budget(monkeypatch) -> None:
+    from cost_insight.jobs import cleanup_gcs_cache
+
+    calls: list[dict[str, object]] = []
+    active_count = 0
+    max_active_count = 0
+    lock = Lock()
+    three_workers_active = Event()
+
+    def fake_sync(**kwargs):
+        nonlocal active_count, max_active_count
+        calls.append(kwargs)
+        with lock:
+            active_count += 1
+            max_active_count = max(max_active_count, active_count)
+            if active_count >= 3:
+                three_workers_active.set()
+        three_workers_active.wait(timeout=2)
+        with lock:
+            active_count -= 1
+
+    monkeypatch.setattr(cleanup_gcs_cache, "run_sync_gcs_cache_ac_references", fake_sync)
+
+    _run_catch_up_sync(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            ac_reference_shard_count=3,
+            ac_reference_download_workers=3,
+            ac_reference_http_pool_maxsize=9,
+            ac_reference_catch_up_workers=100,
+            ac_reference_catch_up_max_workers=8,
+        ),
+        until=datetime(2026, 7, 5, 10, 0, tzinfo=UTC),
+        execute=lambda query, parameters: None,
+    )
+
+    assert sorted(call["shard_start"] for call in calls) == [0, 1, 2]
+    assert max_active_count == 3
+    assert all(call["settings"].ac_reference_download_workers == 1 for call in calls)
+    assert all(call["settings"].ac_reference_http_pool_maxsize == 3 for call in calls)
+
+
+def test_run_catch_up_sync_clamps_shard_workers_to_bigquery_dml_cap(monkeypatch) -> None:
+    from cost_insight.jobs import cleanup_gcs_cache
+
+    calls: list[dict[str, object]] = []
+    active_count = 0
+    max_active_count = 0
+    lock = Lock()
+    two_workers_active = Event()
+
+    def fake_sync(**kwargs):
+        nonlocal active_count, max_active_count
+        calls.append(kwargs)
+        with lock:
+            active_count += 1
+            max_active_count = max(max_active_count, active_count)
+            if active_count >= 2:
+                two_workers_active.set()
+        two_workers_active.wait(timeout=2)
+        with lock:
+            active_count -= 1
+
+    monkeypatch.setattr(cleanup_gcs_cache, "run_sync_gcs_cache_ac_references", fake_sync)
+
+    _run_catch_up_sync(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            ac_reference_shard_count=4,
+            ac_reference_download_workers=64,
+            ac_reference_http_pool_maxsize=128,
+            ac_reference_catch_up_workers=64,
+            ac_reference_catch_up_max_workers=2,
+        ),
+        until=datetime(2026, 7, 5, 10, 0, tzinfo=UTC),
+        execute=lambda query, parameters: None,
+    )
+
+    assert sorted(call["shard_start"] for call in calls) == [0, 1, 2, 3]
+    assert max_active_count == 2
+    assert all(call["settings"].ac_reference_download_workers == 32 for call in calls)
+    assert all(call["settings"].ac_reference_http_pool_maxsize == 64 for call in calls)
+
+
+def test_run_catch_up_sync_reports_failed_shards(monkeypatch, caplog) -> None:
+    from cost_insight.jobs import cleanup_gcs_cache
+
+    def fake_sync(**kwargs):
+        if kwargs["shard_start"] in {1, 3}:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(cleanup_gcs_cache, "run_sync_gcs_cache_ac_references", fake_sync)
+
+    with pytest.raises(RuntimeError, match=r"2 shard\(s\).*shard 1: boom.*shard 3: boom"):
+        _run_catch_up_sync(
+            settings=GcsCacheSettings(
+                project_id="pingcap-testing-account",
+                ac_reference_shard_count=4,
+                ac_reference_download_workers=64,
+                ac_reference_catch_up_workers=2,
+                ac_reference_catch_up_max_workers=8,
+            ),
+            until=datetime(2026, 7, 5, 10, 0, tzinfo=UTC),
+            execute=lambda query, parameters: None,
+        )
+
+    assert "AC reference catch-up shard failed: shard=1" in caplog.text
+    assert "AC reference catch-up shard failed: shard=3" in caplog.text
+    assert "Traceback" in caplog.text
+
+
+def test_run_catch_up_sync_serial_path_aggregates_failed_shards(monkeypatch, caplog) -> None:
+    from cost_insight.jobs import cleanup_gcs_cache
+
+    calls: list[int] = []
+
+    def fake_sync(**kwargs):
+        shard = int(kwargs["shard_start"])
+        calls.append(shard)
+        if shard in {0, 2}:
+            raise RuntimeError(f"boom-{shard}")
+
+    monkeypatch.setattr(cleanup_gcs_cache, "run_sync_gcs_cache_ac_references", fake_sync)
+
+    with pytest.raises(RuntimeError, match=r"2 shard\(s\).*shard 0: boom-0.*shard 2: boom-2"):
+        _run_catch_up_sync(
+            settings=GcsCacheSettings(
+                project_id="pingcap-testing-account",
+                ac_reference_shard_count=3,
+                ac_reference_download_workers=64,
+                ac_reference_catch_up_workers=1,
+                ac_reference_catch_up_max_workers=8,
+            ),
+            until=datetime(2026, 7, 5, 10, 0, tzinfo=UTC),
+            execute=lambda query, parameters: None,
+        )
+
+    assert calls == [0, 1, 2]
+    assert "AC reference catch-up shard failed: shard=0" in caplog.text
+    assert "AC reference catch-up shard failed: shard=2" in caplog.text
+
+
+def test_run_catch_up_sync_returns_when_shard_count_is_zero(monkeypatch) -> None:
+    from cost_insight.jobs import cleanup_gcs_cache
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        cleanup_gcs_cache,
+        "run_sync_gcs_cache_ac_references",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    _run_catch_up_sync(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            ac_reference_shard_count=0,
+            ac_reference_download_workers=64,
+            ac_reference_catch_up_workers=4,
+        ),
+        until=datetime(2026, 7, 5, 10, 0, tzinfo=UTC),
+        execute=lambda query, parameters: None,
+    )
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    (
+        ("ac_reference_download_workers", "ac_reference_download_workers must be positive"),
+        ("ac_reference_catch_up_workers", "ac_reference_catch_up_workers must be positive"),
+        ("ac_reference_catch_up_max_workers", "ac_reference_catch_up_max_workers must be positive"),
+    ),
+)
+def test_run_catch_up_sync_rejects_non_positive_worker_settings(field, message) -> None:
+    settings_kwargs = {
+        "project_id": "pingcap-testing-account",
+        "ac_reference_shard_count": 1,
+        "ac_reference_download_workers": 64,
+        "ac_reference_catch_up_workers": 4,
+        "ac_reference_catch_up_max_workers": 8,
+        field: 0,
+    }
+
+    with pytest.raises(ValueError, match=message):
+        _run_catch_up_sync(
+            settings=GcsCacheSettings(**settings_kwargs),
+            until=datetime(2026, 7, 5, 10, 0, tzinfo=UTC),
+            execute=lambda query, parameters: None,
+        )
 
 
 def test_cleanup_gcs_cache_summary_query_targets_current_and_reference_tables() -> None:

--- a/cost-insight/tests/test_config.py
+++ b/cost-insight/tests/test_config.py
@@ -106,6 +106,9 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_CURRENT_TABLE": "current_table",
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT": "CustomTransferService",
             "COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_PRINCIPAL_EMAIL": "cleanup@example.com",
+            "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_HTTP_POOL_MAXSIZE": "256",
+            "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_CATCH_UP_WORKERS": "16",
+            "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_CATCH_UP_MAX_WORKERS": "12",
             "COST_INSIGHT_GCS_CACHE_AC_REFERENCE_MAX_INDEX_STALENESS_HOURS": "6",
             "COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS": "21",
             "COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS": "35",
@@ -131,6 +134,9 @@ def test_load_settings_reads_gcs_cache_settings_without_database() -> None:
     assert settings.gcs_cache.last_seen_current_table == "current_table"
     assert settings.gcs_cache.last_seen_excluded_get_user_agent == "CustomTransferService"
     assert settings.gcs_cache.last_seen_excluded_get_principal_email == "cleanup@example.com"
+    assert settings.gcs_cache.ac_reference_http_pool_maxsize == 256
+    assert settings.gcs_cache.ac_reference_catch_up_workers == 16
+    assert settings.gcs_cache.ac_reference_catch_up_max_workers == 12
     assert settings.gcs_cache.ac_reference_max_index_staleness_hours == 6
     assert settings.gcs_cache.ac_retention_days == 21
     assert settings.gcs_cache.cas_retention_days == 35

--- a/cost-insight/tests/test_gcs_cache_references.py
+++ b/cost-insight/tests/test_gcs_cache_references.py
@@ -94,7 +94,9 @@ def test_extract_cas_references_from_tree_bytes_rejects_overlong_varint() -> Non
         extract_cas_references_from_tree_bytes(tree_bytes)
 
 
-def test_extract_action_cache_references_batch_uses_worker_count_for_http_pool(monkeypatch) -> None:
+def test_extract_action_cache_references_batch_pool_maxsize_overrides_worker_count(
+    monkeypatch,
+) -> None:
     observed_pool_sizes: list[int] = []
 
     class _FakeBucket:
@@ -127,9 +129,10 @@ def test_extract_action_cache_references_batch_uses_worker_count_for_http_pool(m
         bucket_name="test-bucket",
         ac_object_names=("ac/one", "ac/two"),
         max_workers=32,
+        pool_maxsize=96,
     )
 
-    assert observed_pool_sizes == [32]
+    assert observed_pool_sizes == [96]
     assert rows == (
         gcs_cache_references.AcReferenceExtraction(
             ac_object_name="ac/one",
@@ -142,6 +145,90 @@ def test_extract_action_cache_references_batch_uses_worker_count_for_http_pool(m
             cas_object_names=("cas/a", "cas/b"),
         ),
     )
+
+
+def test_extract_action_cache_references_batch_preserves_explicit_zero_pool_maxsize(
+    monkeypatch,
+) -> None:
+    observed_pool_sizes: list[int] = []
+
+    class _FakeBucket:
+        def blob(self, object_name: str):
+            class _FakeBlob:
+                def download_as_bytes(self) -> bytes:
+                    return b""
+
+            return _FakeBlob()
+
+    class _FakeClient:
+        def bucket(self, bucket_name: str) -> _FakeBucket:
+            assert bucket_name == "test-bucket"
+            return _FakeBucket()
+
+    monkeypatch.setattr(
+        gcs_cache_references,
+        "create_storage_client",
+        lambda *, project_id, pool_maxsize: (
+            observed_pool_sizes.append(pool_maxsize) or _FakeClient()
+        ),
+    )
+    monkeypatch.setattr(
+        gcs_cache_references,
+        "extract_cas_references_from_action_result_bytes",
+        lambda action_result_bytes, *, fetch_cas_blob: set(),
+    )
+
+    gcs_cache_references.extract_action_cache_references_batch(
+        project_id="test-project",
+        bucket_name="test-bucket",
+        ac_object_names=("ac/one",),
+        max_workers=32,
+        pool_maxsize=0,
+    )
+
+    assert observed_pool_sizes == [0]
+
+
+def test_extract_action_cache_references_batch_floors_positive_pool_maxsize_at_worker_count(
+    monkeypatch,
+) -> None:
+    observed_pool_sizes: list[int] = []
+
+    class _FakeBucket:
+        def blob(self, object_name: str):
+            class _FakeBlob:
+                def download_as_bytes(self) -> bytes:
+                    return b""
+
+            return _FakeBlob()
+
+    class _FakeClient:
+        def bucket(self, bucket_name: str) -> _FakeBucket:
+            assert bucket_name == "test-bucket"
+            return _FakeBucket()
+
+    monkeypatch.setattr(
+        gcs_cache_references,
+        "create_storage_client",
+        lambda *, project_id, pool_maxsize: (
+            observed_pool_sizes.append(pool_maxsize) or _FakeClient()
+        ),
+    )
+    monkeypatch.setattr(
+        gcs_cache_references,
+        "extract_cas_references_from_action_result_bytes",
+        lambda action_result_bytes, *, fetch_cas_blob: set(),
+    )
+
+    gcs_cache_references.extract_action_cache_references_batch(
+        project_id="test-project",
+        bucket_name="test-bucket",
+        ac_object_names=("ac/one",),
+        max_workers=32,
+        pool_maxsize=16,
+    )
+
+    assert observed_pool_sizes == [32]
 
 
 def test_extract_action_cache_references_batch_shares_cas_blob_cache(monkeypatch) -> None:

--- a/cost-insight/tests/test_gcs_objects.py
+++ b/cost-insight/tests/test_gcs_objects.py
@@ -84,7 +84,7 @@ def test_fetch_object_metadata_batch_reads_objects_sequentially(monkeypatch) -> 
     assert bucket.requested_names == ["cas/present", "cas/missing", "cas/no-generation"]
 
 
-def test_fetch_object_metadata_batch_uses_executor_for_parallel_path(monkeypatch) -> None:
+def test_fetch_object_metadata_batch_pool_maxsize_overrides_worker_count(monkeypatch) -> None:
     bucket = _FakeBucket(
         {
             "cas/one": _FakeBlob("11"),
@@ -122,11 +122,58 @@ def test_fetch_object_metadata_batch_uses_executor_for_parallel_path(monkeypatch
         bucket_name="test-bucket",
         object_names=("cas/one", "cas/two"),
         max_workers=4,
+        pool_maxsize=16,
     )
 
     assert used_max_workers == [4]
-    assert observed_pool_sizes == [4]
+    assert observed_pool_sizes == [16]
     assert metadata == (
         gcs_objects.GcsObjectMetadata(object_name="cas/one", exists=True, generation=11, size_bytes=1024),
         gcs_objects.GcsObjectMetadata(object_name="cas/two", exists=True, generation=22, size_bytes=1024),
     )
+
+
+def test_fetch_object_metadata_batch_preserves_explicit_zero_pool_maxsize(monkeypatch) -> None:
+    observed_pool_sizes: list[int] = []
+    monkeypatch.setattr(
+        gcs_objects,
+        "create_storage_client",
+        lambda *, project_id, pool_maxsize: (
+            observed_pool_sizes.append(pool_maxsize)
+            or _FakeClient(project=project_id, bucket=_FakeBucket({"cas/one": _FakeBlob("1")}))
+        ),
+    )
+
+    gcs_objects.fetch_object_metadata_batch(
+        project_id="test-project",
+        bucket_name="test-bucket",
+        object_names=("cas/one",),
+        max_workers=4,
+        pool_maxsize=0,
+    )
+
+    assert observed_pool_sizes == [0]
+
+
+def test_fetch_object_metadata_batch_floors_positive_pool_maxsize_at_worker_count(
+    monkeypatch,
+) -> None:
+    observed_pool_sizes: list[int] = []
+    monkeypatch.setattr(
+        gcs_objects,
+        "create_storage_client",
+        lambda *, project_id, pool_maxsize: (
+            observed_pool_sizes.append(pool_maxsize)
+            or _FakeClient(project=project_id, bucket=_FakeBucket({"cas/one": _FakeBlob("1")}))
+        ),
+    )
+
+    gcs_objects.fetch_object_metadata_batch(
+        project_id="test-project",
+        bucket_name="test-bucket",
+        object_names=("cas/one",),
+        max_workers=4,
+        pool_maxsize=2,
+    )
+
+    assert observed_pool_sizes == [4]

--- a/cost-insight/tests/test_sync_gcs_cache_ac_references.py
+++ b/cost-insight/tests/test_sync_gcs_cache_ac_references.py
@@ -7,6 +7,7 @@ from cost_insight.jobs.sync_gcs_cache_ac_references import (
     build_bootstrap_gcs_cache_ac_reference_source_query,
     build_ensure_gcs_cache_ac_reference_tables_query,
     build_incremental_gcs_cache_ac_reference_source_query,
+    build_reconcile_missing_ac_query,
     _execute_with_bigquery_dml_retry,
     run_sync_gcs_cache_ac_references,
 )
@@ -41,6 +42,19 @@ def test_incremental_gcs_cache_ac_reference_source_query_targets_create_events()
     assert "timestamp > @indexed_through" in query
     assert "timestamp <= @run_until" in query
     assert "REGEXP_CONTAINS(object_name, r'^ac/[0-9a-fA-F]{64}$')" in query
+
+
+def test_reconcile_missing_ac_query_scopes_by_ac_delete_to_shard() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    query = build_reconcile_missing_ac_query(
+        settings,
+        shard=17,
+        missing_stage_table="`project.dataset.missing_ac`",
+    )
+
+    assert "DELETE FROM `pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_ac_cas_refs_by_ac`" in query
+    assert "WHERE shard = 17" in query
+    assert "ac_object_name IN (SELECT object_name FROM `project.dataset.missing_ac`)" in query
 
 
 def test_run_sync_gcs_cache_ac_references_bootstrap_dry_run_counts_objects_and_refs() -> None:


### PR DESCRIPTION
## Summary
- parallelize GCS cache AC reference catch-up by shard with a BigQuery DML worker cap
- keep GCS download and HTTP pool concurrency bounded while preserving pool floor semantics
- add shard-scoped missing-AC reconciliation and failure logging with traceback

## Tests
- pytest --no-cov cost-insight/tests/test_config.py cost-insight/tests/test_cleanup_gcs_cache.py cost-insight/tests/test_sync_gcs_cache_ac_references.py cost-insight/tests/test_gcs_client.py cost-insight/tests/test_gcs_objects.py cost-insight/tests/test_gcs_cache_references.py
- python -m ruff check cost-insight/src/cost_insight/common/config.py cost-insight/src/cost_insight/common/gcs_client.py cost-insight/src/cost_insight/common/gcs_cache_references.py cost-insight/src/cost_insight/common/gcs_objects.py cost-insight/src/cost_insight/jobs/sync_gcs_cache_ac_references.py cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py cost-insight/tests/test_config.py cost-insight/tests/test_cleanup_gcs_cache.py cost-insight/tests/test_sync_gcs_cache_ac_references.py cost-insight/tests/test_gcs_objects.py cost-insight/tests/test_gcs_cache_references.py