### PR TITLE
fix: stabilize cost dashboard query plans

### DIFF
--- a/ci-dashboard/src/ci_dashboard/api/queries/cost.py
+++ b/ci-dashboard/src/ci_dashboard/api/queries/cost.py
@@ -44,6 +44,8 @@ ENGINEERING_GROUP_NAME = "Engineering Group"
 COST_DATA_LAG_DAYS = 4
 FORECAST_WINDOW_DAYS = 14
 BUDGET_FALLBACK_MAX_DAYS = 31
+COST_ATTRIBUTION_SOURCE_DATE_INDEX = "idx_cost_attribution_source_date_employee"
+COST_UNMATCHED_SOURCE_DATE_NAMESPACE_INDEX = "idx_cost_unmatched_source_date_namespace"
 UNALLOCATED_GKE_NAMESPACE_BUCKETS = (
     "kube:unallocated",
     "kube:system-overhead",
@@ -750,6 +752,8 @@ def get_unmatched_resources(
     with engine.begin() as connection:
         attr_where_clause, attr_params = _build_cost_where(filters, table_alias="c")
         resource_where_clause, resource_params = _build_cost_where(filters, table_alias="r")
+        attr_index_hint = _cost_attribution_index_hint(connection, filters)
+        resource_index_hint = _cost_unmatched_resource_index_hint(connection, filters)
         namespace_clause, namespace_params = _build_unallocated_namespace_where("r.namespace")
         org_match = _null_safe_eq(connection, "m.org", "r.org")
         repo_match = _null_safe_eq(connection, "m.repo", "r.repo")
@@ -757,7 +761,7 @@ def get_unmatched_resources(
         resource_list_cost_expr = _billing_report_list_cost_expr("r")
         base_cte = f"""
             WITH unmatched_dimensions AS (
-              SELECT
+              SELECT {attr_index_hint}
                 c.usage_date AS usage_date,
                 c.vendor AS vendor,
                 c.account_id AS account_id,
@@ -779,7 +783,7 @@ def get_unmatched_resources(
                 c.author
             ),
             unallocated_resource_rows AS (
-              SELECT
+              SELECT {resource_index_hint}
                 r.resource_name AS resource_name,
                 COALESCE(NULLIF(r.service_name, ''), '(no service)') AS service_name,
                 r.sku_name AS sku_name,
@@ -1561,6 +1565,48 @@ def _build_cost_where(
         conditions.append(f"{prefix}target_branch = :branch")
         params["branch"] = filters.branch
     return " AND ".join(conditions), params
+
+
+def _cost_attribution_index_hint(
+    connection: Connection,
+    filters: CommonFilters,
+    table_alias: str = "c",
+) -> str:
+    return _source_date_index_hint(
+        connection,
+        filters,
+        table_alias=table_alias,
+        index_name=COST_ATTRIBUTION_SOURCE_DATE_INDEX,
+    )
+
+
+def _cost_unmatched_resource_index_hint(
+    connection: Connection,
+    filters: CommonFilters,
+    table_alias: str = "r",
+) -> str:
+    return _source_date_index_hint(
+        connection,
+        filters,
+        table_alias=table_alias,
+        index_name=COST_UNMATCHED_SOURCE_DATE_NAMESPACE_INDEX,
+    )
+
+
+def _source_date_index_hint(
+    connection: Connection,
+    filters: CommonFilters,
+    *,
+    table_alias: str,
+    index_name: str,
+) -> str:
+    if connection.dialect.name == "sqlite":
+        return ""
+    if not (filters.cost_vendor and filters.cost_account_id):
+        return ""
+    if not (filters.start_date or filters.end_date):
+        return ""
+    return f"/*+ USE_INDEX({table_alias}, {index_name}) */"
 
 
 def _billing_report_list_cost_expr(table_alias: str) -> str:

--- a/ci-dashboard/tests/api/test_routes.py
+++ b/ci-dashboard/tests/api/test_routes.py
@@ -47,6 +47,32 @@ def test_cost_null_safe_eq_uses_dialect_specific_operator() -> None:
     assert cost_queries._null_safe_eq(mysql_connection, "m.org", "r.org") == "m.org <=> r.org"
 
 
+def test_cost_unmatched_source_date_index_hints_only_apply_to_scoped_windows() -> None:
+    mysql_connection = SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
+    sqlite_connection = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    scoped = CommonFilters(
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 7, 19),
+        cost_vendor="aws",
+        cost_account_id="946646677266",
+    )
+    all_sources = CommonFilters(start_date=date(2026, 6, 1), end_date=date(2026, 7, 19))
+    unbounded_source = CommonFilters(
+        cost_vendor="aws",
+        cost_account_id="946646677266",
+    )
+
+    assert cost_queries._cost_attribution_index_hint(mysql_connection, scoped) == (
+        "/*+ USE_INDEX(c, idx_cost_attribution_source_date_employee) */"
+    )
+    assert cost_queries._cost_unmatched_resource_index_hint(mysql_connection, scoped) == (
+        "/*+ USE_INDEX(r, idx_cost_unmatched_source_date_namespace) */"
+    )
+    assert cost_queries._cost_attribution_index_hint(mysql_connection, all_sources) == ""
+    assert cost_queries._cost_attribution_index_hint(mysql_connection, unbounded_source) == ""
+    assert cost_queries._cost_attribution_index_hint(sqlite_connection, scoped) == ""
+
+
 def _insert_build(
     sqlite_engine,
     *,

--- a/cost-insight/sql/009_add_cost_serving_indexes.sql
+++ b/cost-insight/sql/009_add_cost_serving_indexes.sql
@@ -1,0 +1,7 @@
+-- Keep dashboard cost reads bounded by source and date when TiDB's optimizer
+-- would otherwise choose broad scans under concurrent load.
+CREATE INDEX IF NOT EXISTS idx_cost_attribution_source_date_employee
+  ON cost_attribution_daily (vendor, account_id, usage_date, employee_id);
+
+CREATE INDEX IF NOT EXISTS idx_cost_unmatched_source_date_namespace
+  ON cost_unmatched_resource_daily (vendor, account_id, usage_date, namespace);


### PR DESCRIPTION
## Summary
- add TiDB source/date index hints only for the confirmed hot path: the cost unmatched resources CTE
- keep other cost panels on optimizer-selected plans to avoid unverified regressions
- add an idempotent cost-insight serving-index migration for the hinted indexes

## Investigation
- dashboard route and health endpoint were healthy; the 504s came from cost panel API requests waiting in TiDB resource control
- TiDB statement summary for 2026-07-27 00:59:21-01:01:23 UTC showed cost queries queued for tens of seconds, with `MAX_QUEUED_RC_TIME` up to hundreds of seconds
- the high-RU path was `cost-unmatched-resources` over `cost_unmatched_resource_daily`, which amplified resource queueing during page load

## TiDB validation
- verified corrected hint syntax with live TiDB: `/*+ USE_INDEX(c, idx_cost_attribution_source_date_employee) */`
- `EXPLAIN + SHOW WARNINGS` produced no hint warnings for the scoped unmatched CTE
- the plan uses:
  - `IndexRangeScan ... index:idx_cost_attribution_source_date_employee(vendor, account_id, usage_date, employee_id)`
  - `IndexRangeScan ... index:idx_cost_unmatched_source_date_namespace(vendor, account_id, usage_date, namespace)`

## Tests
- `PYTHONPATH=src make PYTHON=.venv/bin/python test`
- `./.venv/bin/ruff check src/ci_dashboard/api/queries/cost.py src/ci_dashboard/api/queries/ebs.py tests/api/test_routes.py`
- live TiDB `EXPLAIN + SHOW WARNINGS` for the unmatched resources query
