### PR TITLE
fix(ci-dashboard): filter flaky issues by label

### DIFF
--- a/ci-dashboard/README.md
+++ b/ci-dashboard/README.md
@@ -73,6 +73,7 @@ Notes:
 - during UI iteration, run `make api` and `make web-dev` in separate terminals
 - `backfill-range` is stateless and does not update `ci_job_state`, so the same time window can be re-imported safely
 - `CI_DASHBOARD_REFRESH_BUILD_LIMIT` controls how many impacted builds one `refresh-build-derived` run will process before checkpointing and continuing in the next CronJob run; the default is `5000`, valid values are positive integers, and smaller values trade shorter/faster runs for more CronJob passes before backlog catch-up finishes
+- `CI_DASHBOARD_FORCE_FLAKY_STALE_CLEANUP=true` lets `sync-flaky-issues` apply stale flaky issue cleanup after an intentional large `flaky-test` label purge; empty source sets still skip cleanup, and the one-off Job renderer exposes this as `--force-flaky-stale-cleanup true`
 - `scripts/render_backfill_job.sh` renders a one-off Kubernetes Job manifest for GKE backfill runs
 - `scripts/render_flaky_issue_sync_cronjob.sh` renders a recurring Kubernetes CronJob manifest for daily flaky issue sync
 - `scripts/render_jenkins_worker_deployment.sh` renders the V3 Jenkins event worker Deployment manifest

--- a/ci-dashboard/k8s/backfill/README.md
+++ b/ci-dashboard/k8s/backfill/README.md
@@ -70,6 +70,19 @@ If you want to backfill a closed date range instead of open-ended import:
   > /tmp/ci-dashboard-backfill.yaml
 ```
 
+For a one-off forced flaky issue stale cleanup after an intentional large
+`flaky-test` label purge:
+
+```bash
+./scripts/render_backfill_job.sh \
+  --job-command sync-flaky-issues \
+  --force-flaky-stale-cleanup true \
+  --image ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:<tag> \
+  --db-secret ci-dashboard-eq-prd-insight-db \
+  --github-secret prow-github \
+  > /tmp/ci-dashboard-sync-flaky-issues-once.yaml
+```
+
 ## 4. Watch Progress
 
 ```bash

--- a/ci-dashboard/scripts/render_backfill_job.sh
+++ b/ci-dashboard/scripts/render_backfill_job.sh
@@ -4,12 +4,15 @@ set -euo pipefail
 namespace="apps"
 image="ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:latest"
 db_secret="ci-dashboard-eq-prd-insight-db"
+github_secret=""
+github_token_key="token"
 start_date=""
 end_date=""
 job_command="backfill-range"
 batch_size="2000"
 refresh_group_batch_size=""
 log_level="INFO"
+force_flaky_stale_cleanup="false"
 job_name="ci-dashboard-backfill-$(date -u +%Y%m%d%H%M%S)"
 image_pull_policy="IfNotPresent"
 service_account=""
@@ -29,9 +32,10 @@ Render a one-off Kubernetes Job manifest for CI dashboard backfill.
 
 Usage:
   render_backfill_job.sh --start-date YYYY-MM-DD [options]
+  render_backfill_job.sh --job-command sync-flaky-issues [options]
 
 Required:
-  --start-date DATE         Inclusive start date for the selected job command.
+  --start-date DATE         Inclusive start date for date-window job commands.
 
 Optional:
   --job-command NAME        CLI subcommand. Default: backfill-range
@@ -39,11 +43,15 @@ Optional:
   --namespace NAME          Kubernetes namespace. Default: apps
   --image IMAGE             Jobs image. Default: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:latest
   --db-secret NAME          Secret containing TIDB_* or CI_DASHBOARD_DB_URL. Default: ci-dashboard-eq-prd-insight-db
+  --github-secret NAME      Optional secret containing GitHub API token.
+  --github-token-key NAME   Key inside GitHub secret. Default: token
   --job-name NAME           Fixed Job name. Default: ci-dashboard-backfill-<timestamp>
   --batch-size N            CI_DASHBOARD_BATCH_SIZE override. Default: 2000
   --refresh-group-batch-size N
                             CI_DASHBOARD_REFRESH_GROUP_BATCH_SIZE override.
   --log-level LEVEL         CI_DASHBOARD_LOG_LEVEL override. Default: INFO
+  --force-flaky-stale-cleanup true|false
+                            Set CI_DASHBOARD_FORCE_FLAKY_STALE_CLEANUP. Default: false
   --image-pull-policy P     Image pull policy. Default: IfNotPresent
   --service-account NAME    Optional service account name.
   --ca-secret NAME          Optional secret containing CA file for TIDB SSL.
@@ -85,6 +93,14 @@ while [[ $# -gt 0 ]]; do
       db_secret="${2:-}"
       shift 2
       ;;
+    --github-secret)
+      github_secret="${2:-}"
+      shift 2
+      ;;
+    --github-token-key)
+      github_token_key="${2:-}"
+      shift 2
+      ;;
     --job-name)
       job_name="${2:-}"
       shift 2
@@ -99,6 +115,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --log-level)
       log_level="${2:-}"
+      shift 2
+      ;;
+    --force-flaky-stale-cleanup)
+      force_flaky_stale_cleanup="${2:-}"
       shift 2
       ;;
     --image-pull-policy)
@@ -157,18 +177,40 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${start_date}" ]]; then
-  echo "--start-date is required" >&2
+case "${force_flaky_stale_cleanup}" in
+  true|false)
+    ;;
+  *)
+    echo "--force-flaky-stale-cleanup must be true or false" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${job_command}" == "sync-flaky-issues" || "${job_command}" == "backfill-flaky-issue-pr-links" ]]; then
+  if [[ -n "${start_date}" || -n "${end_date}" ]]; then
+    echo "${job_command} does not accept --start-date or --end-date" >&2
+    usage >&2
+    exit 1
+  fi
+elif [[ -z "${start_date}" ]]; then
+  echo "--start-date is required for ${job_command}" >&2
   usage >&2
   exit 1
 fi
 
 args_block=$(cat <<EOF
             - ${job_command}
+EOF
+)
+if [[ -n "${start_date}" ]]; then
+  args_block+=$'\n'
+  args_block+=$(cat <<EOF
             - --start-date
             - "${start_date}"
 EOF
 )
+fi
 if [[ -n "${end_date}" ]]; then
   args_block+=$'\n'
   args_block+=$(cat <<EOF
@@ -191,6 +233,18 @@ if [[ -n "${refresh_group_batch_size}" ]]; then
   refresh_group_env_block=$(cat <<EOF
             - name: CI_DASHBOARD_REFRESH_GROUP_BATCH_SIZE
               value: "${refresh_group_batch_size}"
+EOF
+)
+fi
+
+github_env_block=""
+if [[ -n "${github_secret}" ]]; then
+  github_env_block=$(cat <<EOF
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ${github_secret}
+                  key: ${github_token_key}
 EOF
 )
 fi
@@ -256,9 +310,12 @@ ${args_block}
           env:
             - name: PYTHONUNBUFFERED
               value: "1"
+${github_env_block}
             - name: CI_DASHBOARD_BATCH_SIZE
               value: "${batch_size}"
 ${refresh_group_env_block}
+            - name: CI_DASHBOARD_FORCE_FLAKY_STALE_CLEANUP
+              value: "${force_flaky_stale_cleanup}"
             - name: CI_DASHBOARD_LOG_LEVEL
               value: "${log_level}"
 ${ca_env_block}

--- a/ci-dashboard/src/ci_dashboard/common/config.py
+++ b/ci-dashboard/src/ci_dashboard/common/config.py
@@ -24,6 +24,18 @@ def _read_int(environ: Mapping[str, str], key: str, default: int) -> int:
     return value
 
 
+def _read_bool(environ: Mapping[str, str], key: str, default: bool) -> bool:
+    raw = environ.get(key)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{key} must be a boolean, got {raw!r}")
+
+
 def _read_csv(environ: Mapping[str, str], key: str, default: tuple[str, ...]) -> tuple[str, ...]:
     raw = environ.get(key)
     if raw is None:
@@ -48,6 +60,7 @@ class JobSettings:
     batch_size: int = 1000
     refresh_group_batch_size: int = 25
     refresh_build_limit: int = 5000
+    force_flaky_stale_cleanup: bool = False
 
 
 @dataclass(frozen=True)
@@ -137,6 +150,11 @@ def load_settings(environ: Mapping[str, str] | None = None) -> Settings:
                 env,
                 "CI_DASHBOARD_REFRESH_BUILD_LIMIT",
                 5000,
+            ),
+            force_flaky_stale_cleanup=_read_bool(
+                env,
+                "CI_DASHBOARD_FORCE_FLAKY_STALE_CLEANUP",
+                False,
             ),
         ),
         kafka=KafkaSettings(

--- a/ci-dashboard/src/ci_dashboard/common/models.py
+++ b/ci-dashboard/src/ci_dashboard/common/models.py
@@ -99,6 +99,11 @@ class RefreshBuildDerivedSummary:
 class SyncFlakyIssuesSummary:
     source_rows_scanned: int = 0
     rows_written: int = 0
+    stale_cleanup_skipped: bool = False
+    stale_cleanup_forced: bool = False
+    stale_cleanup_skip_reason: str | None = None
+    stale_issue_rows_deleted: int = 0
+    stale_issue_pr_links_deleted: int = 0
     issue_pr_links_written: int = 0
     linked_pr_rows_written: int = 0
     linked_pr_fetch_attempted: int = 0

--- a/ci-dashboard/src/ci_dashboard/jobs/sync_flaky_issues.py
+++ b/ci-dashboard/src/ci_dashboard/jobs/sync_flaky_issues.py
@@ -33,8 +33,8 @@ LOG = logging.getLogger(__name__)
 JOB_NAME = "ci-sync-flaky-issues"
 DEFAULT_FLAKY_ISSUE_REPOS = ("pingcap/tidb", "tikv/pd")
 BODY_PR_FALLBACK_REPOS = {"tikv/pd"}
-TITLE_COLON_PATTERN = "flaky test:%"
-TITLE_SPACE_PATTERN = "flaky test %"
+FLAKY_ISSUE_LABEL = "flaky-test"
+MIN_STALE_CLEANUP_SOURCE_TO_EXISTING_RATIO = 0.5
 CASE_NAME_PATTERN = re.compile(
     r"^flaky test(?::\s*|\s+)(.+?)(?:\s+in\s+.+)?$",
     re.IGNORECASE,
@@ -119,6 +119,11 @@ def run_sync_flaky_issues(engine: Engine, settings: Settings) -> SyncFlakyIssues
             existing_rows = _load_existing_issue_rows(connection)
 
         summary.source_rows_scanned = len(source_rows)
+        source_issue_keys = sorted({(str(row["repo"]), int(row["number"])) for row in source_rows})
+        existing_issue_count = _count_existing_issue_rows_for_repos(
+            existing_rows,
+            DEFAULT_FLAKY_ISSUE_REPOS,
+        )
 
         prepared_batches: list[tuple[FlakyIssueRow, list[FlakyIssuePrLinkRow]]] = []
         fetched_linked_prs: set[tuple[str, int]] = set()
@@ -174,10 +179,57 @@ def run_sync_flaky_issues(engine: Engine, settings: Settings) -> SyncFlakyIssues
 
         last_ticket_updated_at = _format_watermark_datetime(latest_updated_at)
         new_watermark = {"last_ticket_updated_at": last_ticket_updated_at}
+        stale_cleanup_skip_reason = _stale_cleanup_skip_reason(
+            source_issue_count=len(source_issue_keys),
+            existing_issue_count=existing_issue_count,
+        )
+        stale_cleanup_forced = (
+            stale_cleanup_skip_reason == "source_count_below_safety_ratio"
+            and settings.jobs.force_flaky_stale_cleanup
+        )
+        if stale_cleanup_forced:
+            stale_cleanup_skip_reason = None
         with engine.begin() as connection:
+            if stale_cleanup_skip_reason is None:
+                if stale_cleanup_forced:
+                    LOG.warning(
+                        "forcing stale flaky issue cleanup despite safety ratio",
+                        extra={
+                            "source_issue_count": len(source_issue_keys),
+                            "existing_issue_count": existing_issue_count,
+                            "minimum_source_to_existing_ratio": (
+                                MIN_STALE_CLEANUP_SOURCE_TO_EXISTING_RATIO
+                            ),
+                        },
+                    )
+                stale_links_deleted, stale_issues_deleted = _delete_stale_flaky_issue_rows(
+                    connection,
+                    repos=DEFAULT_FLAKY_ISSUE_REPOS,
+                    source_issue_keys=source_issue_keys,
+                )
+            else:
+                stale_links_deleted = 0
+                stale_issues_deleted = 0
+                LOG.warning(
+                    "skipping stale flaky issue cleanup because source set looks unsafe",
+                    extra={
+                        "reason": stale_cleanup_skip_reason,
+                        "source_issue_count": len(source_issue_keys),
+                        "existing_issue_count": existing_issue_count,
+                        "force_stale_cleanup": settings.jobs.force_flaky_stale_cleanup,
+                        "minimum_source_to_existing_ratio": (
+                            MIN_STALE_CLEANUP_SOURCE_TO_EXISTING_RATIO
+                        ),
+                    },
+                )
             _delete_orphaned_flaky_linked_prs(connection)
             mark_job_succeeded(connection, JOB_NAME, new_watermark)
 
+        summary.stale_cleanup_skipped = stale_cleanup_skip_reason is not None
+        summary.stale_cleanup_forced = stale_cleanup_forced
+        summary.stale_cleanup_skip_reason = stale_cleanup_skip_reason
+        summary.stale_issue_rows_deleted = stale_issues_deleted
+        summary.stale_issue_pr_links_deleted = stale_links_deleted
         summary.last_ticket_updated_at = last_ticket_updated_at
         return summary
     except Exception as exc:
@@ -451,37 +503,45 @@ def _fetch_source_issue_rows(
 ) -> list[dict[str, Any]]:
     repo_params = {f"repo_{index}": repo for index, repo in enumerate(repos)}
     repo_placeholders = ", ".join(f":repo_{index}" for index in range(len(repos)))
+    label_filter = _flaky_issue_label_filter(connection)
     rows = connection.execute(
         text(
             f"""
             SELECT
-              id,
-              repo,
-              number,
-              title,
-              body,
-              comments,
-              state,
-              created_at,
-              updated_at,
-              timeline
-            FROM github_tickets
-            WHERE type = 'issue'
-              AND repo IN ({repo_placeholders})
-              AND (
-                LOWER(title) LIKE :title_colon_pattern
-                OR LOWER(title) LIKE :title_space_pattern
-              )
-            ORDER BY repo, number
+              gt.id,
+              gt.repo,
+              gt.number,
+              gt.title,
+              gt.body,
+              gt.comments,
+              gt.state,
+              gt.created_at,
+              gt.updated_at,
+              gt.timeline
+            FROM github_tickets gt
+            WHERE gt.type = 'issue'
+              AND gt.repo IN ({repo_placeholders})
+              AND {label_filter}
+            ORDER BY gt.repo, gt.number
             """
         ),
         {
             **repo_params,
-            "title_colon_pattern": TITLE_COLON_PATTERN,
-            "title_space_pattern": TITLE_SPACE_PATTERN,
+            "flaky_issue_label": FLAKY_ISSUE_LABEL,
         },
     ).mappings()
     return [dict(row) for row in rows]
+
+
+def _flaky_issue_label_filter(connection: Connection) -> str:
+    if connection.dialect.name == "sqlite":
+        return (
+            "EXISTS ("
+            "SELECT 1 FROM json_each(gt.labels) "
+            "WHERE json_each.value = :flaky_issue_label"
+            ")"
+        )
+    return "JSON_CONTAINS(gt.labels, JSON_QUOTE(:flaky_issue_label))"
 
 
 def _load_existing_issue_rows(
@@ -1019,6 +1079,97 @@ def _delete_orphaned_flaky_linked_prs(connection: Connection) -> None:
             """
         )
     )
+
+
+def _delete_stale_flaky_issue_rows(
+    connection: Connection,
+    *,
+    repos: tuple[str, ...],
+    source_issue_keys: list[tuple[str, int]],
+) -> tuple[int, int]:
+    if not repos:
+        return 0, 0
+
+    repo_clause, repo_params = _build_repo_in_clause("repo", repos)
+    issue_repo_clause, issue_repo_params = _build_repo_in_clause("issue_repo", repos)
+    keep_clause, keep_params = _build_issue_key_keep_clause(source_issue_keys)
+    params = {**repo_params, **keep_params}
+
+    stale_links_result = connection.execute(
+        text(
+            f"""
+            DELETE FROM ci_l1_flaky_issue_pr_links
+            WHERE {issue_repo_clause}
+              AND (issue_repo, issue_number) IN (
+                SELECT repo, issue_number
+                FROM ci_l1_flaky_issues
+                WHERE {repo_clause}
+                  AND NOT ({keep_clause})
+              )
+            """
+        ),
+        {**issue_repo_params, **params},
+    )
+    stale_issues_result = connection.execute(
+        text(
+            f"""
+            DELETE FROM ci_l1_flaky_issues
+            WHERE {repo_clause}
+              AND NOT ({keep_clause})
+            """
+        ),
+        params,
+    )
+    return _statement_rowcount(stale_links_result.rowcount), _statement_rowcount(
+        stale_issues_result.rowcount
+    )
+
+
+def _count_existing_issue_rows_for_repos(
+    existing_rows: dict[tuple[str, int], dict[str, Any]],
+    repos: tuple[str, ...],
+) -> int:
+    repo_set = set(repos)
+    return sum(1 for repo, _issue_number in existing_rows if repo in repo_set)
+
+
+def _stale_cleanup_skip_reason(
+    *,
+    source_issue_count: int,
+    existing_issue_count: int,
+) -> str | None:
+    if source_issue_count == 0:
+        return "empty_source"
+    if existing_issue_count == 0:
+        return None
+    if source_issue_count / existing_issue_count < MIN_STALE_CLEANUP_SOURCE_TO_EXISTING_RATIO:
+        return "source_count_below_safety_ratio"
+    return None
+
+
+def _statement_rowcount(value: int | None) -> int:
+    if value is None or value < 0:
+        return 0
+    return int(value)
+
+
+def _build_repo_in_clause(column_name: str, repos: tuple[str, ...]) -> tuple[str, dict[str, str]]:
+    params = {f"{column_name}_{index}": repo for index, repo in enumerate(repos)}
+    placeholders = ", ".join(f":{key}" for key in params)
+    return f"{column_name} IN ({placeholders})", params
+
+
+def _build_issue_key_keep_clause(issue_keys: list[tuple[str, int]]) -> tuple[str, dict[str, Any]]:
+    if not issue_keys:
+        return "0 = 1", {}
+
+    clauses: list[str] = []
+    params: dict[str, Any] = {}
+    for index, (repo, issue_number) in enumerate(issue_keys):
+        clauses.append(f"(repo = :keep_repo_{index} AND issue_number = :keep_issue_number_{index})")
+        params[f"keep_repo_{index}"] = repo
+        params[f"keep_issue_number_{index}"] = issue_number
+    return " OR ".join(clauses), params
 
 
 def _row_to_params(row: FlakyIssueRow) -> dict[str, Any]:

--- a/ci-dashboard/tests/conftest.py
+++ b/ci-dashboard/tests/conftest.py
@@ -147,6 +147,7 @@ def _create_test_schema(engine: Engine) -> None:
           number INTEGER NOT NULL,
           title TEXT NULL,
           body TEXT NULL,
+          labels TEXT NULL,
           comments TEXT NULL,
           state TEXT NULL,
           created_at TEXT NULL,

--- a/ci-dashboard/tests/jobs/test_sync_flaky_issues.py
+++ b/ci-dashboard/tests/jobs/test_sync_flaky_issues.py
@@ -26,6 +26,7 @@ from ci_dashboard.jobs.sync_flaky_issues import (
     _parse_timeline,
     _resolve_issue_branch,
     _reuse_existing_issue_branch_if_fresh,
+    _stale_cleanup_skip_reason,
     _upsert_flaky_issues,
     fetch_issue_details_via_github_api,
     parse_issue_branch,
@@ -35,7 +36,7 @@ from ci_dashboard.jobs.sync_flaky_issues import (
 )
 
 
-def _settings(batch_size: int = 100) -> Settings:
+def _settings(batch_size: int = 100, *, force_flaky_stale_cleanup: bool = False) -> Settings:
     return Settings(
         database=DatabaseSettings(
             url="sqlite+pysqlite:///:memory:",
@@ -46,7 +47,10 @@ def _settings(batch_size: int = 100) -> Settings:
             database=None,
             ssl_ca=None,
         ),
-        jobs=JobSettings(batch_size=batch_size),
+        jobs=JobSettings(
+            batch_size=batch_size,
+            force_flaky_stale_cleanup=force_flaky_stale_cleanup,
+        ),
         log_level="INFO",
     )
 
@@ -59,6 +63,7 @@ def _insert_issue_ticket(
     number: int,
     title: str,
     body: str | None = None,
+    labels: list[str] | None = None,
     comments: list[dict[str, object]] | None = None,
     state: str,
     created_at: str,
@@ -70,9 +75,9 @@ def _insert_issue_ticket(
             text(
                 """
                 INSERT INTO github_tickets (
-                  id, type, repo, number, title, body, comments, state, created_at, updated_at, timeline, branches
+                  id, type, repo, number, title, body, labels, comments, state, created_at, updated_at, timeline, branches
                 ) VALUES (
-                  :ticket_id, 'issue', :repo, :number, :title, :body, :comments, :state, :created_at, :updated_at,
+                  :ticket_id, 'issue', :repo, :number, :title, :body, :labels, :comments, :state, :created_at, :updated_at,
                   :timeline, NULL
                 )
                 """
@@ -83,6 +88,7 @@ def _insert_issue_ticket(
                 "number": number,
                 "title": title,
                 "body": body,
+                "labels": json.dumps(["flaky-test"] if labels is None else labels),
                 "comments": json.dumps(comments) if comments is not None else None,
                 "state": state,
                 "created_at": created_at,
@@ -156,6 +162,40 @@ def _insert_pull_ticket(
         )
 
 
+def _insert_derived_flaky_issue(
+    connection,
+    *,
+    repo: str = "pingcap/tidb",
+    number: int,
+    source_ticket_id: int | None = None,
+) -> None:
+    connection.execute(
+        text(
+            """
+            INSERT INTO ci_l1_flaky_issues (
+              repo, issue_number, issue_url, issue_title, case_name, issue_status,
+              issue_branch, branch_source, issue_created_at, issue_updated_at,
+              issue_closed_at, last_reopened_at, reopen_count, source_ticket_id,
+              source_ticket_updated_at
+            ) VALUES (
+              :repo, :number, :issue_url, :issue_title, :case_name, 'open',
+              'master', 'legacy_title_seed', '2026-04-10 08:00:00',
+              '2026-04-15 09:00:00', NULL, NULL, 0, :source_ticket_id,
+              '2026-04-15 09:00:00'
+            )
+            """
+        ),
+        {
+            "repo": repo,
+            "number": number,
+            "issue_url": f"https://github.com/{repo}/issues/{number}",
+            "issue_title": f"Flaky test: TestDerived{number} in nightly",
+            "case_name": f"TestDerived{number}",
+            "source_ticket_id": source_ticket_id if source_ticket_id is not None else number,
+        },
+    )
+
+
 def test_sync_flaky_issues_end_to_end_and_idempotent_refresh(sqlite_engine, monkeypatch) -> None:
     _insert_issue_ticket(
         sqlite_engine,
@@ -179,6 +219,7 @@ def test_sync_flaky_issues_end_to_end_and_idempotent_refresh(sqlite_engine, monk
         repo="pingcap/tidb",
         number=80000,
         title="RFC: not a flaky issue",
+        labels=[],
         state="open",
         created_at="2026-04-10T08:00:00Z",
         updated_at="2026-04-10T08:00:00Z",
@@ -283,7 +324,7 @@ def test_sync_flaky_issues_end_to_end_and_idempotent_refresh(sqlite_engine, monk
     assert total_rows["count"] == 1
 
 
-def test_sync_flaky_issues_accepts_legacy_flaky_test_title(sqlite_engine, monkeypatch) -> None:
+def test_sync_flaky_issues_filters_by_flaky_test_label_not_title(sqlite_engine, monkeypatch) -> None:
     _insert_issue_ticket(
         sqlite_engine,
         ticket_id=52792,
@@ -302,10 +343,22 @@ def test_sync_flaky_issues_accepts_legacy_flaky_test_title(sqlite_engine, monkey
         ticket_id=52793,
         repo="pingcap/tidb",
         number=52793,
-        title="flaky testcase should not match",
+        title="Flaky test: title-only issue should not match",
+        labels=[],
         state="closed",
         created_at="2024-04-22T03:31:12Z",
         updated_at="2026-06-22T12:47:18Z",
+        timeline=[],
+    )
+    _insert_issue_ticket(
+        sqlite_engine,
+        ticket_id=52794,
+        repo="pingcap/tidb",
+        number=52794,
+        title="Issue with flaky-test label but custom title",
+        state="open",
+        created_at="2024-04-23T03:31:12Z",
+        updated_at="2026-06-23T12:47:18Z",
         timeline=[],
     )
 
@@ -318,8 +371,8 @@ def test_sync_flaky_issues_accepts_legacy_flaky_test_title(sqlite_engine, monkey
 
     summary = run_sync_flaky_issues(sqlite_engine, _settings(batch_size=10))
 
-    assert summary.source_rows_scanned == 1
-    assert summary.rows_written == 1
+    assert summary.source_rows_scanned == 2
+    assert summary.rows_written == 2
 
     with sqlite_engine.begin() as connection:
         rows = connection.execute(
@@ -339,8 +392,396 @@ def test_sync_flaky_issues_accepts_legacy_flaky_test_title(sqlite_engine, monkey
             "case_name": "TestSomeOfStoreUnsupported",
             "issue_status": "closed",
             "issue_branch": "master",
-        }
+        },
+        {
+            "issue_number": 52794,
+            "issue_title": "Issue with flaky-test label but custom title",
+            "case_name": "Issue with flaky-test label but custom title",
+            "issue_status": "open",
+            "issue_branch": "master",
+        },
     ]
+
+
+def test_sync_flaky_issues_deletes_stale_rows_outside_label_source(
+    sqlite_engine,
+    monkeypatch,
+) -> None:
+    _insert_issue_ticket(
+        sqlite_engine,
+        ticket_id=71000,
+        repo="pingcap/tidb",
+        number=71000,
+        title="Flaky test: TestKept in nightly",
+        state="open",
+        created_at="2026-04-10T08:00:00Z",
+        updated_at="2026-04-15T09:00:00Z",
+        timeline=[],
+    )
+    _insert_issue_ticket(
+        sqlite_engine,
+        ticket_id=71001,
+        repo="pingcap/tidb",
+        number=71001,
+        title="Flaky test: TestStaleTitleOnly in nightly",
+        labels=[],
+        state="open",
+        created_at="2026-04-10T08:00:00Z",
+        updated_at="2026-04-15T09:00:00Z",
+        timeline=[],
+    )
+
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_flaky_issues (
+                  repo,
+                  issue_number,
+                  issue_url,
+                  issue_title,
+                  case_name,
+                  issue_status,
+                  issue_branch,
+                  branch_source,
+                  issue_created_at,
+                  issue_updated_at,
+                  issue_closed_at,
+                  last_reopened_at,
+                  reopen_count,
+                  source_ticket_id,
+                  source_ticket_updated_at,
+                  created_at,
+                  updated_at
+                ) VALUES (
+                  'pingcap/tidb',
+                  71001,
+                  'https://github.com/pingcap/tidb/issues/71001',
+                  'Flaky test: TestStaleTitleOnly in nightly',
+                  'TestStaleTitleOnly',
+                  'open',
+                  'master',
+                  'legacy_title_seed',
+                  '2026-04-10 08:00:00',
+                  '2026-04-15 09:00:00',
+                  NULL,
+                  NULL,
+                  0,
+                  71001,
+                  '2026-04-15 09:00:00',
+                  CURRENT_TIMESTAMP,
+                  CURRENT_TIMESTAMP
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_flaky_issue_pr_links (
+                  issue_repo,
+                  issue_number,
+                  pr_repo,
+                  pr_number,
+                  pr_url,
+                  pr_title,
+                  link_type,
+                  source_event_type,
+                  source_event_id,
+                  linked_at,
+                  source_ticket_updated_at
+                ) VALUES (
+                  'pingcap/tidb',
+                  71001,
+                  'pingcap/tidb',
+                  71002,
+                  'https://github.com/pingcap/tidb/pull/71002',
+                  'stale flaky fix',
+                  'linked_pull_request',
+                  'cross-referenced',
+                  71002,
+                  '2026-04-16 10:00:00',
+                  '2026-04-16 10:00:00'
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_flaky_linked_prs (
+                  pr_repo,
+                  pr_number,
+                  pr_url,
+                  pr_title,
+                  pr_state,
+                  pr_created_at,
+                  pr_closed_at,
+                  pr_merged_at
+                ) VALUES (
+                  'pingcap/tidb',
+                  71002,
+                  'https://github.com/pingcap/tidb/pull/71002',
+                  'stale flaky fix',
+                  'closed',
+                  '2026-04-16 10:00:00',
+                  '2026-04-17 10:00:00',
+                  '2026-04-17 10:00:00'
+                )
+                """
+            )
+        )
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.fetch_issue_details_via_github_api",
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("GitHub API should not be called for pingcap/tidb issue sync")
+        ),
+    )
+
+    summary = run_sync_flaky_issues(sqlite_engine, _settings(batch_size=10))
+
+    assert summary.source_rows_scanned == 1
+    assert summary.rows_written == 1
+    assert summary.stale_cleanup_forced is False
+    assert summary.stale_issue_rows_deleted == 1
+    assert summary.stale_issue_pr_links_deleted == 1
+
+    with sqlite_engine.begin() as connection:
+        issues = connection.execute(
+            text(
+                """
+                SELECT issue_number
+                FROM ci_l1_flaky_issues
+                ORDER BY issue_number
+                """
+            )
+        ).mappings().all()
+        stale_links = connection.execute(
+            text("SELECT COUNT(*) AS count FROM ci_l1_flaky_issue_pr_links")
+        ).mappings().one()
+        stale_linked_prs = connection.execute(
+            text("SELECT COUNT(*) AS count FROM ci_l1_flaky_linked_prs")
+        ).mappings().one()
+
+    assert [row["issue_number"] for row in issues] == [71000]
+    assert stale_links["count"] == 0
+    assert stale_linked_prs["count"] == 0
+
+
+def test_sync_flaky_issues_skips_stale_cleanup_when_label_source_is_empty(
+    sqlite_engine,
+    monkeypatch,
+) -> None:
+    _insert_issue_ticket(
+        sqlite_engine,
+        ticket_id=72001,
+        repo="pingcap/tidb",
+        number=72001,
+        title="Flaky test: TestPreservedWhenSourceIsEmpty in nightly",
+        labels=[],
+        state="open",
+        created_at="2026-04-10T08:00:00Z",
+        updated_at="2026-04-15T09:00:00Z",
+        timeline=[],
+    )
+
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_flaky_issues (
+                  repo, issue_number, issue_url, issue_title, case_name, issue_status,
+                  issue_branch, branch_source, issue_created_at, issue_updated_at,
+                  issue_closed_at, last_reopened_at, reopen_count, source_ticket_id,
+                  source_ticket_updated_at
+                ) VALUES (
+                  'pingcap/tidb', 72001, 'https://github.com/pingcap/tidb/issues/72001',
+                  'Flaky test: TestPreservedWhenSourceIsEmpty in nightly',
+                  'TestPreservedWhenSourceIsEmpty', 'open', 'master', 'legacy_title_seed',
+                  '2026-04-10 08:00:00', '2026-04-15 09:00:00', NULL, NULL, 0,
+                  72001, '2026-04-15 09:00:00'
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_flaky_issue_pr_links (
+                  issue_repo, issue_number, pr_repo, pr_number, pr_url, pr_title,
+                  link_type, source_event_type, source_event_id, linked_at,
+                  source_ticket_updated_at
+                ) VALUES (
+                  'pingcap/tidb', 72001, 'pingcap/tidb', 72002,
+                  'https://github.com/pingcap/tidb/pull/72002', 'preserved flaky fix',
+                  'linked_pull_request', 'cross-referenced', 72002,
+                  '2026-04-16 10:00:00', '2026-04-16 10:00:00'
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO ci_l1_flaky_linked_prs (
+                  pr_repo, pr_number, pr_url, pr_title, pr_state, pr_created_at,
+                  pr_closed_at, pr_merged_at
+                ) VALUES (
+                  'pingcap/tidb', 72002, 'https://github.com/pingcap/tidb/pull/72002',
+                  'preserved flaky fix', 'closed', '2026-04-16 10:00:00',
+                  '2026-04-17 10:00:00', '2026-04-17 10:00:00'
+                )
+                """
+            )
+        )
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.fetch_issue_details_via_github_api",
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("GitHub API should not be called when source is empty")
+        ),
+    )
+
+    summary = run_sync_flaky_issues(sqlite_engine, _settings(batch_size=10))
+
+    assert summary.source_rows_scanned == 0
+    assert summary.rows_written == 0
+    assert summary.stale_cleanup_skipped is True
+    assert summary.stale_cleanup_forced is False
+    assert summary.stale_cleanup_skip_reason == "empty_source"
+    assert summary.stale_issue_rows_deleted == 0
+    assert summary.stale_issue_pr_links_deleted == 0
+
+    with sqlite_engine.begin() as connection:
+        issue_count = connection.execute(
+            text("SELECT COUNT(*) AS count FROM ci_l1_flaky_issues")
+        ).mappings().one()
+        link_count = connection.execute(
+            text("SELECT COUNT(*) AS count FROM ci_l1_flaky_issue_pr_links")
+        ).mappings().one()
+        linked_pr_count = connection.execute(
+            text("SELECT COUNT(*) AS count FROM ci_l1_flaky_linked_prs")
+        ).mappings().one()
+
+    assert issue_count["count"] == 1
+    assert link_count["count"] == 1
+    assert linked_pr_count["count"] == 1
+
+
+def test_sync_flaky_issues_skips_stale_cleanup_when_source_ratio_is_low(
+    sqlite_engine,
+    monkeypatch,
+) -> None:
+    for offset in range(3):
+        number = 73001 + offset
+        _insert_issue_ticket(
+            sqlite_engine,
+            ticket_id=number,
+            repo="pingcap/tidb",
+            number=number,
+            title=f"Flaky test: TestKept{offset} in nightly",
+            state="open",
+            created_at="2026-04-10T08:00:00Z",
+            updated_at="2026-04-15T09:00:00Z",
+            timeline=[],
+        )
+
+    with sqlite_engine.begin() as connection:
+        for number in range(73101, 73111):
+            _insert_derived_flaky_issue(connection, number=number)
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.fetch_issue_details_via_github_api",
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("GitHub API should not be called for pingcap/tidb issue sync")
+        ),
+    )
+
+    summary = run_sync_flaky_issues(sqlite_engine, _settings(batch_size=10))
+
+    assert summary.source_rows_scanned == 3
+    assert summary.rows_written == 3
+    assert summary.stale_cleanup_skipped is True
+    assert summary.stale_cleanup_forced is False
+    assert summary.stale_cleanup_skip_reason == "source_count_below_safety_ratio"
+    assert summary.stale_issue_rows_deleted == 0
+    assert summary.stale_issue_pr_links_deleted == 0
+
+    with sqlite_engine.begin() as connection:
+        issue_count = connection.execute(
+            text("SELECT COUNT(*) AS count FROM ci_l1_flaky_issues")
+        ).mappings().one()
+
+    assert issue_count["count"] == 13
+
+
+def test_sync_flaky_issues_force_stale_cleanup_allows_low_source_ratio(
+    sqlite_engine,
+    monkeypatch,
+) -> None:
+    for offset in range(3):
+        number = 74001 + offset
+        _insert_issue_ticket(
+            sqlite_engine,
+            ticket_id=number,
+            repo="pingcap/tidb",
+            number=number,
+            title=f"Flaky test: TestForceKept{offset} in nightly",
+            state="open",
+            created_at="2026-04-10T08:00:00Z",
+            updated_at="2026-04-15T09:00:00Z",
+            timeline=[],
+        )
+
+    with sqlite_engine.begin() as connection:
+        for number in range(74101, 74111):
+            _insert_derived_flaky_issue(connection, number=number)
+
+    monkeypatch.setattr(
+        "ci_dashboard.jobs.sync_flaky_issues.fetch_issue_details_via_github_api",
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("GitHub API should not be called for pingcap/tidb issue sync")
+        ),
+    )
+
+    summary = run_sync_flaky_issues(
+        sqlite_engine,
+        _settings(batch_size=10, force_flaky_stale_cleanup=True),
+    )
+
+    assert summary.source_rows_scanned == 3
+    assert summary.rows_written == 3
+    assert summary.stale_cleanup_skipped is False
+    assert summary.stale_cleanup_forced is True
+    assert summary.stale_cleanup_skip_reason is None
+    assert summary.stale_issue_rows_deleted == 10
+
+    with sqlite_engine.begin() as connection:
+        issues = connection.execute(
+            text(
+                """
+                SELECT issue_number
+                FROM ci_l1_flaky_issues
+                ORDER BY issue_number
+                """
+            )
+        ).mappings().all()
+
+    assert [row["issue_number"] for row in issues] == [74001, 74002, 74003]
+
+
+def test_stale_cleanup_skip_reason_guards_empty_and_low_source() -> None:
+    assert (
+        _stale_cleanup_skip_reason(source_issue_count=0, existing_issue_count=10)
+        == "empty_source"
+    )
+    assert (
+        _stale_cleanup_skip_reason(source_issue_count=4, existing_issue_count=10)
+        == "source_count_below_safety_ratio"
+    )
+    assert _stale_cleanup_skip_reason(source_issue_count=5, existing_issue_count=10) is None
+    assert _stale_cleanup_skip_reason(source_issue_count=1, existing_issue_count=0) is None
 
 
 def test_sync_flaky_issues_defaults_branch_to_master_when_ticket_body_missing(

--- a/ci-dashboard/tests/test_config_and_db.py
+++ b/ci-dashboard/tests/test_config_and_db.py
@@ -17,6 +17,7 @@ def test_load_settings_supports_db_url() -> None:
             "CI_DASHBOARD_BATCH_SIZE": "12",
             "CI_DASHBOARD_REFRESH_GROUP_BATCH_SIZE": "7",
             "CI_DASHBOARD_REFRESH_BUILD_LIMIT": "3456",
+            "CI_DASHBOARD_FORCE_FLAKY_STALE_CLEANUP": "true",
             "CI_DASHBOARD_KAFKA_BOOTSTRAP_SERVERS": "kafka-a:9092,kafka-b:9092",
             "CI_DASHBOARD_KAFKA_JENKINS_EVENTS_TOPIC": "jenkins-event-test",
             "CI_DASHBOARD_KAFKA_JENKINS_GROUP_ID": "ci-dashboard-test",
@@ -44,6 +45,7 @@ def test_load_settings_supports_db_url() -> None:
     assert settings.jobs.batch_size == 12
     assert settings.jobs.refresh_group_batch_size == 7
     assert settings.jobs.refresh_build_limit == 3456
+    assert settings.jobs.force_flaky_stale_cleanup is True
     assert settings.kafka.bootstrap_servers == ("kafka-a:9092", "kafka-b:9092")
     assert settings.kafka.jenkins_events_topic == "jenkins-event-test"
     assert settings.kafka.jenkins_consumer_group == "ci-dashboard-test"
@@ -118,6 +120,19 @@ def test_load_settings_rejects_non_positive_refresh_build_limit() -> None:
             {
                 "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
                 "CI_DASHBOARD_REFRESH_BUILD_LIMIT": "0",
+            }
+        )
+
+
+def test_load_settings_rejects_invalid_flaky_stale_cleanup_force() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"CI_DASHBOARD_FORCE_FLAKY_STALE_CLEANUP must be a boolean, got 'sometimes'",
+    ):
+        load_settings(
+            {
+                "CI_DASHBOARD_DB_URL": "sqlite+pysqlite:///tmp/example.db",
+                "CI_DASHBOARD_FORCE_FLAKY_STALE_CLEANUP": "sometimes",
             }
         )
 


### PR DESCRIPTION
## Summary
- select flaky GitHub issues by exact `flaky-test` label membership instead of title prefixes
- clean up derived flaky issues and PR links that no longer belong to the label-backed source set
- guard stale cleanup when the source set is empty or suspiciously small compared with existing derived rows
- add `CI_DASHBOARD_FORCE_FLAKY_STALE_CLEANUP=true` for operator-confirmed large label purges; empty source sets still skip cleanup
- expose forced cleanup in `SyncFlakyIssuesSummary.stale_cleanup_forced` so operator runs can confirm the force path actually applied
- add regression coverage for label-backed inclusion, title-only exclusion, stale derived-row cleanup, empty-source skipping, low-ratio skipping, and forced low-ratio cleanup

## Production dependency check
- Verified in the current TiDB source that `github_tickets.labels` exists as a JSON column.
- Verified tracked issue rows have populated valid JSON labels: `pingcap/tidb` has 20,367/20,367 issue rows with labels and valid JSON labels; `tikv/pd` has 3,301/3,301.
- Verified exact `flaky-test` label membership currently returns `pingcap/tidb=318` and `tikv/pd=1`.

## Data refresh impact
- This needs `sync-flaky-issues` to run after deploy; waiting for the CronJob is enough, or trigger it once for immediate correction.
- Current read-only estimate: source set becomes 319 labeled issues total (pingcap/tidb=318, tikv/pd=1).
- Existing derived table would delete about 199 stale issue rows and 188 stale issue-PR links, while adding about 13 newly included labeled issues.
- For the default flaky progress snapshot as of 2026-07-18, estimated cards move from 497/281/98/261 to about 317/111/94/160.
- Stale cleanup is skipped if the label source unexpectedly returns 0 rows or below 50% of existing tracked derived rows, preserving old data instead of deleting aggressively.
- If a legitimate label purge drops the source below that 50% safety ratio, render a one-off Job with `--job-command sync-flaky-issues --force-flaky-stale-cleanup true`; the force path only bypasses the ratio guard, not the empty-source guard.

## Review follow-ups
- Added the requested manual escape hatch for legitimate large label cleanup so stale rows do not accumulate forever behind the ratio guard.
- Added `stale_cleanup_forced` to the sync summary, with tests covering normal cleanup, skipped cleanup, and forced cleanup observability.
- Refactored stale cleanup safety evaluation to compute the unforced skip reason once, then derive whether force bypasses only `source_count_below_safety_ratio`.
- Kept forced stale cleanup out of the recurring CronJob renderer to avoid accidentally making the daily path permanently bypass the ratio guard.
- Exposed `--force-flaky-stale-cleanup true|false` only in `render_backfill_job.sh`; the backfill renderer validates the value, can generate a one-off `sync-flaky-issues` Job, and can optionally inject `GITHUB_TOKEN` through `--github-secret`.
- Kept `existing_issue_count` as the run-start snapshot. The ratio can be slightly loose after new upserts, but stale cleanup still deletes only rows outside the source keep set, so newly written source rows are preserved; this is an acceptable precision trade-off for now.
- Kept force scoped to the configured default repo set for this PR. Repo-level force can be split later if the flaky source expands beyond the current two repos.

## Tests
- `PYTHONPATH=src ./.venv/bin/python -m pytest tests/jobs/test_sync_flaky_issues.py tests/jobs/test_cli.py tests/test_config_and_db.py -q`
- `./.venv/bin/python -m ruff check src tests`
- `bash -n ci-dashboard/scripts/render_flaky_issue_sync_cronjob.sh ci-dashboard/scripts/render_backfill_job.sh && git diff --check`
- Render smoke checks for normal flaky CronJob without force env, rejected force flag on CronJob, one-off forced `sync-flaky-issues` Job, normal `backfill-range` Job, invalid force value, and invalid date args for `sync-flaky-issues`
- TiDB read-only checks for `github_tickets.labels` shape and `flaky-test` counts
- TiDB read-only `EXPLAIN DELETE` syntax check for stale cleanup

## Note
- Full `PYTHONPATH=src ./.venv/bin/python -m pytest` still has one unrelated date-sensitive failure in `tests/jobs/test_sync_pods.py::test_sync_pods_build_matching_helpers_cover_jenkins_paths`.
