### PR TITLE
fix(insight): skip invalid prow jobs

### DIFF
--- a/insight/crawlers/ci/prow-jobs.test.ts
+++ b/insight/crawlers/ci/prow-jobs.test.ts
@@ -128,3 +128,26 @@ Deno.test("rejects prow jobs with states outside the database enum", () => {
     "invalid status.state: unknown-state",
   );
 });
+
+Deno.test("rejects prow jobs missing insert-required metadata and spec fields", () => {
+  assertEquals(
+    invalidProwJobReason(makeProwJob({ metadata: { namespace: "" } })),
+    "missing metadata.namespace",
+  );
+  assertEquals(
+    invalidProwJobReason(makeProwJob({ metadata: { name: "" } })),
+    "missing metadata.name",
+  );
+  assertEquals(
+    invalidProwJobReason(makeProwJob({ spec: { job: "" } })),
+    "missing spec.job",
+  );
+  assertEquals(
+    invalidProwJobReason(makeProwJob({ spec: { type: "" } })),
+    "missing spec.type",
+  );
+  assertEquals(
+    invalidProwJobReason(makeProwJob({ spec: { type: "weird" } })),
+    "invalid spec.type: weird",
+  );
+});

--- a/insight/crawlers/ci/prow-jobs.test.ts
+++ b/insight/crawlers/ci/prow-jobs.test.ts
@@ -1,5 +1,44 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert";
-import { convertDsnToClientConfig } from "./prow-jobs.ts";
+import { assertEquals, assertThrows } from "jsr:@std/assert@1.0.19";
+import { convertDsnToClientConfig } from "../../db/utils.ts";
+import {
+  filterInsertableJobs,
+  invalidProwJobReason,
+  type prowJobRun,
+} from "./prow-jobs.ts";
+
+function makeProwJob(overrides: Partial<prowJobRun> = {}): prowJobRun {
+  const job: prowJobRun = {
+    kind: "ProwJob",
+    metadata: {
+      name: "valid-prow-job",
+      namespace: "prow-test-pods",
+      labels: {},
+    },
+    spec: {
+      type: "periodic",
+      agent: "kubernetes",
+      cluster: "default",
+      namespace: "prow-test-pods",
+      job: "periodic-crawl-ci-run-data",
+      report: true,
+    },
+    status: {
+      state: "success",
+      startTime: "2026-07-11T02:11:48Z",
+      pendingTime: "2026-07-11T02:11:48Z",
+      completionTime: "2026-07-11T02:14:10Z",
+      url: "https://prow.tidb.net/view/gs/prow-tidb-logs/logs/example/1",
+    },
+  };
+
+  return {
+    ...job,
+    ...overrides,
+    metadata: { ...job.metadata, ...overrides.metadata },
+    spec: { ...job.spec, ...overrides.spec },
+    status: { ...job.status, ...overrides.status },
+  };
+}
 
 Deno.test("should correctly parse a valid DSN", () => {
   const dsn = "mysql://user:password@localhost:5432/database";
@@ -43,4 +82,49 @@ Deno.test("should correctly parse a DSN with special characters in user and pass
     password: "pass:word",
     db: "database",
   });
+});
+
+Deno.test("filters prow jobs missing insert-required status fields", () => {
+  const validJob = makeProwJob();
+  const missingStateJob = makeProwJob({
+    metadata: {
+      name: "missing-state",
+      namespace: "prow-test-pods",
+      labels: {},
+    },
+    status: { state: null },
+  });
+  const missingStartTimeJob = makeProwJob({
+    metadata: {
+      name: "missing-start-time",
+      namespace: "prow-test-pods",
+      labels: {},
+    },
+    status: { startTime: null },
+  });
+
+  const { insertableJobs, skippedJobs } = filterInsertableJobs([
+    validJob,
+    missingStateJob,
+    missingStartTimeJob,
+  ]);
+
+  assertEquals(insertableJobs.map((job) => job.metadata.name), [
+    "valid-prow-job",
+  ]);
+  assertEquals(skippedJobs.map(({ reason }) => reason), [
+    "missing status.state",
+    "missing or invalid status.startTime",
+  ]);
+});
+
+Deno.test("rejects prow jobs with states outside the database enum", () => {
+  const job = makeProwJob({
+    status: { state: "unknown-state" },
+  });
+
+  assertEquals(
+    invalidProwJobReason(job),
+    "invalid status.state: unknown-state",
+  );
 });

--- a/insight/crawlers/ci/prow-jobs.ts
+++ b/insight/crawlers/ci/prow-jobs.ts
@@ -2,7 +2,23 @@ import { parseArgs } from "jsr:@std/cli@1.0.14/parse-args";
 import * as mysql from "https://deno.land/x/mysql@v2.12.1/mod.ts";
 import { convertDsnToClientConfig } from "../../db/utils.ts";
 
-interface prowJobRun {
+const VALID_JOB_STATES = new Set([
+  "triggered",
+  "pending",
+  "success",
+  "failure",
+  "error",
+  "aborted",
+]);
+
+const VALID_JOB_TYPES = new Set([
+  "presubmit",
+  "postsubmit",
+  "batch",
+  "periodic",
+]);
+
+export interface prowJobRun {
   kind: string;
   metadata: {
     name: string;
@@ -15,7 +31,7 @@ interface prowJobRun {
     cluster: string;
     namespace: string;
     job: string;
-    report: boolean;
+    report?: boolean;
     refs?: {
       org: string;
       repo: string;
@@ -33,11 +49,11 @@ interface prowJobRun {
     };
   };
   status: {
-    state: string;
-    startTime: string;
-    pendingTime: string;
-    completionTime: string;
-    url: string;
+    state?: string | null;
+    startTime?: string | null;
+    pendingTime?: string | null;
+    completionTime?: string | null;
+    url?: string | null;
   };
 }
 
@@ -50,10 +66,63 @@ export async function fetchProwJobs(prowBaseUrl: string) {
   return data.items;
 }
 
+function hasValidDate(value: string | null | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+  return !Number.isNaN(new Date(value).getTime());
+}
+
+export function invalidProwJobReason(job: prowJobRun): string | null {
+  if (!job.metadata?.namespace) {
+    return "missing metadata.namespace";
+  }
+  if (!job.metadata?.name) {
+    return "missing metadata.name";
+  }
+  if (!job.spec?.job) {
+    return "missing spec.job";
+  }
+  if (!job.spec?.type) {
+    return "missing spec.type";
+  }
+  if (!VALID_JOB_TYPES.has(job.spec.type)) {
+    return `invalid spec.type: ${job.spec.type}`;
+  }
+  if (!job.status?.state) {
+    return "missing status.state";
+  }
+  if (!VALID_JOB_STATES.has(job.status.state)) {
+    return `invalid status.state: ${job.status.state}`;
+  }
+  if (!hasValidDate(job.status.startTime)) {
+    return "missing or invalid status.startTime";
+  }
+  return null;
+}
+
+export function filterInsertableJobs(jobs: prowJobRun[]) {
+  const insertableJobs: prowJobRun[] = [];
+  const skippedJobs: { job: prowJobRun; reason: string }[] = [];
+
+  for (const job of jobs) {
+    const reason = invalidProwJobReason(job);
+    if (reason) {
+      skippedJobs.push({ job, reason });
+      continue;
+    }
+    insertableJobs.push(job);
+  }
+
+  return { insertableJobs, skippedJobs };
+}
+
 export async function createJobTable(client: mysql.Client, tableName: string) {
   // Validate table name to prevent SQL injection (only allow alphanumeric and underscores)
   if (!/^[a-zA-Z0-9_]+$/.test(tableName)) {
-    throw new Error(`Invalid table name: ${tableName}. Only alphanumeric characters and underscores are allowed.`);
+    throw new Error(
+      `Invalid table name: ${tableName}. Only alphanumeric characters and underscores are allowed.`,
+    );
   }
 
   const sql = `
@@ -89,17 +158,22 @@ export async function createJobTable(client: mysql.Client, tableName: string) {
 export async function migrateJobTable(client: mysql.Client, tableName: string) {
   // Validate table name to prevent SQL injection (only allow alphanumeric and underscores)
   if (!/^[a-zA-Z0-9_]+$/.test(tableName)) {
-    throw new Error(`Invalid table name: ${tableName}. Only alphanumeric characters and underscores are allowed.`);
+    throw new Error(
+      `Invalid table name: ${tableName}. Only alphanumeric characters and underscores are allowed.`,
+    );
   }
 
   // Check if table exists
   const tableExistsResult = await client.query(
     `SELECT COUNT(*) as count FROM information_schema.tables
      WHERE table_schema = DATABASE() AND table_name = ?`,
-    [tableName]
+    [tableName],
   );
 
-  if (!tableExistsResult || tableExistsResult.length === 0 || tableExistsResult[0].count === 0) {
+  if (
+    !tableExistsResult || tableExistsResult.length === 0 ||
+    tableExistsResult[0].count === 0
+  ) {
     console.info(`Table ${tableName} does not exist, skipping migration`);
     return;
   }
@@ -108,18 +182,18 @@ export async function migrateJobTable(client: mysql.Client, tableName: string) {
   const columnsResult = await client.query(
     `SELECT COLUMN_NAME FROM information_schema.columns
      WHERE table_schema = DATABASE() AND table_name = ?`,
-    [tableName]
+    [tableName],
   );
 
   const existingColumns = new Set(
-    columnsResult.map((row: any) => row.COLUMN_NAME)
+    columnsResult.map((row: { COLUMN_NAME: string }) => row.COLUMN_NAME),
   );
 
   // Add retest column if it doesn't exist
   if (!existingColumns.has("retest")) {
     console.info(`Adding column 'retest' to table ${tableName}`);
     await client.execute(
-      `ALTER TABLE \`${tableName}\` ADD COLUMN retest BOOLEAN DEFAULT NULL AFTER url`
+      `ALTER TABLE \`${tableName}\` ADD COLUMN retest BOOLEAN DEFAULT NULL AFTER url`,
     );
   }
 
@@ -127,7 +201,7 @@ export async function migrateJobTable(client: mysql.Client, tableName: string) {
   if (!existingColumns.has("author")) {
     console.info(`Adding column 'author' to table ${tableName}`);
     await client.execute(
-      `ALTER TABLE \`${tableName}\` ADD COLUMN author VARCHAR(128) AFTER retest`
+      `ALTER TABLE \`${tableName}\` ADD COLUMN author VARCHAR(128) AFTER retest`,
     );
   }
 
@@ -135,7 +209,7 @@ export async function migrateJobTable(client: mysql.Client, tableName: string) {
   if (!existingColumns.has("event_guid")) {
     console.info(`Adding column 'event_guid' to table ${tableName}`);
     await client.execute(
-      `ALTER TABLE \`${tableName}\` ADD COLUMN event_guid VARCHAR(128) AFTER author`
+      `ALTER TABLE \`${tableName}\` ADD COLUMN event_guid VARCHAR(128) AFTER author`,
     );
   }
 
@@ -143,6 +217,8 @@ export async function migrateJobTable(client: mysql.Client, tableName: string) {
 }
 
 function jobInsertValues(job: prowJobRun) {
+  const labels = job.metadata.labels ?? {};
+
   // Helper to parse the retest label into a nullable boolean
   const parseRetestLabel = (label: string | undefined): boolean | null => {
     if (label === "true") return true;
@@ -164,20 +240,20 @@ function jobInsertValues(job: prowJobRun) {
     job.metadata.name,
     job.spec.job,
     job.spec.type,
-    job.status.state,
-    new Date(job.status.startTime),
+    job.status.state!,
+    new Date(job.status.startTime!),
     job.status.completionTime ? new Date(job.status.completionTime) : null,
-    job.metadata.labels["prow.k8s.io/is-optional"] === "true",
+    labels["prow.k8s.io/is-optional"] === "true",
     job.spec.report || false,
     job.spec.refs?.org || null,
     job.spec.refs?.repo || null,
     job.spec.refs?.base_ref || null,
-    job.metadata.labels["prow.k8s.io/refs.pull"] || null,
-    job.metadata.labels["prow.k8s.io/context"] || null,
+    labels["prow.k8s.io/refs.pull"] || null,
+    labels["prow.k8s.io/context"] || null,
     job.status.url || null,
-    parseRetestLabel(job.metadata.labels["prow.k8s.io/retest"]),
+    parseRetestLabel(labels["prow.k8s.io/retest"]),
     getAuthor(),
-    job.metadata.labels["event-GUID"] || null,
+    labels["event-GUID"] || null,
     JSON.stringify(job.spec),
     JSON.stringify(job.status),
   ];
@@ -189,8 +265,21 @@ export async function saveJobs(
   jobs: prowJobRun[],
   chunkSize = 100, // Default chunk size
 ) {
-  for (let i = 0; i < jobs.length; i += chunkSize) {
-    const chunk = jobs.slice(i, i + chunkSize);
+  const { insertableJobs, skippedJobs } = filterInsertableJobs(jobs);
+
+  if (skippedJobs.length > 0) {
+    console.warn(
+      `Skipping ${skippedJobs.length}/${jobs.length} prow jobs with incomplete data`,
+    );
+    for (const { job, reason } of skippedJobs.slice(0, 5)) {
+      console.warn(
+        `Skipped prow job ${job.metadata?.name ?? "<unknown>"}: ${reason}`,
+      );
+    }
+  }
+
+  for (let i = 0; i < insertableJobs.length; i += chunkSize) {
+    const chunk = insertableJobs.slice(i, i + chunkSize);
     const values = chunk.map((job) => jobInsertValues(job));
     const placeholders = values.map((value) =>
       `(${value.map(() => "?").join(", ")})`
@@ -212,7 +301,7 @@ export async function saveJobs(
     `;
     const flattenedValues = values.flat();
     await client.execute(sql, flattenedValues);
-    console.info(`Saved ${i}/${jobs.length} jobs`);
+    console.info(`Saved ${i}/${insertableJobs.length} jobs`);
   }
 }
 

--- a/insight/crawlers/ci/prow-jobs.ts
+++ b/insight/crawlers/ci/prow-jobs.ts
@@ -21,16 +21,16 @@ const VALID_JOB_TYPES = new Set([
 export interface prowJobRun {
   kind: string;
   metadata: {
-    name: string;
-    namespace: string;
-    labels: Record<string, string>;
+    name?: string;
+    namespace?: string;
+    labels?: Record<string, string>;
   };
   spec: {
-    type: string;
-    agent: string;
-    cluster: string;
-    namespace: string;
-    job: string;
+    type?: string;
+    agent?: string;
+    cluster?: string;
+    namespace?: string;
+    job?: string;
     report?: boolean;
     refs?: {
       org: string;
@@ -236,10 +236,10 @@ function jobInsertValues(job: prowJobRun) {
   };
 
   return [
-    job.metadata.namespace,
-    job.metadata.name,
-    job.spec.job,
-    job.spec.type,
+    job.metadata.namespace!,
+    job.metadata.name!,
+    job.spec.job!,
+    job.spec.type!,
     job.status.state!,
     new Date(job.status.startTime!),
     job.status.completionTime ? new Date(job.status.completionTime) : null,
@@ -301,7 +301,11 @@ export async function saveJobs(
     `;
     const flattenedValues = values.flat();
     await client.execute(sql, flattenedValues);
-    console.info(`Saved ${i}/${insertableJobs.length} jobs`);
+    console.info(
+      `Saved ${
+        Math.min(i + chunkSize, insertableJobs.length)
+      }/${insertableJobs.length} jobs`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Skip Prow jobs that cannot be inserted into the prow_jobs table because required fields are missing or outside the DB enum
- Log a small sample of skipped jobs so the crawler can finish successfully while still surfacing bad source records
- Add Deno tests for missing status fields and invalid states; also fix the existing DSN parser test import

## Verification
- npx --yes deno fmt insight/crawlers/ci/prow-jobs.ts insight/crawlers/ci/prow-jobs.test.ts
- npx --yes deno test --allow-net insight/crawlers/ci/prow-jobs.test.ts
- npx --yes deno lint insight/crawlers/ci/prow-jobs.ts insight/crawlers/ci/prow-jobs.test.ts
- Read-only live check against https://prow.tidb.net: 8123 jobs fetched, 8120 insertable, 3 skipped due to missing status.state