### PR TITLE
fix(cost-insight): refresh storage batch polling token

### DIFF
--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -128,6 +128,24 @@ def wait_for_delete_job(
     while True:
         try:
             _refresh_credentials_if_needed(credentials, auth_request)
+        except StorageBatchOperationsTransientError:
+            logger.debug(
+                "Refreshing credentials while polling Storage Batch Operations job %s "
+                "hit transient error after %ss",
+                job_name,
+                elapsed,
+                exc_info=True,
+            )
+            elapsed = _sleep_or_raise_timeout(
+                job_name=job_name,
+                timeout_seconds=timeout_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                elapsed=elapsed,
+            )
+            auth_retried = False
+            continue
+
+        try:
             payload = _get_job_payload(request_url=request_url, token=credentials.token)
         except StorageBatchOperationsAuthError:
             if auth_retried:

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -125,18 +125,21 @@ def wait_for_delete_job(
 
     request_url = f"https://storagebatchoperations.googleapis.com/v1/{job_name}"
     elapsed = 0
+    auth_retried = False
     while True:
         try:
             _refresh_credentials_if_needed(credentials, auth_request)
             payload = _get_job_payload(request_url=request_url, token=credentials.token)
         except StorageBatchOperationsAuthError:
+            if auth_retried:
+                raise
             logger.info(
                 "Refreshing credentials while polling Storage Batch Operations job %s",
                 job_name,
-                exc_info=True,
             )
+            auth_retried = True
             credentials.refresh(auth_request)
-            payload = _get_job_payload(request_url=request_url, token=credentials.token)
+            continue
         except StorageBatchOperationsTransientError:
             logger.debug(
                 "Polling Storage Batch Operations job %s hit transient error after %ss",
@@ -151,6 +154,7 @@ def wait_for_delete_job(
                 elapsed=elapsed,
             )
             continue
+        auth_retried = False
         state = str(payload.get("state") or "STATE_UNSPECIFIED")
         logger.debug(
             "Polling Storage Batch Operations job %s: state=%s elapsed=%ss",

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -230,7 +230,7 @@ def _refresh_credentials(credentials, auth_request) -> None:
         raise StorageBatchOperationsTransientError(
             f"Storage Batch Operations credential refresh transient failure: {str(exc.reason)}"
         ) from exc
-    except (google_auth_exceptions.RefreshError, google_auth_exceptions.TransportError) as exc:
+    except google_auth_exceptions.TransportError as exc:
         raise StorageBatchOperationsTransientError(
             f"Storage Batch Operations credential refresh transient failure: {exc}"
         ) from exc

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -121,7 +121,6 @@ def wait_for_delete_job(
 
     credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
     auth_request = GoogleAuthRequest()
-    _refresh_credentials_if_needed(credentials, auth_request)
 
     request_url = f"https://storagebatchoperations.googleapis.com/v1/{job_name}"
     elapsed = 0
@@ -137,8 +136,24 @@ def wait_for_delete_job(
                 "Refreshing credentials while polling Storage Batch Operations job %s",
                 job_name,
             )
+            try:
+                _refresh_credentials(credentials, auth_request)
+            except StorageBatchOperationsTransientError:
+                logger.debug(
+                    "Refreshing credentials while polling Storage Batch Operations job %s "
+                    "hit transient error after %ss",
+                    job_name,
+                    elapsed,
+                    exc_info=True,
+                )
+                elapsed = _sleep_or_raise_timeout(
+                    job_name=job_name,
+                    timeout_seconds=timeout_seconds,
+                    poll_interval_seconds=poll_interval_seconds,
+                    elapsed=elapsed,
+                )
+                continue
             auth_retried = True
-            credentials.refresh(auth_request)
             continue
         except StorageBatchOperationsTransientError:
             logger.debug(
@@ -153,6 +168,7 @@ def wait_for_delete_job(
                 poll_interval_seconds=poll_interval_seconds,
                 elapsed=elapsed,
             )
+            auth_retried = False
             continue
         auth_retried = False
         state = str(payload.get("state") or "STATE_UNSPECIFIED")
@@ -202,7 +218,22 @@ def _get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
 
 def _refresh_credentials_if_needed(credentials, auth_request) -> None:
     if not credentials.valid:
+        _refresh_credentials(credentials, auth_request)
+
+
+def _refresh_credentials(credentials, auth_request) -> None:
+    from google.auth import exceptions as google_auth_exceptions
+
+    try:
         credentials.refresh(auth_request)
+    except URLError as exc:
+        raise StorageBatchOperationsTransientError(
+            f"Storage Batch Operations credential refresh transient failure: {str(exc.reason)}"
+        ) from exc
+    except (google_auth_exceptions.RefreshError, google_auth_exceptions.TransportError) as exc:
+        raise StorageBatchOperationsTransientError(
+            f"Storage Batch Operations credential refresh transient failure: {exc}"
+        ) from exc
 
 
 def _coerce_job_status(

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -35,6 +35,10 @@ class StorageBatchOperationsTransientError(RuntimeError):
     """Raised when polling should retry after a transient API failure."""
 
 
+class StorageBatchOperationsAuthError(RuntimeError):
+    """Raised when polling should refresh credentials and retry once."""
+
+
 def create_delete_job(
     *,
     project_id: str,
@@ -48,8 +52,8 @@ def create_delete_job(
     from google.auth.transport.requests import Request as GoogleAuthRequest
 
     credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
-    if not credentials.valid:
-        credentials.refresh(GoogleAuthRequest())
+    auth_request = GoogleAuthRequest()
+    _refresh_credentials_if_needed(credentials, auth_request)
 
     request_url = (
         "https://storagebatchoperations.googleapis.com/v1/"
@@ -116,13 +120,22 @@ def wait_for_delete_job(
     from google.auth.transport.requests import Request as GoogleAuthRequest
 
     credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
-    if not credentials.valid:
-        credentials.refresh(GoogleAuthRequest())
+    auth_request = GoogleAuthRequest()
+    _refresh_credentials_if_needed(credentials, auth_request)
 
     request_url = f"https://storagebatchoperations.googleapis.com/v1/{job_name}"
     elapsed = 0
     while True:
         try:
+            _refresh_credentials_if_needed(credentials, auth_request)
+            payload = _get_job_payload(request_url=request_url, token=credentials.token)
+        except StorageBatchOperationsAuthError:
+            logger.info(
+                "Refreshing credentials while polling Storage Batch Operations job %s",
+                job_name,
+                exc_info=True,
+            )
+            credentials.refresh(auth_request)
             payload = _get_job_payload(request_url=request_url, token=credentials.token)
         except StorageBatchOperationsTransientError:
             logger.debug(
@@ -168,6 +181,10 @@ def _get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
             return json.loads(response.read().decode("utf-8"))
     except HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
+        if exc.code == 401:
+            raise StorageBatchOperationsAuthError(
+                f"Storage Batch Operations get job authentication failure ({exc.code}): {detail}"
+            ) from exc
         if exc.code in {429, 500, 502, 503, 504}:
             raise StorageBatchOperationsTransientError(
                 f"Storage Batch Operations get job transient failure ({exc.code}): {detail}"
@@ -177,6 +194,11 @@ def _get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
         raise StorageBatchOperationsTransientError(
             f"Storage Batch Operations get job transient failure: {str(exc.reason)}"
         ) from exc
+
+
+def _refresh_credentials_if_needed(credentials, auth_request) -> None:
+    if not credentials.valid:
+        credentials.refresh(auth_request)
 
 
 def _coerce_job_status(

--- a/cost-insight/src/cost_insight/common/storage_batch_operations.py
+++ b/cost-insight/src/cost_insight/common/storage_batch_operations.py
@@ -129,18 +129,12 @@ def wait_for_delete_job(
         try:
             _refresh_credentials_if_needed(credentials, auth_request)
         except StorageBatchOperationsTransientError:
-            logger.debug(
-                "Refreshing credentials while polling Storage Batch Operations job %s "
-                "hit transient error after %ss",
-                job_name,
-                elapsed,
-                exc_info=True,
-            )
-            elapsed = _sleep_or_raise_timeout(
+            elapsed = _sleep_for_transient(
                 job_name=job_name,
                 timeout_seconds=timeout_seconds,
                 poll_interval_seconds=poll_interval_seconds,
                 elapsed=elapsed,
+                log_prefix="Refreshing credentials while polling",
             )
             auth_retried = False
             continue
@@ -157,34 +151,23 @@ def wait_for_delete_job(
             try:
                 _refresh_credentials(credentials, auth_request)
             except StorageBatchOperationsTransientError:
-                logger.debug(
-                    "Refreshing credentials while polling Storage Batch Operations job %s "
-                    "hit transient error after %ss",
-                    job_name,
-                    elapsed,
-                    exc_info=True,
-                )
-                elapsed = _sleep_or_raise_timeout(
+                elapsed = _sleep_for_transient(
                     job_name=job_name,
                     timeout_seconds=timeout_seconds,
                     poll_interval_seconds=poll_interval_seconds,
                     elapsed=elapsed,
+                    log_prefix="Refreshing credentials while polling",
                 )
                 continue
             auth_retried = True
             continue
         except StorageBatchOperationsTransientError:
-            logger.debug(
-                "Polling Storage Batch Operations job %s hit transient error after %ss",
-                job_name,
-                elapsed,
-                exc_info=True,
-            )
-            elapsed = _sleep_or_raise_timeout(
+            elapsed = _sleep_for_transient(
                 job_name=job_name,
                 timeout_seconds=timeout_seconds,
                 poll_interval_seconds=poll_interval_seconds,
                 elapsed=elapsed,
+                log_prefix="Polling",
             )
             auth_retried = False
             continue
@@ -277,6 +260,29 @@ def _coerce_counter(value: object) -> int:
     if value is None:
         return 0
     return int(str(value))
+
+
+def _sleep_for_transient(
+    *,
+    job_name: str,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    elapsed: int,
+    log_prefix: str,
+) -> int:
+    logger.debug(
+        "%s Storage Batch Operations job %s hit transient error after %ss",
+        log_prefix,
+        job_name,
+        elapsed,
+        exc_info=True,
+    )
+    return _sleep_or_raise_timeout(
+        job_name=job_name,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        elapsed=elapsed,
+    )
 
 
 def _sleep_or_raise_timeout(

--- a/cost-insight/tests/test_storage_batch_operations.py
+++ b/cost-insight/tests/test_storage_batch_operations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 from datetime import UTC, datetime
 from urllib.error import HTTPError, URLError
 
@@ -504,6 +505,7 @@ def test_wait_for_delete_job_retries_refresh_transport_error(
 
 def test_wait_for_delete_job_retries_proactive_refresh_transport_error(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     import google.auth
     from google.auth.exceptions import TransportError
@@ -545,6 +547,7 @@ def test_wait_for_delete_job_retries_proactive_refresh_transport_error(
     sleeps: list[int] = []
     monkeypatch.setattr(storage_batch_operations, "_get_job_payload", fake_get_job_payload)
     monkeypatch.setattr(storage_batch_operations, "sleep", lambda seconds: sleeps.append(seconds))
+    caplog.set_level(logging.DEBUG, logger=storage_batch_operations.logger.name)
 
     status = storage_batch_operations.wait_for_delete_job(
         job_name="projects/test/locations/global/jobs/job-proactive-refresh",
@@ -555,6 +558,16 @@ def test_wait_for_delete_job_retries_proactive_refresh_transport_error(
     assert seen_tokens == ["fresh-token-2"]
     assert sleeps == [5]
     assert credentials.refresh_count == 2
+    assert (
+        "Refreshing credentials while polling Storage Batch Operations job "
+        "projects/test/locations/global/jobs/job-proactive-refresh hit transient error after 0s"
+        in caplog.text
+    )
+    assert (
+        "Polling Storage Batch Operations job "
+        "projects/test/locations/global/jobs/job-proactive-refresh hit transient error"
+        not in caplog.text
+    )
     assert status == storage_batch_operations.StorageBatchOperationsJobStatus(
         job_name="projects/test/locations/global/jobs/job-proactive-refresh",
         state="SUCCEEDED",

--- a/cost-insight/tests/test_storage_batch_operations.py
+++ b/cost-insight/tests/test_storage_batch_operations.py
@@ -430,11 +430,11 @@ def test_wait_for_delete_job_resets_auth_retry_after_transient_boundary(
     )
 
 
-def test_wait_for_delete_job_retries_refresh_transient_error(
+def test_wait_for_delete_job_retries_refresh_transport_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import google.auth
-    from google.auth.exceptions import RefreshError
+    from google.auth.exceptions import TransportError
     from google.auth.transport import requests
 
     class ExpiringCredentials:
@@ -447,7 +447,7 @@ def test_wait_for_delete_job_retries_refresh_transient_error(
         def refresh(self, _request) -> None:
             self.refresh_count += 1
             if self.refresh_count == 1:
-                raise RefreshError("token endpoint unavailable")
+                raise TransportError("token endpoint unavailable")
             self.token = f"fresh-token-{self.refresh_count}"
             self.valid = True
 
@@ -502,11 +502,75 @@ def test_wait_for_delete_job_retries_refresh_transient_error(
     )
 
 
+def test_wait_for_delete_job_retries_proactive_refresh_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import google.auth
+    from google.auth.exceptions import TransportError
+    from google.auth.transport import requests
+
+    class ExpiringCredentials:
+        valid = False
+        token = "expired-token"
+
+        def __init__(self) -> None:
+            self.refresh_count = 0
+
+        def refresh(self, _request) -> None:
+            self.refresh_count += 1
+            if self.refresh_count == 1:
+                raise TransportError("token endpoint unavailable")
+            self.token = f"fresh-token-{self.refresh_count}"
+            self.valid = True
+
+    credentials = ExpiringCredentials()
+    monkeypatch.setattr(google.auth, "default", lambda scopes=None: (credentials, "test"))
+    monkeypatch.setattr(requests, "Request", lambda: object())
+
+    seen_tokens: list[str] = []
+
+    def fake_get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
+        assert request_url.endswith("/projects/test/locations/global/jobs/job-proactive-refresh")
+        seen_tokens.append(token)
+        return {
+            "state": "SUCCEEDED",
+            "counters": {
+                "totalObjectCount": "2",
+                "succeededObjectCount": "2",
+                "failedObjectCount": "0",
+                "totalBytesTransformed": "321",
+            },
+        }
+
+    sleeps: list[int] = []
+    monkeypatch.setattr(storage_batch_operations, "_get_job_payload", fake_get_job_payload)
+    monkeypatch.setattr(storage_batch_operations, "sleep", lambda seconds: sleeps.append(seconds))
+
+    status = storage_batch_operations.wait_for_delete_job(
+        job_name="projects/test/locations/global/jobs/job-proactive-refresh",
+        timeout_seconds=60,
+        poll_interval_seconds=5,
+    )
+
+    assert seen_tokens == ["fresh-token-2"]
+    assert sleeps == [5]
+    assert credentials.refresh_count == 2
+    assert status == storage_batch_operations.StorageBatchOperationsJobStatus(
+        job_name="projects/test/locations/global/jobs/job-proactive-refresh",
+        state="SUCCEEDED",
+        total_object_count=2,
+        succeeded_object_count=2,
+        failed_object_count=0,
+        total_bytes_transformed=321,
+        complete_time=None,
+    )
+
+
 def test_refresh_credentials_wraps_transient_errors() -> None:
-    from google.auth.exceptions import RefreshError
+    from google.auth.exceptions import TransportError
 
     for refresh_error, expected in [
-        (RefreshError("token endpoint unavailable"), "token endpoint unavailable"),
+        (TransportError("token endpoint unavailable"), "token endpoint unavailable"),
         (URLError("socket timeout"), "socket timeout"),
     ]:
 
@@ -519,6 +583,17 @@ def test_refresh_credentials_wraps_transient_errors() -> None:
             match=expected,
         ):
             storage_batch_operations._refresh_credentials(Credentials(), object())
+
+
+def test_refresh_credentials_raises_refresh_error_without_wrapping() -> None:
+    from google.auth.exceptions import RefreshError
+
+    class Credentials:
+        def refresh(self, _request) -> None:
+            raise RefreshError("invalid_grant")
+
+    with pytest.raises(RefreshError, match="invalid_grant"):
+        storage_batch_operations._refresh_credentials(Credentials(), object())
 
 
 def test_wait_for_delete_job_raises_after_repeated_auth_error(

--- a/cost-insight/tests/test_storage_batch_operations.py
+++ b/cost-insight/tests/test_storage_batch_operations.py
@@ -360,6 +360,167 @@ def test_wait_for_delete_job_retries_transient_after_auth_refresh(
     )
 
 
+def test_wait_for_delete_job_resets_auth_retry_after_transient_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import google.auth
+    from google.auth.transport import requests
+
+    class ExpiringCredentials:
+        valid = True
+        token = "expired-token"
+
+        def __init__(self) -> None:
+            self.refresh_count = 0
+
+        def refresh(self, _request) -> None:
+            self.refresh_count += 1
+            self.token = f"fresh-token-{self.refresh_count}"
+            self.valid = True
+
+    credentials = ExpiringCredentials()
+    monkeypatch.setattr(google.auth, "default", lambda scopes=None: (credentials, "test"))
+    monkeypatch.setattr(requests, "Request", lambda: object())
+
+    responses: list[object] = [
+        storage_batch_operations.StorageBatchOperationsAuthError("expired"),
+        storage_batch_operations.StorageBatchOperationsTransientError("outage"),
+        storage_batch_operations.StorageBatchOperationsAuthError("expired again"),
+        {
+            "state": "SUCCEEDED",
+            "counters": {
+                "totalObjectCount": "9",
+                "succeededObjectCount": "9",
+                "failedObjectCount": "0",
+                "totalBytesTransformed": "1234",
+            },
+        },
+    ]
+    seen_tokens: list[str] = []
+
+    def fake_get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
+        assert request_url.endswith("/projects/test/locations/global/jobs/job-boundary")
+        seen_tokens.append(token)
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    sleeps: list[int] = []
+    monkeypatch.setattr(storage_batch_operations, "_get_job_payload", fake_get_job_payload)
+    monkeypatch.setattr(storage_batch_operations, "sleep", lambda seconds: sleeps.append(seconds))
+
+    status = storage_batch_operations.wait_for_delete_job(
+        job_name="projects/test/locations/global/jobs/job-boundary",
+        timeout_seconds=60,
+        poll_interval_seconds=5,
+    )
+
+    assert seen_tokens == ["expired-token", "fresh-token-1", "fresh-token-1", "fresh-token-2"]
+    assert sleeps == [5]
+    assert credentials.refresh_count == 2
+    assert status == storage_batch_operations.StorageBatchOperationsJobStatus(
+        job_name="projects/test/locations/global/jobs/job-boundary",
+        state="SUCCEEDED",
+        total_object_count=9,
+        succeeded_object_count=9,
+        failed_object_count=0,
+        total_bytes_transformed=1234,
+        complete_time=None,
+    )
+
+
+def test_wait_for_delete_job_retries_refresh_transient_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import google.auth
+    from google.auth.exceptions import RefreshError
+    from google.auth.transport import requests
+
+    class ExpiringCredentials:
+        valid = True
+        token = "expired-token"
+
+        def __init__(self) -> None:
+            self.refresh_count = 0
+
+        def refresh(self, _request) -> None:
+            self.refresh_count += 1
+            if self.refresh_count == 1:
+                raise RefreshError("token endpoint unavailable")
+            self.token = f"fresh-token-{self.refresh_count}"
+            self.valid = True
+
+    credentials = ExpiringCredentials()
+    monkeypatch.setattr(google.auth, "default", lambda scopes=None: (credentials, "test"))
+    monkeypatch.setattr(requests, "Request", lambda: object())
+
+    responses: list[object] = [
+        storage_batch_operations.StorageBatchOperationsAuthError("expired"),
+        storage_batch_operations.StorageBatchOperationsAuthError("expired after refresh outage"),
+        {
+            "state": "SUCCEEDED",
+            "counters": {
+                "totalObjectCount": "4",
+                "succeededObjectCount": "4",
+                "failedObjectCount": "0",
+                "totalBytesTransformed": "987",
+            },
+        },
+    ]
+    seen_tokens: list[str] = []
+
+    def fake_get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
+        assert request_url.endswith("/projects/test/locations/global/jobs/job-refresh-outage")
+        seen_tokens.append(token)
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    sleeps: list[int] = []
+    monkeypatch.setattr(storage_batch_operations, "_get_job_payload", fake_get_job_payload)
+    monkeypatch.setattr(storage_batch_operations, "sleep", lambda seconds: sleeps.append(seconds))
+
+    status = storage_batch_operations.wait_for_delete_job(
+        job_name="projects/test/locations/global/jobs/job-refresh-outage",
+        timeout_seconds=60,
+        poll_interval_seconds=5,
+    )
+
+    assert seen_tokens == ["expired-token", "expired-token", "fresh-token-2"]
+    assert sleeps == [5]
+    assert credentials.refresh_count == 2
+    assert status == storage_batch_operations.StorageBatchOperationsJobStatus(
+        job_name="projects/test/locations/global/jobs/job-refresh-outage",
+        state="SUCCEEDED",
+        total_object_count=4,
+        succeeded_object_count=4,
+        failed_object_count=0,
+        total_bytes_transformed=987,
+        complete_time=None,
+    )
+
+
+def test_refresh_credentials_wraps_transient_errors() -> None:
+    from google.auth.exceptions import RefreshError
+
+    for refresh_error, expected in [
+        (RefreshError("token endpoint unavailable"), "token endpoint unavailable"),
+        (URLError("socket timeout"), "socket timeout"),
+    ]:
+
+        class Credentials:
+            def refresh(self, _request) -> None:
+                raise refresh_error
+
+        with pytest.raises(
+            storage_batch_operations.StorageBatchOperationsTransientError,
+            match=expected,
+        ):
+            storage_batch_operations._refresh_credentials(Credentials(), object())
+
+
 def test_wait_for_delete_job_raises_after_repeated_auth_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/cost-insight/tests/test_storage_batch_operations.py
+++ b/cost-insight/tests/test_storage_batch_operations.py
@@ -168,6 +168,13 @@ def test_get_job_payload_handles_success_and_error_branches(monkeypatch: pytest.
                 hdrs=None,
                 fp=io.BytesIO(b"missing"),
             ),
+            HTTPError(
+                url="https://example.invalid/job",
+                code=401,
+                msg="unauthorized",
+                hdrs=None,
+                fp=io.BytesIO(b'{"reason":"ACCESS_TOKEN_EXPIRED"}'),
+            ),
             URLError("socket timeout"),
         ]
     )
@@ -205,6 +212,15 @@ def test_get_job_payload_handles_success_and_error_branches(monkeypatch: pytest.
         )
 
     with pytest.raises(
+        storage_batch_operations.StorageBatchOperationsAuthError,
+        match="Storage Batch Operations get job authentication failure",
+    ):
+        storage_batch_operations._get_job_payload(
+            request_url="https://example.invalid/job",
+            token="test-token",
+        )
+
+    with pytest.raises(
         storage_batch_operations.StorageBatchOperationsTransientError,
         match="Storage Batch Operations get job transient failure: socket timeout",
     ):
@@ -212,6 +228,67 @@ def test_get_job_payload_handles_success_and_error_branches(monkeypatch: pytest.
             request_url="https://example.invalid/job",
             token="test-token",
         )
+
+
+def test_wait_for_delete_job_refreshes_token_after_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import google.auth
+    from google.auth.transport import requests
+
+    class ExpiringCredentials:
+        valid = True
+        token = "expired-token"
+
+        def __init__(self) -> None:
+            self.refresh_count = 0
+
+        def refresh(self, _request) -> None:
+            self.refresh_count += 1
+            self.token = f"fresh-token-{self.refresh_count}"
+            self.valid = True
+
+    credentials = ExpiringCredentials()
+    monkeypatch.setattr(google.auth, "default", lambda scopes=None: (credentials, "test"))
+    monkeypatch.setattr(requests, "Request", lambda: object())
+
+    seen_tokens: list[str] = []
+
+    def fake_get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
+        assert request_url.endswith("/projects/test/locations/global/jobs/job-refresh")
+        seen_tokens.append(token)
+        if token == "expired-token":
+            raise storage_batch_operations.StorageBatchOperationsAuthError("expired")
+        return {
+            "state": "SUCCEEDED",
+            "counters": {
+                "totalObjectCount": "3",
+                "succeededObjectCount": "3",
+                "failedObjectCount": "0",
+                "totalBytesTransformed": "456",
+            },
+            "completeTime": "2026-07-07T00:26:13Z",
+        }
+
+    monkeypatch.setattr(storage_batch_operations, "_get_job_payload", fake_get_job_payload)
+
+    status = storage_batch_operations.wait_for_delete_job(
+        job_name="projects/test/locations/global/jobs/job-refresh",
+        timeout_seconds=60,
+        poll_interval_seconds=5,
+    )
+
+    assert seen_tokens == ["expired-token", "fresh-token-1"]
+    assert credentials.refresh_count == 1
+    assert status == storage_batch_operations.StorageBatchOperationsJobStatus(
+        job_name="projects/test/locations/global/jobs/job-refresh",
+        state="SUCCEEDED",
+        total_object_count=3,
+        succeeded_object_count=3,
+        failed_object_count=0,
+        total_bytes_transformed=456,
+        complete_time=datetime(2026, 7, 7, 0, 26, 13, tzinfo=UTC),
+    )
 
 
 def test_wait_for_delete_job_retries_transient_errors_and_state_unspecified(

--- a/cost-insight/tests/test_storage_batch_operations.py
+++ b/cost-insight/tests/test_storage_batch_operations.py
@@ -291,6 +291,120 @@ def test_wait_for_delete_job_refreshes_token_after_auth_error(
     )
 
 
+def test_wait_for_delete_job_retries_transient_after_auth_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import google.auth
+    from google.auth.transport import requests
+
+    class ExpiringCredentials:
+        valid = True
+        token = "expired-token"
+
+        def __init__(self) -> None:
+            self.refresh_count = 0
+
+        def refresh(self, _request) -> None:
+            self.refresh_count += 1
+            self.token = f"fresh-token-{self.refresh_count}"
+            self.valid = True
+
+    credentials = ExpiringCredentials()
+    monkeypatch.setattr(google.auth, "default", lambda scopes=None: (credentials, "test"))
+    monkeypatch.setattr(requests, "Request", lambda: object())
+
+    responses: list[object] = [
+        storage_batch_operations.StorageBatchOperationsAuthError("expired"),
+        storage_batch_operations.StorageBatchOperationsTransientError("retry later"),
+        {
+            "state": "SUCCEEDED",
+            "counters": {
+                "totalObjectCount": "5",
+                "succeededObjectCount": "5",
+                "failedObjectCount": "0",
+                "totalBytesTransformed": "789",
+            },
+        },
+    ]
+    seen_tokens: list[str] = []
+
+    def fake_get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
+        assert request_url.endswith("/projects/test/locations/global/jobs/job-transient")
+        seen_tokens.append(token)
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    sleeps: list[int] = []
+    monkeypatch.setattr(storage_batch_operations, "_get_job_payload", fake_get_job_payload)
+    monkeypatch.setattr(storage_batch_operations, "sleep", lambda seconds: sleeps.append(seconds))
+
+    status = storage_batch_operations.wait_for_delete_job(
+        job_name="projects/test/locations/global/jobs/job-transient",
+        timeout_seconds=60,
+        poll_interval_seconds=5,
+    )
+
+    assert seen_tokens == ["expired-token", "fresh-token-1", "fresh-token-1"]
+    assert sleeps == [5]
+    assert credentials.refresh_count == 1
+    assert status == storage_batch_operations.StorageBatchOperationsJobStatus(
+        job_name="projects/test/locations/global/jobs/job-transient",
+        state="SUCCEEDED",
+        total_object_count=5,
+        succeeded_object_count=5,
+        failed_object_count=0,
+        total_bytes_transformed=789,
+        complete_time=None,
+    )
+
+
+def test_wait_for_delete_job_raises_after_repeated_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import google.auth
+    from google.auth.transport import requests
+
+    class ExpiringCredentials:
+        valid = True
+        token = "expired-token"
+
+        def __init__(self) -> None:
+            self.refresh_count = 0
+
+        def refresh(self, _request) -> None:
+            self.refresh_count += 1
+            self.token = f"fresh-token-{self.refresh_count}"
+            self.valid = True
+
+    credentials = ExpiringCredentials()
+    monkeypatch.setattr(google.auth, "default", lambda scopes=None: (credentials, "test"))
+    monkeypatch.setattr(requests, "Request", lambda: object())
+
+    seen_tokens: list[str] = []
+
+    def fake_get_job_payload(*, request_url: str, token: str) -> dict[str, object]:
+        assert request_url.endswith("/projects/test/locations/global/jobs/job-auth-fail")
+        seen_tokens.append(token)
+        raise storage_batch_operations.StorageBatchOperationsAuthError("still unauthorized")
+
+    monkeypatch.setattr(storage_batch_operations, "_get_job_payload", fake_get_job_payload)
+
+    with pytest.raises(
+        storage_batch_operations.StorageBatchOperationsAuthError,
+        match="still unauthorized",
+    ):
+        storage_batch_operations.wait_for_delete_job(
+            job_name="projects/test/locations/global/jobs/job-auth-fail",
+            timeout_seconds=60,
+            poll_interval_seconds=5,
+        )
+
+    assert seen_tokens == ["expired-token", "fresh-token-1"]
+    assert credentials.refresh_count == 1
+
+
 def test_wait_for_delete_job_retries_transient_errors_and_state_unspecified(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- refresh Google credentials before each Storage Batch Operations polling request
- refresh and retry once when a polling request returns 401, covering expired access tokens during long-running delete jobs
- add regression coverage for auth refresh while waiting for batch delete jobs

## Tests
- python -m pytest tests/test_storage_batch_operations.py -q --no-cov
- python -m ruff check src tests
- python -m pytest -q