### PR TITLE
fix(cost-dashboard): bucket GCP regionless billing rows

### DIFF
--- a/cost-insight/sql/007_add_region_cost_dimension.sql
+++ b/cost-insight/sql/007_add_region_cost_dimension.sql
@@ -1,9 +1,13 @@
 -- Operational note:
--- Region is part of cost_bq_export_summary_daily.source_row_hash. After this
--- migration, historical summary rows must be rebuilt with
+-- Region is part of cost_bq_export_summary_daily.source_row_hash, and
+-- cost_raw_details.source_row_hash already includes region. After changing
+-- ingestion-time region values, historical summary rows must be rebuilt with
 -- sync-*-billing-summary --replace-existing-partitions before attribution is
--- refreshed. Incremental sync alone cannot overwrite old regionless hashes and
--- will double count rows if old and new hashes remain in the same partition.
+-- refreshed. If raw history is re-imported or used for refine backfills, rebuild
+-- the matching raw usage-date window with sync-gcp-billing-export
+-- --replace-existing-dates. Incremental sync alone cannot overwrite old
+-- regionless hashes and will double count rows if old and new hashes remain in
+-- the same partition or usage-date window.
 
 ALTER TABLE cost_bq_export_summary_daily
   ADD COLUMN IF NOT EXISTS region VARCHAR(128) NULL AFTER sku_name;

--- a/cost-insight/src/cost_insight/sources/gcp_billing_export.py
+++ b/cost-insight/src/cost_insight/sources/gcp_billing_export.py
@@ -7,6 +7,38 @@ from typing import Any
 
 
 DEFAULT_COST_OWNER_AUTHOR = "wei_zheng"
+_GCP_MULTI_REGION_LOCATIONS = ("us", "eu", "asia", "nam4", "eur4")
+_GCP_MULTI_REGION_SKU_PATTERN = r"\b(multi[- ]region|dual[- ]region)\b"
+_GCP_CROSS_REGION_SKU_PATTERN = r"\b(inter[- ]region|cross[- ]region|replication)\b"
+_GCP_TRANSFER_SKU_PATTERN = r"\b(data transfer|egress)\b.*\b(to|from|within)\b"
+
+
+def _region_expr() -> str:
+    lower_location = "LOWER(COALESCE(location.location, ''))"
+    lower_sku = "LOWER(COALESCE(sku.description, ''))"
+    multi_region_locations = ", ".join(repr(location) for location in _GCP_MULTI_REGION_LOCATIONS)
+    return f"""
+CASE
+  WHEN NULLIF(location.region, '') IS NOT NULL THEN location.region
+  WHEN {lower_location} IN ({multi_region_locations})
+    THEN 'multi-region'
+  WHEN REGEXP_CONTAINS({lower_sku}, r'{_GCP_MULTI_REGION_SKU_PATTERN}')
+    THEN 'multi-region'
+  WHEN REGEXP_CONTAINS(
+    {lower_sku},
+    r'{_GCP_CROSS_REGION_SKU_PATTERN}'
+  )
+    THEN 'cross-region'
+  WHEN REGEXP_CONTAINS(
+    {lower_sku},
+    r'{_GCP_TRANSFER_SKU_PATTERN}'
+  )
+    THEN 'cross-region'
+  WHEN {lower_location} = 'global'
+    THEN 'global'
+  ELSE 'unknown'
+END
+""".strip()
 
 
 def fetch_gcp_billing_rows(
@@ -114,6 +146,7 @@ def build_gcp_billing_query(*, billing_table: str, limit: int | None = None) -> 
     limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
     author_expr = _author_expr_with_overrides()
     target_branch_expr = _target_branch_expr()
+    region_expr = _region_expr()
     return f"""
 WITH normalized AS (
   SELECT
@@ -122,7 +155,7 @@ WITH normalized AS (
     DATE(usage_start_time) AS usage_date,
     service.description AS service_name,
     sku.description AS sku_name,
-    location.region AS region,
+    {region_expr} AS region,
     {_label_expr(("k8s-namespace", "namespace"))} AS namespace,
     {author_expr} AS author,
     {_label_expr(("k8s-label/org", "org"))} AS org,
@@ -195,6 +228,7 @@ def build_gcp_billing_summary_query(*, billing_table: str, limit: int | None = N
     limit_clause = f"\nLIMIT {int(limit)}" if limit is not None else ""
     author_expr = _author_expr_with_overrides()
     target_branch_expr = _target_branch_expr()
+    region_expr = _region_expr()
     return f"""
 SELECT
   'gcp' AS vendor,
@@ -204,7 +238,7 @@ SELECT
   DATE(usage_start_time) AS usage_date,
   service.description AS service_name,
   sku.description AS sku_name,
-  location.region AS region,
+  {region_expr} AS region,
   {author_expr} AS author,
   {_label_expr(("k8s-label/org", "org"))} AS org,
   {_label_expr(("k8s-label/repo", "repo"))} AS repo,

--- a/cost-insight/tests/test_gcp_billing_export.py
+++ b/cost-insight/tests/test_gcp_billing_export.py
@@ -4,6 +4,7 @@ from datetime import date
 from decimal import Decimal
 
 from cost_insight.sources.gcp_billing_export import (
+    _region_expr,
     build_gcp_billing_query,
     build_gcp_billing_summary_query,
     build_gcp_unmatched_resource_query,
@@ -15,6 +16,41 @@ from cost_insight.sources.gcp_billing_export import (
 def _assert_target_branch_label_keys(query: str) -> None:
     assert "'k8s-label/prow.k8s.io/refs.base_ref'" in query
     assert "'prow.k8s.io/refs.base_ref'" in query
+
+
+def _assert_region_bucket_expr(query: str) -> None:
+    region_expr = _region_expr()
+
+    assert f"{region_expr} AS region" in query
+    assert "location.region AS region" not in query
+    assert "service.description" not in region_expr
+    assert "artifact registry" not in region_expr.lower()
+    assert "bigquery" not in region_expr.lower()
+    assert "cloud logging" not in region_expr.lower()
+    assert "'multi-region'" in query
+    assert "'cross-region'" in query
+    assert "'global'" in query
+    assert "'unknown'" in query
+
+
+def test_region_expr_keeps_region_bucket_branch_order() -> None:
+    expr = _region_expr()
+
+    region_idx = expr.index("NULLIF(location.region, '') IS NOT NULL")
+    location_multi_idx = expr.index("LOWER(COALESCE(location.location, '')) IN")
+    sku_multi_idx = expr.index(r"r'\b(multi[- ]region|dual[- ]region)\b'")
+    sku_cross_idx = expr.index(r"r'\b(inter[- ]region|cross[- ]region|replication)\b'")
+    transfer_idx = expr.index(r"r'\b(data transfer|egress)\b.*\b(to|from|within)\b'")
+    location_global_idx = expr.index("LOWER(COALESCE(location.location, '')) = 'global'")
+
+    assert (
+        region_idx
+        < location_multi_idx
+        < sku_multi_idx
+        < sku_cross_idx
+        < transfer_idx
+        < location_global_idx
+    )
 
 
 def test_build_gcp_billing_query_keeps_expected_dimensions() -> None:
@@ -29,6 +65,7 @@ def test_build_gcp_billing_query_keeps_expected_dimensions() -> None:
     assert "cost_at_list" in query
     assert "pricing_unit NOT IN ('hour', 'minute', 'second')" in query
     assert "ROUND(SUM(amount_in_pricing_units) * 60, 2)" in query
+    _assert_region_bucket_expr(query)
     assert "Cloud Logging" in query
     assert "Compute Flexible Committed Use Discounts - 3 Year" in query
     assert "Compute Flexible Committed Use Discounts - 1 Year" in query
@@ -56,6 +93,7 @@ def test_build_gcp_billing_summary_query_uses_partition_pruning() -> None:
     assert "resource_name" not in query
     assert "service.description AS service_name" in query
     assert "sku.description AS sku_name" in query
+    _assert_region_bucket_expr(query)
     assert "Cloud Logging" in query
     assert "Compute Flexible Committed Use Discounts - 3 Year" in query
     assert "Compute Flexible Committed Use Discounts - 1 Year" in query


### PR DESCRIPTION
## Summary
- replace the `(no region)` catch-all with ingestion-time GCP region buckets written into `region`
- keep real `location.region` values unchanged
- map empty GCP region rows from `location.location` and SKU signals to `multi-region`, `cross-region`, `global` when `location.location = 'global'`, or `unknown`

## Rollout Note
- `region` is part of both `cost_bq_export_summary_daily.source_row_hash` and `cost_raw_details.source_row_hash`; incremental sync cannot clean historical NULL-region hashes after bucket values are written.
- Required dashboard summary path for the current window (`2026-04-01` through `2026-07-18`):
  - `cost-insight sync-gcp-billing-summary --export-partition-start 2026-04-01 --export-partition-end 2026-07-18 --earliest-usage-date 2026-04-01 --replace-existing-partitions`
  - `cost-insight refresh-cost-attribution-from-summary --start-date 2026-04-01 --end-date 2026-07-18 --split-by-day`
- If raw GCP history is re-imported or `backfill-gcp-cost-refine-from-raw` is used for this same window, first rebuild raw with:
  - `cost-insight sync-gcp-billing-export --start-date 2026-04-01 --end-date 2026-07-18 --replace-existing-dates --split-by-day`
- AWS does not need a rerun for this change.

## Tests
- `ruff check src/cost_insight/sources/gcp_billing_export.py tests/test_gcp_billing_export.py`
- `PYTHONPATH=src pytest --no-cov tests/test_gcp_billing_export.py`
  - 7 passed
- `PYTHONPATH=src pytest --no-cov tests/test_gcp_billing_export.py tests/test_sync_gcp_billing_summary.py tests/test_sync_gcp_billing_export.py`
  - 33 passed
- `PYTHONPATH=src pytest --no-cov tests/test_sync_gcp_billing_summary.py tests/test_sync_gcp_billing_export.py tests/test_backfill_cost_refine_from_raw.py tests/test_refresh_attribution_daily.py`
  - 44 passed