### PR TITLE
feat(roster): sync linked organization members

### DIFF
--- a/cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py
+++ b/cost-insight/src/cost_insight/jobs/refresh_attribution_daily.py
@@ -387,19 +387,16 @@ _INSERT_ATTRIBUTION_DAILY = text(
         raw.net_cost
       FROM cost_raw_details raw
       LEFT JOIN roster_employees override_employee
-        ON override_employee.is_active = 1
-       AND raw.author IS NOT NULL
+        ON raw.author IS NOT NULL
        AND override_employee.email IS NOT NULL
        AND LOWER(override_employee.email) = LOWER({_RAW_AUTHOR_OVERRIDE_EMAIL})
       LEFT JOIN roster_employees github_employee
         ON override_employee.id IS NULL
-       AND github_employee.is_active = 1
        AND raw.author IS NOT NULL
        AND github_employee.github_id IS NOT NULL
        AND LOWER(github_employee.github_id) = LOWER(raw.author)
       LEFT JOIN roster_employees email_employee
         ON github_employee.id IS NULL
-       AND email_employee.is_active = 1
        AND raw.author IS NOT NULL
        AND email_employee.email IS NOT NULL
        AND (
@@ -409,7 +406,6 @@ _INSERT_ATTRIBUTION_DAILY = text(
       LEFT JOIN roster_employees normalized_employee
         ON github_employee.id IS NULL
        AND email_employee.id IS NULL
-       AND normalized_employee.is_active = 1
        AND raw.author IS NOT NULL
        AND (
          normalized_employee.github_id IS NOT NULL
@@ -603,19 +599,16 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
         summary.net_cost
       FROM cost_bq_export_summary_daily summary
       LEFT JOIN roster_employees override_employee
-        ON override_employee.is_active = 1
-       AND summary.author IS NOT NULL
+        ON summary.author IS NOT NULL
        AND override_employee.email IS NOT NULL
        AND LOWER(override_employee.email) = LOWER({_SUMMARY_AUTHOR_OVERRIDE_EMAIL})
       LEFT JOIN roster_employees github_employee
         ON override_employee.id IS NULL
-       AND github_employee.is_active = 1
        AND summary.author IS NOT NULL
        AND github_employee.github_id IS NOT NULL
        AND LOWER(github_employee.github_id) = LOWER(summary.author)
       LEFT JOIN roster_employees email_employee
         ON github_employee.id IS NULL
-       AND email_employee.is_active = 1
        AND summary.author IS NOT NULL
        AND email_employee.email IS NOT NULL
        AND (
@@ -625,7 +618,6 @@ _INSERT_ATTRIBUTION_DAILY_FROM_SUMMARY = text(
       LEFT JOIN roster_employees normalized_employee
         ON github_employee.id IS NULL
        AND email_employee.id IS NULL
-       AND normalized_employee.is_active = 1
        AND summary.author IS NOT NULL
        AND (
          normalized_employee.github_id IS NOT NULL

--- a/cost-insight/tests/test_refresh_attribution_daily.py
+++ b/cost-insight/tests/test_refresh_attribution_daily.py
@@ -331,6 +331,10 @@ def test_insert_sql_contains_roster_matching_and_daily_dimensions() -> None:
 
     assert "LEFT JOIN roster_employees github_employee" in sql
     assert "LEFT JOIN roster_employees override_employee" in sql
+    assert "override_employee.is_active" not in sql
+    assert "github_employee.is_active" not in sql
+    assert "email_employee.is_active" not in sql
+    assert "normalized_employee.is_active" not in sql
     assert "flaky-claw" in sql
     assert "yinsu@pingcap.com" in sql
     assert "ti-chi-bot" in sql
@@ -361,6 +365,10 @@ def test_summary_insert_sql_uses_summary_source_and_nullable_resource_columns() 
     assert "target_branch" in sql
     assert "LEFT JOIN roster_employees github_employee" in sql
     assert "LEFT JOIN roster_employees override_employee" in sql
+    assert "override_employee.is_active" not in sql
+    assert "github_employee.is_active" not in sql
+    assert "email_employee.is_active" not in sql
+    assert "normalized_employee.is_active" not in sql
     assert "LOWER(github_employee.github_id) = LOWER(summary.author)" in sql
     assert "author_override" in sql
     assert "author_normalized" in sql

--- a/roster/README.md
+++ b/roster/README.md
@@ -60,10 +60,19 @@ Optional Lark settings:
 
 ```bash
 ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID=...
+ROSTER_LARK_COLLABORATION_TENANT_KEYS=tenant_key_a,tenant_key_b
 ROSTER_LARK_NOTIFY_OPEN_ID=...
 ROSTER_LARK_NOTIFY_OPEN_IDS=ou_xxx,ou_yyy
 ROSTER_LARK_ROOT_DEPARTMENT_ID=0
 ```
+
+`ROSTER_LARK_COLLABORATION_TENANT_KEYS` enables syncing visible linked
+organization departments and members via the trust party visible organization
+API. The Lark app must have `trust_party:collaboration.tenant:readonly`; use
+`trust_party:collaboration_rule:read` to list available collaboration tenant
+keys from the admin API. Linked organization responses do not include Lark
+custom attributes such as GitHub ID, so this path only fills sparse roster
+identity and group data.
 
 `ROSTER_LARK_NOTIFY_OPEN_ID` stays supported for the existing single-recipient setup.
 Use `ROSTER_LARK_NOTIFY_OPEN_IDS` when the weekly summary should be sent to
@@ -89,5 +98,6 @@ Render a CronJob manifest:
 ```
 
 The DB secret should contain `ROSTER_DB_URL`, `CI_DASHBOARD_DB_URL`,
-`ROSTER_TIDB_*`, or `TIDB_*` fields. The Lark secret should contain `ROSTER_LARK_APP_ID` and
-`ROSTER_LARK_APP_SECRET`, plus optional `ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID`.
+`ROSTER_TIDB_*`, or `TIDB_*` fields. The Lark secret should contain
+`ROSTER_LARK_APP_ID` and `ROSTER_LARK_APP_SECRET`, plus optional
+`ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID` and `ROSTER_LARK_COLLABORATION_TENANT_KEYS`.

--- a/roster/src/roster/common/config.py
+++ b/roster/src/roster/common/config.py
@@ -40,6 +40,7 @@ class LarkSettings:
     app_id: str | None = None
     app_secret: str | None = None
     github_custom_attr_id: str | None = None
+    collaboration_tenant_keys: tuple[str, ...] = ()
     notify_open_id: str | None = None
     notify_open_ids: tuple[str, ...] = ()
     root_department_id: str = "0"
@@ -110,6 +111,9 @@ def load_settings(
             app_id=env.get("ROSTER_LARK_APP_ID") or None,
             app_secret=env.get("ROSTER_LARK_APP_SECRET") or None,
             github_custom_attr_id=env.get("ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID") or None,
+            collaboration_tenant_keys=_read_csv(
+                env.get("ROSTER_LARK_COLLABORATION_TENANT_KEYS")
+            ),
             notify_open_id=env.get("ROSTER_LARK_NOTIFY_OPEN_ID") or None,
             notify_open_ids=_read_csv(env.get("ROSTER_LARK_NOTIFY_OPEN_IDS")),
             root_department_id=env.get("ROSTER_LARK_ROOT_DEPARTMENT_ID") or "0",

--- a/roster/src/roster/jobs/cli.py
+++ b/roster/src/roster/jobs/cli.py
@@ -126,6 +126,7 @@ def _build_lark_source(settings) -> LarkRosterSource:
         LarkApiClient(settings.lark.app_id, settings.lark.app_secret),
         github_custom_attr_id=settings.lark.github_custom_attr_id,
         root_department_id=settings.lark.root_department_id,
+        collaboration_tenant_keys=settings.lark.collaboration_tenant_keys,
     )
 
 

--- a/roster/src/roster/sources/lark.py
+++ b/roster/src/roster/sources/lark.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import logging
+from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Protocol
@@ -9,6 +11,9 @@ from urllib import error, parse, request
 from roster.jobs.sync_roster import FetchedEmployee, FetchedGroup, FetchedRoster, RosterSource
 
 LARK_OPENAPI_BASE_URL = "https://open.feishu.cn/open-apis"
+COLLABORATION_GROUP_PREFIX = "collab"
+COLLABORATION_ROOT_DEPARTMENT_ID = "0"
+LOG = logging.getLogger(__name__)
 
 
 class LarkTransport(Protocol):
@@ -146,12 +151,24 @@ class LarkRosterSource(RosterSource):
     client: LarkApiClient
     root_department_id: str = "0"
     github_custom_attr_id: str | None = None
+    collaboration_tenant_keys: tuple[str, ...] = ()
     page_size: int = 50
 
     def fetch_roster(self) -> FetchedRoster:
         token = self.client.tenant_access_token()
         groups = self._fetch_groups(token)
         employees = self._fetch_employees(token, groups)
+        if self.collaboration_tenant_keys:
+            collaboration_roster = self._fetch_collaboration_roster(token)
+            groups.extend(collaboration_roster.groups)
+            # Both the contact API request below and the trust_party API return union_id values
+            # (called union_user_id by visible_organization). Prefer the richer contact row.
+            existing_employee_ids = {employee.lark_id for employee in employees}
+            for employee in collaboration_roster.employees:
+                if employee.lark_id in existing_employee_ids:
+                    continue
+                employees.append(employee)
+                existing_employee_ids.add(employee.lark_id)
         return FetchedRoster(groups=groups, employees=employees)
 
     def _fetch_groups(self, token: str) -> list[FetchedGroup]:
@@ -185,12 +202,79 @@ class LarkRosterSource(RosterSource):
                 employees_by_lark_id.setdefault(employee.lark_id, employee)
         return list(employees_by_lark_id.values())
 
+    def _fetch_collaboration_roster(self, token: str) -> FetchedRoster:
+        groups: list[FetchedGroup] = []
+        employees_by_lark_id: dict[str, FetchedEmployee] = {}
+        for tenant_key in self.collaboration_tenant_keys:
+            tenant_roster = self._fetch_collaboration_tenant_roster(token, tenant_key)
+            groups.extend(tenant_roster.groups)
+            for employee in tenant_roster.employees:
+                employees_by_lark_id.setdefault(employee.lark_id, employee)
+        return FetchedRoster(groups=groups, employees=list(employees_by_lark_id.values()))
+
+    def _fetch_collaboration_tenant_roster(
+        self,
+        token: str,
+        tenant_key: str,
+    ) -> FetchedRoster:
+        groups_by_id: dict[str, FetchedGroup] = {}
+        employees_by_lark_id: dict[str, FetchedEmployee] = {}
+        queue: deque[tuple[str, str | None]] = deque(
+            [(COLLABORATION_ROOT_DEPARTMENT_ID, None)]
+        )
+        visited_departments: set[str] = set()
+
+        while queue:
+            target_department_id, parent_group_id = queue.popleft()
+            if target_department_id in visited_departments:
+                continue
+            visited_departments.add(target_department_id)
+            entities = self._paginate(
+                token,
+                f"/trust_party/v1/collaboration_tenants/{tenant_key}/visible_organization",
+                params={
+                    "department_id_type": "open_department_id",
+                    "target_department_id": target_department_id,
+                    "page_size": self.page_size,
+                },
+                items_key="collaboration_entity_list",
+            )
+            for item in entities:
+                entity_type = item.get("collaboration_entity_type")
+                if entity_type == "department":
+                    department_id = _required_text(item, "open_department_id")
+                    group_id = _collaboration_group_id(tenant_key, department_id)
+                    if group_id in groups_by_id:
+                        continue
+                    group = self._map_collaboration_group(
+                        item,
+                        tenant_key=tenant_key,
+                        parent_group_id=parent_group_id,
+                    )
+                    groups_by_id[group.lark_group_id] = group
+                    if department_id not in visited_departments:
+                        queue.append((department_id, group.lark_group_id))
+                elif entity_type == "user":
+                    employee = self._map_collaboration_employee(
+                        item,
+                        tenant_key=tenant_key,
+                        fallback_group_id=parent_group_id,
+                    )
+                    if employee is not None:
+                        employees_by_lark_id.setdefault(employee.lark_id, employee)
+
+        return FetchedRoster(
+            groups=list(groups_by_id.values()),
+            employees=list(employees_by_lark_id.values()),
+        )
+
     def _paginate(
         self,
         token: str,
         path: str,
         *,
         params: dict[str, object],
+        items_key: str = "items",
     ) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
         page_token: str | None = None
@@ -202,9 +286,9 @@ class LarkRosterSource(RosterSource):
             data = response.get("data")
             if not isinstance(data, dict):
                 raise RuntimeError(f"Lark API {path} response did not include data")
-            page_items = data.get("items") or []
+            page_items = data.get(items_key) or []
             if not isinstance(page_items, list):
-                raise RuntimeError(f"Lark API {path} data.items is not a list")
+                raise RuntimeError(f"Lark API {path} data.{items_key} is not a list")
             items.extend(item for item in page_items if isinstance(item, dict))
             if not data.get("has_more"):
                 return items
@@ -235,6 +319,51 @@ class LarkRosterSource(RosterSource):
             join_time=_join_time_from_epoch(item.get("join_time")),
             manager_lark_id=_optional_text(item.get("leader_user_id")),
             group_lark_id=_primary_group_id(item, fallback_group_id=fallback_group_id),
+        )
+
+    def _map_collaboration_group(
+        self,
+        item: dict[str, Any],
+        *,
+        tenant_key: str,
+        parent_group_id: str | None,
+    ) -> FetchedGroup:
+        group_id = _collaboration_group_id(tenant_key, _required_text(item, "open_department_id"))
+        return FetchedGroup(
+            lark_group_id=group_id,
+            name=_collaboration_department_name(item),
+            parent_lark_group_id=parent_group_id,
+        )
+
+    def _map_collaboration_employee(
+        self,
+        item: dict[str, Any],
+        *,
+        tenant_key: str,
+        fallback_group_id: str | None,
+    ) -> FetchedEmployee | None:
+        raw_lark_id = _optional_text(item.get("union_user_id"))
+        if raw_lark_id is None:
+            LOG.warning(
+                "skipping Lark collaboration user without union_user_id",
+                extra={
+                    "tenant_key": tenant_key,
+                    "open_user_id": _optional_text(item.get("open_user_id")),
+                    "user_id": _optional_text(item.get("user_id")),
+                },
+            )
+            return None
+        department_id = _optional_text(item.get("open_department_id"))
+        group_lark_id = (
+            _collaboration_group_id(tenant_key, department_id)
+            if department_id and department_id != COLLABORATION_ROOT_DEPARTMENT_ID
+            else fallback_group_id
+        )
+        return FetchedEmployee(
+            lark_id=raw_lark_id,
+            name=_collaboration_user_name(item),
+            en_name=_i18n_text(item.get("i18n_user_name"), "en_us"),
+            group_lark_id=group_lark_id,
         )
 
     def _github_id_from_custom_attrs(self, item: dict[str, Any]) -> str | None:
@@ -283,6 +412,34 @@ def _primary_group_id(item: dict[str, Any], *, fallback_group_id: str) -> str:
             if normalized:
                 return normalized
     return fallback_group_id
+
+
+def _collaboration_group_id(tenant_key: str, open_department_id: str) -> str:
+    return f"{COLLABORATION_GROUP_PREFIX}:{tenant_key}:{open_department_id}"
+
+
+def _collaboration_department_name(item: dict[str, Any]) -> str:
+    return (
+        _optional_text(item.get("department_name"))
+        or _i18n_text(item.get("i18n_department_name"), "zh_cn")
+        or _i18n_text(item.get("i18n_department_name"), "en_us")
+        or _required_text(item, "open_department_id")
+    )
+
+
+def _collaboration_user_name(item: dict[str, Any]) -> str:
+    return (
+        _optional_text(item.get("user_name"))
+        or _i18n_text(item.get("i18n_user_name"), "zh_cn")
+        or _i18n_text(item.get("i18n_user_name"), "en_us")
+        or _required_text(item, "open_user_id")
+    )
+
+
+def _i18n_text(value: object, locale: str) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    return _optional_text(value.get(locale))
 
 
 def _required_text(item: dict[str, Any], key: str) -> str:

--- a/roster/tests/test_cli.py
+++ b/roster/tests/test_cli.py
@@ -90,6 +90,7 @@ def test_main_builds_lark_source_when_configured(monkeypatch) -> None:
         app_secret="secret",
         github_custom_attr_id="github_attr",
         root_department_id="od-root",
+        collaboration_tenant_keys=("tenant-key",),
     )
     settings = SimpleNamespace(log_level="INFO", lark=lark_settings)
     engine = SimpleNamespace(dispose=lambda: calls.setdefault("disposed", True))
@@ -104,8 +105,18 @@ def test_main_builds_lark_source_when_configured(monkeypatch) -> None:
         calls["client"] = (app_id, app_secret)
         return client
 
-    def fake_lark_roster_source(built_client, github_custom_attr_id, root_department_id):
-        calls["source_args"] = (built_client, github_custom_attr_id, root_department_id)
+    def fake_lark_roster_source(
+        built_client,
+        github_custom_attr_id,
+        root_department_id,
+        collaboration_tenant_keys,
+    ):
+        calls["source_args"] = (
+            built_client,
+            github_custom_attr_id,
+            root_department_id,
+            collaboration_tenant_keys,
+        )
         return source
 
     monkeypatch.setattr(cli, "LarkApiClient", fake_lark_api_client)
@@ -120,7 +131,7 @@ def test_main_builds_lark_source_when_configured(monkeypatch) -> None:
     assert cli.main(["sync-roster"]) == 0
     assert calls == {
         "client": ("cli_xxx", "secret"),
-        "source_args": (client, "github_attr", "od-root"),
+        "source_args": (client, "github_attr", "od-root", ("tenant-key",)),
         "sync": (engine, source),
         "disposed": True,
     }
@@ -219,6 +230,7 @@ def test_main_validate_lark_prints_json(monkeypatch, capsys) -> None:
         app_secret="secret",
         github_custom_attr_id="github_attr",
         root_department_id="od-root",
+        collaboration_tenant_keys=("tenant-key",),
     )
     settings = SimpleNamespace(log_level="INFO", lark=lark_settings)
     client = object()

--- a/roster/tests/test_config_and_db.py
+++ b/roster/tests/test_config_and_db.py
@@ -28,6 +28,7 @@ def test_load_settings_builds_tidb_fields() -> None:
             "ROSTER_LARK_APP_ID": "cli_xxx",
             "ROSTER_LARK_APP_SECRET": "secret",
             "ROSTER_LARK_GITHUB_CUSTOM_ATTR_ID": "github_attr",
+            "ROSTER_LARK_COLLABORATION_TENANT_KEYS": "tenant-a, tenant-b, tenant-a",
             "ROSTER_LARK_NOTIFY_OPEN_ID": "ou_xxx",
             "ROSTER_LARK_NOTIFY_OPEN_IDS": "ou_xxx, ou_yyy",
             "ROSTER_LARK_ROOT_DEPARTMENT_ID": "od-root",
@@ -43,6 +44,7 @@ def test_load_settings_builds_tidb_fields() -> None:
     assert settings.lark.app_id == "cli_xxx"
     assert settings.lark.app_secret == "secret"
     assert settings.lark.github_custom_attr_id == "github_attr"
+    assert settings.lark.collaboration_tenant_keys == ("tenant-a", "tenant-b")
     assert settings.lark.notify_open_id == "ou_xxx"
     assert settings.lark.notify_open_ids == ("ou_xxx", "ou_yyy")
     assert settings.lark.all_notify_open_ids == ("ou_xxx", "ou_yyy")

--- a/roster/tests/test_lark_source.py
+++ b/roster/tests/test_lark_source.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import urllib.error
 
 import pytest
@@ -203,6 +204,265 @@ def test_lark_roster_source_handles_pagination_and_deduplicates_users() -> None:
     assert roster.employees[0].name == "Alice"
     assert transport.calls[2]["params"]["page_token"] == "next-dept"
     assert transport.calls[4]["params"]["page_token"] == "next-user"
+
+
+def test_lark_roster_source_fetches_collaboration_visible_organization() -> None:
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {"code": 0, "data": {"has_more": False, "items": []}},
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "department",
+                            "open_department_id": "od-product-rd",
+                            "department_name": "产品研发部",
+                        }
+                    ],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "department",
+                            "open_department_id": "od-kernel",
+                            "department_name": "内核研发中心",
+                        }
+                    ],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "department",
+                            "open_department_id": "od-rd3",
+                            "department_name": "研发三组",
+                        }
+                    ],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "user",
+                            "open_department_id": "od-rd3",
+                            "union_user_id": "on_sun",
+                            "open_user_id": "ou_sun",
+                            "user_name": "孙小琳",
+                            "i18n_user_name": {"en_us": "Lynn Sun"},
+                        },
+                        {
+                            "collaboration_entity_type": "user",
+                            "open_department_id": "od-rd3",
+                            "union_user_id": "on_li",
+                            "open_user_id": "ou_li",
+                            "user_name": "李淳竹",
+                            "i18n_user_name": {"en_us": "Chunzhu Li"},
+                        },
+                    ],
+                },
+            },
+        ]
+    )
+    source = LarkRosterSource(
+        LarkApiClient("app_id", "app_secret", transport=transport),
+        collaboration_tenant_keys=("tenant-key",),
+    )
+
+    roster = source.fetch_roster()
+
+    assert [group.name for group in roster.groups] == ["产品研发部", "内核研发中心", "研发三组"]
+    assert roster.groups[0].lark_group_id == "collab:tenant-key:od-product-rd"
+    assert roster.groups[0].parent_lark_group_id is None
+    assert roster.groups[1].parent_lark_group_id == "collab:tenant-key:od-product-rd"
+    assert roster.groups[2].parent_lark_group_id == "collab:tenant-key:od-kernel"
+    assert [(employee.lark_id, employee.name, employee.en_name) for employee in roster.employees] == [
+        ("on_sun", "孙小琳", "Lynn Sun"),
+        ("on_li", "李淳竹", "Chunzhu Li"),
+    ]
+    assert {employee.group_lark_id for employee in roster.employees} == {
+        "collab:tenant-key:od-rd3"
+    }
+    assert [employee.github_id for employee in roster.employees] == [None, None]
+    assert transport.calls[2]["path"] == (
+        "/trust_party/v1/collaboration_tenants/tenant-key/visible_organization"
+    )
+    assert transport.calls[2]["method"] == "GET"
+    assert transport.calls[2]["params"]["target_department_id"] == "0"
+    assert transport.calls[5]["params"]["target_department_id"] == "od-rd3"
+
+
+def test_lark_roster_source_paginates_collaboration_visible_organization() -> None:
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {"code": 0, "data": {"has_more": False, "items": []}},
+            {
+                "code": 0,
+                "data": {
+                    "has_more": True,
+                    "page_token": "next-collab",
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "department",
+                            "open_department_id": "od-rd2",
+                            "department_name": "研发二组",
+                        }
+                    ],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "user",
+                            "open_department_id": "0",
+                            "union_user_id": "on_root",
+                            "user_name": "Root User",
+                        }
+                    ],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "user",
+                            "open_department_id": "od-rd2",
+                            "union_user_id": "on_rd2",
+                            "user_name": "研发二组成员",
+                        }
+                    ],
+                },
+            },
+        ]
+    )
+    source = LarkRosterSource(
+        LarkApiClient("app_id", "app_secret", transport=transport),
+        collaboration_tenant_keys=("tenant-key",),
+    )
+
+    roster = source.fetch_roster()
+
+    assert [employee.lark_id for employee in roster.employees] == ["on_root", "on_rd2"]
+    assert roster.employees[0].group_lark_id is None
+    assert roster.employees[1].group_lark_id == "collab:tenant-key:od-rd2"
+    assert transport.calls[2]["method"] == "GET"
+    assert transport.calls[3]["params"]["page_token"] == "next-collab"
+    assert transport.calls[4]["params"]["target_department_id"] == "od-rd2"
+
+
+def test_lark_roster_source_keeps_primary_employee_when_collaboration_id_matches() -> None:
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [{"open_department_id": "od-eng", "name": "Engineering"}],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "items": [
+                        {
+                            "union_id": "on_same",
+                            "name": "Primary Employee",
+                            "enterprise_email": "primary@example.com",
+                            "department_ids": ["od-eng"],
+                            "custom_attrs": [
+                                {
+                                    "id": "github_attr",
+                                    "type": "TEXT",
+                                    "value": {"text": "primary-gh"},
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "user",
+                            "open_department_id": "0",
+                            "union_user_id": "on_same",
+                            "user_name": "Sparse Collaboration Employee",
+                        }
+                    ],
+                },
+            },
+        ]
+    )
+    source = LarkRosterSource(
+        LarkApiClient("app_id", "app_secret", transport=transport),
+        github_custom_attr_id="github_attr",
+        collaboration_tenant_keys=("tenant-key",),
+    )
+
+    roster = source.fetch_roster()
+
+    assert len(roster.employees) == 1
+    employee = roster.employees[0]
+    assert employee.name == "Primary Employee"
+    assert employee.email == "primary@example.com"
+    assert employee.github_id == "primary-gh"
+
+
+def test_lark_roster_source_skips_collaboration_user_without_union_id(caplog) -> None:
+    caplog.set_level(logging.WARNING, logger="roster.sources.lark")
+    transport = FakeTransport(
+        [
+            {"code": 0, "tenant_access_token": "token"},
+            {"code": 0, "data": {"has_more": False, "items": []}},
+            {
+                "code": 0,
+                "data": {
+                    "has_more": False,
+                    "collaboration_entity_list": [
+                        {
+                            "collaboration_entity_type": "user",
+                            "open_department_id": "0",
+                            "open_user_id": "ou_unstable",
+                            "user_id": "user_unstable",
+                            "user_name": "Unstable User",
+                        }
+                    ],
+                },
+            },
+        ]
+    )
+    source = LarkRosterSource(
+        LarkApiClient("app_id", "app_secret", transport=transport),
+        collaboration_tenant_keys=("tenant-key",),
+    )
+
+    roster = source.fetch_roster()
+
+    assert roster.employees == []
+    assert "without union_user_id" in caplog.text
 
 
 def test_lark_api_client_raises_on_lark_error() -> None:


### PR DESCRIPTION
## Summary
- add optional Lark linked-organization roster sync via trust party visible organization API
- pass collaboration tenant keys from config/CLI and document the required env/scopes
- allow cost attribution to match inactive roster employees, preserving attribution for departed users

## Tests
- cd roster && PYTHONPATH=src python -m pytest --no-cov
- cd roster && python -m ruff check src tests
- cd cost-insight && PYTHONPATH=src python -m pytest tests/test_refresh_attribution_daily.py --no-cov
- cd cost-insight && python -m ruff check src/cost_insight/jobs/refresh_attribution_daily.py tests/test_refresh_attribution_daily.py

## Notes
- live Lark verification still requires trust_party:collaboration_rule:read to list tenant keys and trust_party:collaboration.tenant:readonly to read visible organizations
- visible organization responses do not include GitHub custom attrs, so linked-org GitHub ID mapping still needs a separate source