### PR TITLE
fix(tibuild-v2): format lark notification template

### DIFF
--- a/experiments/tibuild-v2/internal/service/impl/lark_templates/devbuild-notify.yaml.tmpl
+++ b/experiments/tibuild-v2/internal/service/impl/lark_templates/devbuild-notify.yaml.tmpl
@@ -39,7 +39,7 @@ elements:
       - **Product:** {{ .Product }}
       - **Version:** {{ .Version }}
       - **Platform:** {{ .Platform }}
-      {{- with .GithubRepo }}
+      {{- with .GithubRepo -}}
       - **Repository:** [{{ . }}](https://github.com/{{ . }})
       {{- end }}
       {{- $gitRefURL := GitRefURL .GitRef .GithubRepo }}
@@ -64,15 +64,19 @@ elements:
       {{- end }}
       {{- if .Images }}
       - **Docker Images:**
+        ```YAML
         {{- range .Images }}
-        - `{{ .URL }}` ({{ .Platform }})
+        - {{ .URL }}
         {{- end }}
+        ```
       {{- end }}
       {{- if .Binaries }}
       - **Binaries:**
+        ```YAML
         {{- range .Binaries }}
-        - `{{ .OciReference }}`
+        - {{ .OciReference }}
         {{- end }}
+        ```
       {{- end }}
   {{- end }}
 

--- a/experiments/tibuild-v2/internal/service/impl/lark_templates/devbuild-notify.yaml.tmpl
+++ b/experiments/tibuild-v2/internal/service/impl/lark_templates/devbuild-notify.yaml.tmpl
@@ -39,7 +39,7 @@ elements:
       - **Product:** {{ .Product }}
       - **Version:** {{ .Version }}
       - **Platform:** {{ .Platform }}
-      {{- with .GithubRepo -}}
+      {{- with .GithubRepo }}
       - **Repository:** [{{ . }}](https://github.com/{{ . }})
       {{- end }}
       {{- $gitRefURL := GitRefURL .GitRef .GithubRepo }}


### PR DESCRIPTION
Format the devbuild Lark notification template:

- Trim whitespace after `{{- with .GithubRepo }}` to avoid trailing spaces
- Wrap Docker images and binaries lists in YAML code blocks
- Remove backticks from individual list items (already inside code block)