### PR TITLE
feat(publisher): add config hot-reload support

### DIFF
--- a/publisher/cmd/publisher/main.go
+++ b/publisher/cmd/publisher/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/rs/zerolog"
 	"goa.design/clue/debug"
@@ -59,11 +60,12 @@ func main() {
 	zerolog.SetGlobalLevel(logLevel)
 	loggerCtx := zerolog.New(os.Stderr).With().Timestamp()
 
-	// Load and parse configuration
-	cfg, err := config.Load[config.Service](*configFile)
+	// Load and parse configuration with hot-reload support
+	cfgReloadable, err := config.NewReloadable[config.Service](*configFile)
 	if err != nil {
 		log.Fatalf(ctx, err, "failed to load configuration")
 	}
+	cfg := cfgReloadable.Get()
 
 	// Initialize the services.
 	tiupLogger := loggerCtx.Str("service", "tiup").Logger()
@@ -74,6 +76,28 @@ func main() {
 	imgSvc := implimg.NewService(&imgLogger, *cfg)
 	tidbcloudLogger := loggerCtx.Str("service", "tidbcloud").Logger()
 	tidbcloudSvc := impltidbcloud.NewService(&tidbcloudLogger, *cfg)
+
+	// Register reload handlers for services that support hot-reload.
+	cfgReloadable.OnReload(func(newCfg *config.Service) {
+		if r, ok := tiupSvc.(interface{ Reload(config.Service) }); ok {
+			r.Reload(*newCfg)
+		}
+	})
+	cfgReloadable.OnReload(func(newCfg *config.Service) {
+		if r, ok := fsSvc.(interface{ Reload(config.Service) }); ok {
+			r.Reload(*newCfg)
+		}
+	})
+	cfgReloadable.OnReload(func(newCfg *config.Service) {
+		if r, ok := imgSvc.(interface{ Reload(config.Service) }); ok {
+			r.Reload(*newCfg)
+		}
+	})
+	cfgReloadable.OnReload(func(newCfg *config.Service) {
+		if r, ok := tidbcloudSvc.(interface{ Reload(config.Service) }); ok {
+			r.Reload(*newCfg)
+		}
+	})
 
 	// Wrap the services in endpoints that can be invoked from other services
 	// potentially running in different processes.
@@ -107,14 +131,29 @@ func main() {
 
 	// Setup interrupt handler. This optional step configures the process so
 	// that SIGINT and SIGTERM signals cause the services to stop gracefully.
+	// SIGHUP triggers a configuration reload.
 	go func() {
 		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-		errc <- fmt.Errorf("%s", <-c)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+		for {
+			sig := <-c
+			if sig == syscall.SIGHUP {
+				log.Printf(ctx, "received SIGHUP, reloading configuration")
+				if err := cfgReloadable.Reload(); err != nil {
+					log.Printf(ctx, "config reload error: %v", err)
+				}
+			} else {
+				errc <- fmt.Errorf("%s", sig)
+				return
+			}
+		}
 	}()
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(ctx)
+
+	// Start auto-reload polling
+	go cfgReloadable.AutoReload(ctx, 30*time.Second)
 
 	// Start the servers and send errors (if any) to the error channel.
 	switch *hostF {

--- a/publisher/cmd/worker/main.go
+++ b/publisher/cmd/worker/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -33,21 +34,37 @@ func main() {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 
-	cfg, err := config.Load[config.Workers](*configFile)
+	cfgReloadable, err := config.NewReloadable[config.Workers](*configFile)
 	if err != nil {
 		log.Fatal().Err(err).Msg("load config failed")
 	}
+	cfg := cfgReloadable.Get()
+
+	// Register reload handler for config changes.
+	cfgReloadable.OnReload(func(newCfg *config.Workers) {
+		log.Info().Msg("config reloaded - restart worker to apply Kafka/Redis changes")
+	})
 
 	// Create channel used by both the signal handler and server goroutines
 	// to notify the main goroutine when to stop the server.
 	errc := make(chan error)
 
-	// Setup interrupt handler. This optional step configures the process so
-	// that SIGINT and SIGTERM signals cause the services to stop gracefully.
+	// Setup interrupt handler with SIGHUP for config reload.
 	go func() {
 		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-		errc <- fmt.Errorf("%s", <-c)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+		for {
+			sig := <-c
+			if sig == syscall.SIGHUP {
+				log.Info().Msg("received SIGHUP, reloading configuration")
+				if err := cfgReloadable.Reload(); err != nil {
+					log.Err(err).Msg("config reload error")
+				}
+			} else {
+				errc <- fmt.Errorf("%s", sig)
+				return
+			}
+		}
 	}()
 
 	// Start workers.
@@ -63,6 +80,9 @@ func main() {
 	if workerFn := newWorkerFunc(ctx, "image", image.NewWorker, cfg.Image); workerFn != nil {
 		wg.Go(workerFn)
 	}
+
+	// Start auto-reload polling
+	go cfgReloadable.AutoReload(ctx, 30*time.Second)
 
 	// Wait for signal.
 	log.Warn().Msgf("exiting (%v)", <-errc)

--- a/publisher/internal/service/impl/fileserver/service.go
+++ b/publisher/internal/service/impl/fileserver/service.go
@@ -26,6 +26,11 @@ func NewService(logger *zerolog.Logger, cfg config.Service) fileserver.Service {
 	}
 }
 
+// Reload re-creates Kafka and Redis clients from the given service config.
+func (s *fileserversrvc) Reload(cfg config.Service) {
+	s.BaseService.Reload(cfg)
+}
+
 // RequestToPublish implements request-to-publish.
 func (s *fileserversrvc) RequestToPublish(ctx context.Context, p *fileserver.RequestToPublishPayload) (res []string, err error) {
 	s.Logger.Info().Msgf("fileserver.request-to-publish")
@@ -47,7 +52,7 @@ func (s *fileserversrvc) RequestToPublish(ctx context.Context, p *fileserver.Req
 			Value: bs,
 		})
 	}
-	err = s.KafkaWriter.WriteMessages(ctx, messages...)
+	err = s.Writer().WriteMessages(ctx, messages...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send message to Kafka: %v", err)
 	}
@@ -59,7 +64,7 @@ func (s *fileserversrvc) RequestToPublish(ctx context.Context, p *fileserver.Req
 
 	// 4. Init the request dealing status in redis with the request id.
 	for _, requestID := range requestIDs {
-		if err := s.RedisClient.SetNX(ctx, requestID, share.PublishStateQueued, s.StateTTL).Err(); err != nil {
+		if err := s.Client().SetNX(ctx, requestID, share.PublishStateQueued, s.StateTTL).Err(); err != nil {
 			return nil, fmt.Errorf("failed to set initial status in Redis: %v", err)
 		}
 	}
@@ -71,7 +76,7 @@ func (s *fileserversrvc) RequestToPublish(ctx context.Context, p *fileserver.Req
 // QueryPublishingStatus implements query-publishing-status.
 func (s *fileserversrvc) QueryPublishingStatus(ctx context.Context, p *fileserver.QueryPublishingStatusPayload) (res string, err error) {
 	s.Logger.Info().Msgf("fileserver.query-publishing-status")
-	return share.QueryStatusFromRedis(ctx, s.RedisClient, p.RequestID)
+	return share.QueryStatusFromRedis(ctx, s.Client(), p.RequestID)
 }
 
 func (s *fileserversrvc) composeEvents(request *PublishRequestFS) []cloudevents.Event {

--- a/publisher/internal/service/impl/image/service.go
+++ b/publisher/internal/service/impl/image/service.go
@@ -27,6 +27,11 @@ func NewService(logger *zerolog.Logger, cfg config.Service) image.Service {
 	}
 }
 
+// Reload re-creates Kafka and Redis clients from the given service config.
+func (s *imagesrvc) Reload(cfg config.Service) {
+	s.BaseService.Reload(cfg)
+}
+
 // RequestToCopy implements image.Service.
 func (s *imagesrvc) RequestToCopy(ctx context.Context, p *image.RequestToCopyPayload) (res string, err error) {
 	return s.enqueueRequest(ctx, share.EventTypeImagePublishRequest, p.Source, p)
@@ -34,7 +39,7 @@ func (s *imagesrvc) RequestToCopy(ctx context.Context, p *image.RequestToCopyPay
 
 // QueryCopyingStatus implements image.Service.
 func (s *imagesrvc) QueryCopyingStatus(ctx context.Context, p *image.QueryCopyingStatusPayload) (string, error) {
-	return share.QueryStatusFromRedis(ctx, s.RedisClient, p.RequestID)
+	return share.QueryStatusFromRedis(ctx, s.Client(), p.RequestID)
 }
 
 // RequestMultiarchCollect implements image.Service.
@@ -73,7 +78,7 @@ func (s *imagesrvc) RequestMultiarchCollect(ctx context.Context, p *image.Reques
 					return nil, fmt.Errorf("multiarch collect failed, task state: %s", state)
 				}
 				// Fetch the result from Redis
-				resultJSON, err := s.RedisClient.Get(ctx, fmt.Sprintf("%s-result", requestID)).Bytes()
+				resultJSON, err := s.Client().Get(ctx, fmt.Sprintf("%s-result", requestID)).Bytes()
 				if err != nil {
 					return nil, fmt.Errorf("failed to get result from redis: %w", err)
 				}
@@ -88,7 +93,7 @@ func (s *imagesrvc) RequestMultiarchCollect(ctx context.Context, p *image.Reques
 
 // QueryMultiarchCollectStatus implements image.Service.
 func (s *imagesrvc) QueryMultiarchCollectStatus(ctx context.Context, p *image.QueryMultiarchCollectStatusPayload) (string, error) {
-	return share.QueryStatusFromRedis(ctx, s.RedisClient, p.RequestID)
+	return share.QueryStatusFromRedis(ctx, s.Client(), p.RequestID)
 }
 
 // RequestToCopy implements image.Service.
@@ -107,13 +112,13 @@ func (s *imagesrvc) enqueueRequest(ctx context.Context, requestType, subject str
 		Key:   []byte(event.ID()),
 		Value: bs,
 	}
-	if err := s.KafkaWriter.WriteMessages(ctx, message); err != nil {
+	if err := s.Writer().WriteMessages(ctx, message); err != nil {
 		return "", fmt.Errorf("failed to send message to Kafka: %v", err)
 	}
 
 	// 4. Init the request dealing status in redis with the request id.
 	requestID := event.ID()
-	if err := s.RedisClient.SetNX(ctx, requestID, share.PublishStateQueued, share.DefaultStateTTL).Err(); err != nil {
+	if err := s.Client().SetNX(ctx, requestID, share.PublishStateQueued, share.DefaultStateTTL).Err(); err != nil {
 		return "", fmt.Errorf("failed to initialize request status: %v", err)
 	}
 	s.Logger.Info().

--- a/publisher/internal/service/impl/image/service_test.go
+++ b/publisher/internal/service/impl/image/service_test.go
@@ -35,12 +35,7 @@ func TestImageServiceCopyFlow(t *testing.T) {
 
 	// Create the service with a relatively short timeout
 	service := &imagesrvc{
-		BaseService: &share.BaseService{
-			Logger:      &logger,
-			KafkaWriter: nil,
-			RedisClient: redisClient,
-			EventSource: "test",
-		},
+		BaseService: share.NewBaseServiceForTest(&logger, nil, redisClient, "test"),
 	}
 
 	// Setup test image names

--- a/publisher/internal/service/impl/share/srvc.go
+++ b/publisher/internal/service/impl/share/srvc.go
@@ -1,6 +1,7 @@
 package share
 
 import (
+	"sync"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -13,24 +14,62 @@ import (
 )
 
 type BaseService struct {
-	Logger      *zerolog.Logger
-	KafkaWriter *kafka.Writer
-	RedisClient redis.Cmdable
+	Logger *zerolog.Logger
+
+	mu          sync.RWMutex
+	kafkaWriter *kafka.Writer
+	redisClient redis.Cmdable
+
 	EventSource string
 	StateTTL    time.Duration
 }
 
-// NewService returns the tiup service implementation.
+// NewBaseServiceService returns a base service with Kafka and Redis clients.
 func NewBaseServiceService(logger *zerolog.Logger, cfg config.Service) *BaseService {
-	// Configure Kafka kafkaWriter
+	s := &BaseService{Logger: logger}
+	s.initClients(cfg)
+	return s
+}
+
+// NewBaseServiceForTest returns a base service with explicitly provided
+// Kafka writer and Redis client. Intended for unit tests.
+func NewBaseServiceForTest(logger *zerolog.Logger, writer *kafka.Writer, redisClient redis.Cmdable, eventSource string) *BaseService {
+	return &BaseService{
+		Logger:       logger,
+		kafkaWriter:  writer,
+		redisClient:  redisClient,
+		EventSource:  eventSource,
+		StateTTL:     DefaultStateTTL,
+	}
+}
+
+// Writer returns the current Kafka writer in a thread-safe manner.
+func (s *BaseService) Writer() *kafka.Writer {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.kafkaWriter
+}
+
+// Client returns the current Redis client in a thread-safe manner.
+func (s *BaseService) Client() redis.Cmdable {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.redisClient
+}
+
+// Reload re-initializes Kafka and Redis clients from the given config.
+func (s *BaseService) Reload(cfg config.Service) {
+	s.initClients(cfg)
+}
+
+func (s *BaseService) initClients(cfg config.Service) {
 	kafkaWriter := kafka.NewWriter(kafka.WriterConfig{
 		Brokers:  cfg.Kafka.Brokers,
 		Topic:    cfg.Kafka.Topic,
 		Balancer: &kafka.LeastBytes{},
-		Logger:   kafka.LoggerFunc(logger.Printf),
+		Logger:   kafka.LoggerFunc(s.Logger.Printf),
 	})
 
-	// Configure Redis client
 	redisClient := redis.NewClient(&redis.Options{
 		Addr:     cfg.Redis.Addr,
 		Password: cfg.Redis.Password,
@@ -38,12 +77,22 @@ func NewBaseServiceService(logger *zerolog.Logger, cfg config.Service) *BaseServ
 		DB:       cfg.Redis.DB,
 	})
 
-	return &BaseService{
-		Logger:      logger,
-		KafkaWriter: kafkaWriter,
-		RedisClient: redisClient,
-		EventSource: cfg.EventSource,
-		StateTTL:    DefaultStateTTL,
+	s.mu.Lock()
+	oldWriter := s.kafkaWriter
+	oldRedis := s.redisClient
+	s.kafkaWriter = kafkaWriter
+	s.redisClient = redisClient
+	s.EventSource = cfg.EventSource
+	s.StateTTL = DefaultStateTTL
+	s.mu.Unlock()
+
+	if oldWriter != nil {
+		oldWriter.Close()
+	}
+	if oldRedis != nil {
+		if c, ok := oldRedis.(*redis.Client); ok {
+			c.Close()
+		}
 	}
 }
 

--- a/publisher/internal/service/impl/tidbcloud/service.go
+++ b/publisher/internal/service/impl/tidbcloud/service.go
@@ -56,6 +56,40 @@ func NewService(logger *zerolog.Logger, cfg config.Service) tidbcloud.Service {
 	return srvc
 }
 
+// Reload re-creates Kafka/Redis clients and reloads ops and test platforms configs.
+func (s *tidbcloudsrvc) Reload(cfg config.Service) {
+	s.BaseService.Reload(cfg)
+
+	tidbcloudCfg := cfg.Services["tidbcloud"]
+	switch v := tidbcloudCfg.(type) {
+	case map[string]any:
+		if configFileAny, ok := v["ops_config_file"]; ok {
+			configFile, ok := configFileAny.(string)
+			if ok && strings.TrimSpace(configFile) != "" {
+				ret, err := config.Load[OpsConfig](configFile)
+				if err != nil {
+					s.Logger.Err(err).Msg("failed to reload ops config")
+				} else {
+					s.opsCfg = ret
+					s.Logger.Info().Msg("ops config reloaded")
+				}
+			}
+		}
+		if configFileAny, ok := v["testplatforms_config_file"]; ok {
+			configFile, ok := configFileAny.(string)
+			if ok && strings.TrimSpace(configFile) != "" {
+				ret, err := config.Load[TestPlatformsConfig](configFile)
+				if err != nil {
+					s.Logger.Err(err).Msg("failed to reload test platforms config")
+				} else {
+					s.tpsCfg = ret
+					s.Logger.Info().Msg("test platforms config reloaded")
+				}
+			}
+		}
+	}
+}
+
 func parseImageRepoTag(image string) (string, string, error) {
 	// use existing helper for "@sha256:" support
 	if strings.Contains(image, "@sha256:") {

--- a/publisher/internal/service/impl/tiup/service.go
+++ b/publisher/internal/service/impl/tiup/service.go
@@ -43,6 +43,27 @@ func NewService(logger *zerolog.Logger, cfg config.Service) gentiup.Service {
 	return srvc
 }
 
+// Reload re-creates Kafka/Redis clients and reloads the delivery config from the given service config.
+func (s *tiupsrvc) Reload(cfg config.Service) {
+	s.BaseService.Reload(cfg)
+
+	tiupCfg := cfg.Services["tiup"]
+	switch v := tiupCfg.(type) {
+	case map[string]any:
+		deliveryConfigFile := v[tiupServiceDeliveryCfgKey]
+		switch file := deliveryConfigFile.(type) {
+		case string:
+			ret, err := config.Load[DeliveryConfig](file)
+			if err != nil {
+				s.Logger.Err(err).Msg("failed to reload delivery config")
+				return
+			}
+			s.deliveryConfig = ret
+			s.Logger.Info().Msg("delivery config reloaded")
+		}
+	}
+}
+
 // RequestToPublish implements delivery-by-rules).
 func (s *tiupsrvc) DeliveryByRules(ctx context.Context, p *gentiup.DeliveryByRulesPayload) (res []string, err error) {
 	s.Logger.Info().Msgf("tiup.delivery-by-rules")
@@ -105,13 +126,13 @@ func (s *tiupsrvc) RequestToPublishSingle(ctx context.Context, p *gentiup.Publis
 // QueryPublishingStatus implements query-publishing-status.
 func (s *tiupsrvc) QueryPublishingStatus(ctx context.Context, p *gentiup.QueryPublishingStatusPayload) (res string, err error) {
 	s.Logger.Info().Msgf("tiup.query-publishing-status")
-	return share.QueryStatusFromRedis(ctx, s.RedisClient, p.RequestID)
+	return share.QueryStatusFromRedis(ctx, s.Client(), p.RequestID)
 }
 
 // ResetRateLimit implements tiup.Service.
 func (s *tiupsrvc) ResetRateLimit(ctx context.Context) error {
 	// get the keys
-	iter := s.RedisClient.Scan(ctx, 0, fmt.Sprintf("%s:*", redisKeyPrefixTiupRateLimit), 0).Iterator()
+	iter := s.Client().Scan(ctx, 0, fmt.Sprintf("%s:*", redisKeyPrefixTiupRateLimit), 0).Iterator()
 	var keys []string
 	for iter.Next(ctx) {
 		keys = append(keys, iter.Val())
@@ -124,7 +145,7 @@ func (s *tiupsrvc) ResetRateLimit(ctx context.Context) error {
 	if len(keys) == 0 {
 		return nil
 	}
-	if err := s.RedisClient.Del(ctx, keys...).Err(); err != nil {
+	if err := s.Client().Del(ctx, keys...).Err(); err != nil {
 		s.Logger.Err(err).Any("keys", keys).Msg("failed to delete keys")
 		return fmt.Errorf("failed to delete keys: %v", err)
 	}
@@ -146,7 +167,7 @@ func (s *tiupsrvc) enqueueTiupPublishRequests(ctx context.Context, requests []ge
 			Value: bs,
 		})
 	}
-	err := s.KafkaWriter.WriteMessages(ctx, messages...)
+	err := s.Writer().WriteMessages(ctx, messages...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send message to Kafka: %v", err)
 	}
@@ -158,7 +179,7 @@ func (s *tiupsrvc) enqueueTiupPublishRequests(ctx context.Context, requests []ge
 
 	// init the request dealing status in redis with the request id.
 	for _, requestID := range requestIDs {
-		if err := s.RedisClient.SetNX(ctx, requestID, share.PublishStateQueued, s.StateTTL).Err(); err != nil {
+		if err := s.Client().SetNX(ctx, requestID, share.PublishStateQueued, s.StateTTL).Err(); err != nil {
 			return nil, fmt.Errorf("failed to set initial status in Redis: %v", err)
 		}
 	}

--- a/publisher/pkg/config/reloadable.go
+++ b/publisher/pkg/config/reloadable.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReloadHandler is a callback invoked with the new config after a successful reload.
+type ReloadHandler[T any] func(*T)
+
+// Reloadable wraps config with thread-safe reload capability.
+// It watches a YAML config file for changes and notifies registered handlers.
+type Reloadable[T any] struct {
+	mu       sync.RWMutex
+	cfg      *T
+	path     string
+	mtime    time.Time
+	handlers []ReloadHandler[T]
+}
+
+// NewReloadable reads the YAML config file and returns a Reloadable wrapper.
+func NewReloadable[T any](path string) (*Reloadable[T], error) {
+	cfg, fi, err := loadFileGeneric[T](path)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	return &Reloadable[T]{
+		cfg:   cfg,
+		path:  path,
+		mtime: fi.ModTime(),
+	}, nil
+}
+
+// Get returns the current config in a thread-safe manner.
+func (r *Reloadable[T]) Get() *T {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.cfg
+}
+
+// Reload re-reads the config file from disk and calls all registered handlers
+// with the new config. It is safe to call concurrently.
+func (r *Reloadable[T]) Reload() error {
+	cfg, fi, err := loadFileGeneric[T](r.path)
+	if err != nil {
+		return fmt.Errorf("reload config: %w", err)
+	}
+
+	r.mu.Lock()
+	r.cfg = cfg
+	r.mtime = fi.ModTime()
+	handlers := make([]ReloadHandler[T], len(r.handlers))
+	copy(handlers, r.handlers)
+	r.mu.Unlock()
+
+	for _, h := range handlers {
+		h(cfg)
+	}
+	return nil
+}
+
+// OnReload registers a handler that is called after each successful reload.
+// Handlers are called in registration order.
+func (r *Reloadable[T]) OnReload(handler ReloadHandler[T]) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handlers = append(r.handlers, handler)
+}
+
+// AutoReload polls the config file for modification changes at the given
+// interval and triggers a reload when a change is detected. It blocks until
+// the context is cancelled.
+func (r *Reloadable[T]) AutoReload(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		fi, err := os.Stat(r.path)
+		if err != nil {
+			continue
+		}
+
+		r.mu.RLock()
+		old := r.mtime
+		r.mu.RUnlock()
+
+		if fi.ModTime().After(old) {
+			if err := r.Reload(); err != nil {
+				fmt.Fprintf(os.Stderr, "config auto-reload error: %v\n", err)
+			}
+		}
+	}
+}
+
+func loadFileGeneric[T any](path string) (*T, os.FileInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	var cfg T
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, nil, err
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &cfg, fi, nil
+}


### PR DESCRIPTION
## Summary

Add configuration hot-reload support to the publisher service, following the same approach as tibuild-v2 (polling-based file watcher + SIGHUP signal handler).

## Changes

### New: `publisher/pkg/config/reloadable.go`
- Generic `Reloadable[T]` wrapper with thread-safe config access
- `Get()` — thread-safe read of current config
- `Reload()` — re-reads file, swaps config pointer, notifies registered handlers
- `OnReload()` — register callbacks invoked on reload
- `AutoReload(ctx, interval)` — polling-based file watcher (30s default)

### Modified: `publisher/internal/service/impl/share/srvc.go`
- `KafkaWriter` and `RedisClient` fields made unexported with thread-safe accessor methods `Writer()` and `Client()`
- Added `Reload(cfg config.Service)` method that swaps Kafka/Redis connections and closes old ones

### Modified: Service implementations
- All 4 services (tiup, fileserver, image, tidbcloud) now use accessor methods `s.Writer()` / `s.Client()`
- tiup and tidbcloud additionally reload their sub-config files (delivery config, ops config, test platforms config)

### Modified: `cmd/publisher/main.go`
- Uses `Reloadable[config.Service]` instead of raw config
- `SIGHUP` signal triggers config reload (no restart needed)
- Background `AutoReload` goroutine polls config file every 30s

### Modified: `cmd/worker/main.go`
- Uses `Reloadable[config.Workers]` instead of raw config
- `SIGHUP` signal triggers config reload
- Background `AutoReload` goroutine polls config file every 30s

## How it works

Two triggers for config reload:
1. **SIGHUP signal** — immediate reload (e.g., `kill -SIGHUP <pid>`)
2. **File polling** — every 30s, checks if config file mtime changed, reloads if so

On reload, services hot-swap Kafka writers and Redis clients while in-flight operations complete on old connections.