### PR TITLE
fix(cost-insight): harden gcs cache cleanup

### DIFF
--- a/cost-insight/README.md
+++ b/cost-insight/README.md
@@ -198,12 +198,16 @@ Validate the query shape without writing BigQuery summary tables:
 cost-insight sync-gcs-cache-last-seen --run-date 2026-06-08 --dry-run
 ```
 
-Build a daily steady-state dry-run candidate report from the current last-seen
-table:
+Build an index-based dry-run candidate report from the current last-seen table:
 
 ```bash
-cost-insight cleanup-gcs-cache --mode dry-run
+cost-insight cleanup-gcs-cache --mode dry-run --execute-kind cas-from-index
 ```
+
+The dry-run report does not run the post-delete catch-up or live `by_ac`
+recheck used by delete mode, so the CAS delete candidate count is an upper
+bound. A real delete may block additional CAS if newly indexed AC refs appear
+before the manifest is exported.
 
 Override retention windows during validation:
 
@@ -218,14 +222,21 @@ cost-insight cleanup-gcs-cache \
 Run a real-delete steady-state canary with `500 ac + 500 cas`:
 
 ```bash
-cost-insight cleanup-gcs-cache --mode delete --execute-kind mixed-canary
+cost-insight cleanup-gcs-cache \
+  --mode delete \
+  --execute-kind cas-from-index \
+  --max-delete-objects 500
 ```
 
-Run a real-delete `ac` cleanup wave with an explicit hard cap:
+Run a real-delete CAS cleanup wave with an explicit hard cap. The job performs
+one full `by_cas` rebuild, prefers orphan CAS, only expands linked ACs when the
+orphan backlog no longer fills the CAS budget, and rechecks live `by_ac`
+references before exporting the CAS delete manifest:
 
 ```bash
 cost-insight cleanup-gcs-cache \
   --mode delete \
-  --execute-kind ac \
-  --max-delete-objects 10000000
+  --execute-kind cas-from-index \
+  --max-delete-objects 10000000 \
+  --max-delete-ac-objects 100000
 ```

--- a/cost-insight/docs/gcs-bazel-cache-cas-gc-v3-complete-ac-expansion.md
+++ b/cost-insight/docs/gcs-bazel-cache-cas-gc-v3-complete-ac-expansion.md
@@ -356,16 +356,28 @@ cleanup 执行时：
 总是早于检查时刻。必须用固定 snapshot。
 
 **竞态残余风险**（无法完全消除）：
-即使 catch-up 到 `cleanup_snapshot_time`，cleanup 本身需要时间执行（AC 删除 +
-CAS manifest export + delete）。在 cleanup 执行期间，新的 AC 仍可能被上传并引用
-待删除的冷 CAS，且不对 CAS 产生 audit 事件。
+即使 catch-up 到 `cleanup_snapshot_time`，cleanup 本身需要时间执行（metadata
+解析、AC 删除、CAS manifest export + delete）。在 cleanup 执行期间，新的 AC 仍
+可能被上传并引用待删除的冷 CAS，且不对 CAS 产生 audit 事件。orphan-first
+不能防止这种新引用：snapshot 时的 orphan CAS 可能在运行期间第一次被新 AC 引用。
 
 **缓解措施**：
-- 在最终 CAS manifest export 前，再做一次**短增量 catch-up**（覆盖
-  `cleanup_snapshot_time` 到当前时刻），重新计算 zero-ref
-- 仍有极小窗口（第二次 catch-up 到 manifest export 之间），但窗口从小时级
-  缩小到分钟级
-- CAS cap 作为最后防线
+- 当前实现只做一次全量 `by_cas` rebuild，避免第二次重建大表。
+- AC 删除后、CAS manifest export 前再跑一次 incremental catch-up，只把 `by_ac`
+  推进到 post-AC-delete 时间点。
+- 基于本轮 `ac_removed` 临时表从 snapshot `by_cas` 中逻辑扣减引用，得到
+  zero-ref snapshot 候选。
+- 随后用当前 live `by_ac` 对 zero-ref snapshot 候选做 blocklist recheck：
+  只要仍有任意 AC ref 指向该 CAS，就排除该 CAS。这一步检测 cleanup 运行期间
+  新建 AC 对 orphan / linked CAS 的引用，不依赖 `last_seen_current`。
+- 这个 live recheck 按 `cas_object_name` 访问 `by_ac`，而 `by_ac` 当前是
+  `CLUSTER BY shard, ac_object_name`，因此需要按全表扫描级别评估成本。它省掉的是
+  第二次 `by_cas` 全量重建和写入，不是省掉全部 ref 表读取。若成本过高，后续应增加
+  `cas_object_name` 访问路径，或给 `by_ac` 增加 `indexed_at` 后改查 post-snapshot delta。
+- 2026-07-06 实测：当前 `by_ac` 约 36.7M rows / 5.4GB logical bytes；用
+  1M candidate 形状执行 live recheck count，实际 processed/billed 约 2.65GB，
+  final execution duration 约 28.9s。当前可接受，但需要随 ref 表增长继续观察。
+- CAS cap 和 AC cap 作为最后防线，限制异常情况下的影响半径。
 
 **Implementation**：
 
@@ -383,24 +395,20 @@ cleanup():
     # 重建 by_cas 快照 —— 必须在 catch-up + 保鲜之后
     rebuild_by_cas_from_by_ac()
 
-    # Phase 3: AC delete phase
-    # 先 bounded CAS selection（受 CAS cap 限制，控制 AC 删除半径）
-    cold_cas = select_cold_cas(snapshot_time, limit=CAS_CAP)
-    acs_to_delete = reverse_lookup_ac(cold_cas, age > ac_cutoff)
+    # Phase 3: orphan-first CAS selection（受 CAS cap 限制）
+    cold_cas = select_cold_cas_orphan_first(snapshot_time, limit=CAS_CAP)
+    acs_to_delete = reverse_lookup_ac(cold_cas, age > ac_cutoff, limit=AC_CAP)
     delete_ac(acs_to_delete)
-    reconcile_ac(acs_to_delete)  # 只删 by_ac；by_cas 下次重建自动消失
+    ac_removed = reconcile_ac(acs_to_delete)  # deleted + confirmed missing AC
 
-    # 短增量 catch-up + 保鲜（缩小竞态窗口）
-    snapshot_time_2 = NOW()
-    run_incremental_sync(until=snapshot_time_2)
-    assert all_shards_indexed_through >= snapshot_time_2
-    run_stale_reconciliation()
+    # 基于初始 by_cas snapshot 逻辑扣减本轮移除的 AC，避免第二次 by_cas rebuild
+    zero_ref_snapshot = recompute_zero_ref_after_ac_removal(cold_cas, ac_removed)
 
-    # 第二次重建 by_cas 快照 —— AC 删除后的最新状态
-    rebuild_by_cas_from_by_ac()
-
-    # 重新计算 zero-ref（基于最新的 by_cas）
-    cas_to_delete = recompute_zero_ref(cold_cas, snapshot_time_2)
+    # Phase 4: post-delete catch-up + live by_ac recheck
+    post_delete_recheck_time = NOW()
+    run_incremental_sync(until=post_delete_recheck_time)
+    assert all_shards_indexed_through >= post_delete_recheck_time
+    cas_to_delete = exclude_cas_with_any_live_by_ac_ref(zero_ref_snapshot)
 
     # CAS delete phase（受 CAS cap 限制）
     delete_cas(cas_to_delete)
@@ -453,18 +461,42 @@ LIMIT @ac_object_cap;  -- AC cap
 -- → 执行 AC 删除 + reconcile（只删 by_ac）
 ```
 
-### 查询 B：最终 zero-ref CAS 判断（第二次 by_cas 重建后执行）
+### 查询 B：zero-ref snapshot 判断（AC 删除后，基于本轮移除集逻辑扣减）
 
 ```sql
--- AC 删除后重建 by_cas，deleted AC refs 已自然消失，不需要 ac_to_delete 来扣除。
--- 这是故意设计：少一个状态变量，少一个错法。
-CREATE TEMP TABLE cas_to_delete AS
+-- 不做第二次 by_cas 重建。用本轮成功删除或确认 missing 的 AC 集合扣减
+-- cleanup snapshot 中的 refs。
+CREATE TEMP TABLE zero_ref_snapshot AS
 SELECT cold_cas.object_name, cold_cas.last_seen_at
 FROM cold_cas
 LEFT JOIN gcs_cache_ac_cas_refs_by_cas AS refs
   ON refs.cas_object_name = cold_cas.object_name
+LEFT JOIN ac_removed
+  ON ac_removed.object_name = refs.ac_object_name
 GROUP BY cold_cas.object_name, cold_cas.last_seen_at
-HAVING COUNT(refs.ac_object_name) = 0;
+HAVING COUNTIF(
+  refs.ac_object_name IS NOT NULL
+  AND ac_removed.object_name IS NULL
+) = 0;
+```
+
+### 查询 C：live `by_ac` 新引用 recheck（CAS manifest export 前执行）
+
+```sql
+-- AC 删除成功后，先再跑一次 incremental sync，把 by_ac 推进到当前时间点。
+-- 然后只检查本轮 zero-ref snapshot 候选是否仍有 live by_ac ref。
+CREATE TEMP TABLE blocked_by_live_ac_ref AS
+SELECT DISTINCT cas.object_name
+FROM zero_ref_snapshot AS cas
+JOIN gcs_cache_ac_cas_refs_by_ac AS refs
+  ON refs.cas_object_name = cas.object_name;
+
+CREATE TEMP TABLE cas_to_delete AS
+SELECT source.object_name, source.last_seen_at
+FROM zero_ref_snapshot AS source
+LEFT JOIN blocked_by_live_ac_ref AS blocked
+  ON blocked.object_name = source.object_name
+WHERE blocked.object_name IS NULL;
 ```
 
 所有中间结果保留为 row-level，不做 ARRAY_AGG。
@@ -558,19 +590,24 @@ WHERE cas.object_kind = 'cas'
                    │                        │
                    ▼                        │
           ┌─────────────────┐               │
-          │ 第二次短增量       │               │
-          │ catch-up + 保鲜   │               │
-          └────────┬────────┘               │
-                   │                        │
-                   ▼                        │
-          ┌─────────────────┐               │
-          │ ★ 重建 by_cas（第 2 次）         │
-          │ EXPORT by_ac → IMPORT by_cas    │
+          │ ac_removed 逻辑扣减              │
+          │ snapshot by_cas refs             │
           └────────┬────────┘               │
                    │                        │
                    ▼                        ▼
           ┌─────────────────────────────────┐
-          │ CAS 引用计数 = 0                 │
+          │ zero-ref snapshot               │
+          └───────────────┬─────────────────┘
+                          │
+                          ▼
+          ┌─────────────────────────────────┐
+          │ post catch-up + live by_ac       │
+          │ ref blocklist                    │
+          └───────────────┬─────────────────┘
+                          │
+                          ▼
+          ┌─────────────────────────────────┐
+          │ 最终 CAS delete candidates       │
           │ + live metadata (generation,     │
           │   size_bytes) check             │
           │ + audit recheck                 │
@@ -670,6 +707,10 @@ cas_live_metadata:
 - `planned_cas_delete_bytes`：本 run 计划删除的 bytes
 - `deleted_cas_bytes`：实际删除的 bytes
 
+**Dry-run 语义**：dry-run 不执行 post-delete catch-up，也不做 live `by_ac`
+recheck，因此 CAS delete candidate count 是执行前基于 snapshot 的上界估算。真实
+delete 可能因为 post-delete live ref blocklist 再排除一部分 CAS。
+
 ## Implementation Plan
 
 ### Step 0: AC Source 完整性验证
@@ -709,25 +750,25 @@ cas_live_metadata:
 - [ ] NotFound → reconcile（DELETE from by_ac + last_seen_current；by_cas 下次重建时自动消失）
 - [ ] 保鲜完成后才进入 CAS 反查
 
-### Step 5: Cleanup 前置增量 catch-up + by_cas 重建 + 双 snapshot 机制
+### Step 5: Cleanup 前置增量 catch-up + by_cas 重建 + 单 snapshot 机制
 
 - [ ] 实现固定 `cleanup_snapshot_time`（一次性取值）
 - [ ] Cleanup 入口：先增量 catch-up 覆盖到 snapshot_time
 - [ ] 验证 gate：所有 shard `indexed_through >= snapshot_time`
 - [ ] 再跑索引保鲜（Step 4）
-- [ ] **第一次 by_cas 重建**：EXPORT by_ac → IMPORT 重建 by_cas
-- [ ] bounded cold_cas 选择（受 CAS cap 约束，控制 AC 删除半径）
+- [ ] **by_cas 重建**：EXPORT by_ac → IMPORT 重建 by_cas
+- [ ] orphan-first bounded cold_cas 选择（受 CAS cap 约束，控制 AC 删除半径）
 - [ ] AC 删除
-- [ ] 第二次短增量 catch-up + 保鲜
-- [ ] **第二次 by_cas 重建**
-- [ ] 重新计算 zero-ref
+- [ ] 用 `ac_removed` 逻辑扣减 snapshot refs 后重新计算 zero-ref snapshot
+- [ ] CAS manifest export 前再跑 incremental catch-up，并用 live `by_ac` 排除仍有引用的 CAS
 
 ### Step 6: 实现 CAS 反推 AC 清理
 
 - [ ] 新增 `execute_kind: cas-from-index`
-- [ ] 实现两阶段 CAS 选择（初筛 object count → metadata HEAD → bytes cap 二次筛选）
+- [ ] 实现 orphan-first 两阶段 CAS 选择（初筛 object count → metadata HEAD → bytes cap 二次筛选）
 - [ ] 实现 AC 删除规划 query（查询 A）+ AC cap 截断
-- [ ] AC 删除后第二次 by_cas 重建 + 简单 zero-ref 查询（查询 B，LEFT JOIN + HAVING COUNT = 0）
+- [ ] AC 删除后基于 `ac_removed` 做逻辑 zero-ref 查询（查询 B，LEFT JOIN + COUNTIF）
+- [ ] post catch-up 后基于 live `by_ac` 做新引用 blocklist（查询 C）
 - [ ] 实现新 manifest export 和 delete 流程
 - [ ] Dry-run 输出完整中间结果（含 bytes、AC 候选数）
 
@@ -782,7 +823,7 @@ COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS=10000000
 
 - **Shared CAS**：全量索引 → 精确知道每个 CAS 的 AC 引用
 - **Parse error 容忍**：fail-closed，shard 不 ready 则 cleanup 不可用
-- **Index staleness 时间窗口**：cleanup 强制前置增量 catch-up + 双 snapshot
+- **Index staleness 时间窗口**：cleanup 强制前置增量 catch-up + 单 snapshot
 - **O(n²) stage table**：改为全 shard 收集后一次性 replace
 - **CLUSTER 方向与写入冲突**：by_ac 持续维护，by_cas 只做全量快照重建，不增量维护
 - **ARRAY_AGG row size**：改为 row-level 输出
@@ -796,9 +837,15 @@ COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS=10000000
 2. **Missing AC 引用永久丢失**：
    - 缓解：从 last_seen_current + both refs tables reconcile；CAS 受年龄窗口保护
 
-3. **Cleanup 执行期间的竞态**（第二次 catch-up 后到 CAS manifest export 之间）：
-   - 缓解：双 snapshot 机制把窗口缩到分钟级；CAS cap 作为最后防线
-   - 无法完全线性化（除非暂停 GCS 写入，不现实）
+3. **Cleanup 执行期间的新 AC 引用竞态**：
+   - 风险：snapshot 时 orphan 或 zero-ref 的 CAS，可能在 cleanup 运行期间被新 AC 第一次引用
+   - 缓解：AC 删除后、CAS manifest export 前再次 incremental catch-up，并用 live `by_ac` blocklist 排除仍有引用的 CAS
+   - 剩余窗口：post catch-up 完成后到 CAS batch delete 生效前；CAS cap / AC cap 只限制影响半径，不提供逻辑保护
 
 4. **首次零引用 CAS 规模未知**：
    - 缓解：dry-run 先评估规模；双重 cap (object + bytes) 限制
+
+5. **并发 cleanup 运行覆盖 persistent `by_cas` snapshot**：
+   - 风险：`by_cas` 是持久表，每次 delete 入口会 rebuild；两个 cleanup run 并发时，后一个 run 可能覆盖前一个 run 仍在使用的 snapshot
+   - 当前部署：`cost-insight-cleanup-gcs-cache-delete-cas` CronJob 使用 `concurrencyPolicy: Forbid`，按单实例运行
+   - 后续：如果引入手动并发或多个调度入口，需要增加 lease/lock，或改为每 run 独立 snapshot 表

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -1349,6 +1349,8 @@ def run_cleanup_gcs_cache_from_index(
 
     # ---- Gate 2: freshness (catch-up must have reached snapshot_time) ----
     # Now verify all watermarks are within staleness of the cleanup snapshot.
+    # Delete mode should be exact after the preceding catch-up; the staleness
+    # allowance mainly keeps dry-run read-only while still rejecting old indexes.
     bytes_processed_total = _add_bytes(
         bytes_processed_total,
         _require_fresh_ac_reference_index(

--- a/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
+++ b/cost-insight/src/cost_insight/jobs/cleanup_gcs_cache.py
@@ -132,6 +132,7 @@ def run_cleanup_gcs_cache(
     cas_retention_days: int | None = None,
     safety_buffer_days: int | None = None,
     max_delete_objects: int | None = None,
+    max_delete_ac_objects: int | None = None,
     max_delete_cas_objects: int | None = None,
     sample_limit: int | None = None,
     execute: QueryExecutor = execute_query,
@@ -175,6 +176,11 @@ def run_cleanup_gcs_cache(
         if max_delete_cas_objects is not None
         else settings.cleanup_max_delete_cas_objects
     )
+    resolved_max_delete_ac_objects = (
+        max_delete_ac_objects
+        if max_delete_ac_objects is not None
+        else settings.cleanup_max_delete_ac_objects
+    )
     ac_cutoff_days = resolved_ac_days + resolved_safety_buffer_days
     cas_cutoff_days = resolved_cas_days + resolved_safety_buffer_days
 
@@ -196,12 +202,16 @@ def run_cleanup_gcs_cache(
             ac_reference_shard_count=settings.ac_reference_shard_count,
             ac_reference_batch_size=settings.ac_reference_batch_size,
             ac_reference_download_workers=settings.ac_reference_download_workers,
+            ac_reference_http_pool_maxsize=settings.ac_reference_http_pool_maxsize,
+            ac_reference_catch_up_workers=settings.ac_reference_catch_up_workers,
+            ac_reference_catch_up_max_workers=settings.ac_reference_catch_up_max_workers,
             ac_reference_max_index_staleness_hours=settings.ac_reference_max_index_staleness_hours,
             ac_retention_days=resolved_ac_days,
             cas_retention_days=resolved_cas_days,
             cleanup_safety_buffer_days=resolved_safety_buffer_days,
             cleanup_sample_limit=resolved_sample_limit,
             cleanup_max_delete_objects=resolved_max_delete_objects,
+            cleanup_max_delete_ac_objects=resolved_max_delete_ac_objects,
             cleanup_max_delete_cas_objects=(
                 resolved_max_delete_objects
                 if max_delete_objects is not None
@@ -1081,6 +1091,7 @@ def build_ac_reverse_lookup_query(
     snapshot_time: str,
     ac_cutoff_days: int,
     by_cas_table_override: str | None = None,
+    limit: int | None = None,
 ) -> str:
     """Find cold ACs that reference the bounded cold CAS set."""
     by_cas_table = by_cas_table_override or _table_ref(
@@ -1089,6 +1100,7 @@ def build_ac_reverse_lookup_query(
     current_table = _table_ref(
         settings.project_id, settings.dataset, settings.last_seen_current_table
     )
+    limit_clause = "" if limit is None else f"\nLIMIT {limit}"
     return f"""
 SELECT DISTINCT
   refs.ac_object_name AS object_name,
@@ -1101,6 +1113,7 @@ JOIN {current_table} AS cur
  AND cur.object_kind = 'ac'
  AND cur.last_seen_at < TIMESTAMP_SUB(TIMESTAMP('{snapshot_time}'), INTERVAL {ac_cutoff_days} DAY)
 ORDER BY cur.last_seen_at ASC
+{limit_clause}
 """.strip()
 
 
@@ -1143,7 +1156,7 @@ def build_zero_ref_cas_query(
     cold_cas_table: str,
     by_cas_table_override: str | None = None,
 ) -> str:
-    """After AC deletion and by_cas rebuild: find CAS with zero remaining references."""
+    """Find CAS with zero refs in an already-current by_cas table."""
     by_cas_table = by_cas_table_override or _table_ref(
         settings.project_id, settings.dataset, settings.ac_cas_refs_by_cas_table
     )
@@ -1154,6 +1167,67 @@ LEFT JOIN {by_cas_table} AS refs
   ON refs.cas_object_name = cas.object_name
 GROUP BY cas.object_name, cas.last_seen_at
 HAVING COUNT(refs.ac_object_name) = 0
+""".strip()
+
+
+def build_zero_ref_cas_after_ac_removal_query(
+    settings: GcsCacheSettings,
+    *,
+    cold_cas_table: str,
+    removed_ac_table: str,
+    by_cas_table_override: str | None = None,
+) -> str:
+    """Find CAS whose remaining refs are zero after this run's AC removals."""
+    by_cas_table = by_cas_table_override or _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_cas_table
+    )
+    return f"""
+SELECT cas.object_name, cas.last_seen_at
+FROM {cold_cas_table} AS cas
+LEFT JOIN {by_cas_table} AS refs
+  ON refs.cas_object_name = cas.object_name
+LEFT JOIN {removed_ac_table} AS removed_ac
+  ON removed_ac.object_name = refs.ac_object_name
+GROUP BY cas.object_name, cas.last_seen_at
+HAVING COUNTIF(
+  refs.ac_object_name IS NOT NULL
+  AND removed_ac.object_name IS NULL
+) = 0
+""".strip()
+
+
+def build_live_ac_ref_cas_blocklist_query(
+    settings: GcsCacheSettings,
+    *,
+    candidate_table: str,
+) -> str:
+    """Find candidate CAS that still have any live by_ac reference.
+
+    This intentionally scans by_ac by cas_object_name, which is not the cluster
+    prefix. It is a safety recheck, not a cheap point lookup.
+    """
+    by_ac_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_cas_refs_by_ac_table
+    )
+    return f"""
+SELECT DISTINCT cas.object_name
+FROM {candidate_table} AS cas
+JOIN {by_ac_table} AS refs
+  ON refs.cas_object_name = cas.object_name
+""".strip()
+
+
+def build_final_zero_ref_after_live_recheck_query(
+    *,
+    zero_ref_snapshot_table: str,
+    live_ref_blocked_cas_table: str,
+) -> str:
+    return f"""
+SELECT source.object_name, source.last_seen_at
+FROM {zero_ref_snapshot_table} AS source
+LEFT JOIN {live_ref_blocked_cas_table} AS blocked
+  ON blocked.object_name = source.object_name
+WHERE blocked.object_name IS NULL
 """.strip()
 
 
@@ -1215,6 +1289,7 @@ class CleanupGcsCacheAcDeleteResult:
     selected_ac_count: int
     manifest_uri: str
     batch_job_name: str
+    removed_ac_table: str
 
 
 def run_cleanup_gcs_cache_from_index(
@@ -1234,6 +1309,10 @@ def run_cleanup_gcs_cache_from_index(
 
     This is the cas-from-index execution path. It requires a complete
     by_ac index (all 256 shard indexed_through IS NOT NULL).
+    Delete mode catches up the index at the start, builds one by_cas snapshot,
+    and later catches up by_ac again before CAS deletion. The final live by_ac
+    recheck restores detection of ACs created during the run without doing a
+    second full by_cas rebuild.
     """
     stream_rows = _stream_query_rows if stream_rows is None else stream_rows
     load_jsonl_file = _load_jsonl_file if load_jsonl_file is None else load_jsonl_file
@@ -1270,22 +1349,16 @@ def run_cleanup_gcs_cache_from_index(
 
     # ---- Gate 2: freshness (catch-up must have reached snapshot_time) ----
     # Now verify all watermarks are within staleness of the cleanup snapshot.
-    if settings.cleanup_require_fresh_index:
-        staleness_hours = settings.ac_reference_max_index_staleness_hours
-        result = execute(
-            f"""SELECT COUNTIF(indexed_through >= TIMESTAMP_SUB(TIMESTAMP('{snapshot_time}'), INTERVAL {staleness_hours} HOUR)) AS fresh_shards
-FROM {state_table}""",
-            parameters=[],
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        _require_fresh_ac_reference_index(
+            settings=settings,
+            execute=execute,
+            target_time=run_started_at,
+            target_label="cleanup snapshot",
+            max_staleness_hours=settings.ac_reference_max_index_staleness_hours,
         )
-        fresh = int(result.rows[0].get("fresh_shards", 0) or 0) if result.rows else 0
-        if fresh < settings.ac_reference_shard_count:
-            raise RuntimeError(
-                f"AC reference index is stale after catch-up: only {fresh}/{settings.ac_reference_shard_count} "
-                f"shards have indexed_through within {staleness_hours}h of cleanup snapshot "
-                f"({snapshot_time}). Check incremental sync logs, increase max_staleness_hours, "
-                "or set COST_INSIGHT_GCS_CACHE_CLEANUP_REQUIRE_FRESH_INDEX=false to bypass."
-            )
-        bytes_processed_total = _add_bytes(bytes_processed_total, result.total_bytes_processed)
+    )
     cas_cutoff_days = settings.cas_retention_days + settings.cleanup_safety_buffer_days
     ac_cutoff_days = settings.ac_retention_days + settings.cleanup_safety_buffer_days
 
@@ -1404,27 +1477,45 @@ AS
     cas_live_table = _tmp_table_ref(settings, "cas_live_metadata", run_id=run_id)
     cold_cas_table = _tmp_table_ref(settings, "cold_cas", run_id=run_id)
 
-    # ponytail: apply caps in SQL with rolling sum; accept that window function
-    # over the preselected set is enough, per-design preselect window trade-off.
+    # Prefer orphan CAS first. The linked-CAS cascade path remains available
+    # once the orphan backlog stops filling the configured CAS budget.
     bytes_processed_total = _add_bytes(
         bytes_processed_total,
         execute(
             f"""CREATE OR REPLACE TABLE {cold_cas_table}
 OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 AS
-WITH ranked AS (
+WITH annotated AS (
   SELECT
     live.object_name,
     preselect.last_seen_at,
     live.size_bytes,
     live.generation,
-    SUM(live.size_bytes) OVER (ORDER BY live.size_bytes DESC, preselect.last_seen_at ASC) AS running_bytes,
-    ROW_NUMBER() OVER (ORDER BY live.size_bytes DESC, preselect.last_seen_at ASC) AS rn
+    NOT EXISTS (
+      SELECT 1
+      FROM {by_cas_table} AS refs
+      WHERE refs.cas_object_name = live.object_name
+    ) AS is_orphan
   FROM {cas_preselect_table} AS preselect
   JOIN {cas_live_table} AS live
     USING (object_name)
+),
+ranked AS (
+  SELECT
+    object_name,
+    last_seen_at,
+    size_bytes,
+    generation,
+    is_orphan,
+    SUM(size_bytes) OVER (
+      ORDER BY is_orphan DESC, size_bytes DESC, last_seen_at ASC
+    ) AS running_bytes,
+    ROW_NUMBER() OVER (
+      ORDER BY is_orphan DESC, size_bytes DESC, last_seen_at ASC
+    ) AS rn
+  FROM annotated
 )
-SELECT object_name, last_seen_at, size_bytes, generation
+SELECT object_name, last_seen_at, size_bytes, generation, is_orphan
 FROM ranked
 WHERE rn <= {settings.cleanup_max_delete_cas_objects}
   AND running_bytes <= {settings.cleanup_max_delete_cas_bytes}
@@ -1436,16 +1527,46 @@ WHERE rn <= {settings.cleanup_max_delete_cas_objects}
     cold_cas_count = _count_table_rows(execute=execute, table_ref=cold_cas_table)
     bytes_processed_total = _add_bytes(bytes_processed_total, cold_cas_count.bytes_processed)
 
-    ready_cas_table = _tmp_table_ref(settings, "ready_cas", run_id=run_id)
+    orphan_cas_table = _tmp_table_ref(settings, "orphan_cas", run_id=run_id)
     bytes_processed_total = _add_bytes(
         bytes_processed_total,
         execute(
-            f"""CREATE OR REPLACE TABLE {ready_cas_table}
+            f"""CREATE OR REPLACE TABLE {orphan_cas_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+SELECT object_name, last_seen_at, size_bytes, generation
+FROM {cold_cas_table}
+WHERE is_orphan""",
+            parameters=[],
+        ).total_bytes_processed,
+    )
+    orphan_cas_count = _count_table_rows(execute=execute, table_ref=orphan_cas_table)
+    bytes_processed_total = _add_bytes(bytes_processed_total, orphan_cas_count.bytes_processed)
+
+    linked_cas_table = _tmp_table_ref(settings, "linked_cas", run_id=run_id)
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            f"""CREATE OR REPLACE TABLE {linked_cas_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+SELECT object_name, last_seen_at, size_bytes, generation
+FROM {cold_cas_table}
+WHERE NOT is_orphan""",
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
+    ready_linked_cas_table = _tmp_table_ref(settings, "ready_linked_cas", run_id=run_id)
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            f"""CREATE OR REPLACE TABLE {ready_linked_cas_table}
 OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 AS
 {build_cas_ready_for_cascade_query(
     settings,
-    cold_cas_table=cold_cas_table,
+    cold_cas_table=linked_cas_table,
     snapshot_time=snapshot_time,
     ac_cutoff_days=ac_cutoff_days,
     by_cas_table_override=by_cas_table,
@@ -1453,28 +1574,42 @@ AS
             parameters=[],
         ).total_bytes_processed,
     )
-    ready_cas_count = _count_table_rows(execute=execute, table_ref=ready_cas_table)
-    bytes_processed_total = _add_bytes(bytes_processed_total, ready_cas_count.bytes_processed)
+    ready_linked_cas_count = _count_table_rows(
+        execute=execute, table_ref=ready_linked_cas_table
+    )
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total, ready_linked_cas_count.bytes_processed
+    )
+    candidate_cas_delete_count = (
+        orphan_cas_count.object_count + ready_linked_cas_count.object_count
+    )
 
     # ---- AC reverse lookup + deletion (dry-run: compute only) ----
     if mode == "dry-run":
-        ac_candidate_table = _tmp_table_ref(settings, "ac_to_delete", run_id=run_id)
-        execute(
-            f"""CREATE OR REPLACE TABLE {ac_candidate_table}
+        candidate_ac_count = 0
+        if ready_linked_cas_count.object_count > 0:
+            ac_candidate_table = _tmp_table_ref(settings, "ac_to_delete", run_id=run_id)
+            execute(
+                f"""CREATE OR REPLACE TABLE {ac_candidate_table}
 OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 AS
 {build_ac_reverse_lookup_query(
     settings,
-    cold_cas_table=ready_cas_table,
+    cold_cas_table=ready_linked_cas_table,
     snapshot_time=snapshot_time,
     ac_cutoff_days=ac_cutoff_days,
     by_cas_table_override=by_cas_table,
+    limit=settings.cleanup_max_delete_ac_objects,
 )}""",
-            parameters=[],
-        )
-        ac_candidate_count = _count_table_rows(execute=execute, table_ref=ac_candidate_table)
-        bytes_processed_total = _add_bytes(bytes_processed_total, ac_candidate_count.bytes_processed)
-        candidate_ac_count = ac_candidate_count.object_count
+                parameters=[],
+            )
+            ac_candidate_count = _count_table_rows(
+                execute=execute, table_ref=ac_candidate_table
+            )
+            bytes_processed_total = _add_bytes(
+                bytes_processed_total, ac_candidate_count.bytes_processed
+            )
+            candidate_ac_count = ac_candidate_count.object_count
 
         run_finished_at = now()
         return CleanupGcsCacheSummary(
@@ -1489,7 +1624,7 @@ AS
             safety_buffer_days=settings.cleanup_safety_buffer_days,
             candidate_cas_object_count=cold_cas_count.object_count,
             candidate_ac_object_count=candidate_ac_count,
-            candidate_cas_delete_object_count=ready_cas_count.object_count,
+            candidate_cas_delete_object_count=candidate_cas_delete_count,
             ac_parse_error_count=0,
             selected_ac_object_count=0,
             selected_cas_object_count=0,
@@ -1503,40 +1638,118 @@ AS
         )
 
     # ---- DELETE mode from here on ----
-    ac_delete_result = _delete_acs_referenced_by_cold_cas(
-        settings=settings,
-        execute=execute,
-        stream_rows=stream_rows,
-        resolve_object_metadata=resolve_object_metadata,
-        extract_references=None,
-        load_jsonl_file=load_jsonl_file,
-        create_batch_job=create_batch_job,
-        wait_for_batch_job=wait_for_batch_job,
-        cold_cas_table=ready_cas_table,
-        snapshot_time=snapshot_time,
-        ac_cutoff_days=ac_cutoff_days,
-        run_id=run_id,
-        run_started_at=run_started_at,
-    )
+    if ready_linked_cas_count.object_count > 0:
+        ac_delete_result = _delete_acs_referenced_by_cold_cas(
+            settings=settings,
+            execute=execute,
+            stream_rows=stream_rows,
+            resolve_object_metadata=resolve_object_metadata,
+            extract_references=None,
+            load_jsonl_file=load_jsonl_file,
+            create_batch_job=create_batch_job,
+            wait_for_batch_job=wait_for_batch_job,
+            cold_cas_table=ready_linked_cas_table,
+            by_cas_table=by_cas_table,
+            snapshot_time=snapshot_time,
+            ac_cutoff_days=ac_cutoff_days,
+            run_id=run_id,
+            run_started_at=run_started_at,
+        )
+    else:
+        ac_delete_result = CleanupGcsCacheAcDeleteResult(
+            candidate_ac_count=0,
+            selected_ac_count=0,
+            manifest_uri="",
+            batch_job_name="",
+            removed_ac_table="",
+        )
     bytes_processed_total = _add_bytes(bytes_processed_total, 0)
     selected_ac_count = ac_delete_result.selected_ac_count
 
-    # ---- Second incremental catch-up (design requirement) ----
-    # Catch up again after AC deletion to pick up any new ACs created during
-    # the delete phase, before we recompute zero-ref CAS.
-    snapshot_time_2 = now()
-    _run_catch_up_sync(settings=settings, until=snapshot_time_2, execute=execute)
+    # ---- Zero-ref CAS selection from the initial by_cas snapshot ----
+    zero_ref_snapshot_table = _tmp_table_ref(
+        settings, "cas_zero_ref_snapshot", run_id=run_id
+    )
+    if ready_linked_cas_count.object_count > 0:
+        linked_zero_ref_table = _tmp_table_ref(settings, "linked_cas_zero_ref", run_id=run_id)
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            execute(
+                f"""CREATE OR REPLACE TABLE {linked_zero_ref_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{build_zero_ref_cas_after_ac_removal_query(
+    settings,
+    cold_cas_table=ready_linked_cas_table,
+    removed_ac_table=ac_delete_result.removed_ac_table,
+    by_cas_table_override=by_cas_table,
+)}""",
+                parameters=[],
+            ).total_bytes_processed,
+        )
+        zero_ref_source_query = f"""
+SELECT object_name, last_seen_at
+FROM {orphan_cas_table}
+UNION DISTINCT
+SELECT object_name, last_seen_at
+FROM {linked_zero_ref_table}
+""".strip()
+    else:
+        zero_ref_source_query = f"""
+SELECT object_name, last_seen_at
+FROM {orphan_cas_table}
+""".strip()
 
-    # ---- Second by_cas rebuild (after AC deletion + catch-up) ----
     bytes_processed_total = _add_bytes(
         bytes_processed_total,
         execute(
-            build_rebuild_by_cas_from_by_ac_query(settings),
+            f"""CREATE OR REPLACE TABLE {zero_ref_snapshot_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{zero_ref_source_query}""",
             parameters=[],
         ).total_bytes_processed,
     )
 
-    # ---- Final zero-ref CAS selection ----
+    # Catch AC refs created while this cleanup was running, then block any CAS
+    # that still has a live by_ac edge. This keeps the expensive by_cas rebuild
+    # single-snapshot while restoring the old flow's new-AC detection.
+    if candidate_cas_delete_count > 0:
+        post_delete_recheck_time = now()
+        _run_catch_up_sync(
+            settings=settings,
+            until=post_delete_recheck_time,
+            execute=execute,
+        )
+        bytes_processed_total = _add_bytes(
+            bytes_processed_total,
+            _require_fresh_ac_reference_index(
+                settings=settings,
+                execute=execute,
+                target_time=post_delete_recheck_time,
+                target_label="post-delete live by_ac recheck",
+                max_staleness_hours=0,
+            ),
+        )
+
+    live_ref_blocked_cas_table = _tmp_table_ref(
+        settings, "cas_blocked_by_live_ac_ref", run_id=run_id
+    )
+    bytes_processed_total = _add_bytes(
+        bytes_processed_total,
+        execute(
+            f"""CREATE OR REPLACE TABLE {live_ref_blocked_cas_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
+AS
+{build_live_ac_ref_cas_blocklist_query(
+    settings,
+    candidate_table=zero_ref_snapshot_table,
+)}""",
+            parameters=[],
+        ).total_bytes_processed,
+    )
+
+    # ---- Final zero-ref CAS after live by_ac recheck ----
     zero_ref_table = _tmp_table_ref(settings, "cas_zero_ref", run_id=run_id)
     bytes_processed_total = _add_bytes(
         bytes_processed_total,
@@ -1544,7 +1757,10 @@ AS
             f"""CREATE OR REPLACE TABLE {zero_ref_table}
 OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 AS
-{build_zero_ref_cas_query(settings, cold_cas_table=ready_cas_table)}""",
+{build_final_zero_ref_after_live_recheck_query(
+    zero_ref_snapshot_table=zero_ref_snapshot_table,
+    live_ref_blocked_cas_table=live_ref_blocked_cas_table,
+)}""",
             parameters=[],
         ).total_bytes_processed,
     )
@@ -1747,12 +1963,23 @@ def _delete_acs_referenced_by_cold_cas(
     create_batch_job: BatchJobCreator,
     wait_for_batch_job: BatchJobWaiter,
     cold_cas_table: str,
+    by_cas_table: str,
     snapshot_time: str,
     ac_cutoff_days: int,
     run_id: str,
     run_started_at: datetime,
 ) -> CleanupGcsCacheAcDeleteResult:
     """Plan and execute AC deletion for ACs referenced by the bounded cold CAS set."""
+    ac_removed_table = _tmp_table_ref(settings, "ac_removed", run_id=run_id)
+    execute(
+        _create_table_query(
+            ac_removed_table,
+            columns=(("object_name", "STRING"),),
+            ttl_days=settings.cleanup_candidate_ttl_days,
+        ),
+        parameters=[],
+    ).total_bytes_processed
+
     ac_candidate_table = _tmp_table_ref(settings, "ac_to_delete", run_id=run_id)
     execute(
         f"""CREATE OR REPLACE TABLE {ac_candidate_table}
@@ -1763,6 +1990,8 @@ AS
     cold_cas_table=cold_cas_table,
     snapshot_time=snapshot_time,
     ac_cutoff_days=ac_cutoff_days,
+    by_cas_table_override=by_cas_table,
+    limit=settings.cleanup_max_delete_ac_objects,
 )}""",
         parameters=[],
     ).total_bytes_processed
@@ -1775,6 +2004,7 @@ AS
             selected_ac_count=0,
             manifest_uri="",
             batch_job_name="",
+            removed_ac_table=ac_removed_table,
         )
 
     # Resolve live AC metadata
@@ -1789,8 +2019,8 @@ AS
         batch_size=settings.cleanup_batch_size,
     )
 
-    # Reconcile missing ACs from last_seen_current and by_ac so ghost refs
-    # don't survive into the second by_cas rebuild.
+    # Reconcile missing ACs from last_seen_current and by_ac. The old by_cas
+    # snapshot is adjusted later through ac_removed_table.
     missing_ac_table = _tmp_table_ref(settings, "ac_missing_metadata", run_id=run_id)
     current_table = _table_ref(
         settings.project_id, settings.dataset, settings.last_seen_current_table
@@ -1831,12 +2061,25 @@ ORDER BY object_name ASC""",
 
     selected_ac_count = _count_table_rows(execute=execute, table_ref=ac_delete_table)
 
+    execute(
+        f"""CREATE OR REPLACE TABLE {ac_removed_table}
+OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL {settings.cleanup_candidate_ttl_days} DAY))
+AS
+SELECT object_name
+FROM {missing_ac_table}
+UNION DISTINCT
+SELECT object_name
+FROM {ac_delete_table}""",
+        parameters=[],
+    ).total_bytes_processed
+
     if selected_ac_count.object_count <= 0:
         return CleanupGcsCacheAcDeleteResult(
             candidate_ac_count=ac_candidate_count.object_count,
             selected_ac_count=0,
             manifest_uri="",
             batch_job_name="",
+            removed_ac_table=ac_removed_table,
         )
 
     # Export AC manifest + delete
@@ -1893,7 +2136,41 @@ WHERE ac_object_name IN (SELECT object_name FROM {ac_delete_table})""",
         selected_ac_count=selected_ac_count.object_count,
         manifest_uri=ac_manifest_uri,
         batch_job_name=ac_batch_job.job_name,
+        removed_ac_table=ac_removed_table,
     )
+
+
+def _require_fresh_ac_reference_index(
+    *,
+    settings: GcsCacheSettings,
+    execute: QueryExecutor,
+    target_time: datetime,
+    target_label: str,
+    max_staleness_hours: int,
+) -> int:
+    if not settings.cleanup_require_fresh_index:
+        return 0
+
+    target_time_text = target_time.strftime("%Y-%m-%d %H:%M:%S UTC")
+    state_table = _table_ref(
+        settings.project_id, settings.dataset, settings.ac_reference_index_state_table
+    )
+    result = execute(
+        f"""SELECT COUNTIF(indexed_through >= TIMESTAMP_SUB(TIMESTAMP('{target_time_text}'), INTERVAL {max_staleness_hours} HOUR)) AS fresh_shards
+FROM {state_table}""",
+        parameters=[],
+    )
+    fresh = int(result.rows[0].get("fresh_shards", 0) or 0) if result.rows else 0
+    if fresh < settings.ac_reference_shard_count:
+        raise RuntimeError(
+            f"AC reference index is stale after catch-up: only "
+            f"{fresh}/{settings.ac_reference_shard_count} shards have indexed_through "
+            f"within {max_staleness_hours}h of {target_label} ({target_time_text}). "
+            "Check incremental sync logs, increase max_staleness_hours if this is an "
+            "initial cleanup snapshot gate, or set "
+            "COST_INSIGHT_GCS_CACHE_CLEANUP_REQUIRE_FRESH_INDEX=false to bypass."
+        )
+    return result.total_bytes_processed
 
 
 def _run_catch_up_sync(

--- a/cost-insight/src/cost_insight/jobs/cli.py
+++ b/cost-insight/src/cost_insight/jobs/cli.py
@@ -215,6 +215,12 @@ def build_parser() -> argparse.ArgumentParser:
             "--max-delete-objects is not set."
         ),
     )
+    cleanup_gcs_cache.add_argument(
+        "--max-delete-ac-objects",
+        type=_parse_positive_int,
+        default=None,
+        help="AC candidate cap for CAS reverse-lookup cleanup.",
+    )
     cleanup_gcs_cache.add_argument("--sample-limit", type=_parse_positive_int, default=None)
 
     return parser
@@ -427,6 +433,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             cas_retention_days=args.cas_retention_days,
             safety_buffer_days=args.safety_buffer_days,
             max_delete_objects=args.max_delete_objects,
+            max_delete_ac_objects=args.max_delete_ac_objects,
             max_delete_cas_objects=args.max_delete_cas_objects,
             sample_limit=args.sample_limit,
         )

--- a/cost-insight/tests/test_cleanup_gcs_cache.py
+++ b/cost-insight/tests/test_cleanup_gcs_cache.py
@@ -1,5 +1,6 @@
 import json
 import re
+import sqlite3
 from datetime import UTC, datetime
 from threading import Event, Lock
 
@@ -26,7 +27,10 @@ from cost_insight.jobs.cleanup_gcs_cache import (
     build_cleanup_gcs_cache_run_references_table_query,
     build_cleanup_gcs_cache_summary_query,
     build_cas_ready_for_cascade_query,
+    build_final_zero_ref_after_live_recheck_query,
+    build_live_ac_ref_cas_blocklist_query,
     build_stale_ac_candidates_query,
+    build_zero_ref_cas_after_ac_removal_query,
     run_cleanup_gcs_cache,
 )
 
@@ -322,9 +326,84 @@ def test_ac_reverse_lookup_query_outputs_object_name_for_metadata_stage() -> Non
         cold_cas_table="`project.dataset.ready_cas`",
         snapshot_time="2026-07-03 10:00:00 UTC",
         ac_cutoff_days=11,
+        limit=100000,
     )
 
     assert "refs.ac_object_name AS object_name" in query
+    assert "LIMIT 100000" in query
+
+
+def test_zero_ref_cas_after_ac_removal_ignores_removed_ac_refs() -> None:
+    query = build_zero_ref_cas_after_ac_removal_query(
+        GcsCacheSettings(project_id="pingcap-testing-account"),
+        cold_cas_table="`project.dataset.ready_cas`",
+        removed_ac_table="`project.dataset.ac_removed`",
+    )
+
+    assert "LEFT JOIN `project.dataset.ac_removed` AS removed_ac" in query
+    assert "removed_ac.object_name = refs.ac_object_name" in query
+    assert "COUNTIF(" in query
+    assert "removed_ac.object_name IS NULL" in query
+
+
+def test_live_ac_ref_blocklist_uses_current_by_ac_refs() -> None:
+    query = build_live_ac_ref_cas_blocklist_query(
+        GcsCacheSettings(project_id="pingcap-testing-account"),
+        candidate_table="`project.dataset.cas_zero_ref_snapshot`",
+    )
+
+    assert "FROM `project.dataset.cas_zero_ref_snapshot` AS cas" in query
+    assert "gcs_cache_ac_cas_refs_by_ac" in query
+    assert "refs.cas_object_name = cas.object_name" in query
+    assert "removed_ac" not in query
+
+
+def test_live_ac_ref_recheck_blocks_only_candidates_with_live_refs() -> None:
+    settings = GcsCacheSettings(project_id="pingcap-testing-account")
+    snapshot_table = "`project.dataset.cas_zero_ref_snapshot`"
+    blocked_table = "`project.dataset.cas_blocked_by_live_ac_ref`"
+    by_ac_table = (
+        "`pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_ac_cas_refs_by_ac`"
+    )
+    conn = sqlite3.connect(":memory:")
+    conn.execute(f"CREATE TABLE {snapshot_table} (object_name TEXT, last_seen_at TEXT)")
+    conn.execute(
+        f"CREATE TABLE {by_ac_table} ("
+        "shard INTEGER, ac_object_name TEXT, cas_object_name TEXT)"
+    )
+    conn.executemany(
+        f"INSERT INTO {snapshot_table} VALUES (?, ?)",
+        (
+            ("cas/blocked", "2026-07-03 00:00:00 UTC"),
+            ("cas/free", "2026-07-03 00:00:00 UTC"),
+        ),
+    )
+    conn.executemany(
+        f"INSERT INTO {by_ac_table} VALUES (?, ?, ?)",
+        (
+            (1, "ac/new-1", "cas/blocked"),
+            (1, "ac/new-1", "cas/blocked"),
+            (2, "ac/other", "cas/not-a-candidate"),
+        ),
+    )
+
+    conn.execute(
+        f"CREATE TABLE {blocked_table} AS "
+        + build_live_ac_ref_cas_blocklist_query(
+            settings,
+            candidate_table=snapshot_table,
+        )
+    )
+    blocked_rows = conn.execute(f"SELECT object_name FROM {blocked_table}").fetchall()
+    assert blocked_rows == [("cas/blocked",)]
+
+    final_rows = conn.execute(
+        build_final_zero_ref_after_live_recheck_query(
+            zero_ref_snapshot_table=snapshot_table,
+            live_ref_blocked_cas_table=blocked_table,
+        )
+    ).fetchall()
+    assert final_rows == [("cas/free", "2026-07-03 00:00:00 UTC")]
 
 
 def test_cleanup_gcs_cache_manifest_export_query_uses_generation() -> None:
@@ -1413,16 +1492,16 @@ def test_run_cleanup_gcs_cache_from_index_dry_run_returns_summary_with_candidate
 
 
 def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatch) -> None:
-    """cas-from-index delete: AC delete → second catch-up → by_cas rebuild → CAS delete."""
+    """cas-from-index delete: AC delete → post catch-up → live-ref recheck → CAS delete."""
     from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
 
-    # Mock catch-up sync
-    monkeypatch.setattr(
-        cleanup_gcs_cache,
-        "run_sync_gcs_cache_ac_references",
-        lambda **kwargs: sync_gcs_cache_ac_references.SyncGcsCacheAcReferencesSummary(
+    sync_calls: list[dict[str, object]] = []
+
+    def fake_sync(**kwargs):
+        sync_calls.append(kwargs)
+        return sync_gcs_cache_ac_references.SyncGcsCacheAcReferencesSummary(
             account_id="test", bucket_name="test", mode="incremental",
-            shard_start=0, shard_end=255, source_object_count=0,
+            shard_start=kwargs["shard_start"], shard_end=kwargs["shard_end"], source_object_count=0,
             missing_object_count=0, parse_error_count=0,
             replaced_ac_object_count=0, reference_row_count=0,
             sample_parse_errors=(), dry_run=False,
@@ -1430,11 +1509,28 @@ def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatc
             bytes_processed=0,
             run_started_at=datetime(2026, 7, 1, 9, 59, tzinfo=UTC),
             run_finished_at=datetime(2026, 7, 1, 9, 59, tzinfo=UTC),
-        ),
+        )
+
+    monkeypatch.setattr(
+        cleanup_gcs_cache,
+        "run_sync_gcs_cache_ac_references",
+        fake_sync,
     )
 
     captured_queries = []
     step_order: list[str] = []
+    persistent_by_cas_table = (
+        "`pingcap-testing-account.ci_bazel_cache_logs.gcs_cache_ac_cas_refs_by_cas`"
+    )
+    zero_ref_snapshot_table = (
+        "`pingcap-testing-account.ci_bazel_cache_logs._tmp_cas_zero_ref_snapshot_test-delete-run`"
+    )
+    live_ref_blocklist_table = (
+        "`pingcap-testing-account.ci_bazel_cache_logs._tmp_cas_blocked_by_live_ac_ref_test-delete-run`"
+    )
+    final_zero_ref_table = (
+        "`pingcap-testing-account.ci_bazel_cache_logs._tmp_cas_zero_ref_test-delete-run`"
+    )
 
     def fake_execute(query, parameters):
         captured_queries.append(query)
@@ -1446,12 +1542,16 @@ def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatc
             return BigQueryQueryResult(rows=({"object_count": 3},), total_bytes_processed=1)
         # Track operation order
         if "CREATE OR REPLACE TABLE" in query:
-            if "by_cas" in query and "by_cas_dryrun" not in query:
+            if f"CREATE OR REPLACE TABLE {live_ref_blocklist_table}" in query:
+                step_order.append("live_ref_recheck")
+            elif f"CREATE OR REPLACE TABLE {zero_ref_snapshot_table}" in query:
+                step_order.append("zero_ref_snapshot")
+            elif f"CREATE OR REPLACE TABLE {final_zero_ref_table}" in query:
+                step_order.append("zero_ref_cas")
+            elif f"CREATE OR REPLACE TABLE {persistent_by_cas_table}" in query:
                 step_order.append("rebuild_by_cas")
             elif "ac_to_delete" in query:
                 step_order.append("ac_reverse_lookup")
-            elif "cas_zero_ref" in query:
-                step_order.append("zero_ref_cas")
             elif "delete_ac" in query:
                 step_order.append("ac_delete_manifest")
             elif "delete_cas" in query:
@@ -1505,7 +1605,10 @@ def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatc
 
     now = datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
     summary = run_cleanup_gcs_cache(
-        settings=GcsCacheSettings(project_id="pingcap-testing-account"),
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            ac_reference_shard_count=4,
+        ),
         mode="delete",
         execute_kind="cas-from-index",
         execute=fake_execute,
@@ -1522,13 +1625,122 @@ def test_run_cleanup_gcs_cache_from_index_delete_cascades_ac_then_cas(monkeypatc
     assert summary.dry_run is False
     assert summary.selected_ac_object_count > 0
     assert summary.selected_cas_object_count > 0
+    assert sorted(call["shard_start"] for call in sync_calls) == [0, 0, 1, 1, 2, 2, 3, 3]
     # Verify operation order: AC before CAS
     assert step_order.index("ac_manifest_export") < step_order.index("cas_manifest_export")
-    # Second by_cas rebuild before zero-ref
+    # Single by_cas rebuild before zero-ref; live by_ac catches refs created during cleanup.
     rebuild_positions = [i for i, s in enumerate(step_order) if s == "rebuild_by_cas"]
+    zero_ref_snapshot_pos = step_order.index("zero_ref_snapshot")
+    live_ref_recheck_pos = step_order.index("live_ref_recheck")
     zero_ref_pos = step_order.index("zero_ref_cas")
-    assert len(rebuild_positions) >= 2
-    assert rebuild_positions[-1] < zero_ref_pos
+    assert len(rebuild_positions) == 1
+    assert rebuild_positions[0] < zero_ref_snapshot_pos
+    assert step_order.index("ac_manifest_export") < zero_ref_snapshot_pos
+    assert zero_ref_snapshot_pos < live_ref_recheck_pos < zero_ref_pos
+    linked_zero_ref_query = next(
+        q for q in captured_queries if "linked_cas_zero_ref" in q and "removed_ac" in q
+    )
+    assert "removed_ac" in linked_zero_ref_query
+    zero_ref_snapshot_query = next(
+        q
+        for q in captured_queries
+        if f"CREATE OR REPLACE TABLE {zero_ref_snapshot_table}" in q
+    )
+    assert "UNION DISTINCT" in zero_ref_snapshot_query
+    live_ref_recheck_query = next(
+        q for q in captured_queries if "cas_blocked_by_live_ac_ref" in q
+    )
+    assert "gcs_cache_ac_cas_refs_by_ac" in live_ref_recheck_query
+    assert "removed_ac" not in live_ref_recheck_query
+    final_zero_ref_query = next(
+        q
+        for q in captured_queries
+        if "CREATE OR REPLACE TABLE `pingcap-testing-account.ci_bazel_cache_logs._tmp_cas_zero_ref_test-delete-run`"
+        in q
+    )
+    assert "blocked.object_name IS NULL" in final_zero_ref_query
+
+
+def test_cas_from_index_delete_requires_fresh_post_delete_catch_up(monkeypatch) -> None:
+    from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
+
+    monkeypatch.setattr(
+        cleanup_gcs_cache,
+        "run_sync_gcs_cache_ac_references",
+        lambda **kwargs: sync_gcs_cache_ac_references.SyncGcsCacheAcReferencesSummary(
+            account_id="test",
+            bucket_name="test",
+            mode="incremental",
+            shard_start=kwargs["shard_start"],
+            shard_end=kwargs["shard_end"],
+            source_object_count=0,
+            missing_object_count=0,
+            parse_error_count=0,
+            replaced_ac_object_count=0,
+            reference_row_count=0,
+            sample_parse_errors=(),
+            dry_run=False,
+            indexed_through=datetime(2026, 7, 3, 10, 0, tzinfo=UTC),
+            bytes_processed=0,
+            run_started_at=datetime(2026, 7, 3, 10, 0, tzinfo=UTC),
+            run_finished_at=datetime(2026, 7, 3, 10, 0, tzinfo=UTC),
+        ),
+    )
+
+    fresh_shard_counts = [2, 1]
+    captured_queries: list[str] = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append(query)
+        if "ready_shards" in query:
+            return BigQueryQueryResult(rows=({"ready_shards": 2},), total_bytes_processed=1)
+        if "fresh_shards" in query:
+            return BigQueryQueryResult(
+                rows=({"fresh_shards": fresh_shard_counts.pop(0)},),
+                total_bytes_processed=1,
+            )
+        if "_tmp_ready_linked_cas_post-gate" in query and "COUNT(*)" in query:
+            return BigQueryQueryResult(rows=({"object_count": 0},), total_bytes_processed=1)
+        if "COUNT(*)" in query or "object_count" in query:
+            return BigQueryQueryResult(rows=({"object_count": 1},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        if "cas_preselect" in query:
+            yield {"object_name": "cas/aaa"}
+        return
+
+    def fake_resolve_metadata(**kwargs):
+        return (
+            GcsObjectMetadata(
+                object_name="cas/aaa",
+                exists=True,
+                generation=1,
+                size_bytes=1024,
+            ),
+        )
+
+    def fail_create_batch_job(**kwargs):
+        raise AssertionError("CAS delete should not start when post-delete gate fails")
+
+    with pytest.raises(RuntimeError, match="post-delete live by_ac recheck"):
+        run_cleanup_gcs_cache(
+            settings=GcsCacheSettings(
+                project_id="pingcap-testing-account",
+                ac_reference_shard_count=2,
+            ),
+            mode="delete",
+            execute_kind="cas-from-index",
+            execute=fake_execute,
+            stream_rows=fake_stream_rows,
+            resolve_object_metadata=fake_resolve_metadata,
+            load_jsonl_file=lambda *args, **kwargs: None,
+            create_batch_job=fail_create_batch_job,
+            now=lambda: datetime(2026, 7, 3, 10, 0, tzinfo=UTC),
+            run_id_factory=lambda: "post-gate",
+        )
+
+    assert not any("_tmp_delete_cas_post-gate" in query for query in captured_queries)
 
 
 def test_cas_from_index_raises_preselect_to_max_delete_objects(monkeypatch) -> None:
@@ -1605,11 +1817,108 @@ def test_cas_from_index_raises_preselect_to_max_delete_objects(monkeypatch) -> N
     ]
     assert len(cold_cas_queries) >= 1
     assert "rn <= 5000000" in cold_cas_queries[0]
+    assert "is_orphan DESC" in cold_cas_queries[0]
+    assert "NOT EXISTS" in cold_cas_queries[0]
 
-    # AC refs are expanded for the selected CAS set and are not independently capped.
+    # CAS cap stays at 500w while linked AC expansion uses the AC cap.
     ac_queries = [q for q in captured_queries if "ac_to_delete" in q]
     assert len(ac_queries) >= 1
     assert "LIMIT 5000000" not in ac_queries[0]
+    assert "LIMIT 100000" in ac_queries[0]
+
+
+def test_cas_from_index_delete_bypasses_ac_when_only_orphan_cas(monkeypatch) -> None:
+    from cost_insight.jobs import cleanup_gcs_cache, sync_gcs_cache_ac_references
+
+    monkeypatch.setattr(
+        cleanup_gcs_cache,
+        "run_sync_gcs_cache_ac_references",
+        lambda **kwargs: sync_gcs_cache_ac_references.SyncGcsCacheAcReferencesSummary(
+            account_id="test",
+            bucket_name="test",
+            mode="incremental",
+            shard_start=kwargs["shard_start"],
+            shard_end=kwargs["shard_end"],
+            source_object_count=0,
+            missing_object_count=0,
+            parse_error_count=0,
+            replaced_ac_object_count=0,
+            reference_row_count=0,
+            sample_parse_errors=(),
+            dry_run=False,
+            indexed_through=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+            bytes_processed=0,
+            run_started_at=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+            run_finished_at=datetime(2026, 7, 2, 9, 59, tzinfo=UTC),
+        ),
+    )
+
+    captured_queries: list[str] = []
+
+    def fake_execute(query, parameters):
+        captured_queries.append(query)
+        if "ready_shards" in query:
+            return BigQueryQueryResult(rows=({"ready_shards": 2},), total_bytes_processed=1)
+        if "fresh_shards" in query:
+            return BigQueryQueryResult(rows=({"fresh_shards": 2},), total_bytes_processed=1)
+        if "_tmp_ready_linked_cas_orphan-only" in query and "COUNT(*)" in query:
+            return BigQueryQueryResult(rows=({"object_count": 0},), total_bytes_processed=1)
+        if "COUNT(*)" in query or "object_count" in query:
+            return BigQueryQueryResult(rows=({"object_count": 3},), total_bytes_processed=1)
+        return BigQueryQueryResult(rows=(), total_bytes_processed=1)
+
+    def fake_stream_rows(query, parameters):
+        if "cas_preselect" in query:
+            yield {"object_name": "cas/aaa"}
+        return
+
+    def fake_resolve_metadata(**kwargs):
+        return (
+            GcsObjectMetadata(
+                object_name="cas/aaa",
+                exists=True,
+                generation=1,
+                size_bytes=1024,
+            ),
+        )
+
+    def fail_create_batch_job(**kwargs):
+        if "-ac-" in kwargs["job_id"]:
+            raise AssertionError("orphan-only cleanup should not create an AC delete job")
+        return StorageBatchOperationsJob(job_name=kwargs["job_id"], operation_name=None)
+
+    def fake_wait_for_batch_job(**kwargs):
+        return StorageBatchOperationsJobStatus(
+            job_name=kwargs["job_name"],
+            state="SUCCEEDED",
+            failed_object_count=0,
+            total_object_count=3,
+            succeeded_object_count=3,
+            total_bytes_transformed=0,
+            complete_time=None,
+        )
+
+    summary = run_cleanup_gcs_cache(
+        settings=GcsCacheSettings(
+            project_id="pingcap-testing-account",
+            ac_reference_shard_count=2,
+        ),
+        mode="delete",
+        execute_kind="cas-from-index",
+        execute=fake_execute,
+        stream_rows=fake_stream_rows,
+        resolve_object_metadata=fake_resolve_metadata,
+        load_jsonl_file=lambda *args, **kwargs: None,
+        create_batch_job=fail_create_batch_job,
+        wait_for_batch_job=fake_wait_for_batch_job,
+        now=lambda: datetime(2026, 7, 2, 10, 0, tzinfo=UTC),
+        run_id_factory=lambda: "orphan-only",
+    )
+
+    assert summary.selected_ac_object_count == 0
+    assert summary.selected_cas_object_count > 0
+    assert not any("ac_to_delete" in query for query in captured_queries)
+    assert not any("delete_ac" in query for query in captured_queries)
 
 
 def test_cas_from_index_default_cas_cap_without_max_delete_objects(monkeypatch) -> None:
@@ -1680,4 +1989,4 @@ def test_cas_from_index_default_cas_cap_without_max_delete_objects(monkeypatch) 
 
     ac_queries = [q for q in captured_queries if "ac_to_delete" in q]
     assert len(ac_queries) >= 1
-    assert "LIMIT 100000" not in ac_queries[0]
+    assert "LIMIT 100000" in ac_queries[0]


### PR DESCRIPTION
## Summary
- optimize cas-from-index cleanup around orphan-first CAS selection and linked AC cascade
- add post-delete AC reference catch-up freshness gate and live by_ac recheck before CAS delete
- document race/cost tradeoffs and add behavior coverage for live ref blocking

## Tests
- python -m pytest tests/test_cleanup_gcs_cache.py -q --no-cov
- python -m ruff check src tests
- python -m pytest -q

Companion ops change: https://github.com/PingCAP-QE/ee-ops/pull/2097